### PR TITLE
Fix press not activating randomly

### DIFF
--- a/sources/components/AgentInput.tsx
+++ b/sources/components/AgentInput.tsx
@@ -1,8 +1,7 @@
 import { Ionicons, Octicons } from '@expo/vector-icons';
 import * as React from 'react';
-import { View, Platform, useWindowDimensions, ViewStyle, Text, ActivityIndicator, TouchableWithoutFeedback, Image as RNImage } from 'react-native';
+import { View, Platform, useWindowDimensions, ViewStyle, Text, ActivityIndicator, TouchableWithoutFeedback, Image as RNImage, Pressable } from 'react-native';
 import { Image } from 'expo-image';
-import { Pressable } from 'react-native-gesture-handler';
 import { layout } from './layout';
 import { MultiTextInput, KeyPressEvent } from './MultiTextInput';
 import { Typography } from '@/constants/Typography';


### PR DESCRIPTION
Fix the press not activating randomly. We don't need Pressable from `react-native-gesture-handler` here; it is only necessary in a nested ScrollView.