### PR TITLE
feat(sync): add force re-sync messages debug tool in dev menu

### DIFF
--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -125,6 +125,7 @@ interface StorageState {
     updateArtifact: (artifact: DecryptedArtifact) => void;
     deleteArtifact: (artifactId: string) => void;
     deleteSession: (sessionId: string) => void;
+    clearSessionMessages: (sessionId: string) => void;
     // Project management methods
     getProjects: () => import('./projectManager').Project[];
     getProject: (projectId: string) => import('./projectManager').Project | null;
@@ -941,6 +942,10 @@ export const storage = create<StorageState>()((set, get) => {
                 sessionGitStatus: remainingGitStatus,
                 sessionListViewData
             };
+        }),
+        clearSessionMessages: (sessionId: string) => set((state) => {
+            const { [sessionId]: _, ...remainingSessionMessages } = state.sessionMessages;
+            return { ...state, sessionMessages: remainingSessionMessages };
         }),
         // Friend management methods
         applyFriends: (friends: UserProfile[]) => set((state) => {


### PR DESCRIPTION
## Summary

Adds a developer menu action that wipes the local message cache for a specific session and re-fetches all messages from the server. Useful for diagnosing sync issues without a full app reinstall.

### Changes

- `storage.ts`: New `clearSessionMessages(sessionId)` method to remove a session's cached messages from the Zustand store
- `sync.ts`: New `forceResyncMessages(sessionId)` method that stops the existing sync, acquires the message lock, resets `sessionLastSeq` / message queue state, clears the store, then creates a fresh sync and awaits completion
- `dev/index.tsx`: New "Force Re-sync Messages" action in the dev menu with session ID prompt and loading state

## Test plan

- [ ] Dev menu → Force Re-sync Messages → enter session ID → messages reload from server
- [ ] Verify the action properly resets cursor state and re-fetches from seq 0