### PR TITLE
feat(app): Add preset messages for quick slash command input

### DIFF
--- a/packages/happy-app/sources/components/AddPresetButton.tsx
+++ b/packages/happy-app/sources/components/AddPresetButton.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Platform, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+
+const stylesheet = StyleSheet.create((theme) => ({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: Platform.select({ default: 16, android: 20 }),
+        height: 32,
+        width: 32,
+        borderWidth: 1,
+        borderColor: theme.colors.button.secondary.tint,
+        // Android doesn't support dashed, use solid with lower opacity
+        ...Platform.select({
+            ios: { borderStyle: 'dashed' },
+            android: { borderStyle: 'solid', opacity: 0.6 },
+            default: { borderStyle: 'dashed' },
+        }),
+    },
+}));
+
+interface AddPresetButtonProps {
+    onPress: () => void;
+}
+
+export const AddPresetButton = React.memo(({ onPress }: AddPresetButtonProps) => {
+    const { theme } = useUnistyles();
+    const styles = stylesheet;
+
+    return (
+        <TouchableOpacity
+            style={styles.container}
+            onPress={onPress}
+            activeOpacity={0.7}
+        >
+            <Ionicons
+                name="add"
+                size={16}
+                color={theme.colors.button.secondary.tint}
+            />
+        </TouchableOpacity>
+    );
+});
+
+AddPresetButton.displayName = 'AddPresetButton';

--- a/packages/happy-app/sources/components/PresetMessageButton.tsx
+++ b/packages/happy-app/sources/components/PresetMessageButton.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Pressable, Text } from 'react-native';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { Platform } from 'react-native';
+import { Typography } from '@/constants/Typography';
+
+const stylesheet = StyleSheet.create((theme) => ({
+    container: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderRadius: Platform.select({ default: 16, android: 20 }),
+        paddingHorizontal: 8,
+        paddingVertical: 6,
+        justifyContent: 'center',
+        height: 32,
+        width: 32,
+        backgroundColor: theme.colors.surfacePressed,
+    },
+    pressed: {
+        opacity: 0.7,
+    },
+    text: {
+        fontSize: 13,
+        fontWeight: '600',
+        color: theme.colors.button.secondary.tint,
+        ...Typography.default('semiBold'),
+    },
+}));
+
+interface PresetMessageButtonProps {
+    text: string;
+    index: number;
+    onPress: () => void;
+    onLongPress?: () => void;
+}
+
+export const PresetMessageButton = React.memo(({ text, index, onPress, onLongPress }: PresetMessageButtonProps) => {
+    const styles = stylesheet;
+
+    return (
+        <Pressable
+            style={({ pressed }) => [styles.container, pressed && styles.pressed]}
+            onPress={onPress}
+            onLongPress={onLongPress}
+            hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
+            delayLongPress={300}
+        >
+            <Text style={styles.text}>
+                {index + 1}
+            </Text>
+        </Pressable>
+    );
+});
+
+PresetMessageButton.displayName = 'PresetMessageButton';

