### PR TITLE
fix(happy-server): add pagination limit to artifacts list endpoint

### DIFF
--- a/packages/happy-server/sources/app/api/routes/artifactsRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/artifactsRoutes.ts
@@ -34,6 +34,7 @@ export function artifactsRoutes(app: Fastify) {
             const artifacts = await db.artifact.findMany({
                 where: { accountId: userId },
                 orderBy: { updatedAt: 'desc' },
+                take: 200,
                 select: {
                     id: true,
                     header: true,


### PR DESCRIPTION
## Summary

- Add `take: 200` to `GET /v1/artifacts` Prisma query to prevent unbounded result sets

## Problem

The `GET /v1/artifacts` endpoint calls `db.artifact.findMany()` without a `take` limit, returning **all** artifacts for a user in a single response. Each artifact includes Base64-encoded `header` and `dataEncryptionKey` fields, so the response payload grows significantly with artifact count.

Other list endpoints already have limits:
- `GET /v1/sessions`: `take: 150`
- `GET /v1/sessions/:id/messages`: `take: 150`
- `GET /v1/user/search`: `take: 10`

## Fix

```diff
 const artifacts = await db.artifact.findMany({
     where: { accountId: userId },
     orderBy: { updatedAt: 'desc' },
+    take: 200,
     select: {
```

## Test plan

- [x] `tsc --noEmit` passes