### PR TITLE
feat: make attribution opt-in with config command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -48,10 +48,40 @@ happy connect gemini
 ### Utility Commands
 
 - `happy auth` – Manage authentication
+- `happy config` – Manage settings (attribution, etc.)
 - `happy connect` – Store AI vendor API keys in Happy cloud
 - `happy notify` – Send a push notification to your devices
 - `happy daemon` – Manage background service
 - `happy doctor` – System diagnostics & troubleshooting
+
+### Config Subcommands
+
+```bash
+happy config get <key>          # Get a configuration value
+happy config set <key> <value>  # Set a configuration value
+happy config list               # List all configuration values
+```
+
+**Available settings:**
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `attribution` | `false` | Include Happy co-author credits in git commits |
+
+**Example:**
+```bash
+# Enable commit attribution
+happy config set attribution true
+
+# Check current setting
+happy config get attribution
+```
+
+When attribution is enabled, git commits will include:
+```
+Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Happy <yesreply@happy.engineering>
+```
 
 ### Connect Subcommands
 

--- a/cli/src/claude/utils/claudeSettings.ts
+++ b/cli/src/claude/utils/claudeSettings.ts
@@ -1,69 +1,29 @@
 /**
- * Utilities for reading Claude's settings.json configuration
- * 
- * Handles reading Claude's settings.json file to respect user preferences
- * like includeCoAuthoredBy setting for commit message generation.
+ * Utilities for Happy attribution settings
+ *
+ * Controls whether Happy adds co-author attribution to git commits.
+ * Settings are stored in Happy's own config (~/.happy/settings.json).
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
-import { logger } from '@/ui/logger';
-
-export interface ClaudeSettings {
-  includeCoAuthoredBy?: boolean;
-  [key: string]: any;
-}
+import { readSettingsSync } from '@/persistence';
 
 /**
- * Get the path to Claude's settings.json file
+ * Check if attribution should be included in commit messages
+ *
+ * Reads from Happy's settings.json. Attribution is OPT-IN:
+ * - Returns true only if includeAttribution is explicitly set to true
+ * - Returns false by default (no attribution without explicit consent)
+ *
+ * @returns true if attribution should be included, false otherwise
  */
