### PR TITLE
Add auto-focus to text input when window regains focus

### DIFF
--- a/sources/components/AgentInput.tsx
+++ b/sources/components/AgentInput.tsx
@@ -489,6 +489,21 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
         };
     }, [isCodex, props.modelMode, props.onModelModeChange]);
 
+    // Add window focus handler to restore focus to input on web
+    React.useEffect(() => {
+        if (Platform.OS !== 'web') return;
+
+        const handleWindowFocus = () => {
+            // Restore focus to the input when window regains focus
+            inputRef.current?.focus();
+        };
+
+        window.addEventListener('focus', handleWindowFocus);
+        return () => {
+            window.removeEventListener('focus', handleWindowFocus);
+        };
+    }, []);
+
 
 
     return (


### PR DESCRIPTION
## Summary

Automatically return cursor focus to the text input area whenever the browser window or tab regains focus.

## Motivation

This improves UX by allowing users to start typing immediately after switching back to the app without manually clicking the input field. This is especially useful when:
- Switching between tabs to reference documentation
- Returning from another application
- Using the app alongside other tools

## Changes

- Added a window `focus` event listener in `AgentInput.tsx`
- Only runs on web platform (mobile has different focus behavior)
- Uses existing `inputRef` to restore focus programmatically
- Properly cleans up event listener on unmount

## Testing

Tested on web:
- ✅ Focus returns to input when switching browser tabs
- ✅ Focus returns when switching back from another application
- ✅ No impact on mobile platforms
- ✅ Event listener properly cleaned up on unmount

## Implementation Details

The implementation is minimal and follows existing patterns in the codebase:
- Uses React's `useEffect` hook with proper cleanup
- Only activates on `Platform.OS === 'web'`
- Calls the existing `inputRef.current?.focus()` API