### PR TITLE
fix: retry message fetch when session encryption not ready

### DIFF
--- a/sources/sync/sync.ts
+++ b/sources/sync/sync.ts
@@ -1398,11 +1398,12 @@ class Sync {
     private fetchMessages = async (sessionId: string) => {
         log.log(`💬 fetchMessages starting for session ${sessionId} - acquiring lock`);
 
-        // Get encryption
+        // Get encryption - may not be ready yet if session was just created
+        // Throwing an error triggers backoff retry in InvalidateSync
         const encryption = this.encryption.getSessionEncryption(sessionId);
-        if (!encryption) { // Should never happen
-            console.error(`Session ${sessionId} not found`);
-            return;
+        if (!encryption) {
+            log.log(`💬 fetchMessages: Session encryption not ready for ${sessionId}, will retry`);
+            throw new Error(`Session encryption not ready for ${sessionId}`);
         }
 
         // Request


### PR DESCRIPTION
## Summary

Fixes the race condition where messages don't load for new sessions when the user quickly navigates to them.

- When a new session is created and user navigates to it quickly, `fetchMessages()` may run before `fetchSessions()` completes
- Previously, if session encryption wasn't ready, `fetchMessages()` silently returned early
- This left the session stuck with `isLoaded: false` forever (loading spinner)
- Now we throw an error, which triggers the `backoff` retry mechanism in `InvalidateSync`
- Messages will load once session encryption becomes available

## Test plan

- [x] TypeScript type checking passes (`yarn typecheck`)
- [x] Existing sync-related tests pass
- [ ] Manual test: Start session from CLI, quickly open on mobile - messages should load

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)