### PR TITLE
feat(app): add mobile session title editing

### DIFF
--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -374,7 +374,12 @@ export const en = {
         deleteSessionWarning: 'This action cannot be undone. All messages and data associated with this session will be permanently deleted.',
         failedToDeleteSession: 'Failed to delete session',
         sessionDeleted: 'Session deleted successfully',
-        
+        editTitle: 'Edit Title',
+        editTitleSubtitle: 'Change the session title',
+        titlePlaceholder: 'Enter session title',
+        titleUpdated: 'Title updated successfully',
+        failedToUpdateTitle: 'Failed to update title',
+
     },
 
     components: {


### PR DESCRIPTION
## Summary

- Add `sessionUpdateTitle()` function in `ops.ts` to update session titles from mobile app
- Add inline title editing UI in session info page (`info.tsx`)
- Add translation keys for title editing feature

Fixes #593

## Motivation

When the daemon is unstable (stale, version mismatch, hanging, or network issues), the `mcp__happy__change_title` MCP tool becomes unavailable in Claude Code. This leaves users with no way to update session titles.

This PR implements a fallback mechanism by adding title editing functionality directly in the Happy mobile app. Users can now edit session titles from the session info page regardless of daemon status.

## Implementation Details

- Uses the existing `update-metadata` WebSocket event (same mechanism CLI uses)
- Maintains end-to-end encryption for session metadata
- Supports optimistic concurrency control via `metadataVersion`
- Provides inline editing UI with save/cancel actions

## Test plan

- [ ] Verify title editing works when daemon is online
- [ ] Verify title editing works when daemon is offline/unstable
- [ ] Verify title changes sync correctly across devices
- [ ] Verify version mismatch handling works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)