### PR TITLE
Improve new session button visibility with border

### DIFF
--- a/sources/components/FABWide.tsx
+++ b/sources/components/FABWide.tsx
@@ -21,6 +21,8 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         elevation: 5,
         alignItems: 'center',
         justifyContent: 'center',
+        borderWidth: 1,
+        borderColor: theme.colors.divider,
     },
     buttonDefault: {
         backgroundColor: theme.colors.fab.background,


### PR DESCRIPTION
## Problem
The oval-shaped 'Start New Session' button was difficult to read when archived conversations appeared behind it, especially in certain lighting conditions or themes.

## Solution
Added a subtle 1px border using the theme's divider color to improve contrast and make the button more visible in both light and dark modes.

## Changes
- Added `borderWidth: 1` and `borderColor: theme.colors.divider` to FABWide component

## Testing
Tested in both light and dark modes with archived conversations visible behind the button. The border provides better visual separation without being obtrusive.

---
🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)