### PR TITLE
fix: strip CLAUDECODE env var from spawned sessions to prevent crashes

### DIFF
--- a/packages/happy-cli/src/claude/sdk/utils.ts
+++ b/packages/happy-cli/src/claude/sdk/utils.ts
@@ -77,6 +77,13 @@ export function getCleanEnv(): NodeJS.ProcessEnv {
         logger.debug('[Claude SDK] Removed Bun-specific environment variables for Node.js compatibility')
     }
 
+    // Remove Claude Code nested-session detection variables.
+    // When the daemon is started from within a Claude Code session, CLAUDECODE=1 leaks
+    // into all child processes. Claude Code detects this and refuses to start, causing
+    // every remote session to crash with "Process exited unexpectedly".
+    delete env.CLAUDECODE
+    delete env.CLAUDE_CODE_ENTRYPOINT
+
     return env
 }
 

--- a/packages/happy-cli/src/ui/logger.ts
+++ b/packages/happy-cli/src/ui/logger.ts
@@ -201,9 +201,11 @@ class Logger {
   }
 
   private logToFile(prefix: string, message: string, ...args: unknown[]): void {
-    const logLine = `${prefix} ${message} ${args.map(arg => 
-      typeof arg === 'string' ? arg : JSON.stringify(arg)
-    ).join(' ')}\n`
+    const logLine = `${prefix} ${message} ${args.map(arg => {
+      if (typeof arg === 'string') return arg
+      if (arg instanceof Error) return arg.stack || arg.message
+      return JSON.stringify(arg)
+    }).join(' ')}\n`
     
     // Send to remote server if configured
     if (this.dangerouslyUnencryptedServerLoggingUrl) {


### PR DESCRIPTION
## Summary

- Strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` environment variables from all session spawn paths (SDK query, daemon regular spawn, daemon tmux spawn) to prevent Claude Code nested-session detection from crashing remote sessions
- Fix `Error` object serialization in the logger — `JSON.stringify(new Error(...))` produces `{}`, now uses `err.stack` or `err.message` for meaningful log output

## Problem

When `happy daemon start` is run from within a Claude Code session (e.g., VS Code terminal), the daemon inherits `CLAUDECODE=1`. This propagates to all spawned session processes. Claude Code detects this and refuses to start with "cannot be launched inside another Claude Code session", causing every mobile/remote session to immediately crash with **"Process exited unexpectedly"**.

The error was nearly impossible to debug because `JSON.stringify(new Error("..."))` produces `{}` (Error objects have no enumerable properties), so logs only showed `[remote]: launch error {}`.

## Changes

1. **`packages/happy-cli/src/claude/sdk/utils.ts`** — Delete `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` in `getCleanEnv()`, which is used when spawning Claude Code via the SDK
2. **`packages/happy-cli/src/daemon/run.ts`** — Delete these vars in both the regular process spawn path and the tmux spawn path
3. **`packages/happy-cli/src/ui/logger.ts`** — Handle `Error` instances in `logToFile()` by using `err.stack || err.message` instead of `JSON.stringify(err)`

## Test plan

- [x] Start daemon from within a Claude Code session (e.g., VS Code terminal) and verify remote sessions launch successfully from the mobile app
- [x] Start daemon from a clean shell and verify existing behavior is unchanged
- [x] Trigger a session spawn error and verify the log output now shows the actual error message/stack instead of `{}`

Fixes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)