### PR TITLE
feat(ci): add workflow to build and publish server Docker image to GHCR

### DIFF
--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -55,9 +55,8 @@ jobs:
           context: .
           file: Dockerfile.server
           platforms: ${{ matrix.platform }}
-          push: true
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/happy-server,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
 


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds Dockerfile.server and pushes the image to ghcr.io on pushes to main (path-filtered) and semver tags. Includes GHA layer caching and uses GITHUB_TOKEN — no extra secrets needed.