### PR TITLE
fix: add ios permissions check

### DIFF
--- a/sources/components/ConnectButton.tsx
+++ b/sources/components/ConnectButton.tsx
@@ -14,7 +14,9 @@ export const ConnectButton = React.memo(() => {
     const checkScannerPermissions = useCheckScannerPermissions();
 
     const connectTerminal = async () => {
-        if (!await checkScannerPermissions()) {
+        const hasPermissions = await checkScannerPermissions();
+        
+        if (!hasPermissions) {
             return;
         }
 

--- a/sources/components/ConnectButton.tsx
+++ b/sources/components/ConnectButton.tsx
@@ -1,18 +1,23 @@
 import * as React from 'react';
-import { Alert, View } from 'react-native';
+import { Alert } from 'react-native';
 import { RoundButton } from './RoundButton';
 import { CameraView } from 'expo-camera';
 import { useAuth } from '@/auth/AuthContext';
 import { decodeBase64 } from '@/auth/base64';
 import { encryptWithEphemeralKey } from '@/sync/apiEncryption';
 import { authApprove } from '@/auth/authApprove';
+import { useCheckScannerPermissions } from '@/hooks/useCheckCameraPermissions';
 
 export const ConnectButton = React.memo(() => {
-
     const auth = useAuth();
     const [isLoading, setIsLoading] = React.useState(false);
+    const checkScannerPermissions = useCheckScannerPermissions();
 
-    const connectTerminal = () => {
+    const connectTerminal = async () => {
+        if (!await checkScannerPermissions()) {
+            return;
+        }
+
         CameraView.launchScanner({
             barcodeTypes: ['qr']
         });
@@ -46,7 +51,7 @@ export const ConnectButton = React.memo(() => {
         <RoundButton
             title="Connect"
             size="normal"
-            onPress={connectTerminal}
+            action={connectTerminal}
             loading={isLoading}
         />
     )

--- a/sources/hooks/useCheckCameraPermissions.ts
+++ b/sources/hooks/useCheckCameraPermissions.ts
@@ -1,0 +1,25 @@
+import { useCameraPermissions } from "expo-camera";
+import { Platform } from "react-native";
+
+export function useCheckScannerPermissions(): () => Promise<boolean> {
+    const [cameraPermission, requestCameraPermission] = useCameraPermissions();
+
+    return async () => {
+        if (Platform.OS === 'android') {
+            // adroid uses google code scanner which doesn't need permissions
+            return true;
+        }
+
+        if (!cameraPermission) {
+            // camera permissions are loading
+            return false;
+        }
+
+        if (!cameraPermission.granted) {
+            const reqRes = await requestCameraPermission();
+            return reqRes.granted;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Reason: On iOS, if a user cancels the camera permission request when CameraView.launchScanner() is called, the system will never prompt for permissions again. This leaves users unable to use the QR code scanner functionality without manually going to Settings > Privacy & Security > Camera to re-enable permissions.