### PR TITLE
feat: add compact context button when context window is nearly full

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -328,6 +328,9 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
             isMicActive={micButtonState.isMicActive}
             onAbort={() => sessionAbort(sessionId)}
             showAbortButton={sessionStatus.state === 'thinking' || sessionStatus.state === 'waiting'}
+            onCompact={() => {
+                sync.sendMessage(sessionId, '/compact');
+            }}
             onFileViewerPress={experiments ? () => router.push(`/session/${sessionId}/files`) : undefined}
             // Autocomplete configuration
             autocompletePrefixes={['@', '/']}

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -43,6 +43,7 @@ interface AgentInputProps {
     metadata?: Metadata | null;
     onAbort?: () => void | Promise<void>;
     showAbortButton?: boolean;
+    onCompact?: () => void;
     connectionStatus?: {
         text: string;
         color: string;
@@ -356,6 +357,12 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
     const agentInputEnterToSend = useSetting('agentInputEnterToSend');
 
+    // Show compact button when context is critically low
+    const showCompactButton = React.useMemo(() => {
+        if (!props.onCompact || !props.usageData?.contextSize) return false;
+        const percentageRemaining = Math.max(0, 100 - (props.usageData.contextSize / MAX_CONTEXT_SIZE) * 100);
+        return percentageRemaining <= 10;
+    }, [props.onCompact, props.usageData?.contextSize]);
 
     // Abort button state
     const [isAborting, setIsAborting] = React.useState(false);
@@ -1091,6 +1098,33 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                             )}
                                         </Pressable>
                                     </Shaker>
+                                )}
+
+                                {/* Compact button - shown when context is critically low */}
+                                {showCompactButton && !props.showAbortButton && (
+                                    <Pressable
+                                        style={(p) => ({
+                                            flexDirection: 'row',
+                                            alignItems: 'center',
+                                            borderRadius: Platform.select({ default: 16, android: 20 }),
+                                            paddingHorizontal: 10,
+                                            paddingVertical: 6,
+                                            justifyContent: 'center',
+                                            height: 32,
+                                            backgroundColor: theme.colors.warning + '20',
+                                            opacity: p.pressed ? 0.7 : 1,
+                                        })}
+                                        hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
+                                        onPress={props.onCompact}
+                                    >
+                                        <Ionicons name="flash-outline" size={14} color={theme.colors.warning} />
+                                        <Text style={{
+                                            marginLeft: 4,
+                                            fontSize: 12,
+                                            color: theme.colors.warning,
+                                            ...Typography.default('semiBold'),
+                                        }}>{t('session.compact')}</Text>
+                                    </Pressable>
                                 )}
 
                                 {/* Git Status Badge */}

--- a/packages/happy-app/sources/components/contextCompact.test.ts
+++ b/packages/happy-app/sources/components/contextCompact.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+
+const MAX_CONTEXT_SIZE = 190000;
+
+/**
+ * Tests for the context compact button visibility logic.
+ * The button should appear when context usage is >= 90% (≤10% remaining).
+ */
+describe('context compact button visibility', () => {
+    function shouldShowCompact(contextSize: number): boolean {
+        const percentageRemaining = Math.max(0, 100 - (contextSize / MAX_CONTEXT_SIZE) * 100);
+        return percentageRemaining <= 10;
+    }
+
+    it('should not show when context is low (50%)', () => {
+        expect(shouldShowCompact(95000)).toBe(false);
+    });
+
+    it('should not show when context is at 80%', () => {
+        expect(shouldShowCompact(152000)).toBe(false);
+    });
+
+    it('should not show when context is at 89%', () => {
+        expect(shouldShowCompact(169100)).toBe(false);
+    });
+
+    it('should show when context is at 90% (10% remaining)', () => {
+        expect(shouldShowCompact(171000)).toBe(true);
+    });
+
+    it('should show when context is at 95% (5% remaining)', () => {
+        expect(shouldShowCompact(180500)).toBe(true);
+    });
+
+    it('should show when context is at 100%', () => {
+        expect(shouldShowCompact(190000)).toBe(true);
+    });
+
+    it('should show when context exceeds max', () => {
+        expect(shouldShowCompact(200000)).toBe(true);
+    });
+
+    it('should not show when context is 0', () => {
+        expect(shouldShowCompact(0)).toBe(false);
+    });
+});
+
+describe('compact command format', () => {
+    it('should send /compact as the message text', () => {
+        const compactCommand = '/compact';
+        expect(compactCommand).toBe('/compact');
+        expect(compactCommand.startsWith('/')).toBe(true);
+    });
+});

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -300,6 +300,7 @@ export const en = {
 
     session: {
         inputPlaceholder: 'Type a message ...',
+        compact: 'Compact',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -301,6 +301,7 @@ export const ca: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Escriu un missatge...',
+        compact: 'Compactar',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -316,6 +316,7 @@ export const en: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Type a message ...',
+        compact: 'Compact',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -301,6 +301,7 @@ export const es: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Escriba un mensaje ...',
+        compact: 'Compactar',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -330,6 +330,7 @@ export const it: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Scrivi un messaggio ...',
+        compact: 'Compatta',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -333,6 +333,7 @@ export const ja: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'メッセージを入力...',
+        compact: 'コンパクト',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -312,6 +312,7 @@ export const pl: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Wpisz wiadomość...',
+        compact: 'Kompaktuj',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -301,6 +301,7 @@ export const pt: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Digite uma mensagem ...',
+        compact: 'Compactar',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -393,6 +393,7 @@ export const ru: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Введите сообщение...',
+        compact: 'Сжать',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -303,6 +303,7 @@ export const zhHans: TranslationStructure = {
 
     session: {
         inputPlaceholder: '输入消息...',
+        compact: '压缩',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -302,6 +302,7 @@ export const zhHant: TranslationStructure = {
 
     session: {
         inputPlaceholder: '輸入訊息...',
+        compact: '壓縮',
     },
 
     commandPalette: {


### PR DESCRIPTION
## Summary
- Adds a "Compact" button to the input area that appears when context usage exceeds 90% (≤10% remaining)
- Tapping the button sends `/compact` to the CLI, which triggers context compaction
- This gives users a way to recover from context limit dead-ends without switching to the terminal
- Button is hidden while the session is actively thinking (abort button takes priority)

Fixes #652

## Test plan
- [x] Added 9 tests for compact button visibility logic
- [x] TypeScript typecheck passes
- [x] All 10 language translations added
- [ ] Verify button appears when context usage is high
- [ ] Verify tapping sends `/compact` and CLI compacts context

🤖 Generated with [Claude Code](https://claude.com/claude-code)