### PR TITLE
security(docker): run containers as non-root user

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -45,9 +45,12 @@ RUN apt-get update && apt-get install -y python3 ffmpeg && rm -rf /var/lib/apt/l
 ENV NODE_ENV=production
 
 # Copy necessary files from the builder stage
-COPY --from=builder /repo/node_modules /repo/node_modules
-COPY --from=builder /repo/packages/happy-wire /repo/packages/happy-wire
-COPY --from=builder /repo/packages/happy-server /repo/packages/happy-server
+COPY --from=builder --chown=node:node /repo/node_modules /repo/node_modules
+COPY --from=builder --chown=node:node /repo/packages/happy-wire /repo/packages/happy-wire
+COPY --from=builder --chown=node:node /repo/packages/happy-server /repo/packages/happy-server
+
+# Run as non-root user
+USER node
 
 # Expose the port the app will run on
 EXPOSE 3000

--- a/Dockerfile.webapp
+++ b/Dockerfile.webapp
@@ -38,8 +38,8 @@ COPY packages/happy-app ./packages/happy-app
 RUN yarn workspace @slopus/happy-wire build
 RUN yarn workspace happy-app expo export --platform web --output-dir dist
 
-# Stage 3: runtime with Nginx
-FROM nginx:alpine AS runner
+# Stage 3: runtime with Nginx (non-root)
+FROM nginxinc/nginx-unprivileged:alpine AS runner
 
 COPY --from=builder /repo/packages/happy-app/dist /usr/share/nginx/html
 
@@ -48,7 +48,7 @@ RUN rm /etc/nginx/conf.d/default.conf
 
 # Create custom nginx configuration directly in the Dockerfile
 RUN echo 'server { \
-    listen 80; \
+    listen 8080; \
     \
     location /_expo/ { \
         root   /usr/share/nginx/html; \
@@ -91,7 +91,5 @@ RUN echo 'server { \
     } \
 }' > /etc/nginx/conf.d/default.conf
 
-# Expose the standard nginx port
-EXPOSE 80
-
-# Nginx starts automatically in the foreground with CMD ["nginx", "-g", "daemon off;"]
+# nginx-unprivileged listens on 8080 by default
+EXPOSE 8080


### PR DESCRIPTION
## Summary
- Run both server and webapp containers as non-root users, following container security best practices
- `Dockerfile.server`: add `USER node` directive with `--chown=node:node` on COPY steps
- `Dockerfile.webapp`: switch to `nginxinc/nginx-unprivileged:alpine` and listen on port 8080

## Motivation
Both Dockerfiles previously ran as root inside the container. Running as non-root is an industry-standard hardening practice that limits the blast radius if the container process is compromised.

## Changes

**Dockerfile.server**
- Added `--chown=node:node` to `COPY --from=builder` directives so the `node` user owns the application files
- Added `USER node` before `EXPOSE` / `CMD`

**Dockerfile.webapp**
- Replaced `nginx:alpine` with `nginxinc/nginx-unprivileged:alpine` (official Nginx non-root image)
- Changed `listen 80` to `listen 8080` (non-root users cannot bind to ports below 1024)
- Updated `EXPOSE` from 80 to 8080

## Breaking changes
- **Webapp port changed from 80 to 8080.** Any reverse proxy, load balancer, or `docker run -p` mapping that targets port 80 inside the container must be updated to 8080.

## Test plan
- [ ] `docker build -f Dockerfile.server .` builds successfully
- [ ] `docker build -f Dockerfile.webapp .` builds successfully
- [ ] Server container runs and responds on port 3000
- [ ] Webapp container runs and serves static files on port 8080
- [ ] Verify processes run as non-root: `docker exec <container> whoami`