### PR TITLE
fix: inherit parent permissionMode in Task subagents

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -117,6 +117,11 @@ export async function claudeRemote(opts: {
         cwd: opts.path,
         resume: startFrom ?? undefined,
         mcpServers: opts.mcpServers,
+        // IMPORTANT: Use mapToClaudeMode() to translate all 7 PermissionModes to the 4
+        // modes the Claude SDK understands. Do NOT use a ternary like
+        // `=== "plan" ? "plan" : "default"` — that would silently reset bypassPermissions
+        // and acceptEdits to "default", breaking autonomous agent workflows.
+        // See: packages/happy-cli/src/claude/utils/permissionMode.ts
         permissionMode: mapToClaudeMode(initial.mode.permissionMode),
         model: initial.mode.model,
         fallbackModel: initial.mode.fallbackModel,


### PR DESCRIPTION
Closes #521

## Problem

When a Task subagent is spawned, the permission mode was reset to `"default"` for any non-`"plan"` mode:

```typescript
permissionMode: initial.mode.permissionMode === "plan" ? "plan" : "default",
```

This means users with `bypassPermissions` set in `~/.claude/settings.json` find that background Task subagents have all tool calls denied — Bash, Read, Grep, Edit, etc. — because the subagent can't respond to interactive permission prompts and the calls just fail silently.

## Root Cause

The condition only preserves `"plan"` mode. All other modes including `"bypassPermissions"` and `"acceptEdits"` are silently downgraded to `"default"` at the subagent session boundary.

## Fix

The fix already landed in `main` (commit `7f178466`) via `mapToClaudeMode()` which properly passes all 7 permission modes through unchanged. This PR adds a guard comment in `claudeRemote.ts` documenting the anti-pattern to prevent future regression, and formally closes #521.

## Reproduction (before fix)

1. Set `"defaultMode": "bypassPermissions"` in `~/.claude/settings.json`
2. Ask Claude to run a background Task subagent that uses Bash or Read
3. Observe: all tool calls denied in the subagent
4. After fix: subagent inherits `bypassPermissions` and runs fully autonomously

## Related

- #625 — web/Android app sending wrong permissionMode on new sessions (same symptom, different entry point)
- #639 — background task response delivery timing (separate but affects same workflows)