### PR TITLE
feat: add execpolicy approval option for Codex

### DIFF
--- a/sources/sync/ops.ts
+++ b/sources/sync/ops.ts
@@ -16,7 +16,10 @@ interface SessionPermissionRequest {
     reason?: string;
     mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
     allowTools?: string[];
-    decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort';
+    decision?: 'approved' | 'approved_for_session' | 'approved_execpolicy_amendment' | 'denied' | 'abort';
+    execPolicyAmendment?: {
+        command: string[];
+    };
 }
 
 // Mode change operation types
@@ -299,8 +302,22 @@ export async function sessionAbort(sessionId: string): Promise<void> {
 /**
  * Allow a permission request
  */
-export async function sessionAllow(sessionId: string, id: string, mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan', allowedTools?: string[], decision?: 'approved' | 'approved_for_session'): Promise<void> {
-    const request: SessionPermissionRequest = { id, approved: true, mode, allowTools: allowedTools, decision };
+export async function sessionAllow(
+    sessionId: string,
+    id: string,
+    mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan',
+    allowedTools?: string[],
+    decision?: 'approved' | 'approved_for_session' | 'approved_execpolicy_amendment',
+    execPolicyAmendment?: { command: string[] }
+): Promise<void> {
+    const request: SessionPermissionRequest = {
+        id,
+        approved: true,
+        mode,
+        allowTools: allowedTools,
+        decision,
+        execPolicyAmendment
+    };
     await apiSocket.sessionRPC(sessionId, 'permission', request);
 }
 

--- a/sources/sync/reducer/reducer.ts
+++ b/sources/sync/reducer/reducer.ts
@@ -137,7 +137,7 @@ type StoredPermission = {
     reason?: string;
     mode?: string;
     allowedTools?: string[];
-    decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort';
+    decision?: 'approved' | 'approved_for_session' | 'approved_execpolicy_amendment' | 'denied' | 'abort';
 };
 
 export type ReducerState = {
@@ -351,16 +351,20 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
                 // Check if we already have a message for this permission ID
                 const existingMessageId = state.toolIdToMessageId.get(permId);
                 if (existingMessageId) {
-                    // Update existing tool message with permission info
+                    // Update existing tool message with permission info and latest arguments
                     const message = state.messages.get(existingMessageId);
-                    if (message?.tool && !message.tool.permission) {
+                    if (message?.tool) {
                         if (ENABLE_LOGGING) {
                             console.log(`[REDUCER] Updating existing tool ${permId} with permission`);
                         }
-                        message.tool.permission = {
-                            id: permId,
-                            status: 'pending'
-                        };
+                        // Always update input to get latest arguments (e.g., proposedExecpolicyAmendment)
+                        message.tool.input = request.arguments;
+                        if (!message.tool.permission) {
+                            message.tool.permission = {
+                                id: permId,
+                                status: 'pending'
+                            };
+                        }
                         changed.add(existingMessageId);
                     }
                 } else {

--- a/sources/sync/storageTypes.ts
+++ b/sources/sync/storageTypes.ts
@@ -42,7 +42,7 @@ export const AgentStateSchema = z.object({
         reason: z.string().nullish(),
         mode: z.string().nullish(),
         allowedTools: z.array(z.string()).nullish(),
-        decision: z.enum(['approved', 'approved_for_session', 'denied', 'abort']).nullish()
+        decision: z.enum(['approved', 'approved_for_session', 'approved_execpolicy_amendment', 'denied', 'abort']).nullish()
     })).nullish()
 });
 

--- a/sources/sync/typesMessage.ts
+++ b/sources/sync/typesMessage.ts
@@ -16,7 +16,7 @@ export type ToolCall = {
         reason?: string;
         mode?: string;
         allowedTools?: string[];
-        decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort';
+        decision?: 'approved' | 'approved_for_session' | 'approved_execpolicy_amendment' | 'denied' | 'abort';
         date?: number;
     };
 }

--- a/sources/sync/typesRaw.ts
+++ b/sources/sync/typesRaw.ts
@@ -54,7 +54,7 @@ const rawToolResultContentSchema = z.object({
         result: z.enum(['approved', 'denied']),
         mode: z.string().optional(),
         allowedTools: z.array(z.string()).optional(),
-        decision: z.enum(['approved', 'approved_for_session', 'denied', 'abort']).optional(),
+        decision: z.enum(['approved', 'approved_for_session', 'approved_execpolicy_amendment', 'denied', 'abort']).optional(),
     }).optional(),
 });
 export type RawToolResultContent = z.infer<typeof rawToolResultContentSchema>;
