### PR TITLE
docs: Restructure CLAUDE.md with shared rules directory

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,87 @@
+# Code Style Guidelines
+
+## Universal Rules (All Components)
+
+### Indentation & Formatting
+- **Indentation**: 4 spaces (not 2 spaces)
+- **No trailing whitespace**
+- **Unix line endings (LF)**
+
+### TypeScript
+- **Strict mode enabled** - All components enforce strict typing
+- **Use `@/` alias** for src imports (configured separately per component)
+- **Named exports preferred** - Default exports only for main functions
+- **Explicit return types** - All functions should have explicit return type annotations
+
+### Code Patterns
+- **Prefer functional programming** - Avoid classes
+- **Keep it simple** - Avoid over-engineering
+- **Files**: Unless absolutely necessary, do not create new files
+- **ALWAYS prefer editing existing files** over creating new ones
+
+### Package Management
+- **Use yarn, not npm** - All components use yarn workspaces
+- **Yarn version**: 1.22.22
+
+### Comments
+- **Add documentation comments** that explain logic after writing actions
+- **No unnecessary comments** - Code should be self-explanatory
+- **Usernames**: Always use GitHub usernames when referencing users
+
+### Error Handling
+- **Graceful error handling** with proper error messages
+- **Never show loading errors** to users - always retry silently
+- **Centralized error handlers** - Use existing error handling infrastructure
+
+## Project-Specific Conventions
+
+### CLI (happy-cli)
+- **Clean function signatures** - Explicit parameter and return types
+- **Comprehensive JSDoc comments** - Each file includes header comments explaining responsibilities
+- **File-based logging** - Prevents interference with agent terminal UIs
+
+### Expo App (expo-app)
+- **Use Unistyles** - Cross-platform styling with themes and breakpoints
+- **i18n required** - Use `t()` function for all user-visible strings
+- **Put styles at end** - Always put styles at very end of component files
+- **Wrap pages in memo** - All pages should be wrapped in React.memo
+
+### Server (happy-server)
+- **Action files**: Create dedicated files in relevant `sources/app/` subfolders (e.g., `sessionAdd.ts`, `friendRemove.ts`)
+- **Return only essential data** - Don't return values "just in case"
+- **Do not add logging** when not asked
+- **Directory naming**: Lowercase with dashes (e.g., `components/auth-wizard`)
+
+## File Organization
+
+### Naming Conventions
+- **Utility files**: Name file and function the same way for easy discovery
+- **Test files**: Same name as source with `.test.ts` or `.spec.ts` suffix
+- **Action files**: Prefix with entity type then action (e.g., `sessionAdd.ts`)
+
+### Documentation
+- **NEVER proactively create documentation files (*.md)** unless explicitly requested
+- **When using prompts**: Write prompts to `_prompts.ts` file relative to the application
+
+## Cryptography
+
+### Encoding/Decoding
+- **CLI**: Use encryption utilities in `src/api/encryption.ts`
+- **Server**: Always use `privacyKit.decodeBase64` and `privacyKit.encodeBase64` from privacy-kit instead of Buffer directly
+- **Mobile**: Use `@more-tech/react-native-libsodium`
+
+## Testing
+
+### Universal Testing Principles
+- **TDD for utility functions** - Write tests BEFORE implementation
+- **Integration tests for features** - Test real workflows
+- **No mocking** - Tests make real API calls
+- **Test location**: Same directory as source, with `.test.ts` or `.spec.ts` suffix
+
+See @.claude/rules/testing.md for detailed testing guidelines.
+
+## Language-Specific Rules
+
+See @.claude/rules/typescript.md for TypeScript-specific rules.
+See @.claude/rules/react-native.md for React Native-specific rules.
+See @.claude/rules/server.md for Server-specific rules.

--- a/.claude/rules/react-native.md
+++ b/.claude/rules/react-native.md
@@ -1,0 +1,216 @@
+---
+paths:
+- "expo-app/**/*.{ts,tsx}"
+---
+
+# React Native Guidelines
+
+## Core Technology Stack
+
+- **React Native** with **Expo** SDK 54
+- **TypeScript** with strict mode enabled
+- **Unistyles** for cross-platform styling with themes and breakpoints
+- **Expo Router v6** for file-based routing
+- **Socket.io** for real-time WebSocket communication
+- **libsodium** (via `@more-tech/react-native-libsodium`) for end-to-end encryption
+- **LiveKit** for real-time voice communication
+
+## Component Development
+
+### Styling with Unistyles
+
+#### Creating Styles
+Always use `StyleSheet.create` from 'react-native-unistyles':
+
+```typescript
+import { StyleSheet } from 'react-native-unistyles'
+
+const styles = StyleSheet.create((theme, runtime) => ({
+    container: {
+        flex: 1,
+        backgroundColor: theme.colors.background,
+        paddingTop: runtime.insets.top,
+        paddingHorizontal: theme.margins.md,
+    },
+    text: {
+        color: theme.colors.typography,
+        fontSize: 16,
+    }
+}))
+```
+
+#### Using Styles in Components
+For React Native components, provide styles directly:
+
+```typescript
+import React from 'react'
+import { View, Text } from 'react-native'
+
+const MyComponent = () => {
+    return (
+        <View style={styles.container}>
+            <Text style={styles.text}>Hello World</Text>
+        </View>
+    )
+}
+```
+
+For other components, use `useStyles` hook:
+
+```typescript
+import { useStyles } from 'react-native-unistyles'
+
+const MyComponent = () => {
+    const { styles, theme } = useStyles(styles)
+
+    return (
+        <CustomComponent style={styles.container} />
+    )
+}
+```
+
+#### Special Component: Expo Image
+- **Size properties** (`width`, `height`) must be set outside of Unistyles stylesheet as inline styles
+- **`tintColor` property** must be set directly on the component, not in style prop
+- All other styling goes through Unistyles
+
+```typescript
+import { Image } from 'expo-image'
+
+const MyComponent = () => {
+    const { theme } = useStyles()
+
+    return (
+        <Image
+            style={[{ width: 100, height: 100 }, styles.image]}  // Size as inline styles
+            tintColor={theme.colors.primary}                      // tintColor goes on component
+            source={{ uri: 'https://example.com/image.jpg' }}
+        />
+    )
+}
+```
+
+### Internationalization (i18n)
+
+**CRITICAL: Always use the `t(...)` function for ALL user-visible strings**
+
+```typescript
+import { t } from '@/text';
+
+// ✅ Simple constants
+t('common.cancel')              // "Cancel"
+t('settings.title')             // "Settings"
+
+// ✅ Functions with parameters
+t('common.welcome', { name: 'Steve' })           // "Welcome, Steve!"
+t('time.minutesAgo', { count: 5 })               // "5 minutes ago"
+```
+
+#### Important i18n Rules
+- **Never hardcode strings** in JSX - always use `t('key')`
+- **Dev pages exception** - Development/debug pages can skip i18n
+- **Check common first** - Before adding new keys, check if a suitable translation exists in `common`
+- **Context matters** - Consider where the string appears to choose the right section
+- **Update all languages** - New strings must be added to every language file
+- **Use centralized language names** - Import language names from `_all.ts` instead of translation keys
+- **Beware of technical terms** - Keep universally understood terms like "CLI", "API", "URL", "JSON" in their original form
+
+### Navigation
+
+#### Expo Router API
+- **Always use expo-router API**, not react-navigation one
+- **Store app pages** in `@sources/app/(app)/`
+- **Never use custom headers** in navigation, almost never use Stack.Page options in individual pages
+- **Always show header** on all screens
+- **When setting screen parameters ALWAYS set them in _layout.tsx** if possible this avoids layout shifts
+
+#### Custom Header Component
+The app includes a custom header component (`sources/components/Header.tsx`):
+
+```typescript
+import { NavigationHeader } from '@/components/Header';
+
+// As default for all screens in Stack navigator:
+<Stack
+    screenOptions={{
+        header: NavigationHeader,
+    }}
+>
+```
+
+### UI Components
+
+#### Avatar Component
+- **Always use "Avatar" component** for avatars
+
+#### Modal/Alert
+- **Never use Alert module** from React Native
+- **Always use @sources/modal/index.ts instead**
+
+#### Layout
+- **Always apply layout width constraints** from `@/components/layout` to full-screen ScrollViews and content containers for responsive design
+
+#### ItemList
+- **Use ItemList for most containers** for UI, if it is not custom like chat one
+
+### File Organization
+
+#### Page Files
+- **Store pages in** `@sources/app/(app)/`
+- **Always put styles** in the very end of the component or page file
+- **Always wrap pages in memo**
+
+#### Hooks
+- **When non-trivial hook is needed** - create a dedicated one in hooks folder
+- **Add a comment** explaining its logic
+- **Always try to use "useHappyAction"** from @sources/hooks/useHappyAction.ts if you need to run some async operation (error handling is automatic)
+
+#### Other Guidelines
+- **Store all temporary scripts and any test outside of unit tests** in sources/trash folder
+- **For hotkeys use "useGlobalKeyboard"** - do not change it, it works only on Web
+- **Use "AsyncLock" class** for exclusive async locks
+
+### Best Practices
+
+1. **Always use `StyleSheet.create`** from 'react-native-unistyles'
+2. **Provide styles directly** to components from 'react-native' and 'react-native-reanimated' packages
+3. **Use `useStyles` hook only** for other components (but try to avoid it when possible)
+4. **Always use function mode** when you need theme or runtime access
+5. **Use variants** for component state-based styling instead of conditional styles
+6. **Leverage breakpoints** for responsive design rather than manual dimension calculations
+7. **Keep styles close to components** but extract common patterns to shared stylesheets
+8. **Use TypeScript** for better developer experience and type safety
+
+## Development Commands
+
+### Development
+- `yarn start` - Start the Expo development server
+- `yarn ios` - Run the app on iOS simulator
+- `yarn android` - Run the app on Android emulator
+- `yarn web` - Run the app in web browser
+- `yarn prebuild` - Generate native iOS and Android directories
+- `yarn typecheck` - Run TypeScript type checking after all changes
+
+### macOS Desktop (Tauri)
+- `yarn tauri:dev` - Run macOS desktop app with hot reload
+- `yarn tauri:build:dev` - Build development variant
+- `yarn tauri:build:preview` - Build preview variant
+- `yarn tauri:build:production` - Build production variant
+
+## Project Scope and Priorities
+
+- This project targets Android, iOS, and web platforms
+- Web is considered a secondary platform
+- Avoid web-specific implementations unless explicitly requested
+- Core principles: never show loading error, always just retry
+- Always sync main data in "sync" class
+- Always use invalidate sync for it
+- No backward compatibility unless explicitly stated
+
+## See Also
+
+- Detailed Expo app documentation: @expo-app/CLAUDE.md
+- Unistyles styling guide: @expo-app/CLAUDE.md#unistyles-styling-guide
+- i18n guidelines: @expo-app/CLAUDE.md#internationalization-i18n-guidelines
+- Code style guidelines: @.claude/rules/code-style.md
+- TypeScript rules: @.claude/rules/typescript.md

