### PR TITLE
fix(happy-app): remove startup credential logging

### DIFF
--- a/packages/happy-app/sources/app/_layout.tsx
+++ b/packages/happy-app/sources/app/_layout.tsx
@@ -182,7 +182,6 @@ export default function RootLayout() {
                 await loadFonts();
                 await sodium.ready;
                 const credentials = await TokenStorage.getCredentials();
-                console.log('credentials', credentials);
                 if (credentials) {
                     await syncRestore(credentials);
                 }


### PR DESCRIPTION
This removes a startup log in the app that was printing the full `credentials` object (token + secret) to console.

I opened this because of #137. Even though it was “just a log,” that data can end up in captured logs, debugging tools, or crash pipelines and become a real credential leak.

The fix is intentionally minimal: I only removed the `console.log('credentials', credentials)` line in `packages/happy-app/sources/app/_layout.tsx`. Auth flow and startup behavior stay the same.

Fixes #137