--- a/packages/happy-app/sources/components/PresetMessageEditModal.tsx
+++ b/packages/happy-app/sources/components/PresetMessageEditModal.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { Platform, Alert } from 'react-native';
+import { t } from '@/text';
+import { Modal } from '@/modal';
+
+interface PresetMessageEditModalProps {
+    visible: boolean;
+    onClose: () => void;
+    onSave: (text: string) => void;
+    onDelete?: () => void;
+    initialText?: string;
+    isNew?: boolean;
+}
+
+// Type definition for Alert.prompt buttons (iOS only)
+interface AlertButton {
+    text: string;
+    style?: 'default' | 'cancel' | 'destructive';
+    onPress?: ((text?: string) => void) | (() => void);
+}
+
+// Type for the iOS-only Alert.prompt function
+type AlertPromptType = (
+    title: string,
+    message?: string,
+    buttons?: AlertButton[],
+    type?: 'plain-text' | 'secure-text',
+    defaultValue?: string
+) => void;
+
+export const PresetMessageEditModal = React.memo(({
+    visible,
+    onClose,
+    onSave,
+    onDelete,
+    initialText = '',
+    isNew = false,
+}: PresetMessageEditModalProps) => {
+    const wasVisible = React.useRef(false);
+    const paramsRef = React.useRef({ isNew, initialText, onSave, onDelete, onClose });
+
+    // Update params ref
+    paramsRef.current = { isNew, initialText, onSave, onDelete, onClose };
+
+    React.useEffect(() => {
+        if (visible && !wasVisible.current) {
+            wasVisible.current = true;
+
+            const { isNew, initialText, onSave, onDelete, onClose } = paramsRef.current;
+
+            if (Platform.OS === 'ios' && 'prompt' in Alert) {
+                // iOS: Use native Alert.prompt with multiple buttons
+                // Type assertion is safe here because we checked for the prompt property at runtime
+                const prompt = (Alert as { prompt: AlertPromptType }).prompt;
+
+                const buttons: AlertButton[] = isNew
+                    ? [
+                        // Add new: Cancel / Save
+                        {
+                            text: t('common.cancel'),
+                            style: 'cancel',
+                            onPress: onClose
+                        },
+                        {
+                            text: t('common.save'),
+                            onPress: (text?: string) => {
+                                if (text?.trim()) {
+                                    onSave(text.trim());
+                                }
+                            }
+                        }
+                    ]
+                    : [
+                        // Edit existing: Cancel / Delete / Save
+                        {
+                            text: t('common.cancel'),
+                            style: 'cancel',
+                            onPress: onClose
+                        }
+                    ];
+
+                if (!isNew && onDelete) {
+                    buttons.push({
+                        text: t('common.delete'),
+                        style: 'destructive',
+                        onPress: () => {
+                            onDelete();
+                            onClose();
+                        }
+                    });
+                }
+
+                if (!isNew) {
+                    buttons.push({
+                        text: t('common.save'),
+                        onPress: (text?: string) => {
+                            if (text?.trim()) {
+                                onSave(text.trim());
+                            }
+                        }
+                    });
+                }
+
+                prompt(
+                    isNew ? t('presetMessages.addTitle') : t('presetMessages.editTitle'),
+                    t('presetMessages.messagePlaceholder'),
+                    buttons,
+                    'plain-text',
+                    initialText
+                );
+            } else {
+                // Android/Web: Show prompt with delete button for editing existing
+                Modal.prompt(
+                    isNew ? t('presetMessages.addTitle') : t('presetMessages.editTitle'),
+                    t('presetMessages.messagePlaceholder'),
+                    {
+                        placeholder: t('presetMessages.messagePlaceholder'),
+                        defaultValue: initialText,
+                        confirmText: t('common.save'),
+                        cancelText: t('common.cancel'),
+                        destructiveText: !isNew && onDelete ? t('common.delete') : undefined,
+                    }
+                ).then((text) => {
+                    if (text === '__DELETE__') {
+                        // Delete button was clicked
+                        onDelete?.();
+                    } else if (text?.trim()) {
+                        onSave(text.trim());
+                    }
+                    onClose();
+                }).catch(() => {
+                    onClose();
+                });
+            }
+        } else if (!visible) {
+            wasVisible.current = false;
+        }
+    }, [visible]);
+
+    return null;
+});
+
+PresetMessageEditModal.displayName = 'PresetMessageEditModal';

--- a/packages/happy-app/sources/components/haptics.ts
+++ b/packages/happy-app/sources/components/haptics.ts
@@ -1,9 +1,16 @@
 import * as Haptics from 'expo-haptics';
+import { Platform } from 'react-native';
 
 export function hapticsError() {
-    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+    if (Platform.OS === 'web') return;
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error).catch(() => {
+        // Ignore haptics errors
+    });
 }
 
 export function hapticsLight() {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    if (Platform.OS === 'web') return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {
+        // Ignore haptics errors
+    });
 }

