### PR TITLE
feat(gemini): Add ACP integration with model selection and improved tool display

### DIFF
--- a/sources/-session/SessionView.tsx
+++ b/sources/-session/SessionView.tsx
@@ -168,6 +168,9 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     const shouldShowCliWarning = isCliOutdated && !isAcknowledged;
     // Get permission mode from session object, default to 'default'
     const permissionMode = session.permissionMode || 'default';
+    // Get model mode from session object - for Gemini sessions use explicit model, default to gemini-2.5-pro
+    const isGeminiSession = session.metadata?.flavor === 'gemini';
+    const modelMode = session.modelMode || (isGeminiSession ? 'gemini-2.5-pro' : 'default');
     const sessionStatus = useSessionStatus(session);
     const sessionUsage = useSessionUsage(sessionId);
     const alwaysShowContextSize = useSetting('alwaysShowContextSize');
@@ -191,6 +194,11 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     // Function to update permission mode
     const updatePermissionMode = React.useCallback((mode: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo') => {
         storage.getState().updateSessionPermissionMode(sessionId, mode);
+    }, [sessionId]);
+
+    // Function to update model mode (for Gemini sessions)
+    const updateModelMode = React.useCallback((mode: 'default' | 'gemini-2.5-pro' | 'gemini-2.5-flash' | 'gemini-2.5-flash-lite') => {
+        storage.getState().updateSessionModelMode(sessionId, mode);
     }, [sessionId]);
 
     // Memoize header-dependent styles to prevent re-renders
@@ -272,6 +280,8 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
             sessionId={sessionId}
             permissionMode={permissionMode}
             onPermissionModeChange={updatePermissionMode}
