### PR TITLE
Add session rename functionality with UI and translations

### DIFF
--- a/sources/text/_default.ts
+++ b/sources/text/_default.ts
@@ -366,7 +366,12 @@ export const en = {
         deleteSessionWarning: 'This action cannot be undone. All messages and data associated with this session will be permanently deleted.',
         failedToDeleteSession: 'Failed to delete session',
         sessionDeleted: 'Session deleted successfully',
-        
+        renameSession: 'Rename Session',
+        renameSessionSubtitle: 'Change the display name for this session',
+        renameSessionPlaceholder: 'Enter session name...',
+        failedToRenameSession: 'Failed to rename session',
+        sessionRenamed: 'Session renamed successfully',
+
     },
 
     components: {

--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -366,7 +366,12 @@ export const ca: TranslationStructure = {
         deleteSessionWarning: 'Aquesta acció no es pot desfer. Tots els missatges i dades associats amb aquesta sessió s\'eliminaran permanentment.',
         failedToDeleteSession: 'Error en eliminar la sessió',
         sessionDeleted: 'Sessió eliminada amb èxit',
-        
+        renameSession: 'Canvia el nom de la sessió',
+        renameSessionSubtitle: 'Canvia el nom de visualització d\'aquesta sessió',
+        renameSessionPlaceholder: 'Introduïu el nom de la sessió...',
+        failedToRenameSession: 'Error en canviar el nom de la sessió',
+        sessionRenamed: 'S\'ha canviat el nom de la sessió correctament',
+
     },
 
     components: {

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -366,7 +366,12 @@ export const es: TranslationStructure = {
         deleteSessionWarning: 'Esta acción no se puede deshacer. Todos los mensajes y datos asociados con esta sesión se eliminarán permanentemente.',
         failedToDeleteSession: 'Error al eliminar la sesión',
         sessionDeleted: 'Sesión eliminada exitosamente',
-        
+        renameSession: 'Renombrar Sesión',
+        renameSessionSubtitle: 'Cambiar el nombre de visualización de esta sesión',
+        renameSessionPlaceholder: 'Introduce el nombre de la sesión...',
+        failedToRenameSession: 'Error al renombrar la sesión',
+        sessionRenamed: 'Sesión renombrada exitosamente',
+
     },
 
     components: {

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -377,6 +377,11 @@ export const pl: TranslationStructure = {
         deleteSessionWarning: 'Ta operacja jest nieodwracalna. Wszystkie wiadomości i dane powiązane z tą sesją zostaną trwale usunięte.',
         failedToDeleteSession: 'Nie udało się usunąć sesji',
         sessionDeleted: 'Sesja została pomyślnie usunięta',
+        renameSession: 'Zmień nazwę sesji',
+        renameSessionSubtitle: 'Zmień wyświetlaną nazwę tej sesji',
+        renameSessionPlaceholder: 'Wprowadź nazwę sesji...',
+        failedToRenameSession: 'Nie udało się zmienić nazwy sesji',
+        sessionRenamed: 'Pomyślnie zmieniono nazwę sesji',
     },
 
     components: {

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -366,7 +366,12 @@ export const pt: TranslationStructure = {
         deleteSessionWarning: 'Esta ação não pode ser desfeita. Todas as mensagens e dados associados a esta sessão serão excluídos permanentemente.',
         failedToDeleteSession: 'Falha ao excluir sessão',
         sessionDeleted: 'Sessão excluída com sucesso',
-        
+        renameSession: 'Renomear Sessão',
+        renameSessionSubtitle: 'Alterar o nome de exibição desta sessão',
+        renameSessionPlaceholder: 'Digite o nome da sessão...',
+        failedToRenameSession: 'Falha ao renomear sessão',
+        sessionRenamed: 'Sessão renomeada com sucesso',
+
     },
 
     components: {

--- a/sources/text/translations/ru.ts
+++ b/sources/text/translations/ru.ts
@@ -341,6 +341,11 @@ export const ru: TranslationStructure = {
         deleteSessionWarning: 'Это действие нельзя отменить. Все сообщения и данные, связанные с этой сессией, будут удалены навсегда.',
         failedToDeleteSession: 'Не удалось удалить сессию',
         sessionDeleted: 'Сессия успешно удалена',
+        renameSession: 'Переименовать сессию',
+        renameSessionSubtitle: 'Изменить отображаемое имя сессии',
+        renameSessionPlaceholder: 'Введите название сессии...',
+        failedToRenameSession: 'Не удалось переименовать сессию',
+        sessionRenamed: 'Сессия успешно переименована',
     },
 
     components: {

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -368,7 +368,12 @@ export const zhHans: TranslationStructure = {
         deleteSessionWarning: '此操作无法撤销。与此会话相关的所有消息和数据将被永久删除。',
         failedToDeleteSession: '删除会话失败',
         sessionDeleted: '会话删除成功',
-        
+        renameSession: '重命名会话',
+        renameSessionSubtitle: '更改此会话的显示名称',
+        renameSessionPlaceholder: '输入会话名称...',
+        failedToRenameSession: '重命名会话失败',
+        sessionRenamed: '会话重命名成功',
+
     },
 
     components: {


### PR DESCRIPTION
Introduces the ability to rename sessions from the session info screen, including a modal UI for entering the new name. Implements the backend operation in sync/ops.ts, updates the UI in info.tsx, and adds translation strings for the rename feature in all supported languages.