### PR TITLE
fix: normalize paths to match Claude Code naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 6 - 2026-01-18
+
+This release fixes a synchronization issue affecting projects with special characters in folder names.
+
+- Fixed session sync failures when folder names contain underscores, dots, or other special characters
+- Mobile app now correctly matches Claude Code's project naming convention for reliable cross-device sync
+
 ## Version 5 - 2025-12-22
 
 This release expands AI agent support and refines the voice experience, while improving markdown rendering for a better chat experience.

--- a/sources/changelog/changelog.json
+++ b/sources/changelog/changelog.json
@@ -1,6 +1,16 @@
 {
   "entries": [
     {
+      "version": 6,
+      "date": "2026-01-18",
+      "summary": "This release fixes a synchronization issue affecting projects with special characters in folder names.",
+      "changes": [
+        "Fixed session sync failures when folder names contain underscores, dots, or other special characters",
+        "Mobile app now correctly matches Claude Code's project naming convention for reliable cross-device sync"
+      ],
+      "rawMarkdown": "## Version 6 - 2026-01-18\n\n\nThis release fixes a synchronization issue affecting projects with special characters in folder names.\n\n- Fixed session sync failures when folder names contain underscores, dots, or other special characters\n- Mobile app now correctly matches Claude Code's project naming convention for reliable cross-device sync"
+    },
+    {
       "version": 5,
       "date": "2025-12-22",
       "summary": "This release expands AI agent support and refines the voice experience, while improving markdown rendering for a better chat experience.",
@@ -65,5 +75,5 @@
       "rawMarkdown": "## Version 1 - 2025-05-12\n\n\nWelcome to Happy - your secure, encrypted mobile companion for Claude Code. This inaugural release establishes the foundation for private, powerful AI interactions on the go.\n\n- Implemented end-to-end encrypted session management ensuring complete privacy\n- Integrated intelligent voice assistant with natural conversation capabilities\n- Added experimental file manager with syntax highlighting and tree navigation\n- Built seamless real-time synchronization across all your devices\n- Established native support for iOS, Android, and responsive web interfaces"
     }
   ],
-  "latestVersion": 5
+  "latestVersion": 6
 }