+            modelMode={modelMode as any}
+            onModelModeChange={updateModelMode as any}
             metadata={session.metadata}
             connectionStatus={{
                 text: sessionStatus.statusText,

--- a/sources/components/PermissionModeSelector.tsx
+++ b/sources/components/PermissionModeSelector.tsx
@@ -6,7 +6,7 @@ import { hapticsLight } from './haptics';
 
 export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo';
 
-export type ModelMode = 'default' | 'adaptiveUsage' | 'sonnet' | 'opus' | 'gpt-5-codex-high' | 'gpt-5-codex-medium' | 'gpt-5-codex-low' | 'gpt-5-minimal' | 'gpt-5-low' | 'gpt-5-medium' | 'gpt-5-high';
+export type ModelMode = 'default' | 'adaptiveUsage' | 'sonnet' | 'opus' | 'gpt-5-codex-high' | 'gpt-5-codex-medium' | 'gpt-5-codex-low' | 'gpt-5-minimal' | 'gpt-5-low' | 'gpt-5-medium' | 'gpt-5-high' | 'gemini-2.5-pro' | 'gemini-2.5-flash' | 'gemini-2.5-flash-lite';
 
 interface PermissionModeSelectorProps {
     mode: PermissionMode;

--- a/sources/components/tools/ToolView.tsx
+++ b/sources/components/tools/ToolView.tsx
@@ -50,6 +50,14 @@ export const ToolView = React.memo<ToolViewProps>((props) => {
     let icon = <Ionicons name="construct-outline" size={18} color={theme.colors.textSecondary} />;
     let noStatus = false;
     let hideDefaultError = false;
+    
+    // For Gemini: unknown tools should be rendered as minimal (hidden)
+    // This prevents showing raw INPUT/OUTPUT for internal Gemini tools
+    // that we haven't explicitly added to knownTools
+    const isGemini = props.metadata?.flavor === 'gemini';
+    if (!knownTool && isGemini) {
+        minimal = true;
+    }
 
     // Extract status first to potentially use as title
     if (knownTool && typeof knownTool.extractStatus === 'function') {

--- a/sources/components/tools/knownTools.tsx
+++ b/sources/components/tools/knownTools.tsx
@@ -601,6 +601,30 @@ export const knownTools = {
         }).partial().loose(),
         result: z.object({}).partial().loose()
     },
+    // Gemini internal tools - should be hidden (minimal)
+    'search': {
+        title: t('tools.names.search'),
+        icon: ICON_SEARCH,
+        minimal: true,
+        input: z.object({
+            items: z.array(z.any()).optional(),
+            locations: z.array(z.any()).optional()
+        }).partial().loose()
+    },
+    'edit': {
+        title: t('tools.names.editFile'),
+        icon: ICON_EDIT,
+        minimal: true,
+        isMutable: true,
+        input: z.object({}).partial().loose()
+    },
+    'shell': {
+        title: t('tools.names.terminal'),
+        icon: ICON_TERMINAL,
+        minimal: true,
+        isMutable: true,
+        input: z.object({}).partial().loose()
+    },
     'CodexPatch': {
         title: t('tools.names.applyChanges'),
         icon: ICON_EDIT,

--- a/sources/components/tools/knownTools.tsx
+++ b/sources/components/tools/knownTools.tsx
@@ -180,6 +180,11 @@ export const knownTools = {
                 const path = resolvePath(opts.tool.input.file_path, opts.metadata);
                 return path;
             }
+            // Gemini uses 'locations' array with 'path' field
+            if (opts.tool.input.locations && Array.isArray(opts.tool.input.locations) && opts.tool.input.locations[0]?.path) {
+                const path = resolvePath(opts.tool.input.locations[0].path, opts.metadata);
+                return path;
+            }
             return t('tools.names.readFile');
         },
         minimal: true,
@@ -187,7 +192,10 @@ export const knownTools = {
         input: z.object({
             file_path: z.string().describe('The absolute path to the file to read'),
             limit: z.number().optional().describe('The number of lines to read'),
-            offset: z.number().optional().describe('The line number to start reading from')
+            offset: z.number().optional().describe('The line number to start reading from'),
+            // Gemini format
+            items: z.array(z.any()).optional(),
+            locations: z.array(z.object({ path: z.string() }).loose()).optional()
         }).partial().loose(),
         result: z.object({
             file: z.object({
@@ -197,6 +205,28 @@ export const knownTools = {
                 startLine: z.number().describe('The line number to start reading from'),
                 totalLines: z.number().describe('The total number of lines in the file')
             }).loose().optional()
+        }).partial().loose()
+    },
+    // Gemini uses lowercase 'read'
+    'read': {
+        title: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            // Gemini uses 'locations' array with 'path' field
+            if (opts.tool.input.locations && Array.isArray(opts.tool.input.locations) && opts.tool.input.locations[0]?.path) {
+                const path = resolvePath(opts.tool.input.locations[0].path, opts.metadata);
+                return path;
+            }
+            if (typeof opts.tool.input.file_path === 'string') {
+                const path = resolvePath(opts.tool.input.file_path, opts.metadata);
+                return path;
+            }
+            return t('tools.names.readFile');
+        },
+        minimal: true,
+        icon: ICON_READ,
+        input: z.object({
+            items: z.array(z.any()).optional(),
+            locations: z.array(z.object({ path: z.string() }).loose()).optional(),
+            file_path: z.string().optional()
         }).partial().loose()
     },
     'Edit': {
@@ -510,11 +540,149 @@ export const knownTools = {
             return t('tools.names.reasoning');
         }
     },
+    'GeminiReasoning': {
+        title: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            // Use the title from input if provided
+            if (opts.tool.input?.title && typeof opts.tool.input.title === 'string') {
+                return opts.tool.input.title;
+            }
+            return t('tools.names.reasoning');
+        },
+        icon: ICON_REASONING,
+        minimal: true,
+        input: z.object({
+            title: z.string().describe('The title of the reasoning')
+        }).partial().loose(),
+        result: z.object({
+            content: z.string().describe('The reasoning content'),
+            status: z.enum(['completed', 'in_progress', 'canceled']).optional().describe('The status of the reasoning')
+        }).partial().loose(),
+        extractDescription: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            if (opts.tool.input?.title && typeof opts.tool.input.title === 'string') {
+                return opts.tool.input.title;
+            }
+            return t('tools.names.reasoning');
+        }
+    },
+    'think': {
+        title: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            // Use the title from input if provided
+            if (opts.tool.input?.title && typeof opts.tool.input.title === 'string') {
+                return opts.tool.input.title;
+            }
+            return t('tools.names.reasoning');
+        },
+        icon: ICON_REASONING,
+        minimal: true,
+        input: z.object({
+            title: z.string().optional().describe('The title of the thinking'),
+            items: z.array(z.any()).optional().describe('Items to think about'),
+            locations: z.array(z.any()).optional().describe('Locations to consider')
+        }).partial().loose(),
+        result: z.object({
+            content: z.string().optional().describe('The reasoning content'),
+            text: z.string().optional().describe('The reasoning text'),
+            status: z.enum(['completed', 'in_progress', 'canceled']).optional().describe('The status')
+        }).partial().loose(),
+        extractDescription: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            if (opts.tool.input?.title && typeof opts.tool.input.title === 'string') {
+                return opts.tool.input.title;
+            }
+            return t('tools.names.reasoning');
+        }
+    },
+    'change_title': {
+        title: 'Change Title',
+        icon: ICON_EDIT,
+        minimal: true,
+        noStatus: true,
+        input: z.object({
+            title: z.string().optional().describe('New session title')
+        }).partial().loose(),
+        result: z.object({}).partial().loose()
+    },
     'CodexPatch': {
         title: t('tools.names.applyChanges'),
         icon: ICON_EDIT,
         minimal: true,
         hideDefaultError: true,
+        input: z.object({
+            auto_approved: z.boolean().optional().describe('Whether changes were auto-approved'),
+            changes: z.record(z.string(), z.object({
+                add: z.object({
+                    content: z.string()
+                }).optional(),
+                modify: z.object({
+                    old_content: z.string(),
+                    new_content: z.string()
+                }).optional(),
+                delete: z.object({
+                    content: z.string()
+                }).optional()
+            }).loose()).describe('File changes to apply')
+        }).partial().loose(),
+        extractSubtitle: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            // Show the first file being modified
+            if (opts.tool.input?.changes && typeof opts.tool.input.changes === 'object') {
+                const files = Object.keys(opts.tool.input.changes);
+                if (files.length > 0) {
+                    const path = resolvePath(files[0], opts.metadata);
+                    const fileName = path.split('/').pop() || path;
+                    if (files.length > 1) {
+                        return t('tools.desc.modifyingMultipleFiles', { 
+                            file: fileName, 
+                            count: files.length - 1 
+                        });
+                    }
+                    return fileName;
+                }
+            }
+            return null;
+        },
+        extractDescription: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            // Show the number of files being modified
+            if (opts.tool.input?.changes && typeof opts.tool.input.changes === 'object') {
+                const files = Object.keys(opts.tool.input.changes);
+                const fileCount = files.length;
+                if (fileCount === 1) {
+                    const path = resolvePath(files[0], opts.metadata);
+                    const fileName = path.split('/').pop() || path;
+                    return t('tools.desc.modifyingFile', { file: fileName });
+                } else if (fileCount > 1) {
+                    return t('tools.desc.modifyingFiles', { count: fileCount });
+                }
+            }
+            return t('tools.names.applyChanges');
+        }
+    },
+    'GeminiBash': {
+        title: t('tools.names.terminal'),
+        icon: ICON_TERMINAL,
+        minimal: true,
+        hideDefaultError: true,
+        isMutable: true,
+        input: z.object({
+            command: z.array(z.string()).describe('The command array to execute'),
+            cwd: z.string().optional().describe('Current working directory')
+        }).partial().loose(),
+        extractSubtitle: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            if (opts.tool.input?.command && Array.isArray(opts.tool.input.command)) {
+                let cmdArray = opts.tool.input.command;
+                // Remove shell wrapper prefix if present (bash/zsh with -lc flag)
+                if (cmdArray.length >= 3 && (cmdArray[0] === 'bash' || cmdArray[0] === '/bin/bash' || cmdArray[0] === 'zsh' || cmdArray[0] === '/bin/zsh') && cmdArray[1] === '-lc') {
+                    return cmdArray[2];
+                }
+                return cmdArray.join(' ');
+            }
+            return null;
+        }
+    },
+    'GeminiPatch': {
+        title: t('tools.names.applyChanges'),
+        icon: ICON_EDIT,
+        minimal: true,
+        hideDefaultError: true,
+        isMutable: true,
         input: z.object({
             auto_approved: z.boolean().optional().describe('Whether changes were auto-approved'),
             changes: z.record(z.string(), z.object({
@@ -578,6 +746,43 @@ export const knownTools = {
         }).partial().loose(),
         extractSubtitle: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
             // Try to extract filename from unified diff
+            if (opts.tool.input?.unified_diff && typeof opts.tool.input.unified_diff === 'string') {
+                const diffLines = opts.tool.input.unified_diff.split('\n');
+                for (const line of diffLines) {
+                    if (line.startsWith('+++ b/') || line.startsWith('+++ ')) {
+                        const fileName = line.replace(/^\+\+\+ (b\/)?/, '');
+                        const basename = fileName.split('/').pop() || fileName;
+                        return basename;
+                    }
+                }
+            }
+            return null;
+        },
+        extractDescription: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            return t('tools.desc.showingDiff');
+        }
+    },
+    'GeminiDiff': {
+        title: t('tools.names.viewDiff'),
+        icon: ICON_EDIT,
+        minimal: false,  // Show full diff view
+        hideDefaultError: true,
+        noStatus: true,  // Always successful, stateless like Task
+        input: z.object({
+            unified_diff: z.string().optional().describe('Unified diff content'),
+            filePath: z.string().optional().describe('File path'),
+            description: z.string().optional().describe('Edit description')
+        }).partial().loose(),
+        result: z.object({
+            status: z.literal('completed').describe('Always completed')
+        }).partial().loose(),
+        extractSubtitle: (opts: { metadata: Metadata | null, tool: ToolCall }) => {
+            // Try to extract filename from filePath first
+            if (opts.tool.input?.filePath && typeof opts.tool.input.filePath === 'string') {
+                const basename = opts.tool.input.filePath.split('/').pop() || opts.tool.input.filePath;
+                return basename;
+            }
+            // Fall back to extracting from unified diff
             if (opts.tool.input?.unified_diff && typeof opts.tool.input.unified_diff === 'string') {
                 const diffLines = opts.tool.input.unified_diff.split('\n');
                 for (const line of diffLines) {

--- a/sources/components/tools/views/GeminiEditView.tsx
+++ b/sources/components/tools/views/GeminiEditView.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { ToolSectionView } from '../../tools/ToolSectionView';
+import { ToolViewProps } from './_all';
+import { ToolDiffView } from '@/components/tools/ToolDiffView';
+import { trimIdent } from '@/utils/trimIdent';
+import { useSetting } from '@/sync/storage';
+
+/**
+ * Extract edit content from Gemini's nested input format.
+ * 
+ * Gemini sends data in nested structure:
+ * - tool.input.toolCall.content[0] 
+ * - tool.input.input[0]
+ * - tool.input (direct fields)
+ */
+function extractEditContent(input: any): { oldText: string; newText: string; path: string } {
+    // Try various locations where Gemini might put the edit data
+    
+    // 1. Check tool.input.toolCall.content[0]
+    if (input?.toolCall?.content?.[0]) {
+        const content = input.toolCall.content[0];
+        return {
+            oldText: content.oldText || '',
+            newText: content.newText || '',
+            path: content.path || ''
+        };
+    }
+    
+    // 2. Check tool.input.input[0] (array format)
+    if (Array.isArray(input?.input) && input.input[0]) {
+        const content = input.input[0];
+        return {
+            oldText: content.oldText || '',
+            newText: content.newText || '',
+            path: content.path || ''
+        };
+    }
+    
+    // 3. Check direct fields (simple format)
+    return {
+        oldText: input?.oldText || input?.old_string || '',
+        newText: input?.newText || input?.new_string || '',
+        path: input?.path || input?.file_path || ''
+    };
+}
+
+/**
+ * Gemini Edit View
+ * 
+ * Handles Gemini's edit tool format which uses:
+ * - oldText (instead of old_string)
+ * - newText (instead of new_string)
+ * - path (instead of file_path)
+ */
+export const GeminiEditView = React.memo<ToolViewProps>(({ tool }) => {
+    const showLineNumbersInToolViews = useSetting('showLineNumbersInToolViews');
+    
+    const { oldText, newText } = extractEditContent(tool.input);
+    const oldString = trimIdent(oldText);
+    const newString = trimIdent(newText);
+
+    return (
+        <>
+            <ToolSectionView fullWidth>
+                <ToolDiffView 
+                    oldText={oldString} 
+                    newText={newString} 
+                    showLineNumbers={showLineNumbersInToolViews}
+                    showPlusMinusSymbols={showLineNumbersInToolViews}
+                />
+            </ToolSectionView>
+        </>
+    );
+});
+

--- a/sources/components/tools/views/GeminiExecuteView.tsx
+++ b/sources/components/tools/views/GeminiExecuteView.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { View, Text } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+import { ToolSectionView } from '../../tools/ToolSectionView';
+import { ToolViewProps } from './_all';
+import { CodeView } from '@/components/CodeView';
+
+/**
+ * Extract execute command info from Gemini's nested input format.
+ */
+function extractExecuteInfo(input: any): { command: string; description: string; cwd: string } {
+    let command = '';
+    let description = '';
+    let cwd = '';
+    
+    // Try to get title from toolCall.title
+    // Format: "rm file.txt [current working directory /path] (description)"
+    if (input?.toolCall?.title) {
+        const fullTitle = input.toolCall.title;
+        
+        // Extract command (before [)
+        const bracketIdx = fullTitle.indexOf(' [');
+        if (bracketIdx > 0) {
+            command = fullTitle.substring(0, bracketIdx);
+        } else {
+            command = fullTitle;
+        }
+        
+        // Extract cwd from [current working directory /path]
+        const cwdMatch = fullTitle.match(/\[current working directory ([^\]]+)\]/);
+        if (cwdMatch) {
+            cwd = cwdMatch[1];
+        }
+        
+        // Extract description from (...)
+        const descMatch = fullTitle.match(/\(([^)]+)\)$/);
+        if (descMatch) {
+            description = descMatch[1];
+        }
+    }
+    
+    return { command, description, cwd };
+}
+
+/**
+ * Gemini Execute View
+ * 
+ * Displays shell/terminal commands from Gemini's execute tool.
+ */
+export const GeminiExecuteView = React.memo<ToolViewProps>(({ tool }) => {
+    const { command, description, cwd } = extractExecuteInfo(tool.input);
+
+    if (!command) {
+        return null;
+    }
+
+    return (
+        <>
+            <ToolSectionView fullWidth>
+                <CodeView code={command} />
+            </ToolSectionView>
+            {(description || cwd) && (
+                <View style={styles.infoContainer}>
+                    {cwd && (
+                        <Text style={styles.cwdText}>📁 {cwd}</Text>
+                    )}
+                    {description && (
+                        <Text style={styles.descriptionText}>{description}</Text>
+                    )}
+                </View>
+            )}
+        </>
+    );
+});
+
+const styles = StyleSheet.create((theme) => ({
+    infoContainer: {
+        paddingHorizontal: 12,
+        paddingBottom: 8,
+    },
+    cwdText: {
+        fontSize: 12,
+        color: theme.colors.textSecondary,
+        marginBottom: 4,
+    },
+    descriptionText: {
+        fontSize: 13,
+        color: theme.colors.textSecondary,
+        fontStyle: 'italic',
+    },
+}));
+

--- a/sources/components/tools/views/_all.tsx
+++ b/sources/components/tools/views/_all.tsx
@@ -15,6 +15,8 @@ import { CodexBashView } from './CodexBashView';
 import { CodexPatchView } from './CodexPatchView';
 import { CodexDiffView } from './CodexDiffView';
 import { AskUserQuestionView } from './AskUserQuestionView';
+import { GeminiEditView } from './GeminiEditView';
+import { GeminiExecuteView } from './GeminiExecuteView';
 
 export type ToolViewProps = {
     tool: ToolCall;
@@ -39,7 +41,10 @@ export const toolViewRegistry: Record<string, ToolViewComponent> = {
     exit_plan_mode: ExitPlanToolView,
     MultiEdit: MultiEditView,
     Task: TaskView,
-    AskUserQuestion: AskUserQuestionView
+    AskUserQuestion: AskUserQuestionView,
+    // Gemini tools (lowercase)
+    edit: GeminiEditView,
+    execute: GeminiExecuteView,
 };
 
 export const toolFullViewRegistry: Record<string, ToolViewComponent> = {
@@ -71,3 +76,5 @@ export { ExitPlanToolView } from './ExitPlanToolView';
 export { MultiEditView } from './MultiEditView';
 export { TaskView } from './TaskView';
 export { AskUserQuestionView } from './AskUserQuestionView';
+export { GeminiEditView } from './GeminiEditView';
+export { GeminiExecuteView } from './GeminiExecuteView';

--- a/sources/sync/storage.ts
+++ b/sources/sync/storage.ts
@@ -117,7 +117,7 @@ interface StorageState {
     getActiveSessions: () => Session[];
     updateSessionDraft: (sessionId: string, draft: string | null) => void;
     updateSessionPermissionMode: (sessionId: string, mode: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo') => void;
-    updateSessionModelMode: (sessionId: string, mode: 'default') => void;
+    updateSessionModelMode: (sessionId: string, mode: 'default' | 'gemini-2.5-pro' | 'gemini-2.5-flash' | 'gemini-2.5-flash-lite') => void;
     // Artifact methods
     applyArtifacts: (artifacts: DecryptedArtifact[]) => void;
     addArtifact: (artifact: DecryptedArtifact) => void;
@@ -808,7 +808,7 @@ export const storage = create<StorageState>()((set, get) => {
                 sessions: updatedSessions
             };
         }),
-        updateSessionModelMode: (sessionId: string, mode: 'default') => set((state) => {
+        updateSessionModelMode: (sessionId: string, mode: 'default' | 'gemini-2.5-pro' | 'gemini-2.5-flash' | 'gemini-2.5-flash-lite') => set((state) => {
             const session = state.sessions[sessionId];
             if (!session) return state;
 

--- a/sources/sync/storageTypes.ts
+++ b/sources/sync/storageTypes.ts
@@ -70,7 +70,7 @@ export interface Session {
     }>;
     draft?: string | null; // Local draft message, not synced to server
     permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo' | null; // Local permission mode, not synced to server
-    modelMode?: 'default' | null; // Local model mode, not synced to server (models configured in CLI)
+    modelMode?: 'default' | 'gemini-2.5-pro' | 'gemini-2.5-flash' | 'gemini-2.5-flash-lite' | null; // Local model mode, not synced to server
     // IMPORTANT: latestUsage is extracted from reducerState.latestUsage after message processing.
     // We store it directly on Session to ensure it's available immediately on load.
     // Do NOT store reducerState itself on Session - it's mutable and should only exist in SessionMessages.

--- a/sources/sync/sync.ts
+++ b/sources/sync/sync.ts
@@ -223,9 +223,13 @@ class Sync {
             return;
         }
 
-        // Read permission mode and model mode from session state
+        // Read permission mode from session state
         const permissionMode = session.permissionMode || 'default';
-        const modelMode = session.modelMode || 'default';
+        
+        // Read model mode - for Gemini, default to gemini-2.5-pro if not set
+        const flavor = session.metadata?.flavor;
+        const isGemini = flavor === 'gemini';
+        const modelMode = session.modelMode || (isGemini ? 'gemini-2.5-pro' : 'default');
 
         // Generate local ID
         const localId = randomUUID();
@@ -247,8 +251,12 @@ class Sync {
             sentFrom = 'web'; // fallback
         }
 
-        // Model settings - models are configured in CLI settings
-        const model: string | null = null;
+        // Model settings - for Gemini, we pass the selected model; for others, CLI handles it
+        let model: string | null = null;
+        if (isGemini && modelMode !== 'default') {
+            // For Gemini ACP, pass the selected model to CLI
+            model = modelMode;
+        }
         const fallbackModel: string | null = null;
 
         // Create user message content with metadata
@@ -1534,13 +1542,38 @@ class Sync {
                 if (decrypted) {
                     lastMessage = normalizeRawMessage(decrypted.id, decrypted.localId, decrypted.createdAt, decrypted.content);
 
+                    // Check for task lifecycle events to update thinking state
+                    // This ensures UI updates even if volatile activity updates are lost
+                    const rawContent = decrypted.content as { role?: string; content?: { type?: string; data?: { type?: string } } };
+                    const contentType = rawContent.content?.type;
+                    const dataType = rawContent.content?.data?.type;
+                    
+                    // Debug logging to trace lifecycle events
+                    if (dataType === 'task_complete' || dataType === 'turn_aborted' || dataType === 'task_started') {
+                        console.log(`🔄 [Sync] Lifecycle event detected: contentType=${contentType}, dataType=${dataType}`);
+                    }
+                    
+                    const isTaskComplete = 
+                        ((contentType === 'acp' || contentType === 'codex') && 
+                            (dataType === 'task_complete' || dataType === 'turn_aborted'));
+                    
+                    const isTaskStarted = 
+                        ((contentType === 'acp' || contentType === 'codex') && dataType === 'task_started');
+                    
+                    if (isTaskComplete || isTaskStarted) {
+                        console.log(`🔄 [Sync] Updating thinking state: isTaskComplete=${isTaskComplete}, isTaskStarted=${isTaskStarted}`);
+                    }
+
                     // Update session
                     const session = storage.getState().sessions[updateData.body.sid];
                     if (session) {
                         this.applySessions([{
                             ...session,
                             updatedAt: updateData.createdAt,
-                            seq: updateData.seq
+                            seq: updateData.seq,
+                            // Update thinking state based on task lifecycle events
+                            ...(isTaskComplete ? { thinking: false } : {}),
+                            ...(isTaskStarted ? { thinking: true } : {})
                         }])
                     } else {
                         // Fetch sessions again if we don't have this session

--- a/sources/sync/sync.ts
+++ b/sources/sync/sync.ts
@@ -1544,9 +1544,9 @@ class Sync {
 
                     // Check for task lifecycle events to update thinking state
                     // This ensures UI updates even if volatile activity updates are lost
-                    const rawContent = decrypted.content as { role?: string; content?: { type?: string; data?: { type?: string } } };
-                    const contentType = rawContent.content?.type;
-                    const dataType = rawContent.content?.data?.type;
+                    const rawContent = decrypted.content as { role?: string; content?: { type?: string; data?: { type?: string } } } | null;
+                    const contentType = rawContent?.content?.type;
+                    const dataType = rawContent?.content?.data?.type;
                     
                     // Debug logging to trace lifecycle events
                     if (dataType === 'task_complete' || dataType === 'turn_aborted' || dataType === 'task_started') {

--- a/sources/text/_default.ts
+++ b/sources/text/_default.ts
@@ -431,12 +431,12 @@ export const en = {
         geminiPermissionMode: {
             title: 'GEMINI PERMISSION MODE',
             default: 'Default',
-            acceptEdits: 'Accept Edits',
-            plan: 'Plan Mode',
-            bypassPermissions: 'Yolo Mode',
-            badgeAcceptAllEdits: 'Accept All Edits',
-            badgeBypassAllPermissions: 'Bypass All Permissions',
-            badgePlanMode: 'Plan Mode',
+            readOnly: 'Read Only',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Read Only',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `${percent}% left`,
@@ -759,7 +759,7 @@ export const en = {
         permissions: {
             yesAllowAllEdits: 'Yes, allow all edits during this session',
             yesForTool: "Yes, don't ask again for this tool",
-            noTellClaude: 'No, and tell Claude what to do differently',
+            noTellClaude: 'No, and provide feedback',
         }
     },
 

--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -760,7 +760,7 @@ export const ca: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'Sí, permet totes les edicions durant aquesta sessió',
             yesForTool: 'Sí, no tornis a preguntar per aquesta eina',
-            noTellClaude: 'No, i digues a Claude què fer diferent',
+            noTellClaude: 'No, proporciona comentaris',
         }
     },
 

--- a/sources/text/translations/en.ts
+++ b/sources/text/translations/en.ts
@@ -447,12 +447,12 @@ export const en: TranslationStructure = {
         geminiPermissionMode: {
             title: 'GEMINI PERMISSION MODE',
             default: 'Default',
-            acceptEdits: 'Accept Edits',
-            plan: 'Plan Mode',
-            bypassPermissions: 'Yolo Mode',
-            badgeAcceptAllEdits: 'Accept All Edits',
-            badgeBypassAllPermissions: 'Bypass All Permissions',
-            badgePlanMode: 'Plan Mode',
+            readOnly: 'Read Only',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Read Only',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `${percent}% left`,
@@ -775,7 +775,7 @@ export const en: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'Yes, allow all edits during this session',
             yesForTool: "Yes, don't ask again for this tool",
-            noTellClaude: 'No, and tell Claude what to do differently',
+            noTellClaude: 'No, and provide feedback',
         }
     },
 

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -760,7 +760,7 @@ export const es: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'Sí, permitir todas las ediciones durante esta sesión',
             yesForTool: 'Sí, no volver a preguntar para esta herramienta',
-            noTellClaude: 'No, y decirle a Claude qué hacer diferente',
+            noTellClaude: 'No, proporcionar comentarios',
         }
     },
 

--- a/sources/text/translations/it.ts
+++ b/sources/text/translations/it.ts
@@ -789,7 +789,7 @@ export const it: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'Sì, consenti tutte le modifiche durante questa sessione',
             yesForTool: 'Sì, non chiedere più per questo strumento',
-            noTellClaude: 'No, e di a Claude cosa fare diversamente',
+            noTellClaude: 'No, fornisci feedback',
         }
     },
 

--- a/sources/text/translations/ja.ts
+++ b/sources/text/translations/ja.ts
@@ -792,7 +792,7 @@ export const ja: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'はい、このセッション中のすべての編集を許可',
             yesForTool: "はい、このツールについては確認しない",
-            noTellClaude: 'いいえ、Claudeに別の方法を伝える',
+            noTellClaude: 'いいえ、フィードバックを提供',
         }
     },
 

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -770,7 +770,7 @@ export const pl: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'Tak, zezwól na wszystkie edycje podczas tej sesji',
             yesForTool: 'Tak, nie pytaj ponownie dla tego narzędzia',
-            noTellClaude: 'Nie, i powiedz Claude co zrobić inaczej',
+            noTellClaude: 'Nie, przekaż opinię',
         }
     },
 

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -760,7 +760,7 @@ export const pt: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'Sim, permitir todas as edições durante esta sessão',
             yesForTool: 'Sim, não perguntar novamente para esta ferramenta',
-            noTellClaude: 'Não, e dizer ao Claude o que fazer diferente',
+            noTellClaude: 'Não, fornecer feedback',
         }
     },
 

--- a/sources/text/translations/ru.ts
+++ b/sources/text/translations/ru.ts
@@ -442,12 +442,12 @@ export const ru: TranslationStructure = {
         geminiPermissionMode: {
             title: 'РЕЖИМ РАЗРЕШЕНИЙ',
             default: 'По умолчанию',
-            acceptEdits: 'Принимать правки',
-            plan: 'Режим планирования',
-            bypassPermissions: 'YOLO режим',
-            badgeAcceptAllEdits: 'Принимать все правки',
-            badgeBypassAllPermissions: 'Обход всех разрешений',
-            badgePlanMode: 'Режим планирования',
+            readOnly: 'Только чтение',
+            safeYolo: 'Безопасный YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Только чтение',
+            badgeSafeYolo: 'Безопасный YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `Осталось ${percent}%`,
@@ -758,7 +758,7 @@ export const ru: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: 'Да, разрешить все правки в этой сессии',
             yesForTool: 'Да, больше не спрашивать для этого инструмента',
-            noTellClaude: 'Нет, и сказать Claude что делать по-другому',
+            noTellClaude: 'Нет, дать обратную связь',
         }
     },
 

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -762,7 +762,7 @@ export const zhHans: TranslationStructure = {
         permissions: {
             yesAllowAllEdits: '是，允许本次会话的所有编辑',
             yesForTool: '是，不再询问此工具',
-            noTellClaude: '否，并告诉 Claude 该如何不同地操作',
+            noTellClaude: '否，提供反馈',
         }
     },
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive Gemini integration through ACP (Agent Communication Protocol), including model selection, improved tool display, and permission system updates.

## Changes

### ACP Message Support
- Add 'acp' message type schema with provider field (gemini, codex, claude, opencode)
- Implement normalization for all ACP message types
- Handle task_started, task_complete, turn_aborted for thinking state sync

### Gemini Model Selection
- Add Gemini models: gemini-2.5-pro, flash, flash-lite
- Implement model selector UI in AgentInput for Gemini sessions
- Pass selected model in meta.model to CLI
- Default to gemini-2.5-pro for new sessions

### Tool Display Improvements
- Add GeminiEditView for proper diff display (oldText/newText fields)
- Add GeminiExecuteView for shell commands with command/cwd/description
- Auto-hide unknown tools for Gemini sessions
- Add 'read', 'think', 'search', 'edit', 'shell' tools with minimal display

### Permission System
- Update Gemini permission modes (default, read-only, safe-yolo, yolo)
- Replace agent-specific text with generic terms in UI

### Translations
- Update all language files (en, ru, zh-Hans, pt, pl, ja, it, es, ca)