### PR TITLE
fix: inherit parent permission mode in Task subagent sessions

### DIFF
--- a/cli/src/claude/claudeRemote.ts
+++ b/cli/src/claude/claudeRemote.ts
@@ -111,7 +111,7 @@ export async function claudeRemote(opts: {
         cwd: opts.path,
         resume: startFrom ?? undefined,
         mcpServers: opts.mcpServers,
-        permissionMode: initial.mode.permissionMode === 'plan' ? 'plan' : 'default',
+        permissionMode: initial.mode.permissionMode,
         model: initial.mode.model,
         fallbackModel: initial.mode.fallbackModel,
         customSystemPrompt: initial.mode.customSystemPrompt ? initial.mode.customSystemPrompt + '\n\n' + systemPrompt : undefined,


### PR DESCRIPTION
Minimal one-line fix: background Task subagents were having their permission mode reset to default instead of inheriting the parent session's mode (bypassPermissions, acceptEdits, etc.).