### PR TITLE
fix: prevent orphan Claude processes when using native binary

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -497,6 +497,17 @@ function runClaudeCli(cliPath) {
             stdio: 'inherit',
             env: process.env
         });
+
+        // Forward termination signals to child process
+        // Without this, killing the launcher orphans the Claude binary (PPID becomes 1)
+        const forwardSignal = (signal) => {
+            if (!child.killed) {
+                child.kill(signal);
+            }
+        };
+        process.on('SIGTERM', () => forwardSignal('SIGTERM'));
+        process.on('SIGINT', () => forwardSignal('SIGINT'));
+
         child.on('exit', (code) => {
             process.exit(code || 0);
         });

--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -377,6 +377,9 @@ export function query(config: {
 
     config.options?.abort?.addEventListener('abort', cleanup)
     process.on('exit', cleanup)
+    // Also handle SIGTERM/SIGINT to prevent orphan processes when parent is killed
+    process.on('SIGTERM', cleanup)
+    process.on('SIGINT', cleanup)
 
     // Handle process exit
     const processExitPromise = new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary
- Fixes orphan Claude Code processes when installed as native binary
- Adds SIGTERM/SIGINT signal forwarding in launcher and SDK

## Problem
When Claude Code is installed as a native binary (via native installer, not npm), the launcher spawns it as a child process. If the parent process receives SIGTERM/SIGINT (e.g., when switching modes or aborting), it would exit without forwarding the signal to the child. This leaves Claude binary processes running as orphans (PPID becomes 1), consuming memory indefinitely.

## Solution
Added signal handlers in two places:
1. `scripts/claude_version_utils.cjs` - forwards SIGTERM/SIGINT to spawned binary child
2. `src/claude/sdk/query.ts` - adds signal handlers alongside existing cleanup logic

## Test plan
- [ ] Start Happy with native binary Claude installation
- [ ] Send message, switch to remote mode (triggers abort)
- [ ] Verify Claude process terminates (check `ps aux | grep claude`)
- [ ] Previously: orphaned process with PPID=1; Now: process should be gone

🤖 Generated with [Claude Code](https://claude.ai/code)