### PR TITLE
fix: restore terminal state after remote→local mode switch

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -9,6 +9,7 @@ import { claudeFindLastSession } from "./utils/claudeFindLastSession";
 import { getProjectPath } from "./utils/path";
 import { projectPath } from "@/projectPath";
 import { systemPrompt } from "./utils/systemPrompt";
+import { restoreStdin } from "@/utils/restoreStdin";
 
 /**
  * Error thrown when the Claude process exits with a non-zero exit code.
@@ -177,8 +178,10 @@ export async function claudeLocal(opts: {
 
     // Spawn the process
     try {
-        // Start the interactive process
-        process.stdin.pause();
+        // Ensure stdin is fully clean before handing it to the child process.
+        // This guards against edge cases where remote mode cleanup was incomplete
+        // (e.g., encoding left as utf8, raw mode still active, flowing mode).
+        restoreStdin();
         await new Promise<void>((r, reject) => {
             const args: string[] = []
 

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -6,6 +6,7 @@ import React from "react";
 import { claudeRemote } from "./claudeRemote";
 import { PermissionHandler } from "./utils/permissionHandler";
 import { Future } from "@/utils/future";
+import { restoreStdin } from "@/utils/restoreStdin";
 import { SDKAssistantMessage, SDKMessage, SDKUserMessage } from "./sdk";
 import { formatClaudeMessageForInk } from "@/ui/messageFormatterInk";
 import { logger } from "@/ui/logger";
@@ -441,14 +442,19 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
         // Clean up permission handler
         permissionHandler.reset();
 
-        // Reset Terminal
-        process.stdin.off('data', abort);
-        if (process.stdin.isTTY) {
-            process.stdin.setRawMode(false);
-        }
+        // Unmount Ink FIRST — it expects raw mode to still be active during teardown.
+        // Reversing this order (disabling raw mode first) causes Ink to corrupt the terminal.
         if (inkInstance) {
-            inkInstance.unmount();
+            try {
+                inkInstance.unmount();
+            } catch {
+                // Ink unmount can throw if already unmounted
+            }
         }
+
+        // Now restore stdin to a clean state for the next consumer (local mode / child process)
+        restoreStdin();
+
         messageBuffer.clear();
 
         // Resolve abort future

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -27,6 +27,7 @@ import { startOfflineReconnection, connectionState } from '@/utils/serverConnect
 import { claudeLocal } from '@/claude/claudeLocal';
 import { createSessionScanner } from '@/claude/utils/sessionScanner';
 import { Session } from './session';
+import { restoreStdin } from '@/utils/restoreStdin';
 
 /** JavaScript runtime to use for spawning Claude Code */
 export type JsRuntime = 'node' | 'bun'
