### PR TITLE
fix(cli): propagate Claude exit code to happy process

### DIFF
--- a/cli/src/claude/claudeLocal.ts
+++ b/cli/src/claude/claudeLocal.ts
@@ -10,6 +10,19 @@ import { getProjectPath } from "./utils/path";
 import { projectPath } from "@/projectPath";
 import { systemPrompt } from "./utils/systemPrompt";
 
+/**
+ * Error thrown when the Claude process exits with a non-zero exit code.
+ */
+export class ExitCodeError extends Error {
+    public readonly exitCode: number;
+
+    constructor(exitCode: number) {
+        super(`Process exited with code: ${exitCode}`);
+        this.name = 'ExitCodeError';
+        this.exitCode = exitCode;
+    }
+}
+
 
 // Get Claude CLI path from project root
 export const claudeCliPath = resolve(join(projectPath(), 'scripts', 'claude_local_launcher.cjs'))
@@ -308,6 +321,9 @@ export async function claudeLocal(opts: {
                     r();
                 } else if (signal) {
                     reject(new Error(`Process terminated with signal: ${signal}`));
+                } else if (code !== 0 && code !== null) {
+                    // Non-zero exit code - propagate it
+                    reject(new ExitCodeError(code));
                 } else {
                     r();
                 }

--- a/cli/src/claude/runClaude.ts
+++ b/cli/src/claude/runClaude.ts
@@ -428,7 +428,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     registerKillSessionHandler(session.rpcHandlerManager, cleanup);
 
     // Create claude loop
-    await loop({
+    const exitCode = await loop({
         path: workingDirectory,
         model: options.model,
         permissionMode: options.permissionMode,
@@ -488,6 +488,6 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     cleanupHookSettingsFile(hookSettingsPath);
     logger.debug('Stopped Hook server and cleaned up settings file');
 
-    // Exit
-    process.exit(0);
+    // Exit with the code from Claude
+    process.exit(exitCode);
 }


### PR DESCRIPTION
Previously, when Claude exited with a non-zero exit code, happy would always exit with code 0 because the exit code was ignored in the exit handler. This fix:

- Adds ExitCodeError class to capture non-zero exit codes
- Updates claudeLocal.ts to reject with ExitCodeError on non-zero exit
- Updates claudeLocalLauncher.ts to handle exit code errors and return the exit code instead of just 'exit'
- Updates loop.ts to propagate the exit code from the launcher
- Updates runClaude.ts to exit with the actual exit code from Claude

This aims to fix https://github.com/slopus/happy/issues/465