### PR TITLE
fix(ci): fix Windows smoke test build failures

### DIFF
--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -92,7 +92,13 @@ jobs:
         cache-dependency-path: yarn.lock
 
     - name: Install dependencies
+      env:
+        SKIP_HAPPY_WIRE_BUILD: "1"
       run: yarn install --immutable
+
+    - name: Build happy-wire
+      shell: bash
+      run: cd packages/happy-wire && yarn build
 
     - name: Build package
       run: yarn workspace happy-coder build

--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "why do we need to build before running tests / dev?": "We need the binary to be built so we run daemon commands which directly run the binary - we don't want them to go out of sync or have custom spawn logic depending how we started happy",
     "typecheck": "tsc --noEmit",
-    "build": "shx rm -rf dist && npx tsc --noEmit && pkgroll",
+    "build": "shx rm -rf dist && tsc --noEmit && pkgroll",
     "test": "$npm_execpath run build && vitest run",
     "start": "$npm_execpath run build && node ./bin/happy.mjs",
     "cli": "tsx src/index.ts",

--- a/packages/happy-wire/package.json
+++ b/packages/happy-wire/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "build": "shx rm -rf dist && npx tsc --noEmit && pkgroll",
+    "build": "shx rm -rf dist && tsc --noEmit && pkgroll",
     "test": "$npm_execpath run build && vitest run",
     "prepublishOnly": "$npm_execpath run build && $npm_execpath run test",
     "release": "npx --no-install release-it"


### PR DESCRIPTION
## Problem

Windows smoke test jobs fail during build with:
```
Error: Cannot find module 'D:\a\happy\happy\node_modules\node_modules\typescript\bin\tsc'
```

## Root Cause

Two issues on Windows with Yarn 1.22:

1. **`npx tsc` path resolution bug** — `npx` resolves `tsc` via a double-nested `node_modules\node_modules\typescript` path in a Yarn workspace context, which doesn't exist
2. **Postinstall CWD bug** (Yarn 1.22, [GitHub Issue #6175](https://github.com/yarnpkg/yarn/issues/6175)) — workspace postinstall scripts run from the wrong directory on Windows, so `yarn workspace @slopus/happy-wire build` fails

## Fix

**`packages/happy-wire/package.json` and `packages/happy-cli/package.json`:**
Replace `npx tsc` with `tsc` directly — matches the existing `typecheck` script which already uses `tsc` and works on all platforms. TypeScript is in devDependencies so yarn resolves it correctly without npx.

**`.github/workflows/cli-smoke-test.yml` (Windows job only):**
- Set `SKIP_HAPPY_WIRE_BUILD=1` during `yarn install` to skip the broken postinstall on Windows
- Add explicit `cd packages/happy-wire && yarn build` step after install so happy-coder can find happy-wire's dist files

Linux/macOS CI and local development are unaffected.

## Changes

- `.github/workflows/cli-smoke-test.yml`
- `packages/happy-wire/package.json`
- `packages/happy-cli/package.json`