### PR TITLE
fix(i18n): update Gemini permission mode translation keys

### DIFF
--- a/sources/text/translations/ca.ts
+++ b/sources/text/translations/ca.ts
@@ -432,12 +432,12 @@ export const ca: TranslationStructure = {
         geminiPermissionMode: {
             title: 'MODE DE PERMISOS',
             default: 'Per defecte',
-            acceptEdits: 'Accepta edicions',
-            plan: 'Mode de planificació',
-            bypassPermissions: 'Mode Yolo',
-            badgeAcceptAllEdits: 'Accepta totes les edicions',
-            badgeBypassAllPermissions: 'Omet tots els permisos',
-            badgePlanMode: 'Mode de planificació',
+            readOnly: 'Només lectura',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Només lectura',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `${percent}% restant`,

--- a/sources/text/translations/es.ts
+++ b/sources/text/translations/es.ts
@@ -432,12 +432,12 @@ export const es: TranslationStructure = {
         geminiPermissionMode: {
             title: 'MODO DE PERMISOS',
             default: 'Por defecto',
-            acceptEdits: 'Aceptar ediciones',
-            plan: 'Modo de planificación',
-            bypassPermissions: 'Modo Yolo',
-            badgeAcceptAllEdits: 'Aceptar todas las ediciones',
-            badgeBypassAllPermissions: 'Omitir todos los permisos',
-            badgePlanMode: 'Modo de planificación',
+            readOnly: 'Solo lectura',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Solo lectura',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `${percent}% restante`,

--- a/sources/text/translations/it.ts
+++ b/sources/text/translations/it.ts
@@ -461,12 +461,12 @@ export const it: TranslationStructure = {
         geminiPermissionMode: {
             title: 'MODALITÀ PERMESSI GEMINI',
             default: 'Predefinito',
-            acceptEdits: 'Accetta modifiche',
-            plan: 'Modalità piano',
-            bypassPermissions: 'Modalità YOLO',
-            badgeAcceptAllEdits: 'Accetta tutte le modifiche',
-            badgeBypassAllPermissions: 'Bypassa tutti i permessi',
-            badgePlanMode: 'Modalità piano',
+            readOnly: 'Sola lettura',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Sola lettura',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `${percent}% restante`,

--- a/sources/text/translations/ja.ts
+++ b/sources/text/translations/ja.ts
@@ -464,12 +464,12 @@ export const ja: TranslationStructure = {
         geminiPermissionMode: {
             title: 'GEMINI権限モード',
             default: 'デフォルト',
-            acceptEdits: '編集を許可',
-            plan: 'プランモード',
-            bypassPermissions: 'Yoloモード',
-            badgeAcceptAllEdits: 'すべての編集を許可',
-            badgeBypassAllPermissions: 'すべての権限をバイパス',
-            badgePlanMode: 'プランモード',
+            readOnly: '読み取り専用',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: '読み取り専用',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `残り ${percent}%`,

--- a/sources/text/translations/pl.ts
+++ b/sources/text/translations/pl.ts
@@ -442,12 +442,12 @@ export const pl: TranslationStructure = {
         geminiPermissionMode: {
             title: 'TRYB UPRAWNIEŃ',
             default: 'Domyślny',
-            acceptEdits: 'Akceptuj edycje',
-            plan: 'Tryb planowania',
-            bypassPermissions: 'Tryb YOLO',
-            badgeAcceptAllEdits: 'Akceptuj wszystkie edycje',
-            badgeBypassAllPermissions: 'Omiń wszystkie uprawnienia',
-            badgePlanMode: 'Tryb planowania',
+            readOnly: 'Tylko do odczytu',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Tylko do odczytu',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `Pozostało ${percent}%`,

--- a/sources/text/translations/pt.ts
+++ b/sources/text/translations/pt.ts
@@ -432,12 +432,12 @@ export const pt: TranslationStructure = {
         geminiPermissionMode: {
             title: 'MODO DE PERMISSÃO',
             default: 'Padrão',
-            acceptEdits: 'Aceitar edições',
-            plan: 'Modo de planejamento',
-            bypassPermissions: 'Modo Yolo',
-            badgeAcceptAllEdits: 'Aceitar todas as edições',
-            badgeBypassAllPermissions: 'Ignorar todas as permissões',
-            badgePlanMode: 'Modo de planejamento',
+            readOnly: 'Somente leitura',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: 'Somente leitura',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `${percent}% restante`,

--- a/sources/text/translations/zh-Hans.ts
+++ b/sources/text/translations/zh-Hans.ts
@@ -434,12 +434,12 @@ export const zhHans: TranslationStructure = {
         geminiPermissionMode: {
             title: '权限模式',
             default: '默认',
-            acceptEdits: '接受编辑',
-            plan: '计划模式',
-            bypassPermissions: 'Yolo 模式',
-            badgeAcceptAllEdits: '接受所有编辑',
-            badgeBypassAllPermissions: '绕过所有权限',
-            badgePlanMode: '计划模式',
+            readOnly: '只读',
+            safeYolo: 'Safe YOLO',
+            yolo: 'YOLO',
+            badgeReadOnly: '只读',
+            badgeSafeYolo: 'Safe YOLO',
+            badgeYolo: 'YOLO',
         },
         context: {
             remaining: ({ percent }: { percent: number }) => `剩余 ${percent}%`,


### PR DESCRIPTION
## Summary
- Updated Gemini permission mode translation keys across 7 language files to match the updated TypeScript type definition
- Fixed TypeScript type checking errors in CI pipeline

## Changes
Renamed the following translation keys in all language files (ca, es, it, ja, pl, pt, zh-Hans):
- `acceptEdits` → `readOnly`
- `plan` → `safeYolo`
- `bypassPermissions` → `yolo`
- `badgeAcceptAllEdits` → `badgeReadOnly`
- `badgeBypassAllPermissions` → `badgeSafeYolo`
- `badgePlanMode` → `badgeYolo`

## Test plan
- [x] Run `yarn typecheck` to verify no TypeScript errors
- [x] Verify all translation files compile successfully
- [x] Check that translations remain contextually appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)