### PR TITLE
fix: staged file paths were being missing first character

### DIFF
--- a/sources/sync/gitStatusFiles.ts
+++ b/sources/sync/gitStatusFiles.ts
@@ -117,7 +117,7 @@ function parseGitStatusFiles(
         
         const indexStatus = line[0]; // Staged status
         const workingStatus = line[1]; // Working directory status
-        const fileName = line.slice(3); // File path
+        const fileName = line.slice(2).trim(); // File path
 
         // Handle renamed files (format: "R  old_name -> new_name")
         let filePath = fileName;


### PR DESCRIPTION
## Before
<img width="554" height="142" alt="Screenshot 2025-08-22 at 4 06 43 PM" src="https://github.com/user-attachments/assets/af76ec11-035f-437b-9966-234e23940889" />



## After

<img width="566" height="182" alt="Screenshot 2025-08-22 at 4 05 51 PM" src="https://github.com/user-attachments/assets/1db11a8d-8f21-4103-ad5c-34681f3d8d48" />


