### PR TITLE
feat: add collapsible sidebar for tablets/web

### DIFF
--- a/sources/app/_layout.tsx
+++ b/sources/app/_layout.tsx
@@ -12,6 +12,7 @@ import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { initialWindowMetrics, SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SidebarNavigator } from '@/components/SidebarNavigator';
+import { SidebarProvider } from '@/components/SidebarContext';
 import sodium from '@/encryption/libsodium.lib';
 import { View, Platform } from 'react-native';
 import { ModalProvider } from '@/modal';
@@ -228,9 +229,11 @@ export default function RootLayout() {
                             <ModalProvider>
                                 <CommandPaletteProvider>
                                     <RealtimeProvider>
-                                        <HorizontalSafeAreaWrapper>
-                                            <SidebarNavigator />
-                                        </HorizontalSafeAreaWrapper>
+                                        <SidebarProvider>
+                                            <HorizontalSafeAreaWrapper>
+                                                <SidebarNavigator />
+                                            </HorizontalSafeAreaWrapper>
+                                        </SidebarProvider>
                                     </RealtimeProvider>
                                 </CommandPaletteProvider>
                             </ModalProvider>

--- a/sources/components/CollapsedSidebarView.tsx
+++ b/sources/components/CollapsedSidebarView.tsx
@@ -1,0 +1,261 @@
+import * as React from 'react';
+import { View, Pressable, Text, FlatList } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRouter, usePathname } from 'expo-router';
+import { useHeaderHeight } from '@/utils/responsive';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { Image } from 'expo-image';
+import { StatusDot } from './StatusDot';
+import { FABCompact } from './FABCompact';
+import { CollapsibleSidebarEdge } from './CollapsibleSidebarEdge';
+import { Avatar } from './Avatar';
+import { useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
+import { useNavigateToSession } from '@/hooks/useNavigateToSession';
+import { getSessionAvatarId } from '@/utils/sessionUtils';
+import { Session } from '@/sync/storageTypes';
+import { Typography } from '@/constants/Typography';
+
+interface CollapsedSidebarViewProps {
+    onNewSession: () => void;
+    connectionStatus: {
+        color: string;
+        isPulsing: boolean;
+        text: string;
+        textColor?: string;
+    };
+    friendRequestsCount: number;
+    inboxHasContent: boolean;
+    showExperiments: boolean;
+}
+
+const stylesheet = StyleSheet.create((theme) => ({
+    outerContainer: {
+        flex: 1,
+        flexDirection: 'row',
+    },
+    container: {
+        flex: 1,
+        borderStyle: 'solid',
+        backgroundColor: theme.colors.groupped.background,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: theme.colors.divider,
+        borderRightWidth: 0,
+        alignItems: 'center',
+    },
+    header: {
+        width: '100%',
+        alignItems: 'center',
+        paddingVertical: 8,
+        gap: 8,
+    },
+    iconButton: {
+        width: 40,
+        height: 40,
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'relative',
+    },
+    logo: {
+        height: 24,
+        width: 24,
+    },
+    statusDotContainer: {
+        marginTop: 4,
+    },
+    divider: {
+        width: 32,
+        height: StyleSheet.hairlineWidth,
+        backgroundColor: theme.colors.divider,
+        marginVertical: 8,
+    },
+    sessionsList: {
+        flex: 1,
+        width: '100%',
+    },
+    sessionsContent: {
+        alignItems: 'center',
+        paddingTop: 8,
+    },
+    sessionItem: {
+        width: 48,
+        height: 48,
+        marginBottom: 8,
+        borderRadius: 24,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    sessionItemSelected: {
+        backgroundColor: theme.colors.surfaceSelected,
+    },
+    badge: {
+        position: 'absolute',
+        top: -2,
+        right: -2,
+        backgroundColor: theme.colors.status.error,
+        borderRadius: 8,
+        minWidth: 16,
+        height: 16,
+        paddingHorizontal: 4,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    badgeText: {
+        color: '#FFFFFF',
+        fontSize: 10,
+        ...Typography.default('semiBold'),
+    },
+    indicatorDot: {
+        position: 'absolute',
+        top: 2,
+        right: 2,
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        backgroundColor: theme.colors.text,
+    },
+}));
+
+export const CollapsedSidebarView = React.memo(({
+    onNewSession,
+    connectionStatus,
+    friendRequestsCount,
+    inboxHasContent,
+    showExperiments,
+}: CollapsedSidebarViewProps) => {
+    const styles = stylesheet;
+    const { theme } = useUnistyles();
+    const safeArea = useSafeAreaInsets();
+    const headerHeight = useHeaderHeight();
+    const router = useRouter();
+    const pathname = usePathname();
+    const sessionListViewData = useVisibleSessionListViewData();
+    const navigateToSession = useNavigateToSession();
+
+    // Extract active sessions, grouped by project path (alphabetically), sorted by createdAt within groups
+    const sessions = React.useMemo(() => {
+        const activeItem = sessionListViewData?.find(item => item.type === 'active-sessions');
+        if (!activeItem || activeItem.type !== 'active-sessions') return [];
+
+        // Group by project path
+        const groups = new Map<string, Session[]>();
+        activeItem.sessions.forEach(session => {
+            const path = session.metadata?.path || '';
+            if (!groups.has(path)) groups.set(path, []);
+            groups.get(path)!.push(session);
+        });
+
+        // Sort within groups by createdAt (newest first), then flatten by sorted paths
+        return Array.from(groups.keys()).sort().flatMap(path =>
+            groups.get(path)!.sort((a, b) => b.createdAt - a.createdAt)
+        );
+    }, [sessionListViewData]);
+
+    const renderSession = React.useCallback(({ item }: { item: Session }) => {
+        const isSelected = pathname.startsWith(`/session/${item.id}`);
+        const avatarId = getSessionAvatarId(item);
+        return (
+            <Pressable
+                style={[styles.sessionItem, isSelected && styles.sessionItemSelected]}
+                onPress={() => navigateToSession(item.id)}
+            >
+                <Avatar id={avatarId} size={40} flavor={item.metadata?.flavor} />
+            </Pressable>
+        );
+    }, [pathname, navigateToSession, styles]);
+
+    const keyExtractor = React.useCallback((item: Session) => item.id, []);
+
+    return (
+        <View style={styles.outerContainer}>
+            <View style={[styles.container, { paddingTop: safeArea.top }]}>
+                <View style={[styles.header, { minHeight: headerHeight }]}>
+                    {/* Logo */}
+                    <View style={styles.iconButton}>
+                        <Image
+                            source={theme.dark ? require('@/assets/images/logo-white.png') : require('@/assets/images/logo-black.png')}
+                            contentFit="contain"
+                            style={[styles.logo, { height: 24, width: 24 }]}
+                        />
+                    </View>
+
+                    {/* Connection status */}
+                    <View style={styles.statusDotContainer}>
+                        <StatusDot
+                            color={connectionStatus.color}
+                            isPulsing={connectionStatus.isPulsing}
+                            size={8}
+                        />
+                    </View>
+
+                    <View style={styles.divider} />
+
+                    {/* Zen button (if experiments enabled) */}
+                    {showExperiments && (
+                        <Pressable
+                            style={styles.iconButton}
+                            onPress={() => router.push('/(app)/zen')}
+                            hitSlop={10}
+                        >
+                            <Image
+                                source={require('@/assets/images/brutalist/Brutalism 3.png')}
+                                contentFit="contain"
+                                style={[{ width: 28, height: 28 }]}
+                                tintColor={theme.colors.header.tint}
+                            />
+                        </Pressable>
+                    )}
+
+                    {/* Inbox button */}
+                    <Pressable
+                        style={styles.iconButton}
+                        onPress={() => router.push('/(app)/inbox')}
+                        hitSlop={10}
+                    >
+                        <Image
+                            source={require('@/assets/images/brutalist/Brutalism 27.png')}
+                            contentFit="contain"
+                            style={[{ width: 28, height: 28 }]}
+                            tintColor={theme.colors.header.tint}
+                        />
+                        {friendRequestsCount > 0 && (
+                            <View style={styles.badge}>
+                                <Text style={styles.badgeText}>
+                                    {friendRequestsCount > 99 ? '99+' : friendRequestsCount}
+                                </Text>
+                            </View>
+                        )}
+                        {inboxHasContent && friendRequestsCount === 0 && (
+                            <View style={styles.indicatorDot} />
+                        )}
+                    </Pressable>
+
+                    {/* Settings button */}
+                    <Pressable
+                        style={styles.iconButton}
+                        onPress={() => router.push('/settings')}
+                        hitSlop={10}
+                    >
+                        <Image
+                            source={require('@/assets/images/brutalist/Brutalism 9.png')}
+                            contentFit="contain"
+                            style={[{ width: 28, height: 28 }]}
+                            tintColor={theme.colors.header.tint}
+                        />
+                    </Pressable>
+                </View>
+
+                {/* Sessions list (avatars only) */}
+                <FlatList
+                    style={styles.sessionsList}
+                    contentContainerStyle={[styles.sessionsContent, { paddingBottom: safeArea.bottom + 80 }]}
+                    data={sessions}
+                    renderItem={renderSession}
+                    keyExtractor={keyExtractor}
+                    showsVerticalScrollIndicator={false}
+                />
+                <FABCompact onPress={onNewSession} />
+            </View>
+            <CollapsibleSidebarEdge />
+        </View>
+    );
+});

--- a/sources/components/CollapsibleSidebarEdge.tsx
+++ b/sources/components/CollapsibleSidebarEdge.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { View, Pressable } from 'react-native';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { Ionicons } from '@expo/vector-icons';
+import { useSidebar } from './SidebarContext';
+
+const stylesheet = StyleSheet.create((theme) => ({
+    wrapper: {
+        width: 12,
+        backgroundColor: theme.colors.groupped.background,
+        borderRightWidth: StyleSheet.hairlineWidth,
+        borderRightColor: theme.colors.divider,
+    },
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    containerPressed: {
+        backgroundColor: theme.colors.divider,
+    },
+}));
+
+export const CollapsibleSidebarEdge = React.memo(() => {
+    const { theme } = useUnistyles();
+    const { isCollapsed, toggleCollapsed } = useSidebar();
+
+    return (
+        <View style={stylesheet.wrapper}>
+            <Pressable
+                onPress={toggleCollapsed}
+                style={({ pressed }) => [
+                    stylesheet.container,
+                    pressed && stylesheet.containerPressed,
+                ]}
+            >
+                <Ionicons
+                    name={isCollapsed ? 'chevron-forward' : 'chevron-back'}
+                    size={16}
+                    color={theme.colors.textSecondary}
+                />
+            </Pressable>
+        </View>
+    );
+});

--- a/sources/components/FABCompact.tsx
+++ b/sources/components/FABCompact.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { View, Pressable } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { Ionicons } from '@expo/vector-icons';
+
+const stylesheet = StyleSheet.create((theme) => ({
+    container: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        alignItems: 'center',
+    },
+    button: {
+        width: 48,
+        height: 48,
+        borderRadius: 24,
+        shadowColor: theme.colors.shadow.color,
+        shadowOffset: { width: 0, height: 2 },
+        shadowRadius: 3.84,
+        shadowOpacity: theme.colors.shadow.opacity,
+        elevation: 5,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    buttonDefault: {
+        backgroundColor: theme.colors.fab.background,
+    },
+    buttonPressed: {
+        backgroundColor: theme.colors.fab.backgroundPressed,
+    },
+}));
+
+export const FABCompact = React.memo(({ onPress }: { onPress: () => void }) => {
+    const { theme } = useUnistyles();
+    const safeArea = useSafeAreaInsets();
+    return (
+        <View style={[stylesheet.container, { bottom: safeArea.bottom + 16 }]}>
+            <Pressable
+                style={({ pressed }) => [
+                    stylesheet.button,
+                    pressed ? stylesheet.buttonPressed : stylesheet.buttonDefault
+                ]}
+                onPress={onPress}
+            >
+                <Ionicons name="add" size={28} color={theme.colors.fab.icon} />
+            </Pressable>
+        </View>
+    );
+});

--- a/sources/components/SidebarContext.tsx
+++ b/sources/components/SidebarContext.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { useLocalSettings, storage } from '@/sync/storage';
+import { useIsTablet } from '@/utils/responsive';
+
+interface SidebarContextValue {
+    isCollapsed: boolean;
+    toggleCollapsed: () => void;
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | null>(null);
+
+export const SidebarProvider = React.memo(({ children }: { children: React.ReactNode }) => {
+    const localSettings = useLocalSettings();
+    const isTablet = useIsTablet();
+    const isCollapsed = isTablet && localSettings.sidebarCollapsed;
+
+    const toggleCollapsed = React.useCallback(() => {
+        storage.getState().applyLocalSettings({
+            sidebarCollapsed: !localSettings.sidebarCollapsed
+        });
+    }, [localSettings.sidebarCollapsed]);
+
+    const value = React.useMemo(() => ({
+        isCollapsed,
+        toggleCollapsed,
+    }), [isCollapsed, toggleCollapsed]);
+
+    return (
+        <SidebarContext.Provider value={value}>
+            {children}
+        </SidebarContext.Provider>
+    );
+});
+
+export function useSidebar(): SidebarContextValue {
+    const context = React.useContext(SidebarContext);
+    if (!context) {
+        throw new Error('useSidebar must be used within a SidebarProvider');
+    }
+    return context;
+}
+
+// Width constants for sidebar
+export const SIDEBAR_WIDTH_COLLAPSED = 72;
+export const SIDEBAR_WIDTH_MIN = 250;
+export const SIDEBAR_WIDTH_MAX = 360;

--- a/sources/components/SidebarNavigator.tsx
+++ b/sources/components/SidebarNavigator.tsx
@@ -5,18 +5,21 @@ import { useIsTablet } from '@/utils/responsive';
 import { SidebarView } from './SidebarView';
 import { Slot } from 'expo-router';
 import { useWindowDimensions } from 'react-native';
+import { useSidebar, SIDEBAR_WIDTH_COLLAPSED, SIDEBAR_WIDTH_MIN, SIDEBAR_WIDTH_MAX } from './SidebarContext';
 
 export const SidebarNavigator = React.memo(() => {
     const auth = useAuth();
     const isTablet = useIsTablet();
     const showPermanentDrawer = auth.isAuthenticated && isTablet;
     const { width: windowWidth } = useWindowDimensions();
+    const { isCollapsed } = useSidebar();
 
     // Calculate drawer width only when needed
     const drawerWidth = React.useMemo(() => {
         if (!showPermanentDrawer) return 280; // Default width for hidden drawer
-        return Math.min(Math.max(Math.floor(windowWidth * 0.3), 250), 360);
-    }, [windowWidth, showPermanentDrawer]);
+        if (isCollapsed) return SIDEBAR_WIDTH_COLLAPSED;
+        return Math.min(Math.max(Math.floor(windowWidth * 0.3), SIDEBAR_WIDTH_MIN), SIDEBAR_WIDTH_MAX);
+    }, [windowWidth, showPermanentDrawer, isCollapsed]);
 
     const drawerNavigationOptions = React.useMemo(() => {
         if (!showPermanentDrawer) {

--- a/sources/components/SidebarView.tsx
+++ b/sources/components/SidebarView.tsx
@@ -10,18 +10,26 @@ import { FABWide } from './FABWide';
 import { VoiceAssistantStatusBar } from './VoiceAssistantStatusBar';
 import { useRealtimeStatus } from '@/sync/storage';
 import { MainView } from './MainView';
+import { CollapsedSidebarView } from './CollapsedSidebarView';
+import { CollapsibleSidebarEdge } from './CollapsibleSidebarEdge';
 import { Image } from 'expo-image';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { t } from '@/text';
 import { useInboxHasContent } from '@/hooks/useInboxHasContent';
+import { useSidebar } from './SidebarContext';
 
 const stylesheet = StyleSheet.create((theme, runtime) => ({
+    outerContainer: {
+        flex: 1,
+        flexDirection: 'row',
+    },
     container: {
         flex: 1,
         borderStyle: 'solid',
         backgroundColor: theme.colors.groupped.background,
         borderWidth: StyleSheet.hairlineWidth,
         borderColor: theme.colors.divider,
+        borderRightWidth: 0,
     },
     header: {
         flexDirection: 'row',
@@ -132,6 +140,7 @@ export const SidebarView = React.memo(() => {
     const friendRequests = useFriendRequests();
     const inboxHasContent = useInboxHasContent();
     const settings = useSettings();
+    const { isCollapsed } = useSidebar();
 
     // Get connection status styling (matching sessionUtils.ts pattern)
     const getConnectionStatus = () => {
@@ -179,8 +188,21 @@ export const SidebarView = React.memo(() => {
         router.push('/new');
     }, [router]);
 
+    // Render collapsed sidebar view
+    if (isCollapsed) {
+        return (
+            <CollapsedSidebarView
+                onNewSession={handleNewSession}
+                connectionStatus={getConnectionStatus()}
+                friendRequestsCount={friendRequests.length}
+                inboxHasContent={inboxHasContent}
+                showExperiments={settings.experiments}
+            />
+        );
+    }
+
     return (
-        <>
+        <View style={styles.outerContainer}>
             <View style={[styles.container, { paddingTop: safeArea.top }]}>
                 <View style={[styles.header, { height: headerHeight }]}>
                     <View style={styles.logoContainer}>
@@ -262,8 +284,9 @@ export const SidebarView = React.memo(() => {
                     <VoiceAssistantStatusBar variant="sidebar" />
                 )}
                 <MainView variant="sidebar" />
+                <FABWide onPress={handleNewSession} />
             </View>
-            <FABWide onPress={handleNewSession} />
-        </>
+            <CollapsibleSidebarEdge />
+        </View>
     )
 });

--- a/sources/sync/localSettings.ts
+++ b/sources/sync/localSettings.ts
@@ -13,6 +13,8 @@ export const LocalSettingsSchema = z.object({
     markdownCopyV2: z.boolean().describe('Replace native paragraph selection with long-press modal for full markdown copy'),
     // CLI version acknowledgments - keyed by machineId
     acknowledgedCliVersions: z.record(z.string(), z.string()).describe('Acknowledged CLI versions per machine'),
+    // Sidebar state (device-specific, mainly for tablets/desktop)
+    sidebarCollapsed: z.boolean().describe('Whether the sidebar is collapsed to show only icons'),
 });
 
 //
@@ -35,6 +37,7 @@ export const localSettingsDefaults: LocalSettings = {
     themePreference: 'adaptive',
     markdownCopyV2: false,
     acknowledgedCliVersions: {},
+    sidebarCollapsed: false,
 };
 Object.freeze(localSettingsDefaults);
 


### PR DESCRIPTION
Add a button to collapse the side bar in wide webpage (tablet) mode. 
I've see other users requesting this as well (#119). Hope it's a useful feature.

<img width="2674" height="2394" alt="ScreenShot 2025-12-31 at 16 31 40@2x" src="https://github.com/user-attachments/assets/0a5921bc-b5cd-4f6e-903f-4a20d25de7b4" />
