### PR TITLE
fix(cli): intercept --settings flag to prevent conflict with internal hook settings

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -520,6 +520,13 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
       } else if (arg === '--no-chrome') {
         chromeOverride = false
         // Happy-specific flag to disable chrome even if default is on
+      } else if (arg === '--settings') {
+        // Intercept --settings flag - Happy uses this internally for session hooks
+        const settingsValue = args[++i] // consume the value
+        console.warn(chalk.yellow(`⚠️  Warning: --settings is used internally by Happy for session tracking.`))
+        console.warn(chalk.yellow(`   Your settings file "${settingsValue}" will be ignored.`))
+        console.warn(chalk.yellow(`   To configure Claude, edit ~/.claude/settings.json instead.`))
+        // Don't pass through to claudeArgs
       } else {
         // Pass unknown arguments through to claude
         unknownArgs.push(arg)


### PR DESCRIPTION
## Summary

- Intercept `--settings` flag in CLI argument parsing
- Display warning message instead of passing through to Claude (which causes conflict)
- Guide users to use `~/.claude/settings.json` for configuration

## Problem

When running `happy --settings /path/to/settings.json`, users get:

```
error: unknown option '--settings'
```

This happens because:
1. Happy passes user's `--settings` to Claude via `claudeArgs`
2. Happy then adds its own `--settings` for hook configuration
3. Claude receives two `--settings` flags, causing a parsing error

## Solution

Intercept `--settings` in the argument parsing loop and warn users:

```
⚠️  Warning: --settings is used internally by Happy for session tracking.
   Your settings file "/path/to/settings.json" will be ignored.
   To configure Claude, edit ~/.claude/settings.json instead.
```

## Testing

```bash
# Before fix
$ happy --settings /tmp/test.json
error: unknown option '--settings'

# After fix
$ happy --settings /tmp/test.json
⚠️  Warning: --settings is used internally by Happy for session tracking.
   Your settings file "/tmp/test.json" will be ignored.
   To configure Claude, edit ~/.claude/settings.json instead.
```