### PR TITLE
fix: `/new` permission-mode selection + harden per-session permission-mode persistence

### DIFF
--- a/sources/components/AgentInput.tsx
+++ b/sources/components/AgentInput.tsx
@@ -290,9 +290,12 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
     const hasText = props.value.trim().length > 0;
     
-    // Check if this is a Codex or Gemini session
-    const isCodex = props.metadata?.flavor === 'codex';
-    const isGemini = props.metadata?.flavor === 'gemini';
+    // Determine agent flavor for UI decisions (permission modes, labels, etc).
+    // In a live session we can use `metadata.flavor`, but in `/new` we don't have session metadata yet,
+    // so we fall back to the explicitly selected `agentType`.
+    const flavor = props.metadata?.flavor ?? props.agentType ?? null;
+    const isCodex = flavor === 'codex';
+    const isGemini = flavor === 'gemini';
 
     // Calculate context warning
     const contextWarning = props.usageData?.contextSize


### PR DESCRIPTION
This PR fixes a subtle permission-mode mismatch in the **New Session** flow and makes local permission-mode persistence more robust.

- **Fix `/new` permission-mode UI for Codex/Gemini**: `AgentInput` now falls back to the explicitly selected `agentType` when `metadata.flavor` is missing (common in `/new` before a session exists). This ensures the correct permission-mode menu/options are shown and applied for the selected agent.  
  - File: `sources/components/AgentInput.tsx`

- **Harden local per-session permission-mode persistence**: permission modes are stored per sessionId in MMKV under `session-permission-modes`. This PR avoids a bug where an in-memory `'default'` could “win” over a persisted non-default mode during session merges, and updates persistence incrementally so modes for sessions that aren’t currently loaded don’t get accidentally dropped.  
  - File: `sources/sync/storage.ts`

**Testing**
- Manually tested on web: create a new session via `/new`, switch agents (Codex/Gemini/Claude), select a non-default permission mode, send first message, and confirm the created session shows the expected mode.