### PR TITLE
fix(happy-cli): add missing await to fs.writeFile in Codex session spawning

### DIFF
--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -281,7 +281,7 @@ export async function startDaemon(): Promise<void> {
             const codexHomeDir = tmp.dirSync();
 
             // Write the token to the temporary directory
-            fs.writeFile(join(codexHomeDir.name, 'auth.json'), options.token);
+            await fs.writeFile(join(codexHomeDir.name, 'auth.json'), options.token);
 
             // Set the environment variable for Codex
             authEnv.CODEX_HOME = codexHomeDir.name;


### PR DESCRIPTION
## Summary

- Add missing `await` to `fs.writeFile()` call in `src/daemon/run.ts:284`
- `fs` is imported from `fs/promises`, so `writeFile()` returns a Promise
- Without `await`, the Codex process may start before `auth.json` is written to disk

## Problem

When the daemon spawns a Codex session with a token, it writes `auth.json` to a temporary directory and sets `CODEX_HOME` to that directory. However, the `fs.writeFile()` call is not awaited, creating a race condition where the Codex process reads `auth.json` before the write completes — causing intermittent authentication failures.

## Fix

```diff
- fs.writeFile(join(codexHomeDir.name, 'auth.json'), options.token);
+ await fs.writeFile(join(codexHomeDir.name, 'auth.json'), options.token);
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] `pkgroll` build succeeds
- [x] Existing tests pass (374 passed; 1 pre-existing failure in `apiSession.test.ts` unrelated to this change)