--- a/packages/happy-app/sources/modal/ModalManager.ts
+++ b/packages/happy-app/sources/modal/ModalManager.ts
@@ -149,6 +149,7 @@ class ModalManagerClass implements IModal {
             defaultValue?: string;
             cancelText?: string;
             confirmText?: string;
+            destructiveText?: string;
             inputType?: 'default' | 'secure-text' | 'email-address' | 'numeric';
         }
     ): Promise<string | null> {
@@ -190,6 +191,7 @@ class ModalManagerClass implements IModal {
                 defaultValue: options?.defaultValue,
                 cancelText: options?.cancelText,
                 confirmText: options?.confirmText,
+                destructiveText: options?.destructiveText,
                 inputType: options?.inputType
             } as Omit<ModalConfig, 'id'>);
 

--- a/packages/happy-app/sources/modal/components/WebPromptModal.tsx
+++ b/packages/happy-app/sources/modal/components/WebPromptModal.tsx
@@ -34,6 +34,12 @@ export function WebPromptModal({ config, onClose, onConfirm }: WebPromptModalPro
         onClose();
     };
 
+    const handleDestructive = () => {
+        // Return special marker to indicate destructive action
+        onConfirm('__DELETE__');
+        onClose();
+    };
+
     const getKeyboardType = (): KeyboardTypeOptions => {
         switch (config.inputType) {
             case 'email-address':
@@ -86,10 +92,13 @@ export function WebPromptModal({ config, onClose, onConfirm }: WebPromptModalPro
             borderColor: theme.colors.divider,
             borderRadius: 8,
             paddingHorizontal: 10,
+            paddingVertical: 0,
             marginTop: 16,
             fontSize: 14,
+            lineHeight: 18,
             color: theme.colors.text,
-            backgroundColor: theme.colors.input.background
+            backgroundColor: theme.colors.input.background,
+            textAlignVertical: 'center',
         },
         buttonContainer: {
             borderTopWidth: 1,
@@ -148,22 +157,43 @@ export function WebPromptModal({ config, onClose, onConfirm }: WebPromptModalPro
                 </View>
                 
                 <View style={styles.buttonContainer}>
-                    <Pressable
-                        style={({ pressed }) => [
-                            styles.button,
-                            pressed && styles.buttonPressed
-                        ]}
-                        onPress={handleCancel}
-                    >
-                        <Text style={[
-                            styles.buttonText,
-                            styles.cancelText,
-                            Typography.default()
-                        ]}>
-                            {config.cancelText || 'Cancel'}
-                        </Text>
-                    </Pressable>
-                    <View style={styles.buttonSeparator} />
+                    {config.destructiveText ? (
+                        <>
+                            <Pressable
+                                style={({ pressed }) => [
+                                    styles.button,
+                                    pressed && styles.buttonPressed
+                                ]}
+                                onPress={handleDestructive}
+                            >
+                                <Text style={[
+                                    styles.buttonText,
+                                    { color: theme.colors.textDestructive },
+                                    Typography.default()
+                                ]}>
+                                    {config.destructiveText}
+                                </Text>
+                            </Pressable>
+                            <View style={styles.buttonSeparator} />
+                        </>
+                    ) : (
+                        <Pressable
+                            style={({ pressed }) => [
+                                styles.button,
+                                pressed && styles.buttonPressed
+                            ]}
+                            onPress={handleCancel}
+                        >
+                            <Text style={[
+                                styles.buttonText,
+                                styles.cancelText,
+                                Typography.default()
+                            ]}>
+                                {config.cancelText || 'Cancel'}
+                            </Text>
+                        </Pressable>
+                    )}
+                    {config.destructiveText && <View style={styles.buttonSeparator} />}
                     <Pressable
                         style={({ pressed }) => [
                             styles.button,
@@ -178,6 +208,26 @@ export function WebPromptModal({ config, onClose, onConfirm }: WebPromptModalPro
                             {config.confirmText || 'OK'}
                         </Text>
                     </Pressable>
+                    {config.destructiveText && (
+                        <>
+                            <View style={styles.buttonSeparator} />
+                            <Pressable
+                                style={({ pressed }) => [
+                                    styles.button,
+                                    pressed && styles.buttonPressed
+                                ]}
+                                onPress={handleCancel}
+                            >
+                                <Text style={[
+                                    styles.buttonText,
+                                    styles.cancelText,
+                                    Typography.default()
+                                ]}>
+                                    {config.cancelText || 'Cancel'}
+                                </Text>
+                            </Pressable>
+                        </>
+                    )}
                 </View>
             </View>
         </BaseModal>

--- a/packages/happy-app/sources/modal/types.ts
+++ b/packages/happy-app/sources/modal/types.ts
@@ -37,6 +37,7 @@ export interface PromptModalConfig extends BaseModalConfig {
     defaultValue?: string;
     cancelText?: string;
     confirmText?: string;
+    destructiveText?: string;
     inputType?: 'default' | 'secure-text' | 'email-address' | 'numeric';
 }
 
@@ -71,6 +72,7 @@ export interface IModal {
         defaultValue?: string;
         cancelText?: string;
         confirmText?: string;
+        destructiveText?: string;
         inputType?: 'default' | 'secure-text' | 'email-address' | 'numeric';
     }): Promise<string | null>;
     show(config: Omit<CustomModalConfig, 'id' | 'type'>): string;

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -226,3 +226,29 @@ export function retrieveTempText(id: string): string | null {
 export function clearPersistence() {
     mmkv.clearAll();
 }
+
+// Preset Messages Types and Functions
+export type PresetMessage = {
+    id: string;
+    text: string;
+    order: number;
+};
+
+const PRESET_MESSAGES_KEY = 'preset-messages-v1';
+
+export function loadPresetMessages(): Record<string, PresetMessage[]> {
+    const data = mmkv.getString(PRESET_MESSAGES_KEY);
+    if (data) {
+        try {
+            return JSON.parse(data);
+        } catch (e) {
+            console.error('Failed to parse preset messages', e);
+            return {};
+        }
+    }
+    return {};
+}
+
+export function savePresetMessages(messages: Record<string, PresetMessage[]>) {
+    mmkv.set(PRESET_MESSAGES_KEY, JSON.stringify(messages));
+}

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -914,6 +914,14 @@ export const en = {
             confirm: 'Delete',
             cancel: 'Cancel',
         },
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Add Preset Message',
+        editTitle: 'Edit Preset Message',
+        messageLabel: 'Message',
+        messagePlaceholder: 'Enter a preset message...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -913,6 +913,14 @@ export const ca: TranslationStructure = {
         friendRequestGeneric: 'Nova sol·licitud d\'amistat',
         friendAccepted: ({ name }: { name: string }) => `Ara ets amic de ${name}`,
         friendAcceptedGeneric: 'Sol·licitud d\'amistat acceptada',
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Afegir Missatge Predefinit',
+        editTitle: 'Editar Missatge Predefinit',
+        messageLabel: 'Missatge',
+        messagePlaceholder: 'Introdueix un missatge predefinit...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -930,6 +930,14 @@ export const en: TranslationStructure = {
             confirm: 'Delete',
             cancel: 'Cancel',
         },
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Add Preset Message',
+        editTitle: 'Edit Preset Message',
+        messageLabel: 'Message',
+        messagePlaceholder: 'Enter a preset message...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -915,6 +915,14 @@ export const es: TranslationStructure = {
             confirm: 'Eliminar',
             cancel: 'Cancelar',
         },
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Agregar Mensaje Preestablecido',
+        editTitle: 'Editar Mensaje Preestablecido',
+        messageLabel: 'Mensaje',
+        messagePlaceholder: 'Ingresa un mensaje preestablecido...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -913,6 +913,14 @@ export const it: TranslationStructure = {
         friendRequestGeneric: 'Nuova richiesta di amicizia',
         friendAccepted: ({ name }: { name: string }) => `Ora sei amico di ${name}`,
         friendAcceptedGeneric: 'Richiesta di amicizia accettata',
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Aggiungi Messaggio Preset',
+        editTitle: 'Modifica Messaggio Preset',
+        messageLabel: 'Messaggio',
+        messagePlaceholder: 'Inserisci un messaggio preset...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -916,5 +916,13 @@ export const ja: TranslationStructure = {
         friendRequestGeneric: '新しい友達リクエスト',
         friendAccepted: ({ name }: { name: string }) => `${name}さんと友達になりました`,
         friendAcceptedGeneric: '友達リクエストが承認されました',
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'プリセットメッセージを追加',
+        editTitle: 'プリセットメッセージを編集',
+        messageLabel: 'メッセージ',
+        messagePlaceholder: 'プリセットメッセージを入力...',
     }
 } as const;

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -938,6 +938,14 @@ export const pl: TranslationStructure = {
             confirm: 'Usuń',
             cancel: 'Anuluj',
         },
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Dodaj Wiadomość Predefiniowaną',
+        editTitle: 'Edytuj Wiadomość Predefiniowaną',
+        messageLabel: 'Wiadomość',
+        messagePlaceholder: 'Wprowadź wiadomość predefiniowaną...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -913,6 +913,14 @@ export const pt: TranslationStructure = {
         friendRequestGeneric: 'Novo pedido de amizade',
         friendAccepted: ({ name }: { name: string }) => `Agora você é amigo de ${name}`,
         friendAcceptedGeneric: 'Pedido de amizade aceito',
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Adicionar Mensagem Predefinida',
+        editTitle: 'Editar Mensagem Predefinida',
+        messageLabel: 'Mensagem',
+        messagePlaceholder: 'Digite uma mensagem predefinida...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -937,6 +937,14 @@ export const ru: TranslationStructure = {
             confirm: 'Удалить',
             cancel: 'Отмена',
         },
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: 'Добавить Предустановленное Сообщение',
+        editTitle: 'Редактировать Предустановленное Сообщение',
+        messageLabel: 'Сообщение',
+        messagePlaceholder: 'Введите предустановленное сообщение...',
     }
 } as const;
 

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -915,5 +915,13 @@ export const zhHans: TranslationStructure = {
         friendRequestGeneric: '新的好友请求',
         friendAccepted: ({ name }: { name: string }) => `您现在与 ${name} 成为了好友`,
         friendAcceptedGeneric: '好友请求已接受',
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: '添加预设消息',
+        editTitle: '编辑预设消息',
+        messageLabel: '消息',
+        messagePlaceholder: '输入预设消息...',
     }
 } as const;

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -915,5 +915,13 @@ export const zhHant: TranslationStructure = {
             confirm: '刪除',
             cancel: '取消',
         },
+    },
+
+    presetMessages: {
+        // Preset messages feature (iOS only)
+        addTitle: '新增預設訊息',
+        editTitle: '編輯預設訊息',
+        messageLabel: '訊息',
+        messagePlaceholder: '輸入預設訊息...',
     }
 } as const;


### PR DESCRIPTION
## Summary
This feature adds preset message buttons that allow users to quickly send frequently used text, especially long slash commands, with a single tap.

## Changes
- Add preset message buttons for one-tap sending of long commands
- Support custom slash commands and frequently used prompts
- Support create, edit, delete preset messages
- Persist preset messages to local storage
- Add i18n support for all languages (en, ru, pl, es, ca, it, pt, ja, zh-Hans, zh-Hant)

## Test plan
- [x] TypeScript type checking passes
- [x] Create a new preset message
- [x] Edit an existing preset message
- [x] Delete a preset message
- [x] Send a preset message by tapping the button
- [x] Long press to edit (Android)
- [x] Verify data persists after app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)