### PR TITLE
fix: sanitize CLAUDECODE env var in daemon-spawned sessions

### DIFF
--- a/packages/happy-cli/scripts/claude_local_launcher.cjs
+++ b/packages/happy-cli/scripts/claude_local_launcher.cjs
@@ -67,6 +67,9 @@ global.fetch = function(...args) {
 Object.defineProperty(global.fetch, 'name', { value: 'fetch' });
 Object.defineProperty(global.fetch, 'length', { value: originalFetch.length });
 
+// Remove CLAUDECODE to prevent nested session detection when spawning Claude CLI
+delete process.env.CLAUDECODE;
+
 // Import global Claude Code CLI
 const { getClaudeCliPath, runClaudeCli } = require('./claude_version_utils.cjs');
 

--- a/packages/happy-cli/scripts/claude_remote_launcher.cjs
+++ b/packages/happy-cli/scripts/claude_remote_launcher.cjs
@@ -10,6 +10,9 @@ global.setTimeout = function(callback, delay, ...args) {
 Object.defineProperty(global.setTimeout, 'name', { value: 'setTimeout' });
 Object.defineProperty(global.setTimeout, 'length', { value: originalSetTimeout.length });
 
+// Remove CLAUDECODE to prevent nested session detection when spawning Claude CLI
+delete process.env.CLAUDECODE;
+
 // Import global Claude Code CLI
 const { getClaudeCliPath, runClaudeCli } = require('./claude_version_utils.cjs');
 

--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -241,6 +241,8 @@ export async function claudeLocal(opts: {
                 ...process.env,
                 ...opts.claudeEnvVars
             }
+            // Remove CLAUDECODE to prevent nested session detection when spawning Claude CLI
+            delete env.CLAUDECODE
 
             logger.debug(`[ClaudeLocal] Spawning launcher: ${claudeCliPath}`);
             logger.debug(`[ClaudeLocal] Args: ${JSON.stringify(args)}`);

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -402,7 +402,8 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                     session.client.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
                 }
             } catch (e) {
-                logger.debug('[remote]: launch error', e);
+                const errorDetail = e instanceof Error ? `${e.message}\n${e.stack}` : String(e);
+                logger.debug(`[remote]: launch error: ${errorDetail}`);
                 if (!exitReason) {
                     session.client.closeClaudeSessionTurn('failed');
                     session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });

--- a/packages/happy-cli/src/claude/sdk/metadataExtractor.ts
+++ b/packages/happy-cli/src/claude/sdk/metadataExtractor.ts
@@ -60,7 +60,7 @@ export async function extractSDKMetadata(): Promise<SDKMetadata> {
             logger.debug('[metadataExtractor] SDK query aborted after capturing metadata')
             return {}
         }
-        logger.debug('[metadataExtractor] Error extracting SDK metadata:', error)
+        logger.debug(`[metadataExtractor] Error extracting SDK metadata: ${error instanceof Error ? error.message : String(error)}`)
         return {}
     }
 }

--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -340,7 +340,10 @@ export function query(config: {
 
     // Spawn Claude Code process
     // Use clean env for global claude to avoid local node_modules/.bin taking precedence
-    const spawnEnv = isCommandOnly ? getCleanEnv() : process.env
+    const baseEnv = isCommandOnly ? getCleanEnv() : { ...process.env }
+    // Remove CLAUDECODE to prevent nested session detection when spawning Claude CLI
+    delete baseEnv.CLAUDECODE
+    const spawnEnv = baseEnv
     logDebug(`Spawning Claude Code process: ${spawnCommand} ${spawnArgs.join(' ')} (using ${isCommandOnly ? 'clean' : 'normal'} env)`)
 
     const child = spawn(spawnCommand, spawnArgs, {

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -497,14 +497,19 @@ export async function startDaemon(): Promise<void> {
 
           // TODO: In future, sessionId could be used with --resume to continue existing sessions
           // For now, we ignore it - each spawn creates a new session
+          // Build clean environment for child process
+          const childEnv = {
+            ...process.env,
+            ...extraEnv
+          };
+          // Remove CLAUDECODE to prevent nested session detection when spawning Claude CLI
+          delete childEnv.CLAUDECODE;
+
           const happyProcess = spawnHappyCLI(args, {
             cwd: directory,
             detached: true,  // Sessions stay alive when daemon stops
             stdio: ['ignore', 'pipe', 'pipe'],  // Capture stdout/stderr for debugging
-            env: {
-              ...process.env,
-              ...extraEnv
-            }
+            env: childEnv
           });
 
           // Log output for debugging


### PR DESCRIPTION
## Summary

- Remove inherited `CLAUDECODE=1` env var before spawning Claude CLI in all spawn paths, preventing "Process exited unexpectedly" when daemon is started from a Claude Code terminal
- Fix error logging that serialized Error objects as `{}` (non-enumerable properties), making debugging impossible

## Root Cause

When the Happy daemon is started from within a Claude Code terminal, it inherits `CLAUDECODE=1`. Claude CLI detects this and refuses to start, thinking it's a nested session. The daemon didn't sanitize this variable before spawning child processes.

The error was invisible in logs because `JSON.stringify(new Error("msg"))` returns `{}`.

## Changes

**CLAUDECODE removal (5 locations):**
- `scripts/claude_remote_launcher.cjs`
- `scripts/claude_local_launcher.cjs`
- `src/claude/sdk/query.ts`
- `src/claude/claudeLocal.ts`
- `src/daemon/run.ts`

**Error logging fix (2 locations):**
- `src/claude/claudeRemoteLauncher.ts` — extract `e.message` + `e.stack`
- `src/claude/sdk/metadataExtractor.ts` — extract `error.message`

## Test plan

- [ ] Start Happy daemon from within a Claude Code terminal session
- [ ] Create a new conversation from mobile app
- [ ] Verify session starts successfully instead of "Process exited unexpectedly"

Fixes #735

🤖 Generated with [Claude Code](https://claude.ai/code)