### PR TITLE
fix: lock @modelcontextprotocol/sdk to ~1.25.3

### DIFF
--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -90,7 +90,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",
     "@anthropic-ai/sandbox-runtime": "^0.0.37",
-    "@modelcontextprotocol/sdk": "^1.25.3",
+    "@modelcontextprotocol/sdk": "~1.25.3",
     "@paralleldrive/cuid2": "^2.2.2",
     "@slopus/happy-wire": "^0.1.0",
     "@stablelib/base64": "^2.0.1",


### PR DESCRIPTION
## Summary
- Lock `@modelcontextprotocol/sdk` to `~1.25.3` instead of `^1.25.3`
- MCP SDK 1.27.x has breaking changes that cause Happy MCP server to return 500 errors

## Problem
When `@modelcontextprotocol/sdk` is upgraded to 1.27.x, the Happy MCP server returns 500 Internal Server Error, making the MCP connection fail.

## Solution
Using tilde (~) instead of caret (^) locks the version to 1.25.x, allowing patch updates while preventing incompatible minor version upgrades.

## Test plan
- [ ] Verify MCP server works correctly after installing dependencies
- [ ] Test Happy MCP functionality in Claude Code