### PR TITLE
feature(cli): add --chrome and --no-chrome flags for Chrome mode (Claude)

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,7 +10,7 @@
 import chalk from 'chalk'
 import { runClaude, StartOptions } from '@/claude/runClaude'
 import { logger } from './ui/logger'
-import { readCredentials } from './persistence'
+import { readCredentials, readSettings } from './persistence'
 import { authAndSetupMachineIfNeeded } from './ui/auth'
 import packageJson from '../package.json'
 import { z } from 'zod'
@@ -473,6 +473,7 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
     const options: StartOptions = {}
     let showHelp = false
     let showVersion = false
+    let chromeOverride: boolean | undefined = undefined  // Track explicit --chrome or --no-chrome
     const unknownArgs: string[] = [] // Collect unknown args to pass through to claude
 
     for (let i = 0; i < args.length; i++) {
@@ -513,6 +514,12 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
           console.error(chalk.red(`Invalid --claude-env format: ${envArg}. Expected KEY=VALUE`))
           process.exit(1)
         }
+      } else if (arg === '--chrome') {
+        chromeOverride = true
+        // We'll add --chrome to claudeArgs after resolving settings default
+      } else if (arg === '--no-chrome') {
+        chromeOverride = false
+        // Happy-specific flag to disable chrome even if default is on
       } else {
         // Pass unknown arguments through to claude
         unknownArgs.push(arg)
@@ -526,6 +533,13 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
     // Add unknown args to claudeArgs
     if (unknownArgs.length > 0) {
       options.claudeArgs = [...(options.claudeArgs || []), ...unknownArgs]
+    }
+
+    // Resolve Chrome mode: explicit flag > settings > false
+    const settings = await readSettings()
+    const chromeEnabled = chromeOverride ?? settings.chromeMode ?? false
+    if (chromeEnabled) {
+      options.claudeArgs = [...(options.claudeArgs || []), '--chrome']
     }
 
     // Show help
@@ -548,6 +562,8 @@ ${chalk.bold('Examples:')}
   happy                    Start session
   happy --yolo             Start with bypassing permissions
                             happy sugar for --dangerously-skip-permissions
+  happy --chrome           Enable Chrome browser access for this session
+  happy --no-chrome        Disable Chrome even if default is on
   happy --js-runtime bun   Use bun instead of node to spawn Claude Code
   happy --claude-env ANTHROPIC_BASE_URL=http://127.0.0.1:3456
                            Use a custom API endpoint (e.g., claude-code-router)

--- a/cli/src/persistence.ts
+++ b/cli/src/persistence.ts
@@ -203,6 +203,7 @@ interface Settings {
   machineId?: string
   machineIdConfirmedByServer?: boolean
   daemonAutoStartWhenRunningHappy?: boolean
+  chromeMode?: boolean  // Default Chrome mode setting for Claude
   // Profile management settings (synced with happy app)
   activeProfileId?: string
   profiles: AIBackendProfile[]


### PR DESCRIPTION
Add support for Claude --chrome in Happy CLI:
- Add chromeMode setting to persist default preference
- Add --chrome flag to enable Claude chrome browser access for a session
- Add --no-chrome flag to disable Chrome even if default is on
- Flag overrides always take precedence over settings
- Update help text with Chrome examples

-Future todo: Add toggle in mobile app settings page to launch claude with --chrome flag.