### PR TITLE
fix: submit button rendered off screen with long branch names

### DIFF
--- a/sources/components/AgentInput.tsx
+++ b/sources/components/AgentInput.tsx
@@ -210,6 +210,8 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
     actionButtonsLeft: {
         flexDirection: 'row',
         gap: 8,
+        flex: 1,
+        overflow: 'hidden',
     },
     actionButton: {
         flexDirection: 'row',
@@ -232,6 +234,8 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         borderRadius: 16,
         justifyContent: 'center',
         alignItems: 'center',
+        flexShrink: 0,
+        marginLeft: 8,
     },
     sendButtonActive: {
         backgroundColor: theme.colors.button.primary.background,
@@ -845,6 +849,8 @@ function GitStatusButton({ sessionId, onPress }: { sessionId?: string, onPress?:
                 justifyContent: 'center',
                 height: 32,
                 opacity: p.pressed ? 0.7 : 1,
+                flex: 1,
+                overflow: 'hidden',
             })}
             hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
             onPress={() => {

--- a/sources/components/GitStatusBadge.tsx
+++ b/sources/components/GitStatusBadge.tsx
@@ -27,45 +27,60 @@ export function GitStatusBadge({ sessionId }: GitStatusBadgeProps) {
     const hasLineChanges = gitStatus.unstagedLinesAdded > 0 || gitStatus.unstagedLinesRemoved > 0;
 
     return (
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, flex: 1, overflow: 'hidden' }}>
             {/* Branch name */}
-            <Text style={{
-                fontSize: 12,
-                color: theme.colors.button.secondary.tint,
-                fontWeight: '500'
-            }}>
+            <Text
+                style={{
+                    fontSize: 12,
+                    color: theme.colors.button.secondary.tint,
+                    fontWeight: '500',
+                    flexShrink: 1,
+                }}
+                numberOfLines={1}
+                ellipsizeMode="middle"
+            >
                 {gitStatus.branch || 'main'}
             </Text>
 
             {/* Files changed - only show if there are files */}
             {fileCount > 0 && (
-                <Text style={{
-                    fontSize: 12,
-                    color: theme.colors.button.secondary.tint,
-                    fontWeight: '500'
-                }}>
+                <Text
+                    style={{
+                        fontSize: 12,
+                        color: theme.colors.button.secondary.tint,
+                        fontWeight: '500',
+                        flexShrink: 0,
+                    }}
+                    numberOfLines={1}
+                >
                     {fileCount} files
                 </Text>
             )}
 
             {/* Line changes - GitHub style */}
             {hasLineChanges && (
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2, flexShrink: 0 }}>
                     {gitStatus.unstagedLinesAdded > 0 && (
-                        <Text style={{
-                            fontSize: 12,
-                            color: theme.colors.gitAddedText,
-                            fontWeight: '600'
-                        }}>
+                        <Text
+                            style={{
+                                fontSize: 12,
+                                color: theme.colors.gitAddedText,
+                                fontWeight: '600',
+                            }}
+                            numberOfLines={1}
+                        >
                             +{gitStatus.unstagedLinesAdded}
                         </Text>
                     )}
                     {gitStatus.unstagedLinesRemoved > 0 && (
-                        <Text style={{
-                            fontSize: 12,
-                            color: theme.colors.gitRemovedText,
-                            fontWeight: '600'
-                        }}>
+                        <Text
+                            style={{
+                                fontSize: 12,
+                                color: theme.colors.gitRemovedText,
+                                fontWeight: '600',
+                            }}
+                            numberOfLines={1}
+                        >
                             -{gitStatus.unstagedLinesRemoved}
                         </Text>
                     )}


### PR DESCRIPTION
Fixes #33

## Before

<img width="368" height="127" alt="Screenshot 2025-08-22 at 4 07 24 PM" src="https://github.com/user-attachments/assets/fe33e46f-61ed-40fc-b217-64f7a3e8563f" />

## After

<img width="367" height="130" alt="Screenshot 2025-08-22 at 4 07 46 PM" src="https://github.com/user-attachments/assets/03af7ad6-a302-4085-8f7f-88e1bc16a6bb" />
