### PR TITLE
fix: prevent --yolo permission mode from being overridden by mobile app

### DIFF
--- a/cli/src/claude/utils/permissionHandler.ts
+++ b/cli/src/claude/utils/permissionHandler.ts
@@ -14,6 +14,7 @@ import { Session } from "../session";
 import { getToolName } from "./getToolName";
 import { EnhancedMode, PermissionMode } from "../loop";
 import { getToolDescriptor } from "./getToolDescriptor";
+import { mapToClaudeMode } from "./permissionMode";
 import { delay } from "@/utils/time";
 
 interface PermissionResponse {
@@ -57,7 +58,7 @@ export class PermissionHandler {
     }
 
     handleModeChange(mode: PermissionMode) {
-        this.permissionMode = mode;
+        this.permissionMode = mapToClaudeMode(mode);
     }
 
     /**

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -491,6 +491,7 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
       } else if (arg === '--yolo') {
         // Shortcut for --dangerously-skip-permissions
         unknownArgs.push('--dangerously-skip-permissions')
+        options.permissionMode = 'bypassPermissions'
       } else if (arg === '--started-by') {
         options.startedBy = args[++i] as 'daemon' | 'terminal'
       } else if (arg === '--js-runtime') {


### PR DESCRIPTION
## Summary

Fixes three issues that caused `--yolo` / `bypassPermissions` mode to not work reliably when using the mobile app:

- **`--yolo` didn't set internal permission state** — The flag only passed `--dangerously-skip-permissions` to Claude's args but didn't set `options.permissionMode`, so Happy's message handler didn't know bypass was active
- **Mobile messages unconditionally overwrote permission mode** — The mobile app sends `permissionMode: "default"` with every message, which reset the mode even when the session was started with `--yolo`
- **`handleModeChange()` stored raw mode without mapping** — When the mobile app sends `permissionMode: "yolo"`, it was stored as-is, but `handleToolCall()` checks against `"bypassPermissions"` — so the bypass never fired

## Changes

| File | Change |
|------|--------|
| `cli/src/index.ts` | Set `options.permissionMode = 'bypassPermissions'` when `--yolo` is parsed |
| `cli/src/claude/runClaude.ts` | Don't allow mobile messages to downgrade from `bypassPermissions` |
| `cli/src/claude/utils/permissionHandler.ts` | Map mode through `mapToClaudeMode()` in `handleModeChange()` |

## Test plan

- [x] `yarn build` passes (includes `tsc --noEmit`)
- [ ] Manual: run `happy --yolo`, send message from mobile, verify no permission prompts
- [ ] Manual: run `happy` without `--yolo`, toggle to yolo in mobile app, verify bypass works after current turn completes

## Related

- Closes slopus/happy-cli#150 (`--yolo flag gets overridden by mobile app's permissionMode`)
- Related to slopus/happy-cli#8 (`using -p bypassPermissions not working`)
- Credit to @Yehonatan-Bar for the original bug analysis in #150

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)