### PR TITLE
feat(app): add Gemini 3.0 preview models and update defaults

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -24,8 +24,10 @@ type MetadataOption = {
 };
 
 const GEMINI_MODEL_FALLBACKS: ModelMode[] = [
-    { key: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Most capable' },
-    { key: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Fast & efficient' },
+    { key: 'gemini-3-pro-preview', name: 'Gemini 3 Pro Preview', description: 'Most capable' },
+    { key: 'gemini-3-flash-preview', name: 'Gemini 3 Flash Preview', description: 'Fast & capable' },
+    { key: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Previous gen pro' },
+    { key: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Previous gen flash' },
     { key: 'gemini-2.5-flash-lite', name: 'Gemini 2.5 Flash Lite', description: 'Fastest' },
 ];
 
@@ -167,7 +169,7 @@ export function getDefaultModelKey(flavor: AgentFlavor): string {
         return 'gpt-5-codex-high';
     }
     if (flavor === 'gemini') {
-        return 'gemini-2.5-pro';
+        return 'gemini-3-flash-preview';
     }
     return 'default';
 }


### PR DESCRIPTION
## Summary

Updates the Gemini model picker with the new 3.0 preview models.

### Changes

- Add `gemini-3-pro-preview` ("Most capable") and `gemini-3-flash-preview` ("Fast & capable") to the model list
- Demote existing 2.5 models to "Previous gen pro" / "Previous gen flash"
- Change the default Gemini model from `gemini-2.5-pro` to `gemini-3-flash-preview`

### Related

- #397 — context-aware voice interaction using Gemini 3 Flash

## Test plan

- [ ] Model picker shows Gemini 3.0 models at the top with correct labels
- [ ] Default model for new Gemini sessions is `gemini-3-flash-preview`
- [ ] Existing sessions using 2.5 models continue to work