### PR TITLE
fix: align path normalization with Claude Code to fix session sync

### DIFF
--- a/packages/happy-cli/src/claude/utils/path.test.ts
+++ b/packages/happy-cli/src/claude/utils/path.test.ts
@@ -53,6 +53,75 @@ describe('getProjectPath', () => {
         expect(result).toContain(join('/test/home/.claude', 'projects'));
     });
 
+    describe('Claude Code path normalization parity', () => {
+        // Claude Code replaces ALL non-alphanumeric, non-hyphen characters with hyphens.
+        // Happy must match this exactly, otherwise session files won't be found.
+        // See: https://github.com/slopus/happy/issues/563
+
+        it('should replace @ symbols with hyphens (Google Drive paths)', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/adam/Library/CloudStorage/GoogleDrive-user@gmail.com/projects';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-adam-Library-CloudStorage-GoogleDrive-user-gmail-com-projects'));
+        });
+
+        it('should replace parentheses with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/app (copy)';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-app--copy-'));
+        });
+
+        it('should replace square brackets with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/[2024] my-project';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects--2024--my-project'));
+        });
+
+        it('should replace tilde with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/~backup';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects--backup'));
+        });
+
+        it('should replace plus signs with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/c++';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-c--'));
+        });
+
+        it('should replace hash symbols with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/c#-app';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-c--app'));
+        });
+
+        it('should replace equals and ampersand with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/key=value&foo';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-key-value-foo'));
+        });
+
+        it('should replace commas and semicolons with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = '/Users/steve/projects/a,b;c';
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-a-b-c'));
+        });
+
+        it('should replace single quotes and exclamation marks with hyphens', () => {
+            process.env.CLAUDE_CONFIG_DIR = '/test/home/.claude';
+            const workingDir = "/Users/steve/projects/it's-done!";
+            const result = getProjectPath(workingDir);
+            expect(result).toBe(join('/test/home/.claude', 'projects', '-Users-steve-projects-it-s-done-'));
+        });
+    });
+
     describe('CLAUDE_CONFIG_DIR support', () => {
         it('should use default .claude directory when CLAUDE_CONFIG_DIR is not set', () => {
             // When CLAUDE_CONFIG_DIR is not set, it uses homedir()/.claude

--- a/packages/happy-cli/src/claude/utils/path.ts
+++ b/packages/happy-cli/src/claude/utils/path.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
 export function getProjectPath(workingDirectory: string) {
-    const projectId = resolve(workingDirectory).replace(/[\\\/\.: _]/g, '-');
+    const projectId = resolve(workingDirectory).replace(/[^a-zA-Z0-9-]/g, '-');
     const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
     return join(claudeConfigDir, 'projects', projectId);
 }


### PR DESCRIPTION
## Summary

- Replaces the restrictive regex `[\\\\/\\.: _]` with `[^a-zA-Z0-9-]` in `getProjectPath()` to match Claude Code's actual path normalization behavior
- Adds 9 test cases covering special characters: `@`, `()`, `[]`, `~`, `+`, `#`, `=&`, `,;`, `'!`
- Also fixes #579 (underscores in directory names not normalized correctly) — same root cause as #563

## Problem

Claude Code replaces **all** non-alphanumeric, non-hyphen characters with hyphens when creating project directories under `~/.claude/projects/`. Happy's regex only covered 6 specific characters (`\`, `/`, `.`, `:`, space, `_`), causing session files to not be found for paths containing `@`, `#`, `+`, `~`, parentheses, brackets, and other special characters.

Most commonly triggered by:
- Google Drive paths (containing `@`)
- Directory names with parentheses, brackets, or other special characters

The result was the mobile app showing sessions with no messages, because the path normalization mismatch meant session files couldn't be located.

## Changes

- `packages/happy-cli/src/claude/utils/path.ts` — 1 line regex change
- `packages/happy-cli/src/claude/utils/path.test.ts` — 9 new test cases verifying parity with Claude Code's behavior

## Test plan

- [x] All 9 new test cases pass, covering special characters that previously caused mismatches
- [x] Existing tests continue to pass (standard paths with `/`, `.`, `:`, space, `_` are a subset of the new pattern)

Closes #563
Closes #579