### PR TITLE
feat(happy-app): show daemon label in session list subtitle

### DIFF
--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -39,6 +39,7 @@ export const MetadataSchema = z.object({
     homeDir: z.string().optional(), // User's home directory on the machine
     happyHomeDir: z.string().optional(), // Happy configuration directory 
     hostPid: z.number().optional(), // Process ID of the session
+    startedBy: z.string().optional(), // How the session was started ('terminal' | 'daemon')
     flavor: z.string().nullish(), // Session flavor/variant identifier
     sandbox: z.any().nullish(), // Sandbox config metadata from CLI (or null when disabled)
     dangerouslySkipPermissions: z.boolean().nullish(), // Claude --dangerously-skip-permissions mode (or null when unknown)

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -300,6 +300,7 @@ export const en = {
 
     session: {
         inputPlaceholder: 'Type a message ...',
+        startedByDaemon: 'daemon',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -301,6 +301,7 @@ export const ca: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Escriu un missatge...',
+        startedByDaemon: 'daemon',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -316,6 +316,7 @@ export const en: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Type a message ...',
+        startedByDaemon: 'daemon',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -301,6 +301,7 @@ export const es: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Escriba un mensaje ...',
+        startedByDaemon: 'daemon',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -330,6 +330,7 @@ export const it: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Scrivi un messaggio ...',
+        startedByDaemon: 'daemon',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -333,6 +333,7 @@ export const ja: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'メッセージを入力...',
+        startedByDaemon: 'デーモン',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -312,6 +312,7 @@ export const pl: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Wpisz wiadomość...',
+        startedByDaemon: 'daemon',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -301,6 +301,7 @@ export const pt: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Digite uma mensagem ...',
+        startedByDaemon: 'daemon',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -393,6 +393,7 @@ export const ru: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Введите сообщение...',
+        startedByDaemon: 'демон',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -303,6 +303,7 @@ export const zhHans: TranslationStructure = {
 
     session: {
         inputPlaceholder: '输入消息...',
+        startedByDaemon: '守护进程',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -302,6 +302,7 @@ export const zhHant: TranslationStructure = {
 
     session: {
         inputPlaceholder: '輸入訊息...',
+        startedByDaemon: '守護程序',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/utils/sessionUtils.ts
+++ b/packages/happy-app/sources/utils/sessionUtils.ts
@@ -137,7 +137,11 @@ export function formatPathRelativeToHome(path: string, homeDir?: string): string
  */
 export function getSessionSubtitle(session: Session): string {
     if (session.metadata) {
-        return formatPathRelativeToHome(session.metadata.path, session.metadata.homeDir);
+        const path = formatPathRelativeToHome(session.metadata.path, session.metadata.homeDir);
+        if (session.metadata.startedBy === 'daemon') {
+            return `${path} · ${t('session.startedByDaemon')}`;
+        }
+        return path;
     }
     return t('status.unknown');
 }


### PR DESCRIPTION
## Summary

- Display a localized "daemon" label in the session list subtitle when `metadata.startedBy === 'daemon'`, making it easy to distinguish daemon-spawned sessions from terminal sessions
- Add `startedBy` field to `MetadataSchema` so the field is preserved through Zod parsing
- Add `session.startedByDaemon` translation key to all 10 languages

Closes #645

## Changes

| File | Change |
|------|--------|
| `storageTypes.ts` | Add `startedBy: z.string().optional()` to MetadataSchema |
| `sessionUtils.ts` | Append ` · daemon` (localized) to subtitle when startedBy is daemon |
| `_default.ts` + 10 translation files | Add `session.startedByDaemon` key |

## Display

```
~/projects/my-app              ← terminal (default, no label)
~/projects/my-app · daemon     ← daemon-spawned session
```

## Test plan

- [ ] Start a session from terminal — subtitle shows path only
- [ ] Start a session via daemon — subtitle shows `path · daemon`
- [ ] Verify label is localized (switch language in app settings)
- [ ] Verify typecheck passes (`yarn typecheck` — no new errors)