### PR TITLE
fix(expo-app): patch hoisted deps and add libsodium-wrappers ESM shim

### DIFF
--- a/expo-app/package.json
+++ b/expo-app/package.json
@@ -14,7 +14,7 @@
     "ota": "APP_ENV=preview NODE_ENV=preview tsx sources/scripts/parseChangelog.ts && yarn typecheck && eas update --branch preview",
     "ota:production": "npx eas-cli@latest workflow:run ota.yaml",
     "typecheck": "tsc --noEmit",
-    "postinstall": "patch-package && npx setup-skia-web public",
+    "postinstall": "node ./tools/postinstall.mjs",
     "generate-theme": "tsx sources/theme.gen.ts",
     "// ==== Development/Preview/Production Variants ====": "",
     "ios:dev": "cross-env APP_ENV=development expo run:ios",

--- a/expo-app/patches/libsodium-wrappers+0.7.16.patch
+++ b/expo-app/patches/libsodium-wrappers+0.7.16.patch
@@ -1,0 +1,8 @@
+diff --git a/node_modules/libsodium-wrappers/dist/modules-esm/libsodium.mjs b/node_modules/libsodium-wrappers/dist/modules-esm/libsodium.mjs
+new file mode 100644
+index 0000000..38e9e4a
+--- /dev/null
++++ b/node_modules/libsodium-wrappers/dist/modules-esm/libsodium.mjs
+@@ -0,0 +1 @@
++export { default } from "libsodium";
+

--- a/expo-app/tools/postinstall.mjs
+++ b/expo-app/tools/postinstall.mjs
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import url from 'node:url';
+
+// Yarn workspaces can execute this script via a symlinked path (e.g. repoRoot/node_modules/happy/...).
+// Resolve symlinks so repoRootDir/expoAppDir are computed from the real filesystem location.
+const toolsDir = path.dirname(fs.realpathSync(url.fileURLToPath(import.meta.url)));
+const expoAppDir = path.resolve(toolsDir, '..');
+const repoRootDir = path.resolve(expoAppDir, '..');
+
+const patchPackageCliCandidatePaths = [
+  path.resolve(expoAppDir, 'node_modules', 'patch-package', 'dist', 'index.js'),
+  path.resolve(repoRootDir, 'node_modules', 'patch-package', 'dist', 'index.js'),
+];
+
+const patchPackageCliPath = patchPackageCliCandidatePaths.find((candidatePath) => fs.existsSync(candidatePath));
+
+if (!patchPackageCliPath) {
+  console.error(
+    `Could not find patch-package CLI at:\n${patchPackageCliCandidatePaths.map((p) => `- ${p}`).join('\n')}`
+  );
+  process.exit(1);
+}
+
+function run(command, args, options) {
+  const result = spawnSync(command, args, { stdio: 'inherit', ...options });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+// Note: this repo uses Yarn workspaces, so some dependencies are hoisted to the repo root.
+// patch-package only patches packages present in the current working directory's node_modules.
+// We keep patch files under expo-app/patches, but apply them from the repo root so they can patch hoisted deps.
+run(process.execPath, [patchPackageCliPath, '--patch-dir', 'expo-app/patches'], { cwd: repoRootDir });
+
+// Optional: some dependencies may not be hoisted and can live under expo-app/node_modules.
+// If we ever need patches for those, we can place them under expo-app/patches-expo-app/.
+const expoLocalPatchDir = path.resolve(expoAppDir, 'patches-expo-app');
+if (fs.existsSync(expoLocalPatchDir)) {
+  const hasAnyPatch = fs.readdirSync(expoLocalPatchDir).some((f) => f.endsWith('.patch'));
+  if (hasAnyPatch) {
+    run(process.execPath, [patchPackageCliPath, '--patch-dir', 'patches-expo-app'], { cwd: expoAppDir });
+  }
+}
+
+run('npx', ['setup-skia-web', 'public'], { cwd: expoAppDir });
+


### PR DESCRIPTION
Expo web builds can fail at runtime with:
  "Unable to resolve module ./libsodium.mjs from .../libsodium-wrappers.mjs"

Root cause:
- In Yarn workspace installs, libsodium-wrappers is typically hoisted to the repo root.
- Upstream postinstall runs `patch-package` from `expo-app/`, so patches cannot apply to hoisted deps.
- libsodium-wrappers@0.7.16's ESM wrapper imports `./libsodium.mjs`, but that file is not shipped.

Fix:
- Add `expo-app/patches/libsodium-wrappers+0.7.16.patch` to provide the missing ESM shim: `dist/modules-esm/libsodium.mjs` -> `export { default } from "libsodium";`
- Replace the naive postinstall with `expo-app/tools/postinstall.mjs` that:
  - resolves real paths (works when executed via symlinked workspace paths)
  - runs patch-package from the repo root with `--patch-dir expo-app/patches` so hoisted deps are patched
  - keeps the existing `setup-skia-web public` step

This makes the Expo web UI build and load again with the monorepo