### PR TITLE
Fix: Resolve orphaned processes and keyboard input issues (#422, #423, #424)

### DIFF
--- a/cli/src/claude/claudeLocal.ts
+++ b/cli/src/claude/claudeLocal.ts
@@ -225,11 +225,69 @@ export async function claudeLocal(opts: {
             logger.debug(`[ClaudeLocal] Spawning launcher: ${claudeCliPath}`);
             logger.debug(`[ClaudeLocal] Args: ${JSON.stringify(args)}`);
 
+            // Generate a unique session ID for this launcher
+            const sessionId = `happy-session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
             const child = spawn('node', [claudeCliPath, ...args], {
                 stdio: ['inherit', 'inherit', 'inherit', 'pipe'],
-                signal: opts.abort,
                 cwd: opts.path,
-                env,
+                env: {
+                    ...env,
+                    HAPPY_SESSION_ID: sessionId  // Pass session ID to launcher
+                }
+            });
+
+            logger.debug(`[ClaudeLocal] Child spawned with PID: ${child.pid}, session ID: ${sessionId}`);
+
+            // Cleanup: Kill child process and any orphaned processes on abort
+            opts.abort.addEventListener('abort', () => {
+                logger.debug('[ClaudeLocal] Abort signal triggered - terminating Claude processes gracefully');
+
+                const pid = child.pid;
+                if (pid) {
+                    try {
+                        // First: try to kill the child process with SIGTERM (graceful)
+                        process.kill(pid, 'SIGTERM');
+                        logger.debug(`[ClaudeLocal] Sent SIGTERM to child PID ${pid}`);
+                    } catch (e) {
+                        logger.debug(`[ClaudeLocal] Error killing child: ${(e as Error).message}`);
+                    }
+                }
+
+                // Second: wait for graceful shutdown, then hunt down orphaned processes
+                setTimeout(() => {
+                    // Use SIGTERM (15) instead of SIGKILL (9) for graceful shutdown
+                    // Find processes by HAPPY_SESSION_ID environment variable
+                    try {
+                        const { execSync } = require('child_process');
+
+                        // Use pgrep to find processes with our session ID
+                        // Then use pkill with SIGTERM to terminate them gracefully
+                        execSync(`pkill -TERM -f "HAPPY_SESSION_ID=${sessionId}"`, {
+                            stdio: 'ignore',
+                            timeout: 500
+                        });
+                        logger.debug(`[ClaudeLocal] Terminated processes with session ID ${sessionId}`);
+                    } catch (e) {
+                        // No processes found - this is OK
+                        logger.debug(`[ClaudeLocal] No additional processes to terminate (session: ${sessionId})`);
+                    }
+
+                    // Final cleanup: if still alive after 500ms, use SIGKILL
+                    setTimeout(() => {
+                        try {
+                            const { execSync } = require('child_process');
+                            execSync(`pkill -9 -f "HAPPY_SESSION_ID=${sessionId}"`, {
+                                stdio: 'ignore',
+                                timeout: 500
+                            });
+                            logger.debug(`[ClaudeLocal] Force killed remaining processes`);
+                        } catch (e) {
+                            // All processes are dead
+                            logger.debug(`[ClaudeLocal] All processes terminated gracefully`);
+                        }
+                    }, 500);
+                }, 100);
             });
 
             // Listen to the custom fd (fd 3) for thinking state tracking


### PR DESCRIPTION
## Summary

Fixes Issue #422, #423, and #424 (all related to process and terminal management issues during mode switches).

### Issue #422: "Bug: Input handler persists after remote-to-local mode switch" ✅
**Problem:** Input handler persists after switching from Local → Remote, with orphaned processes continuing to read from stdin and blocking subsequent input.

**Root Cause:** Child processes spawned with `signal: opts.abort` were not properly terminated when the parent process exited during Local → Remote switches.

**Solution:**
- Remove `signal: opts.abort` from spawn options
- Add `HAPPY_SESSION_ID` environment variable to track process groups
- Implement pkill-based cleanup in `claudeLocal.ts` (SIGTERM → SIGKILL)
- Add signal handlers in `claude_local_launcher.cjs`

### Issue #424: "After switching back to local mode, the input is starting to getting incomplete." ✅
**Problem:** After switching back to local mode, input is incomplete due to orphaned processes competing for stdin.

**Root Cause:** Same as Issue #422 - orphaned processes from Local mode continue reading from stdin.

**Solution:** Same fixes as Issue #422.

### Issue #423: "Terminal input stuck after exit (raw mode not restored)" ✅
**Problem:** After exiting happy-cli (via Ctrl+C or normal exit), the terminal input becomes stuck at whitespace. Users need to run `stty sane` or `reset` to restore normal terminal behavior.

**Root Cause:** Manual `process.stdin.setRawMode(true)` calls bypassed Ink's cleanup mechanism. When SIGINT/SIGTERM was caught, `process.exit(0)` terminated immediately, skipping the `finally` block that should restore terminal state.

**Solution:**
- Remove manual `process.stdin.setRawMode()` calls from `claudeRemoteLauncher.ts`
- Let Ink handle all stdin management via `stdin.ref()/unref()`
- Ink properly restores terminal state on cleanup through its unmount process

### Additional Issue: Second Remote Fails to Receive Keyboard Input ✅
**Problem:** First Remote worked correctly, but after Local → Remote → Local → Remote, the second Remote's keyboard input was buffered (cooked mode behavior).

**Root Cause:** Orphaned processes (Issues #422/#424) from Local mode modify terminal driver state through `stdio: 'inherit'`. When Ink calls `process.stdin.setRawMode(true)`, the terminal driver doesn't actually enter raw mode.

**Solution:**
- Force raw mode toggle in `RemoteModeDisplay.tsx` component mount
- Wait 100ms for Ink to complete setup
- Toggle sequence: `setRawMode(false)` → `setRawMode(true)` with 10ms delay
- Simplify stdin management in `claudeRemoteLauncher.ts` (let Ink handle everything)

## Test Plan
- [ ] Test Remote → Local → Remote keyboard input works
- [ ] Verify no orphaned processes after mode switches
- [ ] Test multiple mode switches in succession
- [ ] Verify input is complete after switching back to local mode
- [ ] Verify terminal state is properly restored after exit (no need for `stty sane`)
- [ ] Verify first Remote still works correctly

## Files Changed
- `src/ui/ink/RemoteModeDisplay.tsx` - Raw mode toggle fix
- `src/claude/claudeRemoteLauncher.ts` - Simplified stdin management, removed manual setRawMode
- `src/claude/claudeLocal.ts` - Process cleanup logic
- `scripts/claude_local_launcher.cjs` - Signal handlers
- `scripts/claude_version_utils.cjs` - Session ID tracking
- `src/claude/loop.ts` - Removed unnecessary stdin resume
- `src/claude/claudeLocalLauncher.ts` - Removed debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)