### PR TITLE
fix: `Modal.prompt` should render on android platform

### DIFF
--- a/sources/modal/ModalProvider.tsx
+++ b/sources/modal/ModalProvider.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { View, Platform } from 'react-native';
 import { ModalState, ModalConfig, ModalContextValue } from './types';
 import { Modal } from './ModalManager';
 import { WebAlertModal } from './components/WebAlertModal';
@@ -63,7 +62,7 @@ export function ModalProvider({ children }: { children: React.ReactNode }) {
     return (
         <ModalContext.Provider value={contextValue}>
             {children}
-            {Platform.OS === 'web' && currentModal && (
+            {currentModal && (
                 <>
                     {currentModal.type === 'alert' && (
                         <WebAlertModal


### PR DESCRIPTION
when the `ModalProvider` attempts to display a modal on android, it renders nothing, because it refuses to render unless `Platform.OS === 'web'`

correcting this fixes https://github.com/slopus/happy/issues/34