### PR TITLE
feat(codex): add default fallback model option

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -4,6 +4,7 @@ import {
     getAvailablePermissionModes,
     getCodexModelModes,
     getClaudePermissionModes,
+    getDefaultModelKey,
     mapMetadataOptions,
     resolveCurrentOption,
 } from './modelModeOptions';
@@ -30,6 +31,7 @@ describe('modelModeOptions', () => {
     it('builds codex model fallbacks with translated labels', () => {
         const models = getCodexModelModes(translate);
         expect(models.map((model) => model.key)).toEqual([
+            'default',
             'gpt-5-codex-high',
             'gpt-5-codex-medium',
             'gpt-5-codex-low',
@@ -38,7 +40,7 @@ describe('modelModeOptions', () => {
             'gpt-5-medium',
             'gpt-5-high',
         ]);
-        expect(models[0].name).toBe('tr:agentInput.codexModel.gpt5CodexHigh');
+        expect(models[0].name).toBe('tr:agentInput.codexPermissionMode.default');
     });
 
     it('prefers metadata models over hardcoded fallbacks', () => {
@@ -83,5 +85,9 @@ describe('modelModeOptions', () => {
 
         expect(resolveCurrentOption(options, ['missing', 'b', 'a'])).toEqual({ key: 'b', name: 'B' });
         expect(resolveCurrentOption(options, ['missing'])).toBeNull();
+    });
+
+    it('uses default model key for codex fallback', () => {
+        expect(getDefaultModelKey('codex')).toBe('default');
     });
 });

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -79,6 +79,7 @@ export function getClaudeModelModes(): ModelMode[] {
 
 export function getCodexModelModes(translate: Translate): ModelMode[] {
     return [
+        { key: 'default', name: translate('agentInput.codexPermissionMode.default'), description: null },
         { key: 'gpt-5-codex-high', name: translate('agentInput.codexModel.gpt5CodexHigh'), description: null },
         { key: 'gpt-5-codex-medium', name: translate('agentInput.codexModel.gpt5CodexMedium'), description: null },
         { key: 'gpt-5-codex-low', name: translate('agentInput.codexModel.gpt5CodexLow'), description: null },
@@ -164,7 +165,7 @@ export function resolveCurrentOption<T extends ModeOption>(
 
 export function getDefaultModelKey(flavor: AgentFlavor): string {
     if (flavor === 'codex') {
-        return 'gpt-5-codex-high';
+        return 'default';
     }
     if (flavor === 'gemini') {
         return 'gemini-2.5-pro';


### PR DESCRIPTION
## Summary
- add `default` to Codex model fallback options in the app
- switch Codex fallback default model key from `gpt-5-codex-high` to `default`
- update unit tests for fallback model order and default key

## Test
- passed: `bunx vitest sources/components/modelModeOptions.test.ts --run` (run in `packages/happy-app`)