### PR TITLE
fix(web): alert modals not clickable when shown above expo-router modals

### DIFF
--- a/sources/modal/components/BaseModal.tsx
+++ b/sources/modal/components/BaseModal.tsx
@@ -9,6 +9,13 @@ import {
     Platform
 } from 'react-native';
 
+// On web, stop events from propagating to expo-router's modal overlay
+// which intercepts clicks when it applies pointer-events: none to body
+const stopPropagation = (e: { stopPropagation: () => void }) => e.stopPropagation();
+const webEventHandlers = Platform.OS === 'web'
+    ? { onClick: stopPropagation, onPointerDown: stopPropagation, onTouchStart: stopPropagation }
+    : {};
+
 interface BaseModalProps {
     visible: boolean;
     onClose?: () => void;
@@ -57,9 +64,10 @@ export function BaseModal({
             animationType={animationType}
             onRequestClose={onClose}
         >
-            <KeyboardAvoidingView 
+            <KeyboardAvoidingView
                 style={styles.container}
                 behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                {...webEventHandlers}
             >
                 <TouchableWithoutFeedback onPress={handleBackdropPress}>
                     <Animated.View 
@@ -100,7 +108,9 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         justifyContent: 'center',
-        alignItems: 'center'
+        alignItems: 'center',
+        // On web, ensure modal can receive pointer events when body has pointer-events: none
+        ...Platform.select({ web: { pointerEvents: 'auto' as const } })
     },
     backdrop: {
         ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
On web, when an alert modal is shown while an expo-router modal (like "new session") is open, the alert's OK button was unclickable. This happened because expo-router sets pointer-events: none on body and pointer-events: auto on its own overlay, which intercepted clicks meant for our alert modal.

For example, we could never click "OK" and close that modal:
<img width="326" height="191" alt="Screenshot 2026-01-11 at 16 36 27" src="https://github.com/user-attachments/assets/f1e39035-b3a6-4057-b610-3122cddc1001" />

Fix:
- Add pointerEvents: 'auto' to modal container to enable interactions
- Stop event propagation on web to prevent clicks from reaching expo-router's overlay

