### PR TITLE
feat(cli): pass AskUserQuestion answers via permission RPC

### DIFF
--- a/packages/happy-cli/src/claude/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.ts
@@ -23,6 +23,7 @@ interface PermissionResponse {
     mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
     allowTools?: string[];
     receivedAt?: number;
+    answers?: Record<string, string>;
 }
 
 
@@ -102,8 +103,13 @@ export class PermissionHandler {
             }
         } else {
             // Handle default case for all other tools
+            const baseInput = (pending.input as Record<string, unknown>) || {};
+            const updatedInput = response.answers
+                ? { ...baseInput, answers: response.answers }
+                : baseInput;
+
             const result: PermissionResult = response.approved
-                ? { behavior: 'allow', updatedInput: (pending.input as Record<string, unknown>) || {} }
+                ? { behavior: 'allow', updatedInput }
                 : { behavior: 'deny', message: response.reason || `The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed.` };
 
             pending.resolve(result);


### PR DESCRIPTION
## Summary

- When a permission response includes an `answers` field (`Record<string, string>`), merge it into the tool's `updatedInput` so Claude Code receives structured user selections in the AskUserQuestion tool result
- Enables remote clients (mobile app, Discord bot) to send selected answers through the existing permission RPC without a separate `sendMessage` call
- No breaking changes — the `answers` field is optional and backward-compatible

## Changes

**`packages/happy-cli/src/claude/utils/permissionHandler.ts`**
- Added `answers?: Record<string, string>` to `PermissionResponse` interface
- Updated `handlePermissionResponse` to merge `response.answers` into `updatedInput`

## Context

Currently, remote clients like the Discord bot must use a two-step flow to answer AskUserQuestion:
1. `approvePermission` (RPC) — approves the tool call
2. `sendMessage` (HTTP) — sends the answer text separately

This causes Claude to treat the answer as a new user message ("Other" free-text input) rather than a structured selection. With this change, answers are passed directly through `updatedInput.answers`, which the Claude Code SDK natively supports.

## Test plan

- [x] Smoke test: trigger AskUserQuestion from Claude Code, answer via remote client with `answers` field in permission response
- [x] Verify Claude sees structured selection (e.g., "The user selected 'PostgreSQL'") instead of "Other" free-text
- [x] Verify existing permission flow (approve/deny without answers) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)