### PR TITLE
feat: ability to swipe to archive/delete sessions from the top-level page

### DIFF
--- a/sources/components/ActiveSessionsGroup.tsx
+++ b/sources/components/ActiveSessionsGroup.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Pressable, Platform, ActivityIndicator } from 'react-native';
+import { Swipeable } from 'react-native-gesture-handler';
 import { Text } from '@/components/StyledText';
 import { useRouter } from 'expo-router';
 import { Session, Machine } from '@/sync/storageTypes';
@@ -11,7 +12,7 @@ import { StatusDot } from './StatusDot';
 import { useAllMachines, useSetting } from '@/sync/storage';
 import { StyleSheet } from 'react-native-unistyles';
 import { isMachineOnline } from '@/utils/machineUtils';
-import { machineSpawnNewSession } from '@/sync/ops';
+import { machineSpawnNewSession, sessionKill } from '@/sync/ops';
 import { storage } from '@/sync/storage';
 import { Modal } from '@/modal';
 import { CompactGitStatus } from './CompactGitStatus';
@@ -19,6 +20,8 @@ import { ProjectGitStatus } from './ProjectGitStatus';
 import { t } from '@/text';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { useIsTablet } from '@/utils/responsive';
+import { useHappyAction } from '@/hooks/useHappyAction';
+import { HappyError } from '@/utils/errors';
 
 const stylesheet = StyleSheet.create((theme, runtime) => ({
     container: {
@@ -174,6 +177,20 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         color: theme.colors.textSecondary,
         ...Typography.default(),
     },
+    swipeAction: {
+        width: 112,
+        height: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: theme.colors.status.error,
+    },
+    swipeActionText: {
+        marginTop: 4,
+        fontSize: 12,
+        color: '#FFFFFF',
+        textAlign: 'center',
+        ...Typography.default('semiBold'),
+    },
 }));
 
 interface ActiveSessionsGroupProps {
@@ -324,12 +341,37 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder }: { sessi
     const sessionName = getSessionName(session);
     const navigateToSession = useNavigateToSession();
     const isTablet = useIsTablet();
+    const swipeableRef = React.useRef<Swipeable | null>(null);
+    const swipeEnabled = Platform.OS !== 'web';
+
+    const [archivingSession, performArchive] = useHappyAction(async () => {
+        const result = await sessionKill(session.id);
+        if (!result.success) {
+            throw new HappyError(result.message || t('sessionInfo.failedToArchiveSession'), false);
+        }
+    });
+
+    const handleArchive = React.useCallback(() => {
+        swipeableRef.current?.close();
+        Modal.alert(
+            t('sessionInfo.archiveSession'),
+            t('sessionInfo.archiveSessionConfirm'),
+            [
+                { text: t('common.cancel'), style: 'cancel' },
+                {
+                    text: t('sessionInfo.archiveSession'),
+                    style: 'destructive',
+                    onPress: performArchive
+                }
+            ]
+        );
+    }, [performArchive]);
 
     const avatarId = React.useMemo(() => {
         return getSessionAvatarId(session);
     }, [session]);
 
-    return (
+    const itemContent = (
         <Pressable
             style={[
                 styles.sessionRow,
@@ -421,5 +463,33 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder }: { sessi
                 </View>
             </View>
         </Pressable>
+    );
+
+    if (!swipeEnabled) {
+        return itemContent;
+    }
+
+    const renderRightActions = () => (
+        <Pressable
+            style={styles.swipeAction}
+            onPress={handleArchive}
+            disabled={archivingSession}
+        >
+            <Ionicons name="archive-outline" size={20} color="#FFFFFF" />
+            <Text style={styles.swipeActionText} numberOfLines={2}>
+                {t('sessionInfo.archiveSession')}
+            </Text>
+        </Pressable>
+    );
+
+    return (
+        <Swipeable
+            ref={swipeableRef}
+            renderRightActions={renderRightActions}
+            overshootRight={false}
+            enabled={!archivingSession}
+        >
+            {itemContent}
+        </Swipeable>
     );
 });


### PR DESCRIPTION
Something I have long wanted was the ability to quickly/easily clean up terminal sessions from the top level page. Right now the only way to do so is to tap into a session and then tap again into the settings page for it.

This pull request simply adds swipe-to-delete functionality

| Archive | Archive Confirmation | Delete | Delete Confirmation |
|---|---|---|---|
| <img width="180" src="https://github.com/user-attachments/assets/1c8c6c5f-e6cc-4fff-800f-d685eb5397f0" /> | <img width="180" src="https://github.com/user-attachments/assets/038d657f-41d1-4f27-b142-010a672b6227" /> | <img width="180" src="https://github.com/user-attachments/assets/c04f705b-6c75-4674-a547-d6585bb65728" /> | <img width="180" src="https://github.com/user-attachments/assets/621fcf74-e0ea-4d9a-8698-e318b14ea855" /> |