@@ -371,6 +372,11 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Setup signal handlers for graceful shutdown
     const cleanup = async () => {
         logger.debug('[START] Received termination signal, cleaning up...');
+
+        // Restore terminal BEFORE any async work or process.exit() —
+        // signal handlers bypass finally blocks, so this is our only chance
+        // to prevent leaving the terminal in raw mode.
+        restoreStdin();
 
         try {
             // Update lifecycle state to archived before closing

--- a/packages/happy-cli/src/utils/restoreStdin.ts
+++ b/packages/happy-cli/src/utils/restoreStdin.ts
@@ -1,0 +1,53 @@
+/**
+ * Restores process.stdin to a clean state after raw mode / Ink usage.
+ *
+ * When switching from remote mode (Ink UI with raw mode) back to local mode
+ * (Claude with inherited stdio), stdin must be fully reset:
+ *   1. Raw mode disabled (so the terminal handles line editing again)
+ *   2. Paused (exits flowing mode so the child process can read stdin)
+ *   3. Encoding reset from utf8 back to Buffer (setEncoding is sticky)
+ *   4. Orphaned "data" listeners removed (prevents phantom keypress handling)
+ *
+ * Idempotent — safe to call multiple times or when stdin is already clean.
+ */
+export function restoreStdin(): void {
+    try {
+        // 1. Disable raw mode (only on TTY)
+        if (process.stdin.isTTY) {
+            try {
+                process.stdin.setRawMode(false);
+            } catch {
+                // Already not in raw mode, or stdin is destroyed
+            }
+        }
+
+        // 2. Pause stdin (exit flowing mode)
+        try {
+            process.stdin.pause();
+        } catch {
+            // Already paused or destroyed
+        }
+
+        // 3. Reset encoding back to Buffer mode
+        //    setEncoding("utf8") is a one-way operation on the public API —
+        //    the only way to undo it is to null out the internal decoder state.
+        try {
+            const state = (process.stdin as any)._readableState;
+            if (state) {
+                state.encoding = null;
+                state.decoder = null;
+            }
+        } catch {
+            // Internal state not accessible — non-critical
+        }
+
+        // 4. Remove orphaned "data" listeners that Ink or remote mode attached
+        try {
+            process.stdin.removeAllListeners('data');
+        } catch {
+            // Listeners already gone or stdin destroyed
+        }
+    } catch {
+        // Entire restoration failed — non-critical, best-effort cleanup
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the most-reported bug in Happy CLI: terminal input corruption after switching from remote mode (mobile) back to local mode via double-space. Users experience dropped characters, phantom mode switches, and an unresponsive Claude session.

- Fixes #301, #422, #423, #424, #430, #443, #527

## Root cause analysis

Five independent bugs compound to corrupt stdin during the remote→local transition:

| # | Bug | Effect |
|---|-----|--------|
| 1 | **Wrong cleanup order** — raw mode disabled *before* Ink unmounts | Ink expects raw mode during teardown; disabling it first causes Ink to leave the terminal in a half-raw state |
| 2 | **`setEncoding("utf8")` never reset** | This is a sticky, one-way call on the Node.js public API. Once set, stdin delivers strings instead of Buffers to all subsequent consumers, breaking Claude's input handling |
| 3 | **`process.exit()` bypasses finally blocks** | Signal handlers (SIGINT/SIGTERM) call `process.exit()` which skips the finally block that would restore the terminal — leaves it in raw mode |
| 4 | **No signal forwarding to binary children** | When spawning Claude as a binary (e.g. Homebrew install), the parent process doesn't forward signals — child becomes orphan competing for stdin |
| 5 | **stdin left in flowing mode** | No `pause()` after remote cleanup, so stdin data events keep firing into the void |

## Approach: why this fix over alternatives

### Compared to PR #458 (pkill-based process cleanup)

PR #458 addresses the orphan process symptom by adding `HAPPY_SESSION_ID` environment tracking and `pkill`-based cleanup with escalating SIGTERM→SIGKILL. While it correctly identifies the orphan problem, it:

- **Doesn't fix the core stdin corruption** (bugs 1-3 above) — the wrong cleanup order, sticky encoding, and signal handler gaps
- Adds `pkill -f "HAPPY_SESSION_ID=..."` with hardcoded timeouts (100ms → 500ms) which is platform-dependent and fragile
- Registers signal handlers 4+ times ("multiple times to ensure they stick") which is a code smell
- Adds a raw mode toggle hack in `RemoteModeDisplay.tsx` with `setTimeout(100ms)` that papers over the real ordering bug

### Compared to PR #553 (node-pty proxy)

PR #553 takes a nuclear approach: replace `stdio: 'inherit'` with a full PTY proxy via `node-pty`, giving Ink a separate `/dev/tty` fd. This correctly isolates stdin but:

- **Adds a native dependency** (`node-pty`) requiring compilation on every platform — the comment thread already found a PTY fd leak bug in node-pty v1.1.0 (microsoft/node-pty#882)
- Rewrites 200+ lines of `claudeLocal.ts` including IPC socket plumbing to replace fd 3
- Much larger blast radius and review surface for what is fundamentally a cleanup ordering bug

### This PR's approach

Minimal, targeted fixes at each root cause — **94 lines added, 8 removed, zero new dependencies**:

1. **`restoreStdin()` utility** (new file) — idempotent function that properly restores stdin: disable raw mode, pause, reset encoding via `_readableState`, remove orphaned listeners. Every operation wrapped in try-catch.

2. **Fix cleanup order** in `claudeRemoteLauncher.ts` — unmount Ink *first* (while raw mode is still active), *then* call `restoreStdin()`. This is the core fix. Also removed dead code (`process.stdin.off('data', abort)` where `abort` was never a data listener).

3. **Defensive guard** in `claudeLocal.ts` — call `restoreStdin()` before spawning child with inherited stdio. Catches edge cases where remote cleanup was incomplete.

4. **Signal handler protection** in `runClaude.ts` — call `restoreStdin()` at the top of the cleanup function, before any async work or `process.exit()`. Prevents terminal being left in raw mode when signals bypass finally blocks.

5. **Signal forwarding** in `claude_version_utils.cjs` — forward SIGINT/SIGTERM/SIGHUP to binary child processes. Clean up handlers on child exit. Prevents orphan Claude processes.

## Files changed

| File | Lines | Change |
|------|-------|--------|
| `packages/happy-cli/src/utils/restoreStdin.ts` | +53 | **New** — shared stdin restoration utility |
| `packages/happy-cli/src/claude/claudeRemoteLauncher.ts` | +12/-6 | Fix cleanup order, use `restoreStdin()` |
| `packages/happy-cli/src/claude/claudeLocal.ts` | +5/-2 | Defensive `restoreStdin()` before spawn |
| `packages/happy-cli/src/claude/runClaude.ts` | +6 | `restoreStdin()` in signal handler |
| `packages/happy-cli/scripts/claude_version_utils.cjs` | +18 | Signal forwarding to binary children |

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Full build passes (`yarn build`)
- [x] All 273 existing tests pass (`vitest run`)
- [ ] Manual: Start happy → send message from mobile (enter remote mode) → double-space to switch to local → type a sentence with spaces → verify all characters appear, no phantom mode switches
- [ ] Manual: Ctrl-C twice in remote mode → restart → verify terminal is clean
- [ ] Manual: Rapid switching: remote→local→remote→local
- [ ] Manual: `ps aux | grep claude` after mode switches — verify no orphan processes
- [ ] Manual: Test on both macOS and Linux

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)
