### PR TITLE
fix(happy-cli): strip CLAUDECODE env var from daemon-spawned sessions

### DIFF
--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -495,14 +495,18 @@ export async function startDaemon(): Promise<void> {
             '--started-by', 'daemon'
           ];
 
-          // TODO: In future, sessionId could be used with --resume to continue existing sessions
-          // For now, we ignore it - each spawn creates a new session
+          // Strip CLAUDECODE from env — if the daemon was started from
+          // within a Claude Code session, child processes inherit it and
+          // Claude refuses to launch ("cannot be launched inside another
+          // Claude Code session").
+          const { CLAUDECODE: _stripped, ...cleanEnv } = process.env;
+
           const happyProcess = spawnHappyCLI(args, {
             cwd: directory,
             detached: true,  // Sessions stay alive when daemon stops
             stdio: ['ignore', 'pipe', 'pipe'],  // Capture stdout/stderr for debugging
             env: {
-              ...process.env,
+              ...cleanEnv,
               ...extraEnv
             }
           });

--- a/packages/happy-cli/src/daemon/stripClaudeCodeEnv.test.ts
+++ b/packages/happy-cli/src/daemon/stripClaudeCodeEnv.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for CLAUDECODE environment variable stripping (regression #682).
+ *
+ * When the daemon is started from within a Claude Code session, the
+ * CLAUDECODE=1 env var is inherited. If passed to child session processes,
+ * Claude Code refuses to launch with "cannot be launched inside another
+ * Claude Code session". The daemon must strip it before spawning.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('CLAUDECODE env stripping (issue #682)', () => {
+    it('should remove CLAUDECODE from env while preserving other vars', () => {
+        const env: Record<string, string> = {
+            HOME: '/home/user',
+            PATH: '/usr/bin',
+            CLAUDECODE: '1',
+            NODE_ENV: 'production',
+        };
+
+        // Same destructuring pattern used in daemon/run.ts
+        const { CLAUDECODE: _stripped, ...cleanEnv } = env;
+
+        expect(cleanEnv).toEqual({
+            HOME: '/home/user',
+            PATH: '/usr/bin',
+            NODE_ENV: 'production',
+        });
+        expect('CLAUDECODE' in cleanEnv).toBe(false);
+    });
+
+    it('should work when CLAUDECODE is not present', () => {
+        const env: Record<string, string> = {
+            HOME: '/home/user',
+            PATH: '/usr/bin',
+        };
+
+        const { CLAUDECODE: _stripped, ...cleanEnv } = env;
+
+        expect(cleanEnv).toEqual({
+            HOME: '/home/user',
+            PATH: '/usr/bin',
+        });
+    });
+
+    it('should allow extraEnv to override cleaned env', () => {
+        const env: Record<string, string> = {
+            HOME: '/home/user',
+            CLAUDECODE: '1',
+            EXISTING_VAR: 'old',
+        };
+        const extraEnv: Record<string, string> = {
+            EXISTING_VAR: 'new',
+            NEW_VAR: 'value',
+        };
+
+        const { CLAUDECODE: _stripped, ...cleanEnv } = env;
+        const finalEnv = { ...cleanEnv, ...extraEnv };
+
+        expect('CLAUDECODE' in finalEnv).toBe(false);
+        expect(finalEnv.EXISTING_VAR).toBe('new');
+        expect(finalEnv.NEW_VAR).toBe('value');
+    });
+});


### PR DESCRIPTION
## Summary

- When `happy daemon start` is run from within a Claude Code session (VS Code terminal, Claude Code CLI, etc.), the daemon inherits `CLAUDECODE=1` in its environment
- This was passed through to all child session processes via `process.env`
- Claude Code detects `CLAUDECODE=1` and refuses to start with "cannot be launched inside another Claude Code session", causing every remote session to immediately fail with "Process exited unexpectedly"
- Fix: strip `CLAUDECODE` from `process.env` before spawning session processes

Fixes #682

## Test plan

- [x] Added unit tests verifying `CLAUDECODE` is stripped while other env vars are preserved
- [x] Added test verifying `extraEnv` still merges correctly after stripping
- [ ] Manual: start daemon from within a Claude Code session, verify remote sessions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)