### PR TITLE
feat(web): prevent MultiTextInput web keydown handler from firing during IME composition

### DIFF
--- a/sources/components/MultiTextInput.web.tsx
+++ b/sources/components/MultiTextInput.web.tsx
@@ -61,6 +61,11 @@ export const MultiTextInput = React.forwardRef<MultiTextInputHandle, MultiTextIn
     const handleKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         if (!onKeyPress) return;
 
+        const isComposing = e.nativeEvent.isComposing || e.isComposing || e.keyCode === 229;
+        if (isComposing) {
+            return;
+        }
+
         const key = e.key;
         
         // Map browser key names to our normalized format


### PR DESCRIPTION
# Prevent keydown handling during IME composition (Web)

## Background

On the web, IME (Input Method Editor) input relies on a composition phase (`compositionstart` → `compositionend`) to build characters incrementally.

During this phase, the browser may still dispatch `keydown` events for intermediate keystrokes, even though the user has not finalized any input yet.

In `MultiTextInput`, the existing web `keydown` handler was triggered during IME composition, which could cause unintended behavior such as premature event handling, incorrect shortcuts, or disrupted text input for users typing with IMEs (e.g. Chinese, Japanese, Korean).

---

## What This PR Does

This PR updates the web implementation of `MultiTextInput` to **prevent the `keydown` handler from firing while an IME composition is in progress**.

Specifically:
- Detects whether the input is currently in an active IME composition state
- Skips `keydown` handling during composition
- Restores normal `keydown` behavior once composition has ended

This ensures that keyboard events are only processed after the user has completed character composition.

---

## Why This Change Is Needed

Handling `keydown` events during IME composition is generally unsafe, as the input is not yet finalized and does not represent the user's intended text.

By deferring `keydown` logic until after composition ends, we align the component’s behavior with the browser’s IME event model and avoid interfering with native text input workflows.

This improves:
- IME compatibility on the web
- Input correctness for non-Latin languages
- Overall user experience when typing with composition-based input methods

---

## Scope of Impact

- **Platform**: Web only  
- **Component**: `MultiTextInput`  
- **Behavioral change**: No impact on non-IME input or other platforms

---

## Notes

This change is intentionally scoped to the web layer and does not affect native implementations or shared input logic.