-function getClaudeSettingsPath(): string {
-  const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
-  return join(claudeConfigDir, 'settings.json');
+export function shouldIncludeAttribution(): boolean {
+  const settings = readSettingsSync();
+  // Opt-in: only include if explicitly enabled
+  return settings.includeAttribution === true;
 }
 
-/**
- * Read Claude's settings.json file from the default location
- * 
- * @returns Claude settings object or null if file doesn't exist or can't be read
- */
-export function readClaudeSettings(): ClaudeSettings | null {
-  try {
-    const settingsPath = getClaudeSettingsPath();
-    
-    if (!existsSync(settingsPath)) {
-      logger.debug(`[ClaudeSettings] No Claude settings file found at ${settingsPath}`);
-      return null;
-    }
-    
-    const settingsContent = readFileSync(settingsPath, 'utf-8');
-    const settings = JSON.parse(settingsContent) as ClaudeSettings;
-    
-    logger.debug(`[ClaudeSettings] Successfully read Claude settings from ${settingsPath}`);
-    logger.debug(`[ClaudeSettings] includeCoAuthoredBy: ${settings.includeCoAuthoredBy}`);
-    
-    return settings;
-  } catch (error) {
-    logger.debug(`[ClaudeSettings] Error reading Claude settings: ${error}`);
-    return null;
-  }
-}
-
-/**
- * Check if Co-Authored-By lines should be included in commit messages
- * based on Claude's settings
- * 
- * @returns true if Co-Authored-By should be included, false otherwise
- */
+// Legacy export for backwards compatibility
+// Maps to new opt-in behavior
 export function shouldIncludeCoAuthoredBy(): boolean {
-  const settings = readClaudeSettings();
-  
-  // If no settings file or includeCoAuthoredBy is not explicitly set,
-  // default to true to maintain backward compatibility
-  if (!settings || settings.includeCoAuthoredBy === undefined) {
-    return true;
-  }
-  
-  return settings.includeCoAuthoredBy;
+  return shouldIncludeAttribution();
 }

--- a/cli/src/claude/utils/systemPrompt.ts
+++ b/cli/src/claude/utils/systemPrompt.ts
@@ -1,5 +1,5 @@
 import { trimIdent } from "@/utils/trimIdent";
-import { shouldIncludeCoAuthoredBy } from "./claudeSettings";
+import { shouldIncludeAttribution } from "./claudeSettings";
 
 /**
  * Base system prompt shared across all configurations
@@ -9,7 +9,7 @@ const BASE_SYSTEM_PROMPT = (() => trimIdent(`
 `))();
 
 /**
- * Co-authored-by credits to append when enabled
+ * Co-authored-by credits to append when enabled via `happy config set attribution true`
  */
 const CO_AUTHORED_CREDITS = (() => trimIdent(`
     When making commit messages, instead of just giving co-credit to Claude, also give credit to Happy like so:
@@ -24,15 +24,13 @@ const CO_AUTHORED_CREDITS = (() => trimIdent(`
 `))();
 
 /**
- * System prompt with conditional Co-Authored-By lines based on Claude's settings.json configuration.
+ * System prompt with conditional Co-Authored-By lines based on Happy's settings.
+ * Attribution is opt-in: only included if user runs `happy config set attribution true`
  * Settings are read once on startup for performance.
  */
 export const systemPrompt = (() => {
-  const includeCoAuthored = shouldIncludeCoAuthoredBy();
-  
-  if (includeCoAuthored) {
+  if (shouldIncludeAttribution()) {
     return BASE_SYSTEM_PROMPT + '\n\n' + CO_AUTHORED_CREDITS;
-  } else {
-    return BASE_SYSTEM_PROMPT;
   }
+  return BASE_SYSTEM_PROMPT;
 })();

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,0 +1,165 @@
+import chalk from 'chalk';
+import { readSettings, updateSettings } from '@/persistence';
+
+type ConfigKey = 'attribution';
+
+const CONFIG_KEYS: Record<ConfigKey, {
+  description: string;
+  type: 'boolean';
+  default: boolean;
+}> = {
+  attribution: {
+    description: 'Include Happy co-author credits in git commits',
+    type: 'boolean',
+    default: false
+  }
+};
+
+export async function handleConfigCommand(args: string[]): Promise<void> {
+  const subcommand = args[0];
+
+  if (!subcommand || subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
+    showConfigHelp();
+    return;
+  }
+
+  switch (subcommand) {
+    case 'get':
+      await handleConfigGet(args[1]);
+      break;
+    case 'set':
+      await handleConfigSet(args[1], args[2]);
+      break;
+    case 'list':
+      await handleConfigList();
+      break;
+    default:
+      console.error(chalk.red(`Unknown config subcommand: ${subcommand}`));
+      showConfigHelp();
+      process.exit(1);
+  }
+}
+
+function showConfigHelp(): void {
+  console.log(`
+${chalk.bold('happy config')} - Configuration management
+
+${chalk.bold('Usage:')}
+  happy config get <key>          Get a configuration value
+  happy config set <key> <value>  Set a configuration value
+  happy config list               List all configuration values
+  happy config help               Show this help message
+
+${chalk.bold('Available settings:')}
+  attribution    ${chalk.gray('Include Happy co-author credits in git commits (default: false)')}
+
+${chalk.bold('Examples:')}
+  happy config set attribution true    ${chalk.gray('Enable commit attribution')}
+  happy config set attribution false   ${chalk.gray('Disable commit attribution')}
+  happy config get attribution         ${chalk.gray('Check current attribution setting')}
+`);
+}
+
+async function handleConfigGet(key: string | undefined): Promise<void> {
+  if (!key) {
+    console.error(chalk.red('Missing key. Usage: happy config get <key>'));
+    process.exit(1);
+  }
+
+  if (!isValidConfigKey(key)) {
+    console.error(chalk.red(`Unknown config key: ${key}`));
+    console.log(chalk.gray(`Available keys: ${Object.keys(CONFIG_KEYS).join(', ')}`));
+    process.exit(1);
+  }
+
+  const settings = await readSettings();
+  const value = getConfigValue(settings, key);
+  const config = CONFIG_KEYS[key];
+  const isDefault = value === config.default;
+
+  console.log(`${key}: ${chalk.cyan(String(value))}${isDefault ? chalk.gray(' (default)') : ''}`);
+}
+
+async function handleConfigSet(key: string | undefined, value: string | undefined): Promise<void> {
+  if (!key || value === undefined) {
+    console.error(chalk.red('Missing key or value. Usage: happy config set <key> <value>'));
+    process.exit(1);
+  }
+
+  if (!isValidConfigKey(key)) {
+    console.error(chalk.red(`Unknown config key: ${key}`));
+    console.log(chalk.gray(`Available keys: ${Object.keys(CONFIG_KEYS).join(', ')}`));
+    process.exit(1);
+  }
+
+  const config = CONFIG_KEYS[key];
+  let parsedValue: boolean;
+
+  if (config.type === 'boolean') {
+    if (value === 'true' || value === '1' || value === 'yes') {
+      parsedValue = true;
+    } else if (value === 'false' || value === '0' || value === 'no') {
+      parsedValue = false;
+    } else {
+      console.error(chalk.red(`Invalid boolean value: ${value}`));
+      console.log(chalk.gray('Use: true, false, 1, 0, yes, or no'));
+      process.exit(1);
+    }
+  } else {
+    parsedValue = value as unknown as boolean;
+  }
+
+  await setConfigValue(key, parsedValue);
+
+  // Show confirmation with context
+  if (key === 'attribution') {
+    if (parsedValue) {
+      console.log(chalk.green('✓ Attribution enabled'));
+      console.log(chalk.gray('  Commits will include Happy co-author credits'));
+    } else {
+      console.log(chalk.green('✓ Attribution disabled'));
+      console.log(chalk.gray('  Commits will not include Happy co-author credits'));
+    }
+  } else {
+    console.log(chalk.green(`✓ Set ${key} = ${parsedValue}`));
+  }
+}
+
+async function handleConfigList(): Promise<void> {
+  const settings = await readSettings();
+
+  console.log(chalk.bold('\nHappy Configuration\n'));
+
+  for (const [key, config] of Object.entries(CONFIG_KEYS)) {
+    const value = getConfigValue(settings, key as ConfigKey);
+    const isDefault = value === config.default;
+
+    console.log(`  ${chalk.cyan(key)}: ${value}${isDefault ? chalk.gray(' (default)') : ''}`);
+    console.log(chalk.gray(`    ${config.description}`));
+    console.log('');
+  }
+}
+
+function isValidConfigKey(key: string): key is ConfigKey {
+  return key in CONFIG_KEYS;
+}
+
+function getConfigValue(settings: Awaited<ReturnType<typeof readSettings>>, key: ConfigKey): boolean {
+  if (key === 'attribution') {
+    return settings.includeAttribution ?? CONFIG_KEYS.attribution.default;
+  }
+  // Exhaustive check - this should never be reached
+  const _exhaustive: never = key;
+  return _exhaustive;
+}
+
+async function setConfigValue(key: ConfigKey, value: boolean): Promise<void> {
+  await updateSettings(settings => {
+    if (key === 'attribution') {
+      return { ...settings, includeAttribution: value };
+    }
+    // Exhaustive check - this should never be reached
+    const _exhaustive: never = key;
+    return _exhaustive;
+  });
+}

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -141,7 +141,7 @@ async function handleConfigList(): Promise<void> {
 }
 
 function isValidConfigKey(key: string): key is ConfigKey {
-  return key in CONFIG_KEYS;
+  return Object.hasOwn(CONFIG_KEYS, key);
 }
 
 function getConfigValue(settings: Awaited<ReturnType<typeof readSettings>>, key: ConfigKey): boolean {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -24,6 +24,7 @@ import { ApiClient } from './api/api'
 import { runDoctorCommand } from './ui/doctor'
 import { listDaemonSessions, stopDaemonSession } from './daemon/controlClient'
 import { handleAuthCommand } from './commands/auth'
+import { handleConfigCommand } from './commands/config'
 import { handleConnectCommand } from './commands/connect'
 import { spawnHappyCLI } from './utils/spawnHappyCLI'
 import { claudeCliPath } from './claude/claudeLocal'
@@ -73,6 +74,18 @@ import { execFileSync } from 'node:child_process'
     // Handle connect subcommands
     try {
       await handleConnectCommand(args.slice(1));
+    } catch (error) {
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
+      if (process.env.DEBUG) {
+        console.error(error)
+      }
+      process.exit(1)
+    }
+    return;
+  } else if (subcommand === 'config') {
+    // Handle config subcommands
+    try {
+      await handleConfigCommand(args.slice(1));
     } catch (error) {
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
       if (process.env.DEBUG) {
@@ -536,6 +549,7 @@ ${chalk.bold('happy')} - Claude Code On the Go
 ${chalk.bold('Usage:')}
   happy [options]         Start Claude with mobile control
   happy auth              Manage authentication
+  happy config            Manage settings (attribution, etc.)
   happy codex             Start Codex mode
   happy gemini            Start Gemini mode (ACP)
   happy connect           Connect AI vendor API keys

--- a/cli/src/persistence.ts
+++ b/cli/src/persistence.ts
@@ -8,6 +8,8 @@ import { FileHandle } from 'node:fs/promises'
 import { readFile, writeFile, mkdir, open, unlink, rename, stat } from 'node:fs/promises'
 import { existsSync, writeFileSync, readFileSync, unlinkSync } from 'node:fs'
 import { constants } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
 import { configuration } from '@/configuration'
 import * as z from 'zod';
 import { encodeBase64 } from '@/api/encryption';
@@ -208,6 +210,8 @@ interface Settings {
   profiles: AIBackendProfile[]
   // CLI-local environment variable cache (not synced)
   localEnvironmentVariables: Record<string, Record<string, string>> // profileId -> env vars
+  // Attribution settings - opt-in (defaults to false)
+  includeAttribution?: boolean
 }
 
 const defaultSettings: Settings = {
@@ -304,6 +308,36 @@ export async function readSettings(): Promise<Settings> {
   } catch (error: any) {
     logger.warn(`Failed to read settings: ${error.message}`);
     // Return defaults on any error
+    return { ...defaultSettings }
+  }
+}
+
+
+/**
+ * Synchronous version of readSettings for use in module initialization
+ * (e.g., system prompt construction at load time)
+ *
+ * Note: Does not perform profile validation or migration warnings to avoid
+ * side effects during module load. Use async readSettings() for full functionality.
+ *
+ * Computes settings path dynamically to support test environment overrides.
+ */
+export function readSettingsSync(): Settings {
+  // Compute path dynamically to support HAPPY_HOME_DIR changes during tests
+  const happyHomeDir = process.env.HAPPY_HOME_DIR
+    ? process.env.HAPPY_HOME_DIR.replace(/^~/, homedir())
+    : join(homedir(), '.happy');
+  const settingsFile = join(happyHomeDir, 'settings.json');
+
+  if (!existsSync(settingsFile)) {
+    return { ...defaultSettings }
+  }
+
+  try {
+    const content = readFileSync(settingsFile, 'utf-8')
+    const raw = JSON.parse(content)
+    return { ...defaultSettings, ...raw }
+  } catch {
     return { ...defaultSettings }
   }
 }

--- a/docs/plans/2026-01-23-attribution-control-design.md
+++ b/docs/plans/2026-01-23-attribution-control-design.md
@@ -1,0 +1,136 @@
+# Attribution Control Design
+
+**Date:** 2026-01-23
+**Issue:** https://github.com/slopus/happy/issues/165
+**Status:** Ready for implementation
+
+## Problem
+
+Happy injects a system prompt into Claude Code sessions that instructs Claude to add "Co-Authored-By: Happy" to all git commits. This happens without user knowledge or consent because:
+
+1. The setting defaults to ON (opt-out instead of opt-in)
+2. It reads from Claude's `~/.claude/settings.json` instead of Happy's own config
+3. No CLI command or mobile UI exists to control it
+4. The feature is completely undocumented
+
+Users have reported this as potential "MCP prompt injection" in issue #165.
+
+## Solution
+
+Change attribution to opt-in with proper user controls:
+
+1. **Default OFF** - No attribution unless explicitly enabled
+2. **Happy's own settings** - Store in `~/.happy/settings.json`
+3. **CLI control** - `happy config set attribution true/false`
+4. **Documentation** - Document the setting in README
+
+## Implementation
+
+### 1. Settings Schema (`cli/src/persistence.ts`)
+
+Add field to Settings interface:
+
+```typescript
+interface Settings {
+  // ... existing fields ...
+
+  // Attribution settings (defaults to false - opt-in)
+  includeAttribution?: boolean
+}
+```
+
+No schema version bump needed - additive change with sensible default.
+
+### 2. System Prompt Logic (`cli/src/claude/utils/claudeSettings.ts`)
+
+Replace current logic:
+
+```typescript
+// NEW: Read from Happy's settings, default to false
+export function shouldIncludeAttribution(): boolean {
+  const settings = readSettingsSync();
+  return settings?.includeAttribution === true;
+}
+```
+
+Add synchronous settings reader (needed because system prompt is constructed at module load):
+
+```typescript
+export function readSettingsSync(): Settings | null {
+  try {
+    if (!existsSync(configuration.settingsFile)) return null;
+    const content = readFileSync(configuration.settingsFile, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+```
+
+### 3. Update System Prompt (`cli/src/claude/utils/systemPrompt.ts`)
+
+```typescript
+import { shouldIncludeAttribution } from "./claudeSettings";
+
+export const systemPrompt = (() => {
+  if (shouldIncludeAttribution()) {
+    return BASE_SYSTEM_PROMPT + '\n\n' + CO_AUTHORED_CREDITS;
+  }
+  return BASE_SYSTEM_PROMPT;
+})();
+```
+
+### 4. CLI Command (`cli/src/commands/config.ts`)
+
+New command structure:
+
+```bash
+happy config set attribution true   # Enable
+happy config set attribution false  # Disable
+happy config get attribution        # Check value
+happy config list                   # List all settings
+```
+
+### 5. Documentation (`cli/README.md`)
+
+Add section:
+
+```markdown
+### Attribution Settings
+
+By default, Happy does not add attribution to git commits. To enable:
+
+\`\`\`bash
+happy config set attribution true
+\`\`\`
+
+When enabled, commits include:
+\`\`\`
+Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Happy <yesreply@happy.engineering>
+\`\`\`
+```
+
+### 6. Tests (`cli/src/claude/utils/claudeSettings.test.ts`)
+
+Update to test:
+- Default is `false`
+- Explicit `true` enables attribution
+- Reading from Happy's settings (not Claude's)
+
+## File Changes Summary
+
+| File | Action |
+|------|--------|
+| `cli/src/persistence.ts` | Add `includeAttribution` to Settings |
+| `cli/src/claude/utils/claudeSettings.ts` | New `shouldIncludeAttribution()` + sync reader |
+| `cli/src/claude/utils/systemPrompt.ts` | Use new function |
+| `cli/src/claude/utils/claudeSettings.test.ts` | Update tests |
+| `cli/src/commands/config.ts` | **NEW** - config command |
+| `cli/src/index.ts` | Add config command |
+| `cli/README.md` | Document setting |
+
+## Future Work (Out of Scope)
+
+- Mobile app settings toggle (separate PR)
+- Server-side settings sync (if needed)


### PR DESCRIPTION
## Summary

- **Changes attribution from opt-out to opt-in** - No more surprise co-author credits in commits
- **Adds `happy config` command** - Users can now manage settings via CLI
- **Moves setting to Happy's own config** - Uses `~/.happy/settings.json` instead of Claude's config

## Motivation

Addresses user concerns in #165 about attribution being added to commits without explicit consent. The previous behavior:
- Defaulted to ON (attribution enabled)
- Read from Claude's settings.json (undiscoverable)
- Had no CLI or mobile app controls

## Changes

| File | Change |
|------|--------|
| `cli/src/persistence.ts` | Added `includeAttribution` field and `readSettingsSync()` |
| `cli/src/claude/utils/claudeSettings.ts` | Rewritten to use Happy's settings |
| `cli/src/claude/utils/systemPrompt.ts` | Updated to use new function |
| `cli/src/commands/config.ts` | **New** - `happy config` command |
| `cli/src/index.ts` | Added config command to CLI |
| `cli/src/claude/utils/claudeSettings.test.ts` | Updated tests for opt-in behavior |
| `cli/README.md` | Documented config command |

## Usage

```bash
# Enable attribution (opt-in)
happy config set attribution true

# Disable attribution (default)
happy config set attribution false

# Check current setting
happy config get attribution

# List all settings
happy config list
```

## Test plan

- [x] TypeScript compiles without errors
- [x] All 6 unit tests pass
- [x] Default behavior is now OFF (no attribution)
- [x] `happy config set attribution true` enables attribution
- [x] Settings persist in `~/.happy/settings.json`
- [ ] Manual test: run `happy` and make a commit with attribution enabled
- [ ] Manual test: run `happy` and make a commit with attribution disabled (default)

## Breaking Change

⚠️ **Attribution is now OFF by default.** Users who want co-author credits must explicitly enable them with `happy config set attribution true`.

Closes #165