### PR TITLE
fix: skip Ink rendering for daemon-spawned sessions

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -27,8 +27,9 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
     logger.debug('[claudeRemoteLauncher] Starting remote launcher');
 
     // Check if we have a TTY for UI rendering
-    const hasTTY = process.stdout.isTTY && process.stdin.isTTY;
-    logger.debug(`[claudeRemoteLauncher] TTY available: ${hasTTY}`);
+    // Daemon-spawned sessions skip Ink entirely — no human is watching the terminal
+    const hasTTY = process.stdout.isTTY && process.stdin.isTTY && session.startedBy !== 'daemon';
+    logger.debug(`[claudeRemoteLauncher] TTY available: ${hasTTY}, startedBy: ${session.startedBy}`);
 
     // Configure terminal
     let messageBuffer = new MessageBuffer();

--- a/packages/happy-cli/src/claude/loop.ts
+++ b/packages/happy-cli/src/claude/loop.ts
@@ -40,6 +40,8 @@ interface LoopOptions {
     hookSettingsPath: string
     /** JavaScript runtime to use for spawning Claude Code (default: 'node') */
     jsRuntime?: JsRuntime
+    /** Whether this session was started by the daemon or directly from a terminal */
+    startedBy?: 'daemon' | 'terminal'
 }
 
 export async function loop(opts: LoopOptions): Promise<number> {
@@ -59,7 +61,8 @@ export async function loop(opts: LoopOptions): Promise<number> {
         allowedTools: opts.allowedTools,
         onModeChange: opts.onModeChange,
         hookSettingsPath: opts.hookSettingsPath,
-        jsRuntime: opts.jsRuntime
+        jsRuntime: opts.jsRuntime,
+        startedBy: opts.startedBy
     });
 
     opts.onSessionReady?.(session)

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -457,7 +457,8 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         claudeEnvVars: options.claudeEnvVars,
         claudeArgs: options.claudeArgs,
         hookSettingsPath,
-        jsRuntime: options.jsRuntime
+        jsRuntime: options.jsRuntime,
+        startedBy: options.startedBy
     });
 
     // Cleanup session resources (intervals, callbacks) - prevents memory leak

--- a/packages/happy-cli/src/claude/session.ts
+++ b/packages/happy-cli/src/claude/session.ts
@@ -19,6 +19,8 @@ export class Session {
     readonly hookSettingsPath: string;
     /** JavaScript runtime to use for spawning Claude Code (default: 'node') */
     readonly jsRuntime: JsRuntime;
+    /** Whether this session was started by the daemon or directly from a terminal */
+    readonly startedBy: 'daemon' | 'terminal';
 
     sessionId: string | null;
     mode: 'local' | 'remote' = 'local';
@@ -46,6 +48,8 @@ export class Session {
         hookSettingsPath: string,
         /** JavaScript runtime to use for spawning Claude Code (default: 'node') */
         jsRuntime?: JsRuntime,
+        /** Whether this session was started by the daemon or directly from a terminal */
+        startedBy?: 'daemon' | 'terminal',
     }) {
         this.path = opts.path;
         this.api = opts.api;
@@ -60,6 +64,7 @@ export class Session {
         this._onModeChange = opts.onModeChange;
         this.hookSettingsPath = opts.hookSettingsPath;
         this.jsRuntime = opts.jsRuntime ?? 'node';
+        this.startedBy = opts.startedBy ?? 'terminal';
 
         // Start keep alive
         this.client.keepAlive(this.thinking, this.mode);

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -320,7 +320,7 @@ export async function runCodex(opts: {
     //
 
     const messageBuffer = new MessageBuffer();
-    const hasTTY = process.stdout.isTTY && process.stdin.isTTY;
+    const hasTTY = process.stdout.isTTY && process.stdin.isTTY && opts.startedBy !== 'daemon';
     let inkInstance: any = null;
 
     if (hasTTY) {

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -407,7 +407,7 @@ export async function runGemini(opts: {
   //
 
   const messageBuffer = new MessageBuffer();
-  const hasTTY = process.stdout.isTTY && process.stdin.isTTY;
+  const hasTTY = process.stdout.isTTY && process.stdin.isTTY && opts.startedBy !== 'daemon';
   let inkInstance: ReturnType<typeof render> | null = null;
 
   // Track current model for UI display


### PR DESCRIPTION
## Summary
- Threads `startedBy` field through Session class so launchers know if a session was daemon-spawned
- Adds explicit `startedBy !== 'daemon'` guard to `hasTTY` checks across Claude, Codex, and Gemini launchers
- Daemon sessions skip Ink rendering entirely since no human is watching the terminal

## Context
Daemon-spawned processes typically already have `process.stdout.isTTY === false`, so the existing `hasTTY` check was already falsy. This adds a belt-and-suspenders explicit check for the case where a daemon process somehow has a TTY attached.

## Test plan
- [x] Verified via daemon logs: `TTY available: undefined, startedBy: daemon` for daemon-spawned sessions
- [x] Verified terminal sessions still render Ink normally: `TTY available: true, startedBy: terminal`

🤖 Generated with [Claude Code](https://claude.ai/code)