### PR TITLE
fix(cli): prevent session flags from leaking through on retry

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -136,6 +136,9 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
                     exitReason = { type: 'exit', code: e.exitCode };
                     break;
                 }
+                // Always consume one-time flags on error too, to prevent
+                // --continue/--resume from leaking through on retry
+                session.consumeOneTimeFlags();
                 if (!exitReason) {
                     session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
                     continue;

--- a/packages/happy-cli/src/claude/session.ts
+++ b/packages/happy-cli/src/claude/session.ts
@@ -146,43 +146,51 @@ export class Session {
 
     /**
      * Consume one-time Claude flags from claudeArgs after Claude spawn
-     * Handles: --resume (with or without session ID), --continue
+     * Handles: --resume/-r (with or without session ID), --continue/-c, --session-id
      */
     consumeOneTimeFlags = (): void => {
         if (!this.claudeArgs) return;
-        
+
         const filteredArgs: string[] = [];
         for (let i = 0; i < this.claudeArgs.length; i++) {
             const arg = this.claudeArgs[i];
-            
-            if (arg === '--continue') {
-                logger.debug('[Session] Consumed --continue flag');
+
+            if (arg === '--continue' || arg === '-c') {
+                logger.debug(`[Session] Consumed ${arg} flag`);
                 continue;
             }
-            
-            if (arg === '--resume') {
-                // Check if next arg looks like a UUID (contains dashes and alphanumeric)
+
+            if (arg === '--resume' || arg === '-r') {
+                // Check if next arg looks like a value (not another flag)
                 if (i + 1 < this.claudeArgs.length) {
                     const nextArg = this.claudeArgs[i + 1];
-                    // Simple UUID pattern check - contains dashes and is not another flag
-                    if (!nextArg.startsWith('-') && nextArg.includes('-')) {
-                        // Skip both --resume and the UUID
-                        i++; // Skip the UUID
-                        logger.debug(`[Session] Consumed --resume flag with session ID: ${nextArg}`);
+                    if (!nextArg.startsWith('-')) {
+                        // Skip both flag and value
+                        i++;
+                        logger.debug(`[Session] Consumed ${arg} flag with session ID: ${nextArg}`);
                     } else {
-                        // Just --resume without UUID
-                        logger.debug('[Session] Consumed --resume flag (no session ID)');
+                        logger.debug(`[Session] Consumed ${arg} flag (no session ID)`);
                     }
                 } else {
-                    // --resume at the end of args
-                    logger.debug('[Session] Consumed --resume flag (no session ID)');
+                    logger.debug(`[Session] Consumed ${arg} flag (no session ID)`);
                 }
                 continue;
             }
-            
+
+            if (arg === '--session-id') {
+                // Skip --session-id and its value
+                if (i + 1 < this.claudeArgs.length && !this.claudeArgs[i + 1].startsWith('-')) {
+                    i++;
+                    logger.debug(`[Session] Consumed --session-id flag with value`);
+                } else {
+                    logger.debug(`[Session] Consumed --session-id flag (no value)`);
+                }
+                continue;
+            }
+
             filteredArgs.push(arg);
         }
-        
+
         this.claudeArgs = filteredArgs.length > 0 ? filteredArgs : undefined;
         logger.debug(`[Session] Consumed one-time flags, remaining args:`, this.claudeArgs);
     }


### PR DESCRIPTION
## Summary

- **Bug**: `happy --continue` errors with `"--session-id can only be used with --continue or --resume if --fork-session is also specified"` while `claude --continue` works fine
- **Root cause**: Session flags (`--continue`, `-c`) were only extracted from `claudeArgs` when `startFrom` was null. On retry after error (where the SessionStart hook had already set `session.sessionId`), extraction was skipped — causing `--continue` to leak through alongside `--resume <id>`, producing conflicting flags
- **Fix**: Extract all session flags unconditionally from `claudeArgs`, then conditionally use the extracted values to determine `startFrom`. Also consume one-time flags on error in the launcher retry loop, and enhance `consumeOneTimeFlags()` to handle `-c`, `-r` shorthands and `--session-id`

## Changes

### `claudeLocal.ts`
- Move all session flag extraction (`--session-id`, `--resume <id>`, `--continue`) to happen **unconditionally** before the `startFrom` check
- Extracted values are only **used** to set `startFrom` when it's not already set
- Bare `--resume`/`-r` (without value) still passes through to Claude for the interactive session picker
- Fix `hasContinueFlag` reference → `continueFlag.found`

### `claudeLocalLauncher.ts`
- Call `session.consumeOneTimeFlags()` in the `catch` block of the retry loop, preventing flags from leaking on subsequent retries

### `session.ts`
- Enhance `consumeOneTimeFlags()` to handle `-c` (alias for `--continue`), `-r` (alias for `--resume`), and `--session-id` flag
- Simplify value detection (any non-flag next arg, not just UUID pattern)

### `claudeLocal.test.ts`
- Add 2 regression tests for the retry scenario where `sessionId` is already set from a previous hook notification

## Test plan

- [x] All 12 unit tests pass (10 existing + 2 new regression tests)
- [ ] Manual test: `happy --continue` resumes last session without error
- [ ] Manual test: `happy --resume <id>` resumes specific session
- [ ] Manual test: `happy -c` works as alias for `--continue`
- [ ] Manual test: `happy -r` opens Claude's session picker

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)