### PR TITLE
Session display at a glance: machine ID and new session labels

### DIFF
--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -300,6 +300,7 @@ export const en = {
 
     session: {
         inputPlaceholder: 'Type a message ...',
+        newSession: 'New session',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -301,6 +301,7 @@ export const ca: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Escriu un missatge...',
+        newSession: 'Nova sessió',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -316,6 +316,7 @@ export const en: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Type a message ...',
+        newSession: 'New session',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -301,6 +301,7 @@ export const es: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Escriba un mensaje ...',
+        newSession: 'Nueva sesión',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -330,6 +330,7 @@ export const it: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Scrivi un messaggio ...',
+        newSession: 'Nuova sessione',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -333,6 +333,7 @@ export const ja: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'メッセージを入力...',
+        newSession: '新しいセッション',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -312,6 +312,7 @@ export const pl: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Wpisz wiadomość...',
+        newSession: 'Nowa sesja',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -301,6 +301,7 @@ export const pt: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Digite uma mensagem ...',
+        newSession: 'Nova sessão',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -393,6 +393,7 @@ export const ru: TranslationStructure = {
 
     session: {
         inputPlaceholder: 'Введите сообщение...',
+        newSession: 'Новая сессия',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -303,6 +303,7 @@ export const zhHans: TranslationStructure = {
 
     session: {
         inputPlaceholder: '输入消息...',
+        newSession: '新会话',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -302,6 +302,7 @@ export const zhHant: TranslationStructure = {
 
     session: {
         inputPlaceholder: '輸入訊息...',
+        newSession: '新對話',
     },
 
     commandPalette: {

--- a/packages/happy-app/sources/utils/sessionUtils.ts
+++ b/packages/happy-app/sources/utils/sessionUtils.ts
@@ -79,7 +79,12 @@ export function useSessionStatus(session: Session): SessionStatus {
 export function getSessionName(session: Session): string {
     if (session.metadata?.summary) {
         return session.metadata.summary.text;
-    } else if (session.metadata) {
+    }
+    // Active sessions without a title yet — show "New session" instead of the path segment
+    if (session.active && session.metadata) {
+        return t('session.newSession');
+    }
+    if (session.metadata) {
         const segments = session.metadata.path.split('/').filter(Boolean);
         const lastSegment = segments.pop();
         if (!lastSegment) {
@@ -156,6 +161,19 @@ export function isSessionOnline(session: Session): boolean {
  */
 export function isSessionActive(session: Session): boolean {
     return session.active;
+}
+
+/**
+ * Returns an Ionicons icon name for the given OS platform.
+ * Used for at-a-glance machine identification in session lists.
+ */
+export function getOSIconName(os?: string): string {
+    switch (os?.toLowerCase()) {
+        case 'darwin': return 'logo-apple';
+        case 'win32': return 'logo-windows';
+        case 'linux': return 'terminal-outline';
+        default: return 'desktop-outline';
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Show machine name and OS icon (Apple/Windows/Linux) in session list rows for quick identification of which machine a session is running on
- Section headers now display both machine name and git status side-by-side (previously showed one or the other)
- Active sessions without a summary title now show "New session" instead of the raw directory path segment
- Compact view shows machine badges inline for multi-machine projects
- Added `newSession` translation key to all 10 language files (en, ru, pl, es, ca, it, pt, ja, zh-Hans, zh-Hant) plus the `_default.ts` type definition

## Test plan
- [ ] Verify session list shows machine name under session title in full view
- [ ] Verify compact view shows machine badge for multi-machine projects
- [ ] Verify OS icon matches the machine platform (Apple logo for macOS, Windows logo for Windows, terminal for Linux)
- [ ] Verify active sessions without a summary show "New session" text
- [ ] Verify inactive sessions still fall back to the path-based name
- [ ] Verify section headers show both machine name and git status
- [ ] Verify translations render correctly in non-English locales