--- a/sources/sync/gitStatusSync.ts
+++ b/sources/sync/gitStatusSync.ts
@@ -12,6 +12,7 @@ import { parseStatusSummaryV2, getStatusCountsV2, isDirtyV2, getCurrentBranchV2,
 import { parseCurrentBranch } from './git-parsers/parseBranch';
 import { parseNumStat, mergeDiffSummaries } from './git-parsers/parseDiff';
 import { projectManager, createProjectKey } from './projectManager';
+import { normalizePathForKey } from '@/utils/normalizePathForKey';
 
 export class GitStatusSync {
     // Map project keys to sync instances
@@ -20,14 +21,16 @@ export class GitStatusSync {
     private sessionToProjectKey = new Map<string, string>();
 
     /**
-     * Get project key string for a session
+     * Get project key string for a session.
+     * Uses normalized path to ensure consistent matching regardless of
+     * whether the original path contains underscores, dots, or other special characters.
      */
     private getProjectKeyForSession(sessionId: string): string | null {
         const session = storage.getState().sessions[sessionId];
         if (!session?.metadata?.machineId || !session?.metadata?.path) {
             return null;
         }
-        return `${session.metadata.machineId}:${session.metadata.path}`;
+        return `${session.metadata.machineId}:${normalizePathForKey(session.metadata.path)}`;
     }
 
     /**

--- a/sources/sync/projectManager.ts
+++ b/sources/sync/projectManager.ts
@@ -4,6 +4,7 @@
  */
 
 import { Session, MachineMetadata, GitStatus } from "./storageTypes";
+import { normalizePathForKey } from "@/utils/normalizePathForKey";
 
 /**
  * Unique project identifier based on machine ID and path
@@ -45,10 +46,13 @@ class ProjectManager {
     private nextProjectId = 1;
 
     /**
-     * Generate a unique key string from machine ID and path
+     * Generate a unique key string from machine ID and path.
+     * Uses normalized path to ensure consistent matching regardless of
+     * whether the original path contains underscores, dots, or other special characters.
+     * This matches Claude Code's .claude/projects folder naming convention.
      */
     private getProjectKeyString(key: ProjectKey): string {
-        return `${key.machineId}:${key.path}`;
+        return `${key.machineId}:${normalizePathForKey(key.path)}`;
     }
 
     /**

--- a/sources/utils/normalizePathForKey.spec.ts
+++ b/sources/utils/normalizePathForKey.spec.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePathForKey } from './normalizePathForKey';
+
+describe('normalizePathForKey', () => {
+    it('should convert underscores to hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/my_project')).toBe('-Users-dev-my-project');
+        expect(normalizePathForKey('/Users/dev/trading_signals_bot')).toBe('-Users-dev-trading-signals-bot');
+    });
+
+    it('should convert forward slashes to hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/project')).toBe('-Users-dev-project');
+    });
+
+    it('should convert dots to hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/my.project')).toBe('-Users-dev-my-project');
+        expect(normalizePathForKey('/Users/dev/.hidden')).toBe('-Users-dev-hidden');
+    });
+
+    it('should preserve existing hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/car-log-plus')).toBe('-Users-dev-car-log-plus');
+    });
+
+    it('should collapse multiple hyphens into one', () => {
+        expect(normalizePathForKey('/Users//dev///project')).toBe('-Users-dev-project');
+    });
+
+    it('should remove trailing hyphens but keep leading hyphen', () => {
+        expect(normalizePathForKey('/Users/dev/project/')).toBe('-Users-dev-project');
+    });
+
+    it('should handle home directory shortcut', () => {
+        expect(normalizePathForKey('~/Documents/project')).toBe('-Documents-project');
+    });
+
+    it('should return empty string for empty input', () => {
+        expect(normalizePathForKey('')).toBe('');
+    });
+
+    it('should match Claude Code .claude/projects naming convention', () => {
+        // Real-world examples from the issue
+        expect(normalizePathForKey('/Users/iml1s/Documents/mine/trading_signals_bot'))
+            .toBe('-Users-iml1s-Documents-mine-trading-signals-bot');
+        expect(normalizePathForKey('/Users/iml1s/Documents/mine/happy'))
+            .toBe('-Users-iml1s-Documents-mine-happy');
+        expect(normalizePathForKey('/Users/iml1s/Documents/mine/car-log-plus'))
+            .toBe('-Users-iml1s-Documents-mine-car-log-plus');
+    });
+
+    // Edge cases discovered from web search - GitHub issues #15481, #2224, #5814, #14310
+    describe('edge cases from real-world issues', () => {
+        it('should handle paths with spaces (Windows usernames like "John Doe")', () => {
+            // GitHub issue #15481 - Windows paths with spaces fail
+            expect(normalizePathForKey('/Users/John Doe/Documents/project'))
+                .toBe('-Users-John-Doe-Documents-project');
+            expect(normalizePathForKey('C:\\Users\\John Doe\\projects\\myapp'))
+                .toBe('C-Users-John-Doe-projects-myapp');
+            // iCloud Drive paths with spaces
+            expect(normalizePathForKey('/Users/dev/Library/Mobile Documents/project'))
+                .toBe('-Users-dev-Library-Mobile-Documents-project');
+        });
+
+        it('should handle Unicode/CJK paths (Chinese, Japanese, Korean)', () => {
+            // GitHub issues #2224, #14310 - Unicode handling issues
+            expect(normalizePathForKey('/Users/小明/projects/app'))
+                .toBe('-Users-projects-app');
+            expect(normalizePathForKey('/home/田中/code/project'))
+                .toBe('-home-code-project');
+            expect(normalizePathForKey('/Users/김철수/Documents/work'))
+                .toBe('-Users-Documents-work');
+            // Mixed ASCII and Unicode
+            expect(normalizePathForKey('/Users/dev/我的專案'))
+                .toBe('-Users-dev');
+        });
+
+        it('should handle Windows paths with backslashes and drive letters', () => {
+            // GitHub issue #5814 - Windows path normalization
+            expect(normalizePathForKey('C:\\Users\\dev\\project'))
+                .toBe('C-Users-dev-project');
+            expect(normalizePathForKey('D:\\Projects\\my_app'))
+                .toBe('D-Projects-my-app');
+            // UNC paths
+            expect(normalizePathForKey('\\\\server\\share\\project'))
+                .toBe('-server-share-project');
+        });
+
+        it('should handle double hyphens in original path names', () => {
+            // Codex review concern - paths with double hyphens should collapse
+            expect(normalizePathForKey('/Users/dev/my--project'))
+                .toBe('-Users-dev-my-project');
+            expect(normalizePathForKey('/Users/dev/test---app'))
+                .toBe('-Users-dev-test-app');
+        });
+
+        it('should handle trailing special characters', () => {
+            // Paths ending with special characters
+            expect(normalizePathForKey('/Users/dev/project_'))
+                .toBe('-Users-dev-project');
+            expect(normalizePathForKey('/Users/dev/project.'))
+                .toBe('-Users-dev-project');
+            expect(normalizePathForKey('/Users/dev/project-'))
+                .toBe('-Users-dev-project');
+        });
+
+        it('should handle special Unicode whitespace characters', () => {
+            // GitHub issue #2224 - narrow no-break space (U+202F) used in macOS screenshots
+            expect(normalizePathForKey('/Users/dev/Screenshot\u202FPM.png'))
+                .toBe('-Users-dev-Screenshot-PM-png');
+            // Other special whitespace
+            expect(normalizePathForKey('/Users/dev/file\u00A0name')) // non-breaking space
+                .toBe('-Users-dev-file-name');
+        });
+
+        it('should handle mixed special characters', () => {
+            expect(normalizePathForKey('/Users/John_Doe/My.Project/src'))
+                .toBe('-Users-John-Doe-My-Project-src');
+            expect(normalizePathForKey('C:\\Users\\dev\\my_project.v2'))
+                .toBe('C-Users-dev-my-project-v2');
+        });
+    });
+
+    // Additional edge cases from Codex review + Context7/web research
+    describe('advanced edge cases', () => {
+        it('should handle Unicode NFC vs NFD normalization variants (results may differ)', () => {
+            // macOS APFS/HFS+ uses NFD (decomposed), others use NFC (composed)
+            // Source: https://eclecticlight.co/2021/05/08/explainer-unicode-normalization-and-apfs/
+            // café in NFC (precomposed) - single character é (U+00E9)
+            expect(normalizePathForKey('/Users/dev/café'))
+                .toBe('-Users-dev-caf');
+            // café in NFD (decomposed) - e + combining acute accent (U+0065 + U+0301)
+            expect(normalizePathForKey('/Users/dev/cafe\u0301'))
+                .toBe('-Users-dev-cafe');
+            // IMPORTANT: NFC and NFD produce DIFFERENT keys because:
+            // - NFC: 'é' (U+00E9) is stripped as non-ASCII, leaving 'caf'
+            // - NFD: 'e' (U+0065) + combining accent (U+0301) - 'e' is preserved, accent stripped, leaving 'cafe'
+            // This is a known limitation - same folder on different filesystems may produce different keys
+        });
+
+        it('should handle emoji folder names', () => {
+            // Source: https://www.howtogeek.com/682868/you-can-use-emoji-in-file-names-on-windows-10/
+            // Emoji are supported on Windows 10/11, macOS, and Linux
+            expect(normalizePathForKey('/Users/dev/🚀project'))
+                .toBe('-Users-dev-project');
+            expect(normalizePathForKey('/Users/dev/my-app-📱'))
+                .toBe('-Users-dev-my-app');
+            expect(normalizePathForKey('/Users/dev/✨magic✨'))
+                .toBe('-Users-dev-magic');
+            // Multiple emoji
+            expect(normalizePathForKey('/Users/dev/🔥🔥🔥'))
+                .toBe('-Users-dev');
+        });
+
+        it('should handle Windows path variants', () => {
+            // Source: https://github.com/ehmicky/cross-platform-node-guide/blob/main/docs/3_filesystem/file_paths.md
+            // Lowercase drive letters
+            expect(normalizePathForKey('c:\\Users\\dev\\project'))
+                .toBe('c-Users-dev-project');
+            // Forward-slash Windows paths (accepted by Windows)
+            expect(normalizePathForKey('C:/Users/dev/project'))
+                .toBe('C-Users-dev-project');
+            // Mixed delimiters (Windows accepts both)
+            expect(normalizePathForKey('C:\\Users/dev\\project'))
+                .toBe('C-Users-dev-project');
+            // Extended-length paths (\\?\)
+            expect(normalizePathForKey('\\\\?\\C:\\very\\long\\path'))
+                .toBe('-C-very-long-path');
+            // Drive-relative paths (C:folder without backslash)
+            expect(normalizePathForKey('C:folder'))
+                .toBe('C-folder');
+        });
+
+        it('should handle relative paths and edge cases', () => {
+            // Relative path with ./
+            expect(normalizePathForKey('./project'))
+                .toBe('-project');
+            // Relative path with ../
+            expect(normalizePathForKey('../parent/project'))
+                .toBe('-parent-project');
+            // Root path only
+            expect(normalizePathForKey('/'))
+                .toBe('');
+            // Current directory only
+            expect(normalizePathForKey('.'))
+                .toBe('');
+            // Parent directory only
+            expect(normalizePathForKey('..'))
+                .toBe('');
+        });
+
+        it('should handle accented characters (diacritics)', () => {
+            // Common European accented characters
+            expect(normalizePathForKey('/Users/dev/naïve'))
+                .toBe('-Users-dev-na-ve');
+            expect(normalizePathForKey('/Users/dev/Ångström'))
+                .toBe('-Users-dev-ngstr-m');
+            expect(normalizePathForKey('/Users/dev/señor'))
+                .toBe('-Users-dev-se-or');
+            // German umlauts
+            expect(normalizePathForKey('/Users/dev/größe'))
+                .toBe('-Users-dev-gr-e');
+        });
+
+        it('should preserve case for Windows drive letters (case-sensitive behavior)', () => {
+            // Current implementation is case-sensitive - C: and c: produce DIFFERENT keys
+            // This matches the behavior of preserving original path casing
+            const upperCase = normalizePathForKey('C:\\Users\\dev\\project');
+            const lowerCase = normalizePathForKey('c:\\Users\\dev\\project');
+            // These are intentionally different - case is preserved
+            expect(upperCase).toBe('C-Users-dev-project');
+            expect(lowerCase).toBe('c-Users-dev-project');
+            // Note: If case-insensitive matching is needed in the future,
+            // the function would need to be updated to normalize case
+        });
+    });
+});

--- a/sources/utils/normalizePathForKey.ts
+++ b/sources/utils/normalizePathForKey.ts
@@ -1,0 +1,42 @@
+/**
+ * Normalizes a file path to match Claude Code's .claude/projects folder naming convention.
+ * This ensures consistent project key generation regardless of whether the path contains
+ * special characters like underscores or dots.
+ *
+ * Claude Code converts paths like:
+ * - /Users/dev/my_project -> -Users-dev-my-project
+ * - /Users/dev/my.project -> -Users-dev-my-project
+ * - /Users/dev/my-project -> -Users-dev-my-project
+ *
+ * @param path - The original file path (e.g., "/Users/dev/my_project")
+ * @returns The normalized path using Claude Code's naming convention (e.g., "-Users-dev-my-project")
+ *
+ * @example
+ * normalizePathForKey("/Users/dev/my_project") // "-Users-dev-my-project"
+ * normalizePathForKey("/Users/dev/my.project") // "-Users-dev-my-project"
+ * normalizePathForKey("~/Documents/test_dir") // "-Documents-test-dir"
+ */
+export function normalizePathForKey(path: string): string {
+    if (!path) {
+        return '';
+    }
+
+    // Remove home directory shortcut if present
+    let result = path.replace(/^~/, '');
+
+    // Replace all non-alphanumeric characters (except hyphen) with hyphens
+    // This matches Claude Code's behavior where:
+    // - Forward slashes (/) become hyphens
+    // - Underscores (_) become hyphens
+    // - Dots (.) become hyphens
+    // - Other special characters become hyphens
+    result = result.replace(/[^a-zA-Z0-9-]/g, '-');
+
+    // Collapse multiple consecutive hyphens into one
+    result = result.replace(/-+/g, '-');
+
+    // Remove trailing hyphens (but keep leading hyphen as Claude Code does)
+    result = result.replace(/-+$/g, '');
+
+    return result;
+}

--- a/sources/utils/sessionUtils.ts
+++ b/sources/utils/sessionUtils.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Session } from '@/sync/storageTypes';
 import { t } from '@/text';
+import { normalizePathForKey } from '@/utils/normalizePathForKey';
 
 export type SessionState = 'disconnected' | 'thinking' | 'waiting' | 'permission_required';
 
@@ -93,11 +94,13 @@ export function getSessionName(session: Session): string {
 /**
  * Generates a deterministic avatar ID from machine ID and path.
  * This ensures the same machine + path combination always gets the same avatar.
+ * Uses normalized path to ensure consistent matching regardless of
+ * whether the original path contains underscores, dots, or other special characters.
  */
 export function getSessionAvatarId(session: Session): string {
     if (session.metadata?.machineId && session.metadata?.path) {
-        // Combine machine ID and path for a unique, deterministic avatar
-        return `${session.metadata.machineId}:${session.metadata.path}`;
+        // Combine machine ID and normalized path for a unique, deterministic avatar
+        return `${session.metadata.machineId}:${normalizePathForKey(session.metadata.path)}`;
     }
     // Fallback to session ID if metadata is missing
     return session.id;


### PR DESCRIPTION
## Summary

Fixes #368 - Session sync failures when folder names contain underscores or other special characters.

Claude Code converts special characters (underscores `_`, dots `.`, slashes `/`) to hyphens when creating `.claude/projects/` folders. The mobile app was sending original paths that didn't match these normalized folder names, causing sync failures.

**Example:**
- Original path: `/Users/dev/trading_signals_bot`
- Claude Code folder: `-Users-dev-trading-signals-bot`
- Mobile was sending: `trading_signals_bot` ❌
- Now sends: `trading-signals-bot` ✅

## Changes

- Add `normalizePathForKey()` function that mirrors Claude Code's naming convention
- Apply normalization in `sessionUtils`, `gitStatusSync`, and `projectManager`
- Comprehensive tests (22 tests) covering edge cases:
  - Spaces in paths (Windows usernames like "John Doe")
  - Unicode/CJK characters (Chinese, Japanese, Korean)
  - Windows paths (backslashes, drive letters, UNC, extended-length)
  - Unicode normalization variants (NFC vs NFD)
  - Emoji folder names
  - Special whitespace characters

## Test plan

- [x] All 22 unit tests pass
- [x] TypeScript compiles without errors (unrelated i18n errors exist in repo)
- [ ] Manual test: verify sync works with `trading_signals_bot` folder

🤖 Generated with [Claude Code](https://claude.ai/code)