--- a/.claude/rules/server.md
+++ b/.claude/rules/server.md
@@ -1,0 +1,202 @@
+---
+paths:
+- "server/**/*.ts"
+---
+
+# Server Development Rules
+
+## Core Technology Stack
+
+- **Web Framework**: Fastify 5 with fastify-type-provider-zod for type safety
+- **Database**: PostgreSQL with Prisma ORM
+- **Validation**: Zod for runtime and compile-time type checking
+- **Real-time**: Socket.io with Redis adapter for horizontal scaling
+- **Cache/Pub-Sub**: Redis (ioredis)
+- **Object Storage**: Minio (S3-compatible)
+- **Cryptography**: privacy-kit, tweetnacl
+- **Testing**: Vitest
+- **Metrics**: Prometheus (prom-client)
+- **Package Manager**: Yarn (not npm)
+
+## Database Operations
+
+### Transaction Management
+- **CRITICAL**: Always use `inTx()` for database operations
+- **Serializable isolation level** - Prevents race conditions
+- **Automatic retry** - Up to 3 retries with exponential backoff for serialization failures
+- **After-commit callbacks** - `afterTx()` for events that fire only after successful commit
+
+### Transaction Rules
+- **NEVER run non-transactional operations** (like file uploads) inside transactions
+- **Use version fields** for optimistic locking (e.g., `metadataVersion`, `agentStateVersion`)
+- **Use `Json` type** for complex data
+
+### Prisma ORM
+- **Used for all database operations**
+- **CRITICAL**: NEVER create migrations yourself - only run `yarn generate` when new types are needed
+
+### Transaction Wrapper Pattern
+```typescript
+import { inTx } from '@/storage/inTx';
+
+await inTx(async (db) => {
+    // All database operations here
+    const session = await db.session.create({ ... });
+
+    // Use afterTx() for events that fire after commit
+    afterTx(() => {
+        eventRouter.emitUpdate('new-session', { ... });
+    });
+});
+```
+
+## API Development
+
+### Route Structure
+- **Routes** located in `sources/app/api/routes/`
+- **Type Safety**: Use Zod schemas for all route validation
+- **Authentication**: Use `authenticate` preHandler for protected routes
+- **Idempotency**: Design all operations to be idempotent; clients may retry requests automatically
+- **Error Handling**: Centralized error handlers in `sources/app/api/utils/`
+
+### Route Development Pattern
+```typescript
+import { z } from 'zod';
+import { authenticate } from '@/app/api/utils/auth';
+
+const schema = {
+    body: z.object({
+        // Request body validation
+    }),
+    response: {
+        // Response validation
+    }
+};
+
+app.post('/v1/endpoint', {
+    preHandler: [authenticate],
+    schema
+}, async (request, response) => {
+    // Route handler
+});
+```
+
+### Idempotency
+- **All operations must be idempotent**
+- Clients may retry requests automatically on failure
+- Use tag-based deduplication for session creation
+- Use repeat keys for operations that need idempotency
+
+## Event Handling
+
+### Event Router
+- **Use `afterTx()`** - Send events after transaction commit, not directly
+- **Event Router** - Use `eventRouter.emitUpdate()` for persistent updates, `eventRouter.emitEphemeral()` for transient events
+- **Recipient Filters** - Choose appropriate filter for your use case
+
+### Event Types
+
+**Persistent Updates** (`emitUpdate`): Stored in database changes
+- Event types: `new-session`, `update-session`, `delete-session`, `new-message`, `new-machine`, `update-machine`, `new-artifact`, `update-artifact`, `delete-artifact`, `update-account`, `relationship-updated`, `new-feed-post`, `kv-batch-update`
+
+**Ephemeral Events** (`emitEphemeral`): Transient status updates
+- Event types: `activity`, `machine-activity`, `usage`, `machine-status`
+
+### Recipient Filters
+- `all-user-authenticated-connections` - Default (all connection types)
+- `user-scoped-only` - Mobile/web only
+- `session-scoped` - Specific session + user-scoped
+- `machine-scoped-only` - Specific machine + user-scoped
+
+## Cryptography
+
+### Encoding/Decoding
+- **Always use `privacyKit.decodeBase64` and `privacyKit.encodeBase64`** from privacy-kit instead of Buffer directly
+
+### Security Model
+- **End-to-End Encryption**: Server stores encrypted data only
+- **Authentication**: Public key cryptography (NaCl), no passwords
+- **Challenge-response**: Signature verification
+- **Zero-knowledge**: Server cannot read user messages, metadata, or state
+
+## File Operations
+
+### Action Files
+- **Create dedicated files** in relevant `sources/app/` subfolders for operations
+- **Naming**: Prefix with entity type then action (e.g., `sessionAdd.ts`, `friendRemove.ts`)
+- **NEVER create files unless absolutely necessary**
+- **ALWAYS prefer editing existing files over creating new ones**
+
+### Return Values
+- **Only return essential data** from action functions, not "just in case" values
+- **Logging**: Do not add logging when not asked
+- **Comments**: Add documentation comments that explain logic after writing actions
+
+### Directory Naming
+- **Lowercase with dashes** (e.g., `components/auth-wizard`)
+- **Utility files**: Name file and function the same way for easy discovery
+- **Test files**: Same name as source with `.spec.ts` suffix
+
+## Development Commands
+
+### Essential Commands
+- `yarn build` - TypeScript type checking (no emit)
+- `yarn start` - Start production server
+- `yarn dev` - Start development server with hot reload (kills process on port 3005)
+- `yarn test` - Run Vitest test suite
+- `yarn generate` - Generate Prisma client (run after schema changes)
+- `yarn migrate` - Run Prisma migrations (dev only)
+- `yarn migrate:reset` - Reset database and re-run migrations
+
+### Infrastructure Commands
+- `yarn db` - Start local PostgreSQL in Docker
+- `yarn redis` - Start local Redis in Docker
+- `yarn s3` - Start local Minio in Docker
+- `yarn s3:down` - Stop Minio container
+- `yarn s3:init` - Initialize Minio buckets
+
+### Environment Files
+- `.env` - Base environment configuration
+- `.env.dev` - Development overrides
+- Server uses `.env` and `.env.dev` when running `yarn dev`
+
+## Architecture Overview
+
+### Application Startup Flow (`sources/main.ts`)
+1. **Storage Initialization** - Connect to PostgreSQL and Redis
+2. **Module Initialization** - Initialize encryption (privacy-kit), GitHub integration, load S3 files, initialize auth
+3. **Server Startup** - Start Fastify API server (port 3005), Prometheus metrics server, timeout monitor, Socket.io server
+4. **Graceful Shutdown** - All components register cleanup handlers via `onShutdown()`
+
+### API Server (`sources/app/api/api.ts`)
+- **Fastify 5** with type-safe routing
+- **Body Limit**: 100MB for file uploads
+- **Middleware**: Authentication (Bearer token), error handling, Prometheus metrics
+- **15 Route Modules**
+- **Port**: 3005 (configurable via `PORT` env var)
+
+### Real-time Communication (`sources/app/api/socket.ts`)
+**Three Connection Types:**
+1. **User-scoped** - Receives all updates for a user (mobile/web apps)
+2. **Session-scoped** - Receives updates for a specific session (dedicated views)
+3. **Machine-scoped** - Receives updates for a specific machine/daemon
+
+## Important Reminders
+
+1. **Do what has been asked; nothing more, nothing less**
+2. **NEVER create files unless absolutely necessary**
+3. **ALWAYS prefer editing existing files over creating new ones**
+4. **NEVER proactively create documentation files (*.md) unless explicitly requested**
+5. **Use 4 spaces for indentation** (not 2 spaces)
+6. **Use yarn instead of npm** for all package management
+7. **NEVER create migrations yourself** - only run `yarn generate` when new types are needed
+8. **Always use `inTx()` for database operations**
+9. **Never run non-transactional operations** (like file uploads) inside transactions
+10. **Always use `privacyKit.decodeBase64` and `privacyKit.encodeBase64`** from privacy-kit instead of Buffer
+
+## See Also
+
+- Detailed server documentation: @server/CLAUDE.md
+- Code style guidelines: @.claude/rules/code-style.md
+- Testing guidelines: @.claude/rules/testing.md
+- TypeScript rules: @.claude/rules/typescript.md

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,95 @@
+# Testing Guidelines
+
+## Universal Testing Principles
+
+### TDD for Utility Functions
+- **Write tests BEFORE implementation** for utility functions
+- **Test, implement, iterate** until passing
+- **Utility tests** should cover edge cases and error conditions
+
+### Integration Tests for Features
+- **Test real workflows** - No mocking of infrastructure
+- **Make real API calls** - Tests interact with actual services
+- **Test location**: Same directory as source, with `.test.ts` or `.spec.ts` suffix
+
+### Test File Naming
+- **CLI**: `.test.ts` suffix (e.g., `lru.test.ts`)
+- **Server**: `.spec.ts` suffix (e.g., `lru.spec.ts`)
+- **Expo**: `.test.ts` suffix (currently no tests)
+
+## Component-Specific Testing
+
+### CLI Testing
+- **Framework**: Vitest
+- **No mocking** - Tests make real API calls
+- **Descriptive test names** and proper async handling
+- **Run tests**: `yarn test` (builds first), `vitest run src/path/to/test.test.ts` for specific files
+
+### Server Testing
+- **Framework**: Vitest
+- **TDD for utilities** - Write test before implementation
+- **Run tests**: `yarn test` (runs all tests), `vitest run sources/path/to/test.spec.ts` for specific files
+- **Database**: Use test database, not production
+
+### Expo App Testing
+- **Framework**: Vitest
+- **Currently no tests** in the codebase
+- **Run tests**: `yarn test` (runs in watch mode)
+
+## Test Structure
+
+### Arrange-Act-Assert Pattern
+```typescript
+describe('functionName', () => {
+    it('should do something when condition is met', async () => {
+        // Arrange: Set up test data
+        const input = { ... };
+
+        // Act: Call function
+        const result = await functionName(input);
+
+        // Assert: Verify result
+        expect(result).toEqual(expected);
+    });
+});
+```
+
+### Async Testing
+- **Always use async/await** for async operations
+- **Proper error handling** in tests
+- **Cleanup** after tests if needed
+
+## What NOT to Do
+
+- **DO NOT mock** - Tests make real API calls
+- **DO NOT skip tests** - All code should be tested
+- **DO NOT write tests after implementation** for utilities (TDD approach)
+- **DO NOT use test doubles** unless absolutely necessary
+
+## Running Tests
+
+### CLI
+```bash
+cd cli
+yarn test                  # Run all tests (builds first)
+yarn build && vitest run   # Run without rebuilding
+```
+
+### Server
+```bash
+cd server
+yarn test                  # Run all tests
+```
+
+### Expo
+```bash
+cd expo-app
+yarn test                  # Run in watch mode
+```
+
+## See Also
+
+Component-specific testing guidelines:
+- CLI: @cli/CLAUDE.md
+- Server: @server/CLAUDE.md
+- Expo: @expo-app/CLAUDE.md

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,110 @@
+---
+paths:
+- "**/*.ts"
+- "**/*.tsx"
+---
+
+# TypeScript Rules
+
+## Type Safety
+
+### Strict Mode
+- **Strict mode enabled** - All components run with `strict: true` in tsconfig.json
+- **All files must pass** `yarn typecheck` or `tsc --noEmit`
+- **No untyped code** - "I despise untyped code"
+
+### Type Annotations
+- **Explicit return types** - All functions must have explicit return type annotations
+- **Explicit parameter types** - All function parameters must be typed
+- **No `any` types** - Use `unknown` instead of `any`
+- **Prefer interfaces** - Use interfaces over types for object shapes
+- **Use type guards** - For runtime type checking
+
+### Type Imports
+- **Use `import type`** for type-only imports
+- **Use `@/` alias** for src imports (configured per component)
+
+## Component-Specific TypeScript
+
+### CLI
+- **Clean function signatures** - Explicit parameter and return types
+- **Comprehensive JSDoc comments** - Each file includes header comments explaining responsibilities
+- **Type checking**: `yarn typecheck` runs TypeScript compiler check
+
+### Expo App
+- **Strict mode enforced** - All code must be properly typed
+- **Path alias** - `@/*` maps to `./sources/*`
+- **Type checking**: `yarn typecheck` after all changes
+
+### Server
+- **Type-safe routing** - fastify-type-provider-zod for compile-time and runtime validation
+- **Zod schemas** - For all route validation
+- **Type checking**: `yarn build` runs TypeScript type checking (no emit)
+
+## Best Practices
+
+### Avoiding `any`
+```typescript
+// ❌ Bad
+function foo(data: any) {
+    return data.bar;
+}
+
+// ✅ Good
+function foo(data: unknown) {
+    if (typeof data === 'object' && data !== null && 'bar' in data) {
+        return (data as { bar: string }).bar;
+    }
+    throw new Error('Invalid data');
+}
+```
+
+### Type Guards
+```typescript
+function isString(value: unknown): value is string {
+    return typeof value === 'string';
+}
+
+function process(value: unknown) {
+    if (isString(value)) {
+        // TypeScript knows value is string here
+        console.log(value.toUpperCase());
+    }
+}
+```
+
+### Type Imports
+```typescript
+// ✅ Good - Type-only import
+import type { Foo } from './foo';
+import { Bar } from './bar';
+
+// ❌ Bad - Mixed import
+import { Foo, Bar } from './bar';
+```
+
+## Running Type Checks
+
+### CLI
+```bash
+cd cli
+yarn typecheck          # Run TypeScript compiler check
+```
+
+### Expo App
+```bash
+cd expo-app
+yarn typecheck          # Run TypeScript type checking after all changes
+```
+
+### Server
+```bash
+cd server
+yarn build              # TypeScript type checking (no emit)
+```
+
+## See Also
+
+- Code style guidelines: @.claude/rules/code-style.md
+- Testing guidelines: @.claude/rules/testing.md
+- Component-specific TypeScript: @cli/CLAUDE.md, @expo-app/CLAUDE.md, @server/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with the Happy Coder mono-repo.
+
+## Project Overview
+
+Happy Coder is an AI programming assistant multi-device system mono-repo with three components:
+- **happy-cli** - Command-line tool wrapping Claude Code/Gemini/Codex agents
+- **expo-app** - React Native mobile/web client
+- **happy-server** - End-to-end encrypted backend service
+
+## Component Relationships
+
+```
+┌─────────────┐         ┌──────────────┐         ┌────────────┐
+│  Mobile App │ ←─────→ │   Server     │ ←─────→ │     CLI    │
+│  (expo-app) │         │(happy-server)│         │ (happy-cli)│
+└─────────────┘         └──────────────┘         └──────┬─────┘
+                                                              │
+                                                       ┌──────┴─────┐
+                                                       │  Daemon    │
+                                                       │ (bg process)│
+                                                       └────────────┘
+```
+
+**Key flows:**
+- **Authentication**: CLI generates key → Server verifies → Mobile scans QR → Approves → CLI authenticated
+- **Session Creation**: CLI starts session → Server stores encrypted data → Mobile views → Remote control
+- **Daemon Lifecycle**: CLI starts daemon → Daemon registers machine → Server tracks state → Mobile controls
+
+## Code Style & Development Guidelines
+
+Shared code style principles @.claude/rules/code-style.md
+Testing conventions @.claude/rules/testing.md
+TypeScript rules @.claude/rules/typescript.md
+
+## Component-Specific Guidelines
+
+React Native guidelines @.claude/rules/react-native.md
+Server development rules @.claude/rules/server.md
+
+## Quick Reference
+
+Component-specific documentation:
+- **CLI**: @cli/CLAUDE.md - CLI commands, Agent abstraction, Daemon management
+- **Daemon**: @cli/src/daemon/CLAUDE.md - Daemon lifecycle and RPC processors
+- **Expo**: @expo-app/CLAUDE.md - React Native development, i18n, Unistyles
+- **Server**: @server/CLAUDE.md - Fastify server, Prisma, Socket.io architecture
+
+## Development Workflow
+
+### Initial Setup
+```bash
+yarn install                           # Install dependencies (root)
+cd cli && npm run setup:dev           # Setup CLI (creates ~/.happy and ~/.happy-dev)
+cd server && yarn db && yarn redis    # Start local infrastructure
+```
+
+### Development Commands
+```bash
+# CLI (dev mode: ~/.happy-dev)
+cd cli && yarn dev
+
+# Expo app
+cd expo-app && yarn start    # Start dev server
+cd expo-app && yarn ios      # Run on iOS simulator
+
+# Server (dev mode)
+cd server && yarn dev        # Hot reload, kills port 3005
+```
+
+### Testing
+```bash
+cd cli && yarn test          # CLI tests
+cd server && yarn test       # Server tests
+```
+
+## Architecture Overview
+
+### CLI (happy-cli)
+Wraps AI coding agents with universal abstraction layer. Tech: TypeScript, Node.js, Ink.
+
+### Mobile/Web (expo-app)
+Cross-platform client for remote control and viewing. Tech: React Native, Expo SDK 54, Socket.io, LiveKit.
+
+### Server (happy-server)
+Zero-knowledge backend for encrypted data sync. Tech: Fastify 5, Prisma, Socket.io, Redis.
+
+## Environment Variables
+
+Common: `HAPPY_SERVER_URL`, `HAPPY_WEBAPP_URL`, `HAPPY_HOME_DIR`, `HAPPY_VARIANT`
+CLI: `HAPPY_DISABLE_CAFFEINATE`, `HAPPY_EXPERIMENTAL`, `GEMINI_MODEL`
+Server: `PORT`, `DATABASE_URL`, `REDIS_URL`, `S3_ENDPOINT`
+
+## Important Notes
+
+1. **Always use yarn** (not npm) - All components use yarn workspaces
+2. **4 spaces for indentation** - Consistent across all components
+3. **TypeScript strict mode** - All components enforce strict typing
+4. **End-to-end encryption** - Server cannot read user data
+5. **No mocking in tests** - Integration tests make real API calls
+6. **Daemon is critical** - Remote control requires daemon to be running
+7. **Zero-knowledge** - Server stores encrypted data only

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,228 +1,246 @@
-# Happy CLI Codebase Overview
+# CLAUDE.md
 