@@ -158,7 +158,7 @@ type NormalizedAgentContent =
             result: 'approved' | 'denied';
             mode?: string;
             allowedTools?: string[];
-            decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort';
+            decision?: 'approved' | 'approved_for_session' | 'approved_execpolicy_amendment' | 'denied' | 'abort';
         };
     } | {
         type: 'summary',

--- a/sources/text/_default.ts
+++ b/sources/text/_default.ts
@@ -723,6 +723,7 @@ export const en = {
     codex: {
         // Codex permission dialog buttons
         permissions: {
+            yesAlwaysAllowCommand: 'Yes, always allow globally',
             yesForSession: "Yes, and don't ask for a session",
             stopAndExplain: 'Stop, and explain what to do',
         }

--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -723,6 +723,7 @@ export const ca: TranslationStructure = {
     codex: {
         // Codex permission dialog buttons
         permissions: {
+            yesAlwaysAllowCommand: 'Sí, permet globalment',
             yesForSession: 'Sí, i no preguntar per aquesta sessió',
             stopAndExplain: 'Atura, i explica què fer',
         }

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -723,6 +723,7 @@ export const es: TranslationStructure = {
     codex: {
         // Codex permission dialog buttons
         permissions: {
+            yesAlwaysAllowCommand: 'Sí, permitir globalmente',
             yesForSession: 'Sí, y no preguntar por esta sesión',
             stopAndExplain: 'Detener, y explicar qué hacer',
         }

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -733,6 +733,7 @@ export const pl: TranslationStructure = {
     codex: {
         // Codex permission dialog buttons
         permissions: {
+            yesAlwaysAllowCommand: 'Tak, zezwól globalnie',
             yesForSession: 'Tak, i nie pytaj dla tej sesji',
             stopAndExplain: 'Zatrzymaj i wyjaśnij, co zrobić',
         }

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -723,6 +723,7 @@ export const pt: TranslationStructure = {
     codex: {
         // Codex permission dialog buttons
         permissions: {
+            yesAlwaysAllowCommand: 'Sim, permitir globalmente',
             yesForSession: 'Sim, e não perguntar para esta sessão',
             stopAndExplain: 'Parar, e explicar o que fazer',
         }

--- a/sources/text/translations/ru.ts
+++ b/sources/text/translations/ru.ts
@@ -721,6 +721,7 @@ export const ru: TranslationStructure = {
     codex: {
         // Codex permission dialog buttons
         permissions: {
+            yesAlwaysAllowCommand: 'Да, разрешить глобально',
             yesForSession: 'Да, и не спрашивать для этой сессии',
             stopAndExplain: 'Остановить и объяснить, что делать',
         }

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -725,6 +725,7 @@ export const zhHans: TranslationStructure = {
     codex: {
         // Codex permission dialog buttons
         permissions: {
+            yesAlwaysAllowCommand: '是，全局永久允许',
             yesForSession: '是，并且本次会话不再询问',
             stopAndExplain: '停止，并说明该做什么',
         }


### PR DESCRIPTION
## Summary
- Add a Codex permission option to approve an execpolicy amendment ("always allow command").
- Carry execpolicy amendment payloads through sync/request types and storage schemas.
- Ensure permission tool-call inputs stay updated so the proposed amendment is visible.

## Changes
- Permission UI now renders a "Yes, always allow globally" button when `proposedExecpolicyAmendment` is present, with loading/disabled states aligned to other Codex actions.
- `sessionAllow` accepts `approved_execpolicy_amendment` plus an `execPolicyAmendment` payload and sends it via the permission RPC.
- Reducer updates existing tool-call inputs when permission messages arrive (captures updated arguments such as execpolicy amendments).
- Types/schemas updated to include `approved_execpolicy_amendment` across sync, storage, and message models.
- New i18n string added for the execpolicy approval button across locales.

## Related
- https://github.com/slopus/happy-cli/pull/102