### PR TITLE
fix: re-fetch messages when control returns to mobile

### DIFF
--- a/sources/sync/sync.ts
+++ b/sources/sync/sync.ts
@@ -1639,6 +1639,15 @@ class Sync {
                         const toolName = firstRequest?.tool;
                         voiceHooks.onPermissionRequested(updateData.body.id, requestIds[0], toolName, firstRequest?.arguments);
                     }
+
+                    // Re-fetch messages when control returns to mobile (local -> remote mode switch)
+                    // This catches up on any messages that were exchanged while desktop had control
+                    const wasControlledByUser = session.agentState?.controlledByUser;
+                    const isNowControlledByUser = agentState?.controlledByUser;
+                    if (!wasControlledByUser && isNowControlledByUser) {
+                        log.log(`🔄 Control returned to mobile for session ${updateData.body.id}, re-fetching messages`);
+                        this.onSessionVisible(updateData.body.id);
+                    }
                 }
             }
         } else if (updateData.body.t === 'update-account') {


### PR DESCRIPTION
## Summary

When a session is started from mobile and the user continues from desktop (by pressing a key), the CLI switches to local mode and stops syncing messages. This PR ensures that when control returns to mobile, messages are automatically re-fetched to catch up.

### The Problem

1. User starts session from mobile (remote mode, `controlledByUser: true`)
2. User presses key on desktop → CLI switches to local mode (`controlledByUser: false`)
3. Messages exchanged during local mode are not synced to mobile
4. When user switches back to mobile, they're missing the messages

### The Fix

Detects when `controlledByUser` transitions from `false` → `true` in the `update-session` handler, and triggers a message re-fetch via `onSessionVisible()`.

```typescript
const wasControlledByUser = session.agentState?.controlledByUser;
const isNowControlledByUser = agentState?.controlledByUser;
if (!wasControlledByUser && isNowControlledByUser) {
    log.log(`🔄 Control returned to mobile for session ${updateData.body.id}, re-fetching messages`);
    this.onSessionVisible(updateData.body.id);
}
```

### Limitations

This only helps when the CLI syncs the messages to the server before switching back to remote mode. If messages were never synced during local mode, they won't appear on mobile. That would require a CLI-side change to sync message history on mode switch.

## Test plan

- [x] TypeScript type checking passes (`yarn typecheck`)
- [x] Existing sync-related tests pass
- [ ] Manual test: Start session from mobile → continue on desktop → switch back to mobile → messages should sync

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)