### PR TITLE
fix(ios): Enable HTTP connections to local networks including Tailscale

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -34,7 +34,11 @@ export default {
             infoPlist: {
                 NSMicrophoneUsageDescription: "Allow $(PRODUCT_NAME) to access your microphone for voice conversations with AI.",
                 NSLocalNetworkUsageDescription: "Allow $(PRODUCT_NAME) to find and connect to local devices on your network.",
-                NSBonjourServices: ["_http._tcp", "_https._tcp"]
+                NSBonjourServices: ["_http._tcp", "_https._tcp"],
+                NSAppTransportSecurity: {
+                    NSAllowsLocalNetworking: true,
+                    NSAllowsArbitraryLoads: false
+                }
             },
             associatedDomains: variant === 'production' ? ["applinks:app.happy.engineering"] : []
         },


### PR DESCRIPTION
## Problem

When using self-hosted Happy Server instances accessible via Tailscale or local networks, the iOS app fails to connect with "failed to connect" errors, even though the server is accessible in Safari and other browsers.

This occurs because iOS App Transport Security (ATS) blocks HTTP connections to local network IP addresses by default, including:
- RFC1918 private IPs (10.x.x.x, 172.16.x.x, 192.168.x.x)  
- Tailscale CGNAT range (100.64.0.0/10)

## Solution

Add `NSAllowsLocalNetworking: true` to the iOS App Transport Security configuration in `app.config.js`.

This is the [official Apple-recommended approach](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowslocalnetworking) for apps that need to communicate with local network servers over HTTP.

## Changes

- Added `NSAppTransportSecurity` configuration with:
  - `NSAllowsLocalNetworking: true` - Allows HTTP to local networks
  - `NSAllowsArbitraryLoads: false` - Maintains security by still requiring HTTPS for public internet

## Security

This change maintains security by:
- Only allowing HTTP for local network addresses
- Still requiring HTTPS for all public internet connections
- Following Apple's documented best practices for local network communication

## Testing

Tested with self-hosted Happy Server on:
- ✅ Local WiFi (192.168.x.x)
- ✅ Tailscale (100.x.x.x)
- ✅ Localhost (127.0.0.1)

Fixes #319