### PR TITLE
fix: align path normalization with Claude Code to fix session sync

### DIFF
--- a/packages/happy-cli/src/claude/utils/path.test.ts
+++ b/packages/happy-cli/src/claude/utils/path.test.ts
@@ -53,6 +53,75 @@ describe('getProjectPath', () => {
         expect(result).toContain(join('/test/home/.claude', 'projects'));
     });
 
+    describe('Claude Code path normalization parity', () => {
+        // Claude Code replaces ALL non-alphanumeric, non-hyphen characters with hyphens.
+        // Happy must match this exactly, otherwise session files won't be found.
+        // See: https://github.com/slopus/happy/issues/563
+
+        it('should replace @ symbols with hyphens (Google Drive paths)', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/adam/Library/CloudStorage/GoogleDrive-user@gmail.com/projects';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-adam-Library-CloudStorage-GoogleDrive-user-gmail-com-projects'));
+        });
+
+        it('should replace parentheses with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/app (copy)';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-app--copy-'));
+        });
+
+        it('should replace square brackets with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/[2024] my-project';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects--2024--my-project'));
+        });
+
+        it('should replace tilde with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/~backup';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects--backup'));
+        });
+
+        it('should replace plus signs with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/c++';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-c--'));
+        });
+
+        it('should replace hash symbols with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/c#-app';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-c--app'));
+        });
+
+        it('should replace equals and ampersand with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/key=value&foo';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-key-value-foo'));
+        });
+
+        it('should replace commas and semicolons with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/a,b;c';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-a-b-c'));
+        });
+
+        it('should replace single quotes and exclamation marks with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = "/Users/steve/projects/it's-done!";
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-it-s-done-'));
+        });
+    });
+
     describe('CLAUDE_CONFIG_DIR support', () => {
         it('should use default .claude directory when CLAUDE_CONFIG_DIR is not set', () => {
             // When CLAUDE_CONFIG_DIR is not set, it uses homedir()/.claude

--- a/packages/happy-cli/src/claude/utils/path.ts
+++ b/packages/happy-cli/src/claude/utils/path.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
 export function getProjectPath(workingDirectory: string) {
-    const projectId = resolve(workingDirectory).replace(/[\\\/\.: _]/g, '-');
+    const projectId = resolve(workingDirectory).replace(/[^a-zA-Z0-9-]/g, '-');
     const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
     return join(claudeConfigDir, 'projects', projectId);
 }


### PR DESCRIPTION
## Summary

Fixes #563

Happy's `getProjectPath` used a restrictive regex (`/[\\\/\.: _]/g`) that only replaced 6 specific characters with hyphens. Claude Code replaces **all** non-alphanumeric, non-hyphen characters when creating project directories under `~/.claude/projects/`.

This mismatch caused Happy's session scanner to look for files in a different directory than where Claude Code wrote them, resulting in sessions appearing on the mobile app with no messages.

**Commonly affected paths:**
- Google Drive paths containing `@` (e.g. `GoogleDrive-user@gmail.com`)
- Directories with spaces (e.g. `1 Projects`)
- Paths with `#`, `+`, `~`, parentheses, brackets, etc.

### The fix

Replace the restrictive allowlist:
```ts
// Before: only handles \ / . : space _
resolve(workingDirectory).replace(/[\\\/\.: _]/g, '-');

// After: matches Claude Code's behavior — replace anything non-alphanumeric/non-hyphen
resolve(workingDirectory).replace(/[^a-zA-Z0-9-]/g, '-');
```

### Verified empirically

Compared Happy's output against actual Claude Code project directories on macOS:

| Path | Claude Code | Happy (before) | Happy (after) |
|------|------------|----------------|---------------|
| `GoogleDrive-user@gmail.com` | `GoogleDrive-user-gmail-com` | `GoogleDrive-user@gmail-com` | `GoogleDrive-user-gmail-com` |
| `/Users/adam/CC_Sandbox` | `-Users-adam-CC-Sandbox` | `-Users-adam-CC-Sandbox` | `-Users-adam-CC-Sandbox` |
| `/Users/adam/Documents/1 Projects/...` | `-Users-adam-Documents-1-Projects-...` | `-Users-adam-Documents-1-Projects-...` | `-Users-adam-Documents-1-Projects-...` |

## Test plan

- [x] Added 9 new tests covering `@`, parentheses, brackets, tilde, `+`, `#`, `=`, `&`, `,`, `;`, `'`, `!`
- [x] All 19 path tests pass
- [x] Full test suite passes (282 tests, 0 failures)
- [x] Existing tests unchanged — backwards compatible for paths that only had `\ / . : space _`