### PR TITLE
fix(happy-cli) Type error preventing build

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -104,7 +104,7 @@ function formatTextForConsole(text: string): string {
   return JSON.stringify(truncateForConsole(toSingleLine(text), ACP_EVENT_PREVIEW_CHARS));
 }
 
-function formatOptionalDetail(text: string | undefined, limit = ACP_EVENT_PREVIEW_CHARS): string {
+function formatOptionalDetail(text: string | undefined | null, limit = ACP_EVENT_PREVIEW_CHARS): string {
   if (!text) {
     return '';
   }


### PR DESCRIPTION
Building `happy-cli` using following steps:

```
cd packages/happy-cli
yarn install
yarn workspace @slopus/happy-wire build
yarn build
```

Last command fails with
```
src/agent/acp/runAcp.ts:748:88 - error TS2345: Argument of type 'string | null | undefined' is not assignable to parameter of type 'string | undefined'.
  Type 'null' is not assignable to type 'string | undefined'.

748             logAcp('muted', `  mode=${mode.id} name=${mode.name}${formatOptionalDetail(mode.description, 160)}`);
                                                                                           ~~~~~~~~~~~~~~~~


Found 1 error in src/agent/acp/runAcp.ts:748

error Command failed with exit code 2.
```

I believe this is appropriate fix, as the function formatOptionalDetail guards against `!text`
