### PR TITLE
resolve markdown copy issues by adding full-text selection and copy functionality

### DIFF
--- a/sources/app/(app)/_layout.tsx
+++ b/sources/app/(app)/_layout.tsx
@@ -147,6 +147,14 @@ export default function RootLayout() {
                 }}
             />
             <Stack.Screen
+                name="text-selection"
+                options={{
+                    headerShown: true,
+                    headerTitle: 'Select Text',
+                    headerBackTitle: t('common.back'),
+                }}
+            />
+            <Stack.Screen
                 name="dev/index"
                 options={{
                     headerTitle: 'Developer Tools',

--- a/sources/app/(app)/_layout.tsx
+++ b/sources/app/(app)/_layout.tsx
@@ -150,7 +150,7 @@ export default function RootLayout() {
                 name="text-selection"
                 options={{
                     headerShown: true,
-                    headerTitle: 'Select Text',
+                    headerTitle: t('textSelection.title'),
                     headerBackTitle: t('common.back'),
                 }}
             />

--- a/sources/app/(app)/settings/features.tsx
+++ b/sources/app/(app)/settings/features.tsx
@@ -10,6 +10,7 @@ import { t } from '@/text';
 export default function FeaturesSettingsScreen() {
     const [experiments, setExperiments] = useSettingMutable('experiments');
     const [commandPaletteEnabled, setCommandPaletteEnabled] = useLocalSettingMutable('commandPaletteEnabled');
+    const [markdownCopyV2, setMarkdownCopyV2] = useLocalSettingMutable('markdownCopyV2');
     
     return (
         <ItemList style={{ paddingTop: 0 }}>
@@ -26,6 +27,18 @@ export default function FeaturesSettingsScreen() {
                         <Switch
                             value={experiments}
                             onValueChange={setExperiments}
+                        />
+                    }
+                    showChevron={false}
+                />
+                <Item
+                    title="Markdown Copy v2"
+                    subtitle="Long press opens copy modal"
+                    icon={<Ionicons name="text-outline" size={29} color="#34C759" />}
+                    rightElement={
+                        <Switch
+                            value={markdownCopyV2}
+                            onValueChange={setMarkdownCopyV2}
                         />
                     }
                     showChevron={false}

--- a/sources/app/(app)/settings/features.tsx
+++ b/sources/app/(app)/settings/features.tsx
@@ -32,8 +32,8 @@ export default function FeaturesSettingsScreen() {
                     showChevron={false}
                 />
                 <Item
-                    title="Markdown Copy v2"
-                    subtitle="Long press opens copy modal"
+                    title={t('settingsFeatures.markdownCopyV2')}
+                    subtitle={t('settingsFeatures.markdownCopyV2Subtitle')}
                     icon={<Ionicons name="text-outline" size={29} color="#34C759" />}
                     rightElement={
                         <Switch

--- a/sources/app/(app)/text-selection.tsx
+++ b/sources/app/(app)/text-selection.tsx
@@ -2,20 +2,23 @@ import React from 'react';
 import { View, Text, ScrollView, TextInput, Alert } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { retrieveTempText } from '@/sync/persistence';
 import { Typography } from '@/constants/Typography';
+import { t } from '@/text';
 
 export default function TextSelectionScreen() {
     const router = useRouter();
     const { textId } = useLocalSearchParams<{ textId: string }>();
     const { theme } = useUnistyles();
+    const insets = useSafeAreaInsets();
     const [fullText, setFullText] = React.useState<string>('');
     const [loading, setLoading] = React.useState(true);
 
     React.useEffect(() => {
         if (!textId) {
-            Alert.alert('Error', 'No text provided', [
-                { text: 'OK', onPress: () => router.back() }
+            Alert.alert(t('common.error'), t('textSelection.noTextProvided'), [
+                { text: t('common.ok'), onPress: () => router.back() }
             ]);
             return;
         }
@@ -24,8 +27,8 @@ export default function TextSelectionScreen() {
         if (content) {
             setFullText(content);
         } else {
-            Alert.alert('Error', 'Text not found or expired', [
-                { text: 'OK', onPress: () => router.back() }
+            Alert.alert(t('common.error'), t('textSelection.textNotFound'), [
+                { text: t('common.ok'), onPress: () => router.back() }
             ]);
         }
         setLoading(false);
@@ -35,7 +38,7 @@ export default function TextSelectionScreen() {
         return (
             <View style={styles.container}>
                 <Text style={[styles.loadingText, { color: theme.colors.textSecondary }]}>
-                    Loading...
+                    {t('common.loading')}
                 </Text>
             </View>
         );
@@ -46,7 +49,10 @@ export default function TextSelectionScreen() {
             <ScrollView 
                 style={styles.textContainer} 
                 showsVerticalScrollIndicator={true}
-                contentContainerStyle={styles.scrollContent}
+                contentContainerStyle={[
+                    styles.scrollContent,
+                    { paddingBottom: insets.bottom + 16 }
+                ]}
             >
                 <TextInput
                     style={[styles.textInput, { 

--- a/sources/app/(app)/text-selection.tsx
+++ b/sources/app/(app)/text-selection.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { View, Text, ScrollView, TextInput, Alert } from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { retrieveTempText } from '@/sync/persistence';
+import { Typography } from '@/constants/Typography';
+
+export default function TextSelectionScreen() {
+    const router = useRouter();
+    const { textId } = useLocalSearchParams<{ textId: string }>();
+    const { theme } = useUnistyles();
+    const [fullText, setFullText] = React.useState<string>('');
+    const [loading, setLoading] = React.useState(true);
+
+    React.useEffect(() => {
+        if (!textId) {
+            Alert.alert('Error', 'No text provided', [
+                { text: 'OK', onPress: () => router.back() }
+            ]);
+            return;
+        }
+
+        const content = retrieveTempText(textId);
+        if (content) {
+            setFullText(content);
+        } else {
+            Alert.alert('Error', 'Text not found or expired', [
+                { text: 'OK', onPress: () => router.back() }
+            ]);
+        }
+        setLoading(false);
+    }, [textId, router]);
+
+    if (loading) {
+        return (
+            <View style={styles.container}>
+                <Text style={[styles.loadingText, { color: theme.colors.textSecondary }]}>
+                    Loading...
+                </Text>
+            </View>
+        );
+    }
+
+    return (
+        <View style={[styles.container, { backgroundColor: theme.colors.surface }]}>
+            <ScrollView 
+                style={styles.textContainer} 
+                showsVerticalScrollIndicator={true}
+                contentContainerStyle={styles.scrollContent}
+            >
+                <TextInput
+                    style={[styles.textInput, { 
+                        color: theme.colors.text,
+                        backgroundColor: 'transparent'
+                    }]}
+                    value={fullText}
+                    multiline={true}
+                    editable={false}
+                    selectTextOnFocus={false}
+                    scrollEnabled={false}
+                />
+            </ScrollView>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create((theme) => ({
+    container: {
+        flex: 1,
+        backgroundColor: theme.colors.surface,
+    },
+    loadingText: {
+        ...Typography.default(),
+        fontSize: 16,
+        textAlign: 'center',
+        marginTop: 50,
+    },
+    textContainer: {
+        flex: 1,
+        padding: 16,
+    },
+    scrollContent: {
+        flexGrow: 1,
+    },
+    textInput: {
+        ...Typography.mono(),
+        fontSize: 14,
+        lineHeight: 20,
+        color: theme.colors.text,
+        minHeight: 200,
+        textAlignVertical: 'top',
+        backgroundColor: 'transparent',
+        borderWidth: 0,
+        paddingHorizontal: 0,
+        paddingVertical: 0,
+    },
+}));

--- a/sources/components/SimpleSyntaxHighlighter.tsx
+++ b/sources/components/SimpleSyntaxHighlighter.tsx
@@ -6,6 +6,7 @@ import { Typography } from '@/constants/Typography';
 interface SimpleSyntaxHighlighterProps {
   code: string;
   language: string | null;
+  selectable: boolean;
 }
 
 // Get theme-aware colors
@@ -248,7 +249,8 @@ const tokenizeCode = (code: string, language: string | null) => {
 
 export const SimpleSyntaxHighlighter: React.FC<SimpleSyntaxHighlighterProps> = ({
   code,
-  language
+  language,
+  selectable
 }) => {
   const { theme } = useUnistyles();
   const colors = getColors(theme);
@@ -294,7 +296,7 @@ export const SimpleSyntaxHighlighter: React.FC<SimpleSyntaxHighlighterProps> = (
   return (
     <View>
       <Text 
-        selectable
+        selectable={selectable}
         style={{ 
           fontFamily: Typography.mono().fontFamily,
           fontSize: 14,
@@ -304,7 +306,7 @@ export const SimpleSyntaxHighlighter: React.FC<SimpleSyntaxHighlighterProps> = (
         {tokens.map((token, index) => (
           <Text
             key={index}
-            selectable
+            selectable={selectable}
             style={{
               color: getColorForType(token.type, token.nestLevel),
               fontFamily: Typography.mono().fontFamily,

--- a/sources/sync/localSettings.ts
+++ b/sources/sync/localSettings.ts
@@ -10,6 +10,7 @@ export const LocalSettingsSchema = z.object({
     devModeEnabled: z.boolean().describe('Enable developer menu in settings'),
     commandPaletteEnabled: z.boolean().describe('Enable CMD+K command palette (web only)'),
     themePreference: z.enum(['light', 'dark', 'adaptive']).describe('Theme preference: light, dark, or adaptive (follows system)'),
+    markdownCopyV2: z.boolean().describe('Replace native paragraph selection with long-press modal for full markdown copy'),
     // CLI version acknowledgments - keyed by machineId
     acknowledgedCliVersions: z.record(z.string(), z.string()).describe('Acknowledged CLI versions per machine'),
 });
@@ -32,6 +33,7 @@ export const localSettingsDefaults: LocalSettings = {
     devModeEnabled: false,
     commandPaletteEnabled: false,
     themePreference: 'adaptive',
+    markdownCopyV2: false,
     acknowledgedCliVersions: {},
 };
 Object.freeze(localSettingsDefaults);

--- a/sources/sync/persistence.ts
+++ b/sources/sync/persistence.ts
@@ -146,6 +146,23 @@ export function saveProfile(profile: Profile) {
     mmkv.set('profile', JSON.stringify(profile));
 }
 
+// Simple temporary text storage for passing large strings between screens
+export function storeTempText(content: string): string {
+    const id = `temp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    mmkv.set(`temp_text_${id}`, content);
+    return id;
+}
+
+export function retrieveTempText(id: string): string | null {
+    const content = mmkv.getString(`temp_text_${id}`);
+    if (content) {
+        // Auto-delete after retrieval
+        mmkv.delete(`temp_text_${id}`);
+        return content;
+    }
+    return null;
+}
+
 export function clearPersistence() {
     mmkv.clearAll();
 }

--- a/sources/text/_default.ts
+++ b/sources/text/_default.ts
@@ -663,6 +663,17 @@ export const en = {
             yesForTool: "Yes, don't ask again for this tool",
             noTellClaude: 'No, and tell Claude what to do differently',
         }
+    },
+
+    textSelection: {
+        // Text selection modal
+        selectText: 'Select text range',
+        selectFromMessage: ({ title }: { title: string }) => `Select text from ${title}`,
+        copySelected: 'Copy selected text',
+        selectAll: 'Select all',
+        startPosition: 'Start position',
+        endPosition: 'End position',
+        copiedToClipboard: 'Selected text copied to clipboard',
     }
 } as const;
 

--- a/sources/text/_default.ts
+++ b/sources/text/_default.ts
@@ -673,6 +673,9 @@ export const en = {
         title: 'Select Text',
         noTextProvided: 'No text provided',
         textNotFound: 'Text not found or expired',
+        textCopied: 'Text copied to clipboard',
+        failedToCopy: 'Failed to copy text to clipboard',
+        noTextToCopy: 'No text available to copy',
     }
 } as const;
 

--- a/sources/text/_default.ts
+++ b/sources/text/_default.ts
@@ -162,6 +162,8 @@ export const en = {
         commandPalette: 'Command Palette',
         commandPaletteEnabled: 'Press ⌘K to open',
         commandPaletteDisabled: 'Quick command access disabled',
+        markdownCopyV2: 'Markdown Copy v2',
+        markdownCopyV2Subtitle: 'Long press opens copy modal',
     },
 
     errors: {
@@ -666,14 +668,11 @@ export const en = {
     },
 
     textSelection: {
-        // Text selection modal
+        // Text selection screen
         selectText: 'Select text range',
-        selectFromMessage: ({ title }: { title: string }) => `Select text from ${title}`,
-        copySelected: 'Copy selected text',
-        selectAll: 'Select all',
-        startPosition: 'Start position',
-        endPosition: 'End position',
-        copiedToClipboard: 'Selected text copied to clipboard',
+        title: 'Select Text',
+        noTextProvided: 'No text provided',
+        textNotFound: 'Text not found or expired',
     }
 } as const;
 

--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -162,6 +162,8 @@ export const ca: TranslationStructure = {
         commandPalette: 'Paleta de comandes',
         commandPaletteEnabled: 'Prem ⌘K per obrir',
         commandPaletteDisabled: 'Accés ràpid a comandes desactivat',
+        markdownCopyV2: 'Markdown Copy v2',
+        markdownCopyV2Subtitle: 'Pulsació llarga obre modal de còpia',
     },
 
     errors: {
@@ -666,14 +668,11 @@ export const ca: TranslationStructure = {
     },
 
     textSelection: {
-        // Text selection modal
+        // Text selection screen
         selectText: 'Seleccionar rang de text',
-        selectFromMessage: ({ title }: { title: string }) => `Seleccionar text de ${title}`,
-        copySelected: 'Copiar text seleccionat',
-        selectAll: 'Seleccionar tot',
-        startPosition: 'Posició inicial',
-        endPosition: 'Posició final',
-        copiedToClipboard: 'Text seleccionat copiat al porta-retalls',
+        title: 'Seleccionar text',
+        noTextProvided: 'No s\'ha proporcionat text',
+        textNotFound: 'Text no trobat o expirat',
     }
 } as const;
 

--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -673,6 +673,9 @@ export const ca: TranslationStructure = {
         title: 'Seleccionar text',
         noTextProvided: 'No s\'ha proporcionat text',
         textNotFound: 'Text no trobat o expirat',
+        textCopied: 'Text copiat al porta-retalls',
+        failedToCopy: 'No s\'ha pogut copiar el text al porta-retalls',
+        noTextToCopy: 'No hi ha text disponible per copiar',
     }
 } as const;
 

--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -663,6 +663,17 @@ export const ca: TranslationStructure = {
             yesForTool: 'Sí, no tornis a preguntar per aquesta eina',
             noTellClaude: 'No, i digues a Claude què fer diferent',
         }
+    },
+
+    textSelection: {
+        // Text selection modal
+        selectText: 'Seleccionar rang de text',
+        selectFromMessage: ({ title }: { title: string }) => `Seleccionar text de ${title}`,
+        copySelected: 'Copiar text seleccionat',
+        selectAll: 'Seleccionar tot',
+        startPosition: 'Posició inicial',
+        endPosition: 'Posició final',
+        copiedToClipboard: 'Text seleccionat copiat al porta-retalls',
     }
 } as const;
 

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -663,6 +663,17 @@ export const es: TranslationStructure = {
             yesForTool: 'Sí, no volver a preguntar para esta herramienta',
             noTellClaude: 'No, y decirle a Claude qué hacer diferente',
         }
+    },
+
+    textSelection: {
+        // Text selection modal
+        selectText: 'Seleccionar rango de texto',
+        selectFromMessage: ({ title }: { title: string }) => `Seleccionar texto de ${title}`,
+        copySelected: 'Copiar texto seleccionado',
+        selectAll: 'Seleccionar todo',
+        startPosition: 'Posición inicial',
+        endPosition: 'Posición final',
+        copiedToClipboard: 'Texto seleccionado copiado al portapapeles',
     }
 } as const;
 

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -673,6 +673,9 @@ export const es: TranslationStructure = {
         title: 'Seleccionar texto',
         noTextProvided: 'No se proporcionó texto',
         textNotFound: 'Texto no encontrado o expirado',
+        textCopied: 'Texto copiado al portapapeles',
+        failedToCopy: 'Error al copiar el texto al portapapeles',
+        noTextToCopy: 'No hay texto disponible para copiar',
     }
 } as const;
 

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -162,6 +162,8 @@ export const es: TranslationStructure = {
         commandPalette: 'Paleta de comandos',
         commandPaletteEnabled: 'Presione ⌘K para abrir',
         commandPaletteDisabled: 'Acceso rápido a comandos deshabilitado',
+        markdownCopyV2: 'Markdown Copy v2',
+        markdownCopyV2Subtitle: 'Pulsación larga abre modal de copiado',
     },
 
     errors: {
@@ -666,14 +668,11 @@ export const es: TranslationStructure = {
     },
 
     textSelection: {
-        // Text selection modal
+        // Text selection screen
         selectText: 'Seleccionar rango de texto',
-        selectFromMessage: ({ title }: { title: string }) => `Seleccionar texto de ${title}`,
-        copySelected: 'Copiar texto seleccionado',
-        selectAll: 'Seleccionar todo',
-        startPosition: 'Posición inicial',
-        endPosition: 'Posición final',
-        copiedToClipboard: 'Texto seleccionado copiado al portapapeles',
+        title: 'Seleccionar texto',
+        noTextProvided: 'No se proporcionó texto',
+        textNotFound: 'Texto no encontrado o expirado',
     }
 } as const;
 

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -673,6 +673,17 @@ export const pl: TranslationStructure = {
             yesForTool: 'Tak, nie pytaj ponownie dla tego narzędzia',
             noTellClaude: 'Nie, i powiedz Claude co zrobić inaczej',
         }
+    },
+
+    textSelection: {
+        // Text selection modal
+        selectText: 'Wybierz zakres tekstu',
+        selectFromMessage: ({ title }: { title: string }) => `Wybierz tekst z ${title}`,
+        copySelected: 'Kopiuj zaznaczony tekst',
+        selectAll: 'Zaznacz wszystko',
+        startPosition: 'Pozycja początkowa',
+        endPosition: 'Pozycja końcowa',
+        copiedToClipboard: 'Zaznaczony tekst skopiowany do schowka',
     }
 } as const;
 

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -173,6 +173,8 @@ export const pl: TranslationStructure = {
         commandPalette: 'Paleta poleceń',
         commandPaletteEnabled: 'Naciśnij ⌘K, aby otworzyć',
         commandPaletteDisabled: 'Szybki dostęp do poleceń wyłączony',
+        markdownCopyV2: 'Markdown Copy v2',
+        markdownCopyV2Subtitle: 'Długie naciśnięcie otwiera modal kopiowania',
     },
 
     errors: {
@@ -676,14 +678,11 @@ export const pl: TranslationStructure = {
     },
 
     textSelection: {
-        // Text selection modal
+        // Text selection screen
         selectText: 'Wybierz zakres tekstu',
-        selectFromMessage: ({ title }: { title: string }) => `Wybierz tekst z ${title}`,
-        copySelected: 'Kopiuj zaznaczony tekst',
-        selectAll: 'Zaznacz wszystko',
-        startPosition: 'Pozycja początkowa',
-        endPosition: 'Pozycja końcowa',
-        copiedToClipboard: 'Zaznaczony tekst skopiowany do schowka',
+        title: 'Wybierz tekst',
+        noTextProvided: 'Nie podano tekstu',
+        textNotFound: 'Tekst nie został znaleziony lub wygasł',
     }
 } as const;
 

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -683,6 +683,9 @@ export const pl: TranslationStructure = {
         title: 'Wybierz tekst',
         noTextProvided: 'Nie podano tekstu',
         textNotFound: 'Tekst nie został znaleziony lub wygasł',
+        textCopied: 'Tekst skopiowany do schowka',
+        failedToCopy: 'Nie udało się skopiować tekstu do schowka',
+        noTextToCopy: 'Brak tekstu do skopiowania',
     }
 } as const;
 

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -162,6 +162,8 @@ export const pt: TranslationStructure = {
         commandPalette: 'Paleta de comandos',
         commandPaletteEnabled: 'Pressione ⌘K para abrir',
         commandPaletteDisabled: 'Acesso rápido a comandos desativado',
+        markdownCopyV2: 'Markdown Copy v2',
+        markdownCopyV2Subtitle: 'Pressione e segure para abrir modal de cópia',
     },
 
     errors: {
@@ -666,14 +668,11 @@ export const pt: TranslationStructure = {
     },
 
     textSelection: {
-        // Text selection modal
+        // Text selection screen
         selectText: 'Selecionar intervalo de texto',
-        selectFromMessage: ({ title }: { title: string }) => `Selecionar texto de ${title}`,
-        copySelected: 'Copiar texto selecionado',
-        selectAll: 'Selecionar tudo',
-        startPosition: 'Posição inicial',
-        endPosition: 'Posição final',
-        copiedToClipboard: 'Texto selecionado copiado para a área de transferência',
+        title: 'Selecionar texto',
+        noTextProvided: 'Nenhum texto fornecido',
+        textNotFound: 'Texto não encontrado ou expirado',
     }
 } as const;
 

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -673,6 +673,9 @@ export const pt: TranslationStructure = {
         title: 'Selecionar texto',
         noTextProvided: 'Nenhum texto fornecido',
         textNotFound: 'Texto não encontrado ou expirado',
+        textCopied: 'Texto copiado para a área de transferência',
+        failedToCopy: 'Falha ao copiar o texto para a área de transferência',
+        noTextToCopy: 'Nenhum texto disponível para copiar',
     }
 } as const;
 

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -663,6 +663,17 @@ export const pt: TranslationStructure = {
             yesForTool: 'Sim, não perguntar novamente para esta ferramenta',
             noTellClaude: 'Não, e dizer ao Claude o que fazer diferente',
         }
+    },
+
+    textSelection: {
+        // Text selection modal
+        selectText: 'Selecionar intervalo de texto',
+        selectFromMessage: ({ title }: { title: string }) => `Selecionar texto de ${title}`,
+        copySelected: 'Copiar texto selecionado',
+        selectAll: 'Selecionar tudo',
+        startPosition: 'Posição inicial',
+        endPosition: 'Posição final',
+        copiedToClipboard: 'Texto selecionado copiado para a área de transferência',
     }
 } as const;
 

--- a/sources/text/translations/ru.ts
+++ b/sources/text/translations/ru.ts
@@ -154,6 +154,8 @@ export const ru: TranslationStructure = {
         commandPalette: 'Command Palette',
         commandPaletteEnabled: 'Нажмите ⌘K для открытия',
         commandPaletteDisabled: 'Быстрый доступ к командам отключён',
+        markdownCopyV2: 'Markdown Copy v2',
+        markdownCopyV2Subtitle: 'Долгое нажатие открывает модальное окно копирования',
     },
 
     errors: {
@@ -676,14 +678,11 @@ export const ru: TranslationStructure = {
     },
 
     textSelection: {
-        // Text selection modal
+        // Text selection screen
         selectText: 'Выделить диапазон текста',
-        selectFromMessage: ({ title }: { title: string }) => `Выделить текст из ${title}`,
-        copySelected: 'Копировать выделенный текст',
-        selectAll: 'Выделить всё',
-        startPosition: 'Начальная позиция',
-        endPosition: 'Конечная позиция',
-        copiedToClipboard: 'Выделенный текст скопирован в буфер обмена',
+        title: 'Выделить текст',
+        noTextProvided: 'Текст не предоставлен',
+        textNotFound: 'Текст не найден или устарел',
     }
 } as const;
 

--- a/sources/text/translations/ru.ts
+++ b/sources/text/translations/ru.ts
@@ -674,6 +674,17 @@ export const ru: TranslationStructure = {
         needsRestartMessage: 'Приложение нужно перезапустить для применения новых языковых настроек.',
         restartNow: 'Перезапустить',
     },
+
+    textSelection: {
+        // Text selection modal
+        selectText: 'Выделить диапазон текста',
+        selectFromMessage: ({ title }: { title: string }) => `Выделить текст из ${title}`,
+        copySelected: 'Копировать выделенный текст',
+        selectAll: 'Выделить всё',
+        startPosition: 'Начальная позиция',
+        endPosition: 'Конечная позиция',
+        copiedToClipboard: 'Выделенный текст скопирован в буфер обмена',
+    }
 } as const;
 
 export type TranslationsRu = typeof ru;

--- a/sources/text/translations/ru.ts
+++ b/sources/text/translations/ru.ts
@@ -683,6 +683,9 @@ export const ru: TranslationStructure = {
         title: 'Выделить текст',
         noTextProvided: 'Текст не предоставлен',
         textNotFound: 'Текст не найден или устарел',
+        textCopied: 'Текст скопирован в буфер обмена',
+        failedToCopy: 'Не удалось скопировать текст в буфер обмена',
+        noTextToCopy: 'Нет текста для копирования',
     }
 } as const;
 

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -663,5 +663,16 @@ export const zhHans = {
             yesForTool: '是，不再询问此工具',
             noTellClaude: '否，并告诉 Claude 该如何不同地操作',
         }
+    },
+
+    textSelection: {
+        // Text selection modal
+        selectText: '选择文本范围',
+        selectFromMessage: ({ title }: { title: string }) => `从 ${title} 选择文本`,
+        copySelected: '复制选中的文本',
+        selectAll: '全选',
+        startPosition: '起始位置',
+        endPosition: '结束位置',
+        copiedToClipboard: '选中的文本已复制到剪贴板',
     }
 } as const;

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -673,5 +673,8 @@ export const zhHans = {
         title: '选择文本',
         noTextProvided: '未提供文本',
         textNotFound: '文本未找到或已过期',
+        textCopied: '文本已复制到剪贴板',
+        failedToCopy: '复制文本到剪贴板失败',
+        noTextToCopy: '没有可复制的文本',
     }
 } as const;

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -162,6 +162,8 @@ export const zhHans = {
         commandPalette: '命令面板',
         commandPaletteEnabled: '按 ⌘K 打开',
         commandPaletteDisabled: '快速命令访问已禁用',
+        markdownCopyV2: 'Markdown Copy v2',
+        markdownCopyV2Subtitle: '长按打开复制模态框',
     },
 
     errors: {
@@ -666,13 +668,10 @@ export const zhHans = {
     },
 
     textSelection: {
-        // Text selection modal
+        // Text selection screen
         selectText: '选择文本范围',
-        selectFromMessage: ({ title }: { title: string }) => `从 ${title} 选择文本`,
-        copySelected: '复制选中的文本',
-        selectAll: '全选',
-        startPosition: '起始位置',
-        endPosition: '结束位置',
-        copiedToClipboard: '选中的文本已复制到剪贴板',
+        title: '选择文本',
+        noTextProvided: '未提供文本',
+        textNotFound: '文本未找到或已过期',
     }
 } as const;


### PR DESCRIPTION
## Problem

Users reported that copy/paste functionality in markdown content was too limited - they could only copy single paragraphs of text at a time. Too tedious when they wanted to copy the entire message.

## Solution
This PR introduces Markdown Copy v2, a new experimental feature **only for mobile** that:

- **Replaces single-line copying** with full markdown text copying
- **Long-press gesture** opens a dedicated text selection screen
- **Copy all button** in header of new screen for easy full-text copying
- **Maintains backward compatibility** via feature flag (disabled by default)

## Key Changes
- Added `markdownCopyV2` feature flag in settings
- Created dedicated text selection screen (`/text-selection`)
- Use long-press gesture on markdown content
- Store the markdown in MMKV for passing content between screens
- Translations for all supported languages

Fixes: #47 #43 #13 