-## Project Overview
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Happy CLI (`handy-cli`) is a command-line tool that wraps Claude Code to enable remote control and session sharing. It's part of a three-component system:
+**For shared development principles and mono-repo overview, see [CLAUDE.md](../CLAUDE.md)**
 
-1. **handy-cli** (this project) - CLI wrapper for Claude Code
-2. **handy** - React Native mobile client
-3. **handy-server** - Node.js server with Prisma (hosted at https://api.happy-servers.com/)
+## Component Overview
 
-## Code Style Preferences
+Happy CLI (`happy-cli`) - Command-line tool wrapping AI coding agents (Claude Code, Gemini CLI, Codex) with remote control and session sharing capabilities.
+
+## Common Development Commands
+
+### Building & Testing
+
+```bash
+# Type checking
+yarn typecheck          # Run TypeScript compiler check
+
+# Build
+yarn build              # Full build: typecheck + pkgroll
+yarn test               # Build and run all tests
+
+# Development
+yarn dev                # Run without building (uses tsx)
+yarn dev:local-server   # Run with local server (HAPPY_SERVER_URL=http://localhost:3005)
+yarn dev:integration-test-env  # Run with integration test environment
+
+# Create global happy-dev command for local testing
+yarn link:dev           # Create symlink: ~/.npm-global/bin/happy-dev -> dist/
+yarn unlink:dev         # Remove symlink
+```
+
+### Running Tests
+
+```bash
+yarn test               # Run all tests (builds first)
+yarn build && vitest run  # Run tests without rebuilding
+vitest run src/path/to/test.test.ts  # Run specific test file
+vitest run -t "test name"  # Run tests matching pattern
+```
+
+### Stable vs Development Mode
+
+The CLI supports running stable and development versions side-by-side with isolated data:
+
+```bash
+# Initial setup (creates ~/.happy and ~/.happy-dev directories)
+npm run setup:dev
+
+# Stable mode (production, data: ~/.happy)
+npm run stable:daemon:start
+npm run stable auth login
+npm run stable notify "test"
+
+# Dev mode (testing, data: ~/.happy-dev)
+npm run dev:daemon:start
+npm run dev:variant auth login
+npm run dev:variant notify "test"
+```
+
+### Daemon Management
+
+```bash
+# Start daemon (background service for remote control)
+./bin/happy.mjs daemon start
+yarn dev:daemon:start   # Dev mode
+yarn stable:daemon:start  # Stable mode
+
+# Check status
+./bin/happy.mjs daemon status
+
+# Stop daemon
+./bin/happy.mjs daemon stop
+
+# View logs (stored in ~/.happy-dev/logs/ or ~/.happy/logs/)
+tail -f ~/.happy-dev/logs/*.log
+```
+
+### Doctor & Troubleshooting
+
+```bash
+# System diagnostics
+./bin/happy.mjs doctor
+
+# Clean up runaway processes
+./bin/happy.mjs doctor clean
+```
+
+## CLI-Specific Code Style
 
 ### TypeScript Conventions
-- **Strict typing**: No untyped code ("I despise untyped code")
-- **Clean function signatures**: Explicit parameter and return types
-- **As little as possible classes**
-- **Comprehensive JSDoc comments**: Each file includes header comments explaining responsibilities.
-- **Import style**: Uses `@/` alias for src imports, e.g., `import { logger } from '@/ui/logger'`
-- **File extensions**: Uses `.ts` for TypeScript files
+- **Comprehensive JSDoc comments**: Each file includes header comments explaining responsibilities
 - **Export style**: Named exports preferred, with occasional default exports for main functions
 
-### DO NOT
-
-- Create stupid small functions / getters / setters
-- Excessive use of `if` statements - especially if you can avoid control flow changes with a better design
-- **NEVER import modules mid-code** - ALL imports must be at the top of the file
-
 ### Error Handling
-- Graceful error handling with proper error messages
 - Use of `try-catch` blocks with specific error logging
 - Abort controllers for cancellable operations
 - Careful handling of process lifecycle and cleanup
-
-### Testing
-- Unit tests using Vitest
-- No mocking - tests make real API calls
-- Test files colocated with source files (`.test.ts`)
-- Descriptive test names and proper async handling
 
 ### Logging
 - All debugging through file logs to avoid disturbing Claude sessions
 - Console output only for user-facing messages
 - Special handling for large JSON objects with truncation
 
+For shared code style guidelines, see @../.claude/rules/code-style.md
+For testing guidelines, see @../.claude/rules/testing.md
+For TypeScript rules, see @../.claude/rules/typescript.md
+
 ## Architecture & Key Components
 
 ### 1. API Module (`/src/api/`)
-Handles server communication and encryption.
+Handles server communication and encryption using WebSocket (Socket.IO) and REST. Key files: `apiSession.ts` for real-time communication, `apiMachine.ts` for daemon registration, and `encryption.ts` for TweetNaCl-based end-to-end encryption.
 
-- **`api.ts`**: Main API client class for session management
-- **`apiSession.ts`**: WebSocket-based real-time session client with RPC support
-- **`auth.ts`**: Authentication flow using TweetNaCl for cryptographic signatures
-- **`encryption.ts`**: End-to-end encryption utilities using TweetNaCl
-- **`types.ts`**: Zod schemas for type-safe API communication
+### 2. Agent Module (`/src/agent/`)
+Universal agent abstraction layer. `Agent` interface provides generic abstraction over AI coding agents (Claude, Gemini, Codex). `Transport` interface abstracts communication methods (stdio, HTTP, WebSocket). Adapters in `adapters/` translate backend-specific protocols to the generic interface.
 
-**Key Features:**
-- End-to-end encryption for all communications
-- Socket.IO for real-time messaging
-- Optimistic concurrency control for state updates
-- RPC handler registration for remote procedure calls
+### 3. Claude Integration (`/src/claude/`)
+Claude Code integration using `@anthropic-ai/claude-code` SDK. Entry point: `runClaude.ts`. Handles session persistence, permission modes (auto/default/plan).
 
-### 2. Claude Integration (`/src/claude/`)
-Core Claude Code integration layer.
+### 4. Gemini Integration (`/src/gemini/`)
+Gemini CLI integration via stdio transport. Entry point: `runGemini.ts`.
 
-- **`loop.ts`**: Main control loop managing interactive/remote modes
-- **`types.ts`**: Claude message type definitions with parsers
+### 5. Codex Integration (`/src/codex/`)
+OpenAI/Codex integration using Agent Client Protocol. Entry point: `runCodex.ts`.
 
-- **`claudeSdk.ts`**: Direct SDK integration using `@anthropic-ai/claude-code`
-- **`interactive.ts`**: **LIKELY WILL BE DEPRECATED in favor of running through SDK** PTY-based interactive Claude sessions
-- **`watcher.ts`**: File system watcher for Claude session files (for interactive mode snooping)
+### 6. Daemon (`/src/daemon/`)
+Background service for remote control and session management. Key file: `run.ts` handles daemon lifecycle (start, heartbeat, shutdown, version mismatch detection). **For detailed daemon architecture, state machine, and RPC processors, see [CLAUDE.md](./src/daemon/CLAUDE.md)**
 
-- **`mcp/startPermissionServer.ts`**: MCP (Model Context Protocol) permission server
-
-**Key Features:**
-- Dual mode operation: interactive (terminal) and remote (mobile control)
-- Session persistence and resumption
-- Real-time message streaming
-- Permission intercepting via MCP [Permission checking not implemented yet]
-
-### 3. UI Module (`/src/ui/`)
-User interface components.
-
-- **`logger.ts`**: Centralized logging system with file output
-- **`qrcode.ts`**: QR code generation for mobile authentication
-- **`start.ts`**: Main application startup and orchestration
-
-**Key Features:**
-- Clean console UI with chalk styling
-- QR code display for easy mobile connection
-- Graceful mode switching between interactive and remote
-
-### 4. Core Files
-
+### 7. Other Components
+- **`/src/commands/`**: CLI command handlers (auth, connect)
+- **`/src/modules/`**: Pluggable tools (proxy, file watcher, ripgrep, difftastic)
+- **`/src/ui/`**: Terminal UI components using Ink
 - **`index.ts`**: CLI entry point with argument parsing
-- **`persistence.ts`**: Local storage for settings and keys
-- **`utils/time.ts`**: Exponential backoff utilities
+- **`persistence.ts`**: Local storage for settings, keys, profiles
 
 ## Data Flow
 
-1. **Authentication**: 
-   - Generate/load secret key → Create signature challenge → Get auth token
+### 1. Authentication
+```
+Generate/load secret key → Create signature challenge → Get auth token
+```
+- Uses TweetNaCl for cryptographic signatures
+- Private key stored in `~/.happy/access.key` (or `~/.happy-dev/access.key` for dev)
+- Challenge-response authentication prevents replay attacks
 
-2. **Session Creation**:
-   - Create encrypted session with server → Establish WebSocket connection
+### 2. Daemon Startup
+```
+CLI → spawn detached process → startDaemon()
+  → Version check (stop old if mismatch)
+  → Lock acquisition
+  → Auth check
+  → HTTP server start (random port)
+  → WebSocket connection to backend
+  → RPC registration
+  → Heartbeat loop (60s)
+```
 
-3. **Message Flow**:
-   - Interactive mode: User input → PTY → Claude → File watcher → Server
-   - Remote mode: Mobile app → Server → Claude SDK → Server → Mobile app
+### 3. Session Creation
 
-4. **Permission Handling**:
-   - Claude requests permission → MCP server intercepts → Sends to mobile → Mobile responds → MCP approves/denies
+**Terminal-spawned:**
+```
+User runs `happy`
+  → Auto-start daemon if needed
+  → Create session with backend
+  → Notify daemon via /session-started webhook
+  → Daemon tracks session
+```
+
+**Daemon-spawned (remote):**
+```
+Mobile app → Backend → RPC spawn-happy-session
+  → Daemon spawns detached Happy process
+  → Happy creates session, calls /session-started
+  → Daemon updates tracking, RPC returns to mobile
+```
+
+### 4. Message Flow
+
+**Claude SDK mode:**
+```
+User input → Agent → SDK → Agent responses → Server → Mobile app
+```
+
+**Gemini/Codex mode:**
+```
+User input → Agent → stdio transport → CLI process → Agent responses → Server → Mobile app
+```
+
+### 5. Profile Sync Flow
+```
+GUI creates profile → Backend syncs to daemon
+  → Daemon receives via WebSocket
+  → Stores in settings.json
+  → Applied when spawning sessions
+```
 
 ## Key Design Decisions
 
-1. **File-based logging**: Prevents interference with Claude's terminal UI
-2. **Dual Claude integration**: Process spawning for interactive, SDK for remote
-3. **End-to-end encryption**: All data encrypted before leaving the device
-4. **Session persistence**: Allows resuming sessions across restarts
-5. **Optimistic concurrency**: Handles distributed state updates gracefully
+1. **File-based logging**: Prevents interference with agent terminal UIs
+2. **Agent abstraction**: Generic interface supports multiple AI backends
+3. **Transport abstraction**: Separates communication method from agent logic
+4. **End-to-end encryption**: All data encrypted before leaving the device
+5. **Session persistence**: Allows resuming sessions across restarts
+6. **Optimistic concurrency**: Handles distributed state updates gracefully
+7. **Stable/Dev isolation**: Separate data directories for side-by-side testing
 
 ## Security Considerations
 
-- Private keys stored in `~/.handy/access.key` with restricted permissions
+- Private keys stored in `~/.happy/access.key` with restricted permissions
 - All communications encrypted using TweetNaCl
 - Challenge-response authentication prevents replay attacks
 - Session isolation through unique session IDs
+- HTTP control server listens on 127.0.0.1 only (localhost)
 
-## Dependencies
+## Environment Variables
 
-- Core: Node.js, TypeScript
-- Claude: `@anthropic-ai/claude-code` SDK
-- Networking: Socket.IO client, Axios
-- Crypto: TweetNaCl
-- Terminal: node-pty, chalk, qrcode-terminal
-- Validation: Zod
-- Testing: Vitest 
+### Configuration
+- `HAPPY_SERVER_URL` - Custom server URL (default: https://api.cluster-fluster.com)
+- `HAPPY_WEBAPP_URL` - Custom web app URL (default: https://app.happy.engineering)
+- `HAPPY_HOME_DIR` - Custom home directory for Happy data (default: ~/.happy)
+- `HAPPY_VARIANT` - Variant mode: 'stable' or 'dev' (affects HAPPY_HOME_DIR)
+- `HAPPY_DISABLE_CAFFEINATE` - Disable macOS sleep prevention (set to 'true', '1', or 'yes')
+- `HAPPY_EXPERIMENTAL` - Enable experimental features (set to 'true', '1', or 'yes')
+- `HAPPY_DAEMON_HEARTBEAT_INTERVAL` - Daemon heartbeat interval in seconds (default: 60)
 
+### AI Backend Configuration
+- `GEMINI_MODEL` - Override default Gemini model
+- `GOOGLE_CLOUD_PROJECT` - Google Cloud Project ID (required for Workspace accounts)
 
-# Running the Daemon
+## Session Forking and --resume Behavior
 
-## Starting the Daemon
-```bash
-# From the happy-cli directory:
-./bin/happy.mjs daemon start
+When using `--resume` flag with Claude:
+1. Creates a **NEW** session file with a **NEW** session ID
+2. Original session file remains unchanged
+3. New session file contains **complete history** from original session
+4. All historical messages have their `sessionId` field **updated** to the new session ID
+5. Context is fully preserved - Claude maintains full conversational context
 
-# With custom server URL (for local development):
-HAPPY_SERVER_URL=http://localhost:3005 ./bin/happy.mjs daemon start
+**Implications:**
+- Session ID in stream-json output will be the new one, not the resumed one
+- Original session remains as historical record
+- All context preserved but under new session identity
 
-# Stop the daemon:
-./bin/happy.mjs daemon stop
+## Data Directories
 
-# Check daemon status:
-./bin/happy.mjs daemon status
-```
-
-## Daemon Logs
-- Daemon logs are stored in `~/.happy-dev/logs/` (or `$HAPPY_HOME_DIR/logs/`)
-- Named with format: `YYYY-MM-DD-HH-MM-SS-daemon.log`
-
-# Session Forking `claude` and sdk behavior
-
-## Commands Run
-
-### Initial Session
-```bash
-claude --print --output-format stream-json --verbose 'list files in this directory'
-```
-- Original Session ID: `aada10c6-9299-4c45-abc4-91db9c0f935d`
-- Created file: `~/.claude/projects/.../aada10c6-9299-4c45-abc4-91db9c0f935d.jsonl`
-
-### Resume with --resume flag
-```bash
-claude --print --output-format stream-json --verbose --resume aada10c6-9299-4c45-abc4-91db9c0f935d 'what file did we just see?'
-```
-- New Session ID: `1433467f-ff14-4292-b5b2-2aac77a808f0`
-- Created file: `~/.claude/projects/.../1433467f-ff14-4292-b5b2-2aac77a808f0.jsonl`
-
-## Key Findings for --resume
-
-### 1. Session File Behavior
-- Creates a NEW session file with NEW session ID
-- Original session file remains unchanged
-- Two separate files exist after resumption
-
-### 2. History Preservation
-- The new session file contains the COMPLETE history from the original session
-- History is prefixed at the beginning of the new file
-- Includes a summary line at the very top
-
-### 3. Session ID Rewriting
-- **CRITICAL FINDING**: All historical messages have their sessionId field UPDATED to the new session ID
-- Original messages from session `aada10c6-9299-4c45-abc4-91db9c0f935d` now show `sessionId: "1433467f-ff14-4292-b5b2-2aac77a808f0"`
-- This creates a unified session history under the new ID
-
-### 4. Message Structure in New File
-```
-Line 1: Summary of previous conversation
-Lines 2-6: Complete history from original session (with updated session IDs)
-Lines 7-8: New messages from current interaction
-```
-
-### 5. Context Preservation
-- Claude successfully maintains full context
-- Can answer questions about previous interactions
-- Behaves as if it's a continuous conversation
-
-## Technical Details
-
-### Original Session File Structure
-- Contains only messages from the original session
-- All messages have original session ID
-- Remains untouched after resume
-
-### New Session File Structure After Resume
-```json
-{"type":"summary","summary":"Listing directory files in current location","leafUuid":"..."}
-{"parentUuid":null,"sessionId":"1433467f-ff14-4292-b5b2-2aac77a808f0","message":{"role":"user","content":[{"type":"text","text":"list files in this directory"}]},...}
-// ... all historical messages with NEW session ID ...
-{"parentUuid":"...","sessionId":"1433467f-ff14-4292-b5b2-2aac77a808f0","message":{"role":"user","content":"what file did we just see?"},...}
-```
-
-## Implications for handy-cli
-
-When using --resume:
-1. Must handle new session ID in responses
-2. Original session remains as historical record
-3. All context preserved but under new session identity
-4. Session ID in stream-json output will be the new one, not the resumed one
+Stable mode uses `~/.happy/`, dev mode uses `~/.happy-dev/` (set via `HAPPY_VARIANT` or `HAPPY_HOME_DIR`). Each contains `settings.json`, `access.key`, `daemon.state.json`, and `logs/`. Claude Code data is in `~/.claude/`.

--- a/expo-app/CLAUDE.md
+++ b/expo-app/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**For shared development principles and mono-repo overview, see [CLAUDE.md](../CLAUDE.md)**
+
+## Component Overview
+
+Expo App - React Native mobile/web client for remote control and viewing of AI coding sessions, with real-time sync, end-to-end encryption, and multi-platform support (iOS, Android, Web).
+
 ## Commands
 
 ### Development
@@ -106,105 +112,22 @@ sources/
 
 ### Development Guidelines
 
-- Use **4 spaces** for indentation
-- Use **yarn** instead of npm for package management
 - Path alias `@/*` maps to `./sources/*`
-- TypeScript strict mode is enabled - ensure all code is properly typed
-- Follow existing component patterns when creating new UI components
 - Real-time sync operations are handled through SyncSocket and SyncSession classes
 - Store all temporary scripts and any test outside of unit tests in sources/trash folder
-- When setting screen parameters ALWAYS set them in _layout.tsx if possible this avoids layout shifts
-- **Never use Alert module from React Native, always use @sources/modal/index.ts instead**
-- **Always apply layout width constraints** from `@/components/layout` to full-screen ScrollViews and content containers for responsive design across device sizes
-- Always run `yarn typecheck` after all changes to ensure type safety
+- **Use the i18n-translator agent** - When adding new translatable strings or verifying existing translations, use the i18n-translator agent to ensure consistency across all language files
 
-### Internationalization (i18n) Guidelines
+### Internationalization (i18n)
 
 **CRITICAL: Always use the `t(...)` function for ALL user-visible strings**
 
-#### Basic Usage
-```typescript
-import { t } from '@/text';
+For detailed i18n guidelines, see @../.claude/rules/react-native.md
 
-// ✅ Simple constants
-t('common.cancel')              // "Cancel"
-t('settings.title')             // "Settings"
-
-// ✅ Functions with parameters
-t('common.welcome', { name: 'Steve' })           // "Welcome, Steve!"
-t('time.minutesAgo', { count: 5 })               // "5 minutes ago"
-t('errors.fieldError', { field: 'Email', reason: 'Invalid format' })
-```
-
-#### Adding New Translations
-
-1. **Check existing keys first** - Always check if the string already exists in the `common` object or other sections before adding new keys
-2. **Think about context** - Consider the screen/component context when choosing the appropriate section (e.g., `settings.*`, `session.*`, `errors.*`)
-3. **Add to ALL languages** - When adding new strings, you MUST add them to all language files in `sources/text/translations/` (currently: `en`, `ru`, `pl`, `es`, `ca`, `it`, `pt`, `ja`, `zh-Hans`)
-4. **Use descriptive key names** - Use clear, hierarchical keys like `newSession.machineOffline` rather than generic names
-5. **Language metadata** - All supported languages and their metadata are centralized in `sources/text/_all.ts`
-
-#### Translation Structure
-```typescript
-// String constants for static text
-cancel: 'Cancel',
-
-// Functions for dynamic text with typed parameters  
-welcome: ({ name }: { name: string }) => `Welcome, ${name}!`,
-itemCount: ({ count }: { count: number }) => 
-    count === 1 ? '1 item' : `${count} items`,
-```
-
-#### Key Sections
-- `common.*` - Universal strings used across the app (buttons, actions, status)
-- `settings.*` - Settings screen specific strings
-- `session.*` - Session management and display
-- `errors.*` - Error messages and validation
-- `modals.*` - Modal dialogs and popups
-- `components.*` - Component-specific strings organized by component name
-
-#### Language Configuration
-
-The app uses a centralized language configuration system:
-
-- **`sources/text/_all.ts`** - Centralized language metadata including:
-  - `SupportedLanguage` type definition
-  - `SUPPORTED_LANGUAGES` with native names and metadata
-  - Helper functions: `getLanguageNativeName()`, `getLanguageEnglishName()`
-  - Language constants: `SUPPORTED_LANGUAGE_CODES`, `DEFAULT_LANGUAGE`
-
-- **Adding new languages:**
-  1. Add the language code to the `SupportedLanguage` type in `_all.ts`
-  2. Add language metadata to `SUPPORTED_LANGUAGES` object
-  3. Create new translation file in `sources/text/translations/[code].ts`
-  4. Add import and export in `sources/text/index.ts`
-
-#### Important Rules
-- **Never hardcode strings** in JSX - always use `t('key')`
-- **Dev pages exception** - Development/debug pages can skip i18n
-- **Check common first** - Before adding new keys, check if a suitable translation exists in `common`
-- **Context matters** - Consider where the string appears to choose the right section
-- **Update all languages** - New strings must be added to every language file
-- **Use centralized language names** - Import language names from `_all.ts` instead of translation keys
-- **Always re-read translations** - When new strings are added, always re-read the translation files to understand the existing structure and patterns before adding new keys
-- **Use translations for common strings** - Always use the translation function `t()` for any user-visible string that is translatable, especially common UI elements like buttons, labels, and messages
-- **Use the i18n-translator agent** - When adding new translatable strings or verifying existing translations, use the i18n-translator agent to ensure consistency across all language files
-- **Beware of technical terms** - When translating technical terms, consider:
-  - Keep universally understood terms like "CLI", "API", "URL", "JSON" in their original form
-  - Translate terms that have well-established equivalents in the target language
-  - Use descriptive translations for complex technical concepts when direct translations don't exist
-  - Maintain consistency across all technical terminology within the same language
-
-#### i18n-Translator Agent
-
-When working with translations, use the **i18n-translator** agent for:
-- Adding new translatable strings to the application
-- Verifying existing translations across all language files
-- Ensuring translations are consistent and contextually appropriate
-- Checking that all required languages have new strings
-- Validating that translations fit the UI context (headers, buttons, multiline text)
-
-The agent should be called whenever new user-facing text is introduced to the codebase or when translation verification is needed.
+Key points:
+- Language files in `sources/text/translations/` (currently: `en`, `ru`, `pl`, `es`, `ca`, `it`, `pt`, `ja`, `zh-Hans`)
+- Language metadata in `sources/text/_all.ts`
+- Never hardcode strings in JSX - always use `t('key')`
+- Add new strings to ALL language files
 
 ### Important Files
 
@@ -248,215 +171,25 @@ The custom header supports all standard React Navigation header options plus:
 
 This ensures consistent header appearance and behavior across iOS, Android, and web platforms.
 
-## Unistyles Styling Guide
+## Styling & Component Development
 
-### Creating Styles
+For detailed Unistyles styling guide and React Native guidelines, see @../.claude/rules/react-native.md
 
-Always use `StyleSheet.create` from 'react-native-unistyles':
-
-```typescript
-import { StyleSheet } from 'react-native-unistyles'
-
-const styles = StyleSheet.create((theme, runtime) => ({
-    container: {
-        flex: 1,
-        backgroundColor: theme.colors.background,
-        paddingTop: runtime.insets.top,
-        paddingHorizontal: theme.margins.md,
-    },
-    text: {
-        color: theme.colors.typography,
-        fontSize: 16,
-    }
-}))
-```
-
-### Using Styles in Components
-
-For React Native components, provide styles directly:
-
-```typescript
-import React from 'react'
-import { View, Text } from 'react-native'
-import { StyleSheet } from 'react-native-unistyles'
-
-const styles = StyleSheet.create((theme, runtime) => ({
-    container: {
-        flex: 1,
-        backgroundColor: theme.colors.background,
-        paddingTop: runtime.insets.top,
-    },
-    text: {
-        color: theme.colors.typography,
-        fontSize: 16,
-    }
-}))
-
-const MyComponent = () => {
-    return (
-        <View style={styles.container}>
-            <Text style={styles.text}>Hello World</Text>
-        </View>
-    )
-}
-```
-
-For other components, use `useStyles` hook:
-
-```typescript
-import React from 'react'
-import { CustomComponent } from '@/components/CustomComponent'
-import { useStyles } from 'react-native-unistyles'
-
-const MyComponent = () => {
-    const { styles, theme } = useStyles(styles)
-    
-    return (
-        <CustomComponent style={styles.container} />
-    )
-}
-```
-
-### Variants
-
-Create dynamic styles with variants:
-
-```typescript
-const styles = StyleSheet.create(theme => ({
-    button: {
-        paddingHorizontal: 16,
-        paddingVertical: 8,
-        borderRadius: 8,
-        variants: {
-            color: {
-                primary: {
-                    backgroundColor: theme.colors.primary,
-                },
-                secondary: {
-                    backgroundColor: theme.colors.secondary,
-                },
-                default: {
-                    backgroundColor: theme.colors.background,
-                }
-            },
-            size: {
-                small: {
-                    paddingHorizontal: 8,
-                    paddingVertical: 4,
-                },
-                large: {
-                    paddingHorizontal: 24,
-                    paddingVertical: 12,
-                }
-            }
-        }
-    }
-}))
-
-// Usage
-const { styles } = useStyles(styles, {
-    button: {
-        color: 'primary',
-        size: 'large'
-    }
-})
-```
-
-### Media Queries
-
-Use media queries for responsive design:
-
-```typescript
-import { StyleSheet, mq } from 'react-native-unistyles'
-
-const styles = StyleSheet.create(theme => ({
-    container: {
-        padding: theme.margins.sm,
-        backgroundColor: {
-            [mq.only.width(0, 768)]: theme.colors.background,
-            [mq.only.width(768)]: theme.colors.secondary,
-        }
-    }
-}))
-```
-
-### Breakpoints
-
-Access current breakpoint in components:
-
-```typescript
-const MyComponent = () => {
-    const { breakpoint } = useStyles()
-    
-    const isTablet = breakpoint === 'md' || breakpoint === 'lg'
-    
-    return (
-        <View>
-            {isTablet ? <TabletLayout /> : <MobileLayout />}
-        </View>
-    )
-}
-```
-
-### Special Component Considerations
-
-#### Expo Image
-- **Size properties** (`width`, `height`) must be set outside of Unistyles stylesheet as inline styles
-- **`tintColor` property** must be set directly on the component, not in style prop
-- All other styling goes through Unistyles
-
-```typescript
-import { Image } from 'expo-image'
-import { StyleSheet, useStyles } from 'react-native-unistyles'
-
-const styles = StyleSheet.create((theme) => ({
-    image: {
-        borderRadius: 8,
-        backgroundColor: theme.colors.background, // Other styles use theme
-    }
-}))
-
-const MyComponent = () => {
-    const { theme } = useStyles()
-    
-    return (
-        <Image 
-            style={[{ width: 100, height: 100 }, styles.image]}  // Size as inline styles
-            tintColor={theme.colors.primary}                     // tintColor goes on component
-            source={{ uri: 'https://example.com/image.jpg' }}
-        />
-    )
-}
-```
-
-### Best Practices
-
-1. **Always use `StyleSheet.create`** from 'react-native-unistyles'
-2. **Provide styles directly** to components from 'react-native' and 'react-native-reanimated' packages
-3. **Use `useStyles` hook only** for other components (but try to avoid it when possible)
-4. **Always use function mode** when you need theme or runtime access
-5. **Use variants** for component state-based styling instead of conditional styles
-6. **Leverage breakpoints** for responsive design rather than manual dimension calculations
-7. **Keep styles close to components** but extract common patterns to shared stylesheets
-8. **Use TypeScript** for better developer experience and type safety
+Key points:
+- Always use `StyleSheet.create` from 'react-native-unistyles'
+- Never use Alert module from React Native, always use @sources/modal/index.ts instead
+- Always apply layout width constraints from `@/components/layout` to full-screen ScrollViews
+- Store app pages in @sources/app/(app)/
+- Always use expo-router API, not react-navigation one
+- Always wrap pages in memo
+- Always put styles in the very end of the component or page file
+- For hotkeys use "useGlobalKeyboard", do not change it, it works only on Web
+- Use "AsyncLock" class for exclusive async locks
 
 ## Project Scope and Priorities
 
-- This project targets Android, iOS, and web platforms
-- Web is considered a secondary platform
-- Avoid web-specific implementations unless explicitly requested
-- Keep dev pages without i18n, always use t(...) function to translate all strings, when adding new string add it to all languages, think about context before translating.
-- Core principles: never show loading error, always just retry. Always sync main data in "sync" class. Always use invalidate sync for it. Always use Item component first and only then you should use anything else or custom ones for content. Do not ever do backward compatibility if not explicitly stated.
-- Never use custom headers in navigation, almost never use Stack.Page options in individual pages. Only when you need to show something dynamic. Always show header on all screens.
-- store app pages in @sources/app/(app)/
-- use ItemList for most containers for UI, if it is not custom like chat one.
-- Always use expo-router api, not react-navigation one.
-- Always try to use "useHappyAction" from @sources/hooks/useHappyAction.ts if you need to run some async operation, do not handle errors, etc - it is handled automatically.
-- Never use unistyles for expo-image, use classical one
-- Always use "Avatar" for avatars
-- No backward compatibliity ever
-- When non-trivial hook is needed - create a dedicated one in hooks folder, add a comment explaining it's logic
-- Always put styles in the very end of the component or page file
-- Always wrap pages in memo
-- For hotkeys use "useGlobalKeyboard", do not change it, it works only on Web
-- Use "AsyncLock" class for exclusive async locks
+Core principles: never show loading error, always just retry. Always sync main data in "sync" class. No backward compatibility unless explicitly stated.
+
+For shared code style guidelines, see @../.claude/rules/code-style.md
+For testing guidelines, see @../.claude/rules/testing.md
+For TypeScript rules, see @../.claude/rules/typescript.md

--- a/expo-app/PRIVACY.md
+++ b/expo-app/PRIVACY.md
@@ -58,7 +58,7 @@ Push notifications are sent directly from your devices to each other, not from o
 
 ## Data Security
 
-- **End-to-End Encryption**: Using TweetNaCl (same as Signal) for all sensitive data
+- **End-to-End Encryption**: Using libsodium for all sensitive data
 - **Zero-Knowledge**: We cannot decrypt your data even if compelled
 - **Secure Key Exchange**: Encryption keys are transmitted between your devices only in encrypted form that we cannot access
 - **Open Source**: Our encryption implementation is publicly auditable

--- a/expo-app/Stores.md
+++ b/expo-app/Stores.md
@@ -41,7 +41,7 @@ Perfect for developers who:
 - Value privacy and open-source transparency
 - Work from coffee shops, trains, or anywhere
 
-Happy Coder uses the same encryption as Signal (TweetNaCl) and is completely open source. Your encryption keys never leave your device, and all data is encrypted before transmission.
+Happy Coder uses libsodium for end-to-end encryption and is completely open source. Your encryption keys never leave your device, and all data is encrypted before transmission.
 
 Built by Bay Area engineers who believe the best tools come from scratching your own itch. We needed a way to securely check on our AI coding assistant while away from our desks - so we built it and shared it with the community.
 


### PR DESCRIPTION
# Overview

Introduce centralized `.claude/rules/` directory with `@import` syntax to eliminate redundancy and improve maintainability across the mono-repo codebase.

## Summary

This PR adds a new root-level `CLAUDE.md` for mono-repo overview and creates a shared `.claude/rules/` directory. Component-specific `CLAUDE.md` files are refactored to use `@import` references, reducing duplication while maintaining context-specific guidance through path-specific rules with YAML frontmatter.

## Changes

### ✨ New Root Documentation

- **CLAUDE.md** (103 lines): New mono-repo overview with `@import` references to shared rules

### ✨ New Shared Rules Directory (`.claude/rules/`)

Five specialized rule files with `@import` support:

- **code-style.md** (87 lines) - Universal code style guidelines
- **testing.md** (95 lines) - Testing conventions
- **typescript.md** (110 lines) - TypeScript rules with path-specific frontmatter (`**/*.ts`, `**/*.tsx`)
- **react-native.md** (216 lines) - React Native guidelines with path-specific frontmatter (`expo-app/**/*.{ts,tsx}`)
- **server.md** (202 lines) - Server development rules with path-specific frontmatter (`server/**/*.ts`)

### 📝 Refactored Component Documentation

- **cli/CLAUDE.md**: 227 → 245 lines
  - Now imports universal rules from `.claude/rules/`
  - Retains CLI-specific content (Agent abstraction, Daemon lifecycle, etc.)
  
- **expo-app/CLAUDE.md**: 461 → 194 lines (-58%)
  - Now imports universal rules from `.claude/rules/`
  - Retains Expo-specific content (Unistyles, i18n, Expo Router, etc.)
  
- **server/CLAUDE.md**: 280 → 315 lines
  - Now imports universal rules from `.claude/rules/`
  - Retains Server-specific content (Fastify, Prisma, inTx, etc.)

### 🔧 Technical Documentation Updates

- **expo-app/PRIVACY.md**: Updated encryption reference (TweetNaCl → libsodium)
- **expo-app/Stores.md**: Updated encryption reference (TweetNaCl → libsodium)

## Benefits

1. **Single Source of Truth**: Universal rules defined once in `.claude/rules/`
2. **Path-Specific Rules**: TypeScript, React Native, and Server rules use YAML frontmatter to apply only to relevant files via glob patterns
3. **Improved Maintainability**: Changes to universal rules propagate automatically via `@import`
4. **Reduced Redundancy**: Eliminated ~267 lines of duplicate content across component documentation
5. **Better Organization**: Clear separation between universal and component-specific rules

## Technical Details

### @import References
- Root directory: `@.claude/rules/*`
- Subdirectories: `@../.claude/rules/*`

### Path-Specific Rules Example

```yaml
---
paths:
- "**/*.ts"
- "**/*.tsx"
---
# TypeScript Rules
```

This ensures TypeScript rules only apply to `.ts` and `.tsx` files, while React Native rules only apply to files in `expo-app/` directory.

---

Generated with [Claude Code](https://claude.ai/code)  
via [Happy](https://happy.engineering)