### PR TITLE
fix: normalize paths to match Claude Code naming convention

### DIFF
--- a/packages/happy-app/sources/sync/gitStatusSync.ts
+++ b/packages/happy-app/sources/sync/gitStatusSync.ts
@@ -12,6 +12,7 @@ import { parseStatusSummaryV2, getStatusCountsV2, isDirtyV2, getCurrentBranchV2,
 import { parseCurrentBranch } from './git-parsers/parseBranch';
 import { parseNumStat, mergeDiffSummaries } from './git-parsers/parseDiff';
 import { projectManager, createProjectKey } from './projectManager';
+import { normalizePathForKey } from '@/utils/normalizePathForKey';
 
 export class GitStatusSync {
     // Map project keys to sync instances
@@ -20,14 +21,15 @@ export class GitStatusSync {
     private sessionToProjectKey = new Map<string, string>();
 
     /**
-     * Get project key string for a session
+     * Get project key string for a session.
+     * Uses normalized path to match Claude Code's .claude/projects folder naming convention.
      */
     private getProjectKeyForSession(sessionId: string): string | null {
         const session = storage.getState().sessions[sessionId];
         if (!session?.metadata?.machineId || !session?.metadata?.path) {
             return null;
         }
-        return `${session.metadata.machineId}:${session.metadata.path}`;
+        return `${session.metadata.machineId}:${normalizePathForKey(session.metadata.path)}`;
     }
 
     /**

--- a/packages/happy-app/sources/sync/projectManager.ts
+++ b/packages/happy-app/sources/sync/projectManager.ts
@@ -4,6 +4,7 @@
  */
 
 import { Session, MachineMetadata, GitStatus } from "./storageTypes";
+import { normalizePathForKey } from "@/utils/normalizePathForKey";
 
 /**
  * Unique project identifier based on machine ID and path
@@ -45,10 +46,11 @@ class ProjectManager {
     private nextProjectId = 1;
 
     /**
-     * Generate a unique key string from machine ID and path
+     * Generate a unique key string from machine ID and path.
+     * Uses normalized path to match Claude Code's .claude/projects folder naming convention.
      */
     private getProjectKeyString(key: ProjectKey): string {
-        return `${key.machineId}:${key.path}`;
+        return `${key.machineId}:${normalizePathForKey(key.path)}`;
     }
 
     /**

--- a/packages/happy-app/sources/utils/normalizePathForKey.spec.ts
+++ b/packages/happy-app/sources/utils/normalizePathForKey.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePathForKey } from './normalizePathForKey';
+
+describe('normalizePathForKey', () => {
+    it('should replace forward slashes with hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/project')).toBe('-Users-dev-project');
+    });
+
+    it('should replace underscores with hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/my_project')).toBe('-Users-dev-my-project');
+        expect(normalizePathForKey('/Users/dev/trading_signals_bot')).toBe('-Users-dev-trading-signals-bot');
+    });
+
+    it('should replace dots with hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/my.project')).toBe('-Users-dev-my-project');
+    });
+
+    it('should preserve existing hyphens', () => {
+        expect(normalizePathForKey('/Users/dev/car-log-plus')).toBe('-Users-dev-car-log-plus');
+    });
+
+    it('should keep consecutive hyphens (matching Claude Code behavior)', () => {
+        // Claude Code does NOT collapse consecutive hyphens
+        expect(normalizePathForKey('/Users/dev/a..b')).toBe('-Users-dev-a--b');
+        expect(normalizePathForKey('/Users//dev///project')).toBe('-Users--dev---project');
+    });
+
+    it('should keep trailing hyphens (matching Claude Code behavior)', () => {
+        // Claude Code does NOT strip trailing hyphens
+        expect(normalizePathForKey('/Users/dev/project/')).toBe('-Users-dev-project-');
+    });
+
+    it('should replace spaces with hyphens', () => {
+        expect(normalizePathForKey('/Users/John Doe/Documents/project')).toBe('-Users-John-Doe-Documents-project');
+    });
+
+    it('should replace colons with hyphens', () => {
+        expect(normalizePathForKey('C:/Users/dev/project')).toBe('C--Users-dev-project');
+    });
+
+    it('should replace backslashes with hyphens (Windows paths)', () => {
+        expect(normalizePathForKey('C:\\Users\\dev\\project')).toBe('C--Users-dev-project');
+    });
+
+    it('should replace tilde with hyphen (not strip it)', () => {
+        // Claude Code treats ~ as any other non-alphanumeric char
+        // ~/Documents → ~/ both become hyphens → --Documents
+        expect(normalizePathForKey('~/Documents/project')).toBe('--Documents-project');
+    });
+
+    it('should replace Unicode characters with hyphens', () => {
+        expect(normalizePathForKey('/Users/小明/projects')).toBe('-Users----projects');
+    });
+
+    it('should return empty string for empty input', () => {
+        expect(normalizePathForKey('')).toBe('');
+    });
+
+    it('should match real-world Claude Code .claude/projects naming', () => {
+        expect(normalizePathForKey('/Users/iml1s/Documents/mine/trading_signals_bot'))
+            .toBe('-Users-iml1s-Documents-mine-trading-signals-bot');
+        expect(normalizePathForKey('/Users/iml1s/Documents/mine/happy'))
+            .toBe('-Users-iml1s-Documents-mine-happy');
+        expect(normalizePathForKey('/Users/iml1s/Documents/mine/car-log-plus'))
+            .toBe('-Users-iml1s-Documents-mine-car-log-plus');
+    });
+});

--- a/packages/happy-app/sources/utils/normalizePathForKey.ts
+++ b/packages/happy-app/sources/utils/normalizePathForKey.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalizes a file path to match Claude Code's .claude/projects folder naming convention.
+ *
+ * Claude Code's actual algorithm (from @anthropic-ai/claude-code source):
+ *   1. resolve(path) to get absolute path
+ *   2. replace(/[^a-zA-Z0-9]/g, '-') — every non-alphanumeric char becomes a hyphen
+ *   3. if result > 200 chars, truncate to 200 and append a hash suffix
+ *
+ * Since paths arriving via session.metadata.path are already absolute,
+ * we skip the resolve step. We also skip the 200-char truncation since
+ * real-world project paths rarely exceed that limit.
+ *
+ * @param path - The original absolute file path (e.g., "/Users/dev/my_project")
+ * @returns The normalized path using Claude Code's naming convention (e.g., "-Users-dev-my-project")
+ */
+export function normalizePathForKey(path: string): string {
+    if (!path) {
+        return '';
+    }
+
+    return path.replace(/[^a-zA-Z0-9]/g, '-');
+}


### PR DESCRIPTION
## Summary
- Fixes session sync failures when folder names contain special characters (underscores, dots)
- Adds `normalizePathForKey()` function to normalize paths consistently with Claude Code's `.claude/projects` folder naming convention

## Test plan
- Test with folders containing underscores like `test_temp_01`
- Verify session sync works when switching between local and remote modes

Fixes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)