### PR TITLE
fix(happy-app): handle blank lines and empty cells in markdown table parser

### DIFF
--- a/packages/happy-app/sources/components/markdown/parseMarkdownBlock.test.ts
+++ b/packages/happy-app/sources/components/markdown/parseMarkdownBlock.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkdown } from './parseMarkdown';
+
+describe('parseMarkdownBlock - table parsing', () => {
+
+    it('parses a standard table without blank lines', () => {
+        const md = [
+            '| A | B |',
+            '|---|---|',
+            '| 1 | 2 |',
+        ].join('\n');
+
+        const blocks = parseMarkdown(md);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toEqual({
+            type: 'table',
+            headers: ['A', 'B'],
+            rows: [['1', '2']],
+        });
+    });
+
+    it('parses a table with blank lines between rows (LLM output)', () => {
+        const md = [
+            '| A | B |',
+            '',
+            '|---|---|',
+            '',
+            '| 1 | 2 |',
+            '',
+            '| 3 | 4 |',
+        ].join('\n');
+
+        const blocks = parseMarkdown(md);
+        // Should be recognized as a single table, not 4 separate text blocks
+        const tableBlocks = blocks.filter(b => b.type === 'table');
+        expect(tableBlocks).toHaveLength(1);
+        expect(tableBlocks[0]).toEqual({
+            type: 'table',
+            headers: ['A', 'B'],
+            rows: [['1', '2'], ['3', '4']],
+        });
+    });
+
+    it('preserves empty interior cells (e.g. row header column)', () => {
+        const md = [
+            '| | Header1 | Header2 |',
+            '|---|---|---|',
+            '| Row1 | a | b |',
+        ].join('\n');
+
+        const blocks = parseMarkdown(md);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]).toEqual({
+            type: 'table',
+            headers: ['', 'Header1', 'Header2'],
+            rows: [['Row1', 'a', 'b']],
+        });
+    });
+
+    it('handles blank lines and empty first cell combined', () => {
+        const md = [
+            '### Comparison',
+            '',
+            '| | Plan A | Plan B |',
+            '',
+            '|--|----|----|',
+            '',
+            '| Price | $10/mo | $20/mo |',
+            '',
+            '| Storage | 5 GB | 50 GB |',
+            '',
+            '| Support | Email only | 24/7 chat |',
+        ].join('\n');
+
+        const blocks = parseMarkdown(md);
+        const tableBlocks = blocks.filter(b => b.type === 'table');
+        expect(tableBlocks).toHaveLength(1);
+
+        const table = tableBlocks[0];
+        if (table.type !== 'table') throw new Error('not a table');
+
+        // Empty first cell should be preserved
+        expect(table.headers).toHaveLength(3);
+        expect(table.headers[0]).toBe('');
+
+        expect(table.rows).toHaveLength(3);
+        expect(table.rows[0][0]).toBe('Price');
+    });
+
+    it('stops table collection at non-blank, non-pipe lines', () => {
+        const md = [
+            '| A | B |',
+            '|---|---|',
+            '| 1 | 2 |',
+            '',
+            'Some text after the table',
+        ].join('\n');
+
+        const blocks = parseMarkdown(md);
+        const tableBlocks = blocks.filter(b => b.type === 'table');
+        const textBlocks = blocks.filter(b => b.type === 'text');
+
+        expect(tableBlocks).toHaveLength(1);
+        expect(textBlocks).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #506

Two bugs in the markdown table parser:

1. **Blank lines between rows**: LLMs often output tables with `\n\n` between rows. The parser stopped collecting at the first blank line, rendering each row as raw text.
2. **Empty cells filtered out**: `filter(cell => cell.length > 0)` removed interior empty cells (e.g. `| | Header1 | Header2 |` lost the empty first column), causing column misalignment.

### Changes
- Skip blank lines when collecting table rows in `parseTable`
- Add `splitTableRow` helper that strips only leading/trailing pipe artifacts while preserving interior empty cells
- Add 5 unit tests covering both bugs

## Test plan
- [x] 5 new tests pass (blank lines, empty cells, combined case)
- [x] All 444 existing tests pass
- [x] Verified visually in web dev server