### PR TITLE
fix(acp): accept null in formatOptionalDetail type

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -104,7 +104,7 @@ function formatTextForConsole(text: string): string {
   return JSON.stringify(truncateForConsole(toSingleLine(text), ACP_EVENT_PREVIEW_CHARS));
 }
 
-function formatOptionalDetail(text: string | undefined, limit = ACP_EVENT_PREVIEW_CHARS): string {
+function formatOptionalDetail(text: string | null | undefined, limit = ACP_EVENT_PREVIEW_CHARS): string {
   if (!text) {
     return '';
   }


### PR DESCRIPTION
## Summary

Widens the `text` parameter of `formatOptionalDetail` from `string | undefined` to `string | null | undefined` to match actual call sites that pass `null`.

The runtime falsy check (`if (!text)`) already handled `null` correctly, but the TypeScript type was too narrow.

### Related

- #267 — ACP stabilization tracking issue

## Test plan

- [ ] ACP agent runs without type errors when `formatOptionalDetail` receives `null`