### PR TITLE
feat(app): add Resume Session to continue previous conversations

### DIFF
--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -185,6 +185,41 @@ export async function machineSpawnNewSession(options: SpawnSessionOptions): Prom
 }
 
 /**
+ * Resume a previous Claude session on a specific machine.
+ * Creates a new Happy session but continues the Claude conversation via --resume.
+ */
+export async function machineResumeSession(options: {
+    machineId: string;
+    directory: string;
+    claudeSessionId: string;
+    agent?: 'codex' | 'claude' | 'gemini';
+    environmentVariables?: Record<string, string>;
+}): Promise<SpawnSessionResult> {
+    const { machineId, directory, claudeSessionId, agent, environmentVariables } = options;
+
+    try {
+        const result = await apiSocket.machineRPC<SpawnSessionResult, {
+            type: 'spawn-in-directory'
+            directory: string
+            sessionId: string
+            approvedNewDirectoryCreation: boolean
+            agent?: 'codex' | 'claude' | 'gemini'
+            environmentVariables?: Record<string, string>
+        }>(
+            machineId,
+            'spawn-happy-session',
+            { type: 'spawn-in-directory', directory, sessionId: claudeSessionId, approvedNewDirectoryCreation: false, agent, environmentVariables }
+        );
+        return result;
+    } catch (error) {
+        return {
+            type: 'error',
+            errorMessage: error instanceof Error ? error.message : 'Failed to resume session'
+        };
+    }
+}
+
+/**
  * Stop the daemon on a specific machine
  */
 export async function machineStopDaemon(machineId: string): Promise<{ message: string }> {

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -374,7 +374,11 @@ export const en = {
         deleteSessionWarning: 'This action cannot be undone. All messages and data associated with this session will be permanently deleted.',
         failedToDeleteSession: 'Failed to delete session',
         sessionDeleted: 'Session deleted successfully',
-        
+        resumeSession: 'Resume Session',
+        resumeSessionSubtitle: 'Continue this conversation in a new session',
+        resumeSessionMachineOffline: 'Machine is offline',
+        failedToResumeSession: 'Failed to resume session',
+
     },
 
     components: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -375,6 +375,10 @@ export const ca: TranslationStructure = {
         deleteSessionWarning: 'Aquesta acció no es pot desfer. Tots els missatges i dades associats amb aquesta sessió s\'eliminaran permanentment.',
         failedToDeleteSession: 'Error en eliminar la sessió',
         sessionDeleted: 'Sessió eliminada amb èxit',
+        resumeSession: 'Reprendre la sessió',
+        resumeSessionSubtitle: 'Continuar aquesta conversa en una nova sessió',
+        resumeSessionMachineOffline: 'La màquina està fora de línia',
+        failedToResumeSession: 'Error en reprendre la sessió',
         
     },
 

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -390,6 +390,10 @@ export const en: TranslationStructure = {
         deleteSessionWarning: 'This action cannot be undone. All messages and data associated with this session will be permanently deleted.',
         failedToDeleteSession: 'Failed to delete session',
         sessionDeleted: 'Session deleted successfully',
+        resumeSession: 'Resume Session',
+        resumeSessionSubtitle: 'Continue this conversation in a new session',
+        resumeSessionMachineOffline: 'Machine is offline',
+        failedToResumeSession: 'Failed to resume session',
 
     },
 

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -375,6 +375,10 @@ export const es: TranslationStructure = {
         deleteSessionWarning: 'Esta acción no se puede deshacer. Todos los mensajes y datos asociados con esta sesión se eliminarán permanentemente.',
         failedToDeleteSession: 'Error al eliminar la sesión',
         sessionDeleted: 'Sesión eliminada exitosamente',
+        resumeSession: 'Reanudar sesión',
+        resumeSessionSubtitle: 'Continuar esta conversación en una nueva sesión',
+        resumeSessionMachineOffline: 'La máquina está sin conexión',
+        failedToResumeSession: 'Error al reanudar la sesión',
         
     },
 

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -404,6 +404,10 @@ export const it: TranslationStructure = {
         deleteSessionWarning: 'Questa azione non può essere annullata. Tutti i messaggi e i dati associati a questa sessione verranno eliminati definitivamente.',
         failedToDeleteSession: 'Impossibile eliminare la sessione',
         sessionDeleted: 'Sessione eliminata con successo',
+        resumeSession: 'Riprendi sessione',
+        resumeSessionSubtitle: 'Continua questa conversazione in una nuova sessione',
+        resumeSessionMachineOffline: 'La macchina è offline',
+        failedToResumeSession: 'Impossibile riprendere la sessione',
         
     },
 

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -407,6 +407,10 @@ export const ja: TranslationStructure = {
         deleteSessionWarning: 'この操作は取り消せません。このセッションに関連するすべてのメッセージとデータが完全に削除されます。',
         failedToDeleteSession: 'セッションの削除に失敗しました',
         sessionDeleted: 'セッションが正常に削除されました',
+        resumeSession: 'セッションを再開',
+        resumeSessionSubtitle: 'この会話を新しいセッションで続ける',
+        resumeSessionMachineOffline: 'マシンがオフラインです',
+        failedToResumeSession: 'セッションの再開に失敗しました',
 
     },
 

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -386,6 +386,10 @@ export const pl: TranslationStructure = {
         deleteSessionWarning: 'Ta operacja jest nieodwracalna. Wszystkie wiadomości i dane powiązane z tą sesją zostaną trwale usunięte.',
         failedToDeleteSession: 'Nie udało się usunąć sesji',
         sessionDeleted: 'Sesja została pomyślnie usunięta',
+        resumeSession: 'Wznów sesję',
+        resumeSessionSubtitle: 'Kontynuuj tę rozmowę w nowej sesji',
+        resumeSessionMachineOffline: 'Maszyna jest offline',
+        failedToResumeSession: 'Nie udało się wznowić sesji',
     },
 
     components: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -375,6 +375,10 @@ export const pt: TranslationStructure = {
         deleteSessionWarning: 'Esta ação não pode ser desfeita. Todas as mensagens e dados associados a esta sessão serão excluídos permanentemente.',
         failedToDeleteSession: 'Falha ao excluir sessão',
         sessionDeleted: 'Sessão excluída com sucesso',
+        resumeSession: 'Retomar sessão',
+        resumeSessionSubtitle: 'Continuar esta conversa em uma nova sessão',
+        resumeSessionMachineOffline: 'A máquina está offline',
+        failedToResumeSession: 'Falha ao retomar a sessão',
         
     },
 

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -349,6 +349,10 @@ export const ru: TranslationStructure = {
         deleteSessionWarning: 'Это действие нельзя отменить. Все сообщения и данные, связанные с этой сессией, будут удалены навсегда.',
         failedToDeleteSession: 'Не удалось удалить сессию',
         sessionDeleted: 'Сессия успешно удалена',
+        resumeSession: 'Возобновить сессию',
+        resumeSessionSubtitle: 'Продолжить этот разговор в новой сессии',
+        resumeSessionMachineOffline: 'Машина не в сети',
+        failedToResumeSession: 'Не удалось возобновить сессию',
     },
 
     components: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -377,6 +377,10 @@ export const zhHans: TranslationStructure = {
         deleteSessionWarning: '此操作无法撤销。与此会话相关的所有消息和数据将被永久删除。',
         failedToDeleteSession: '删除会话失败',
         sessionDeleted: '会话删除成功',
+        resumeSession: '恢复会话',
+        resumeSessionSubtitle: '在新会话中继续此对话',
+        resumeSessionMachineOffline: '机器离线',
+        failedToResumeSession: '恢复会话失败',
         
     },
 

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -376,6 +376,10 @@ export const zhHant: TranslationStructure = {
         deleteSessionWarning: '此操作無法復原。與此工作階段相關的所有訊息和資料將被永久刪除。',
         failedToDeleteSession: '刪除工作階段失敗',
         sessionDeleted: '工作階段刪除成功',
+        resumeSession: '恢復工作階段',
+        resumeSessionSubtitle: '在新的工作階段中繼續此對話',
+        resumeSessionMachineOffline: '機器離線',
+        failedToResumeSession: '恢復工作階段失敗',
 
     },
 


### PR DESCRIPTION
## Summary

Adds the ability to resume a previous Claude conversation by spawning a new Happy session with `--resume <claudeSessionId>`. This lets users continue where they left off without losing context.

### Related issues

Addresses: #685 — support resuming Claude Code sessions when spawning from mobile.
Also relevant: #478, #621, #611, #353, #437 — various requests for session resume/continue functionality from mobile.

### Comparison with similar PRs

- **#644** — prevents session flags (`--continue`, `--resume`) from leaking through on retry in the local CLI launcher. This is a complementary fix for the local mode retry path; this PR implements the remote-mode resume feature via the daemon's spawn RPC, which is a separate code path. Both can coexist.
- **#308** (closed) pagination PR also touched `sync.ts` — no actual overlap with this feature.

### How it works

- Reuses the existing `spawn-happy-session` / `spawn-in-directory` RPC — the daemon interprets the presence of a `sessionId` field as a resume request and appends `--resume <id>` to the CLI spawn command
- The daemon validates the session ID against a strict UUID regex before using it, guarding against injection in the tmux shell command path
- The UI only shows the resume option when the session is inactive, disconnected, and has the required metadata (`claudeSessionId` + `machineId`)
- The resume button is disabled with a "Machine is offline" subtitle when the target machine is not reachable

### Changes by package

**happy-app**
- `session/[id]/info.tsx`: Add "Resume Session" action in Quick Actions group with online/offline machine status
- `SessionsList.tsx`: Add swipe-to-resume gesture (green "Resume" button alongside existing red "Delete")
- `sync/ops.ts`: New `machineResumeSession()` function that sends `spawn-happy-session` RPC with `sessionId`
- Translation files (10 locales): Add `resumeSession`, `resumeSessionSubtitle`, `resumeSessionMachineOffline`, `failedToResumeSession` keys

**happy-cli**
- `daemon/run.ts`: Handle `sessionId` in spawn payload — validate UUID format, append `--resume <id>` to tmux command or spawn args

## Test plan

- [ ] Open session info for a completed session on an online machine → "Resume Session" button is green and pressable
- [ ] Tap Resume → new session is created and navigated to, Claude resumes the conversation
- [ ] Open session info for a session on an offline machine → button is grayed out with "Machine is offline"
- [ ] Swipe left on a resumable session in the list → green "Resume" button appears alongside "Delete"
- [ ] Session that is currently active → no resume button shown