### PR TITLE
fix(app): correct Project Components URLs in README

### DIFF
--- a/packages/happy-app/README.md
+++ b/packages/happy-app/README.md
@@ -65,8 +65,8 @@ On your computer, run `happy` instead of `claude` or `happy codex` instead of `c
 
 ## 📦 Project Components
 
-- **[happy-cli](https://github.com/slopus/happy-cli)** - Command-line interface for Claude Code and Codex
-- **[happy-server](https://github.com/slopus/happy-server)** - Backend server for encrypted sync
+- **[happy-cli](https://github.com/slopus/happy/tree/main/packages/happy-cli)** - Command-line interface for Claude Code and Codex
+- **[happy-server](https://github.com/slopus/happy/tree/main/packages/happy-server)** - Backend server for encrypted sync
 - **happy-coder** - This mobile client (you are here)
 
 ## 🏠 Who We Are


### PR DESCRIPTION
Thanks for building such an amazing service! I'm using it every day.

Updated the Project Components URLs from the old public archive repositories to the correct monorepo package locations.