### PR TITLE
fix(sync): accept non-text content types in tool_result schema

### DIFF
--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -47,7 +47,7 @@ export type RawToolUseContent = z.infer<typeof rawToolUseContentSchema>;
 const rawToolResultContentSchema = z.object({
     type: z.literal('tool_result'),
     tool_use_id: z.string(),
-    content: z.union([z.array(z.object({ type: z.literal('text'), text: z.string() })), z.string()]),
+    content: z.union([z.array(z.object({ type: z.string() }).passthrough()), z.string()]),
     is_error: z.boolean().optional(),
     permissions: z.object({
         date: z.number(),


### PR DESCRIPTION
## Summary

- The `rawToolResultContentSchema` content array only accepted `type: "text"`, but Claude Code CLI returns other types (e.g. `type: "image"`) in tool results
- This causes Zod validation failures, resulting in **multiple error dialogs on app startup** that cannot be dismissed and block all user interaction
- Changed content array schema to accept any content type via `z.object({ type: z.string() }).passthrough()`, consistent with the WOLOG pattern used elsewhere in this file

## Reproduction

1. Use Claude Code CLI with tools that produce image output (e.g. Read tool on an image file)
2. Open the conversation in the mobile/web app
3. App shows repeated error dialogs that block interaction

## Test plan

- [ ] Verify messages with `type: "image"` content in tool_result no longer cause validation errors
- [ ] Verify messages with `type: "text"` content still work as before
- [ ] Verify no error dialogs appear on app startup