### PR TITLE
feat(cli): improve session title prompt with structured triggers

### DIFF
--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -42,7 +42,7 @@ export async function startHappyServer(client: ApiSessionClient) {
     });
 
     mcp.registerTool('change_title', {
-        description: 'Change the title of the current chat session',
+        description: 'Set or update the chat session title. Titles should be short (under 50 chars) and action-oriented, e.g. "Fix auth token refresh".',
         title: 'Change Chat Title',
         inputSchema: {
             title: z.string().describe('The new title for the chat session'),

--- a/packages/happy-cli/src/claude/utils/systemPrompt.ts
+++ b/packages/happy-cli/src/claude/utils/systemPrompt.ts
@@ -5,7 +5,18 @@ import { shouldIncludeCoAuthoredBy } from "./claudeSettings";
  * Base system prompt shared across all configurations
  */
 const BASE_SYSTEM_PROMPT = (() => trimIdent(`
-    ALWAYS when you start a new chat - you must call a tool "mcp__happy__change_title" to set a chat title. When you think chat title is not relevant anymore - call the tool again to change it. When chat name is too generic and you have a change to make it more specific - call the tool again to change it. This title is needed to easily find the chat in the future. Help human.
+    You MUST call the "mcp__happy__change_title" tool to set and maintain an accurate chat title. This title is how the user identifies sessions at a glance across multiple machines and projects. Follow these rules:
+
+    1. IMMEDIATELY on your first response — set a title based on the user's first message.
+    2. Once you understand the real goal — update the title to be more specific (this often applies after the first exchange).
+    3. When the conversation's focus shifts significantly — update the title to reflect the new focus.
+    4. When you complete a major task and move on to something new — update the title.
+
+    Title guidelines:
+    - Keep titles short (under 50 characters) and action-oriented.
+    - Describe WHAT is being done, not WHERE (the project path is shown separately).
+    - Good: "Fix auth token refresh", "Add dark mode toggle", "Debug flaky CI tests"
+    - Bad: "happy-repo", "Working on code", "Helping with project", "Chat"
 `))();
 
 /**


### PR DESCRIPTION
## Summary

- Replace the vague single-sentence title instruction in the system prompt with explicit numbered triggers (on first response, after understanding goal, on focus shift, after major task completion) and good/bad examples
- Update the `change_title` MCP tool description to reinforce title guidelines (under 50 chars, action-oriented) at the tool level, not just in the system prompt
- No wire, server, or app changes — purely CLI-side prompt improvements

## Problem

Session titles in the mobile app are often generic or stale because the current system prompt instruction ("when you think chat title is not relevant anymore") is too vague. Claude frequently sets a title once and never updates it, or uses the project directory name as the title, which is useless when you have multiple sessions in the same project.

## Changes

### `systemPrompt.ts`
- Structured numbered trigger conditions instead of one vague sentence
- Explicit title guidelines with character limit and good/bad examples
- Tells Claude the project path is shown separately (prevents redundant path-as-title)

### `startHappyServer.ts`
- Updated MCP tool `description` to reinforce the 50-char limit and action-oriented style where Claude reads the tool schema

## Test plan

- [ ] Start a new Happy session — verify Claude calls `change_title` immediately with a descriptive title
- [ ] Send a vague first message ("help me with this project") then clarify — verify title gets refined
- [ ] Shift conversation topic mid-session — verify title updates
- [ ] Confirm titles are action-oriented (e.g., "Fix auth token refresh") not generic ("happy-repo")