### PR TITLE
fix: deduplicate session messages + improve session lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json yarn.lock ./
 COPY scripts ./scripts
+COPY patches ./patches
 
 RUN mkdir -p packages/happy-app packages/happy-server packages/happy-cli packages/happy-agent packages/happy-wire
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -8,6 +8,7 @@ WORKDIR /repo
 
 COPY package.json yarn.lock ./
 COPY scripts ./scripts
+COPY patches ./patches
 
 RUN mkdir -p packages/happy-app packages/happy-server packages/happy-cli packages/happy-wire
 

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -24,9 +24,8 @@ type MetadataOption = {
 };
 
 const GEMINI_MODEL_FALLBACKS: ModelMode[] = [
-    { key: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: 'Most capable' },
-    { key: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Fast & efficient' },
-    { key: 'gemini-2.5-flash-lite', name: 'Gemini 2.5 Flash Lite', description: 'Fastest' },
+    { key: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', description: 'Most capable' },
+    { key: 'gemini-3.0-flash-preview', name: 'Gemini 3.0 Flash', description: 'Fast & efficient' },
 ];
 
 export function mapMetadataOptions(options?: MetadataOption[] | null): ModeOption[] {
@@ -167,7 +166,7 @@ export function getDefaultModelKey(flavor: AgentFlavor): string {
         return 'gpt-5-codex-high';
     }
     if (flavor === 'gemini') {
-        return 'gemini-2.5-pro';
+        return 'gemini-3.1-pro-preview';
     }
     return 'default';
 }

--- a/packages/happy-app/sources/sync/typesRaw.spec.ts
+++ b/packages/happy-app/sources/sync/typesRaw.spec.ts
@@ -1489,6 +1489,30 @@ describe('Zod Transform - WOLOG Content Normalization', () => {
                 }
             }
         });
+
+        it('drops legacy output compatibility mirrors tagged with legacyCompat', () => {
+            const normalized = normalizeRawMessage('compat-output-1', null, 1, {
+                role: 'agent',
+                content: {
+                    type: 'output',
+                    data: {
+                        type: 'assistant',
+                        message: {
+                            role: 'assistant',
+                            model: 'claude-sonnet-4-6',
+                            content: [{ type: 'text', text: 'pong' }]
+                        },
+                        uuid: 'compat-output-uuid-1',
+                        legacyCompat: true
+                    }
+                },
+                meta: {
+                    sentFrom: 'cli'
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
     });
 
     describe('Session protocol normalization', () => {

--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -213,20 +213,6 @@ const rawHyphenatedToolResultSchema = z.object({
 type RawHyphenatedToolResult = z.infer<typeof rawHyphenatedToolResultSchema>;
 
 /**
- * Input schema accepting ALL formats (both hyphenated and canonical)
- * Including Claude's extended thinking content type
- */
-const rawAgentContentInputSchema = z.discriminatedUnion('type', [
-    rawTextContentSchema,           // type: 'text' (canonical)
-    rawToolUseContentSchema,        // type: 'tool_use' (canonical)
-    rawToolResultContentSchema,     // type: 'tool_result' (canonical)
-    rawThinkingContentSchema,       // type: 'thinking' (canonical)
-    rawHyphenatedToolCallSchema,    // type: 'tool-call' (hyphenated)
-    rawHyphenatedToolResultSchema,  // type: 'tool-call-result' (hyphenated)
-]);
-type RawAgentContentInput = z.infer<typeof rawAgentContentInputSchema>;
-
-/**
  * Type-safe transform: Hyphenated tool-call → Canonical tool_use
  * ROBUST: Unknown fields preserved via object spread and .passthrough()
  */
@@ -749,6 +735,11 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
     if (raw.role === 'agent') {
         if (raw.content.type === 'output') {
 
+            const compatibilityOutput = raw.content.data as { legacyCompat?: unknown };
+            if (compatibilityOutput.legacyCompat === true) {
+                return null;
+            }
+
             // Skip Meta messages
             if (raw.content.data.isMeta) {
                 return null;
@@ -891,25 +882,7 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
             };
         }
         if (raw.content.type === 'codex') {
-            if (raw.content.data.type === 'message') {
-                // Cast codex messages to agent text messages
-                return {
-                    id,
-                    localId,
-                    createdAt,
-                    role: 'agent',
-                    isSidechain: false,
-                    content: [{
-                        type: 'text',
-                        text: raw.content.data.message,
-                        uuid: id,
-                        parentUUID: null
-                    }],
-                    meta: raw.meta
-                };
-            }
-            if (raw.content.data.type === 'reasoning') {
-                // Cast codex messages to agent text messages
+            if (raw.content.data.type === 'message' || raw.content.data.type === 'reasoning') {
                 return {
                     id,
                     localId,
@@ -970,23 +943,7 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
         }
         // ACP (Agent Communication Protocol) - unified format for all agent providers
         if (raw.content.type === 'acp') {
-            if (raw.content.data.type === 'message') {
-                return {
-                    id,
-                    localId,
-                    createdAt,
-                    role: 'agent',
-                    isSidechain: false,
-                    content: [{
-                        type: 'text',
-                        text: raw.content.data.message,
-                        uuid: id,
-                        parentUUID: null
-                    }],
-                    meta: raw.meta
-                } satisfies NormalizedMessage;
-            }
-            if (raw.content.data.type === 'reasoning') {
+            if (raw.content.data.type === 'message' || raw.content.data.type === 'reasoning') {
                 return {
                     id,
                     localId,

--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -132,7 +132,7 @@
     "eslint-config-prettier": "^10",
     "pkgroll": "^2.14.2",
     "release-it": "^19.0.6",
-    "shx": "^0.3.3",
+    "shx": "0.3.3",
     "ts-node": "^10",
     "tsx": "^4.20.6",
     "typescript": "5.9.3",

--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -132,7 +132,7 @@
     "eslint-config-prettier": "^10",
     "pkgroll": "^2.14.2",
     "release-it": "^19.0.6",
-    "shx": "0.3.3",
+    "shx": "^0.3.3",
     "ts-node": "^10",
     "tsx": "^4.20.6",
     "typescript": "5.9.3",

--- a/packages/happy-cli/src/agent/acp/runAcp.test.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.test.ts
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => {
     sendSessionProtocolMessage: vi.fn(),
     sendSessionEvent: vi.fn(),
     updateMetadata: vi.fn(),
-    sendSessionDeath: vi.fn(),
+    sendSessionDeath: vi.fn(async () => {}),
     flush: vi.fn(async () => {}),
     close: vi.fn(async () => {}),
     updateAgentState: vi.fn((handler: (state: Record<string, unknown>) => Record<string, unknown>) => {

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -952,7 +952,7 @@ export async function runAcp(opts: {
         archivedBy: 'cli',
         archiveReason: 'Session ended',
       }));
-      session.sendSessionDeath();
+      await session.sendSessionDeath();
       await session.flush();
       await session.close();
     } catch (error) {

--- a/packages/happy-cli/src/agent/factories/gemini.ts
+++ b/packages/happy-cli/src/agent/factories/gemini.ts
@@ -40,7 +40,7 @@ export interface GeminiBackendOptions extends AgentFactoryOptions {
   
   /** Model to use. If undefined, will use local config, env var, or default.
    *  If explicitly set to null, will use default (skip local config).
-   *  (defaults to GEMINI_MODEL env var or 'gemini-2.5-pro') */
+   *  (defaults to GEMINI_MODEL env var or 'gemini-3.1-pro-preview') */
   model?: string | null;
   
   /** MCP servers to make available to the agent */

--- a/packages/happy-cli/src/agent/transport/handlers/GeminiTransport.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/GeminiTransport.ts
@@ -78,9 +78,8 @@ const GEMINI_TOOL_PATTERNS: ExtendedToolPattern[] = [
  * Available Gemini models for error messages
  */
 const AVAILABLE_MODELS = [
-  'gemini-2.5-pro',
-  'gemini-2.5-flash',
-  'gemini-2.5-flash-lite',
+  'gemini-3.1-pro-preview',
+  'gemini-3.0-flash-preview',
 ];
 
 /**

--- a/packages/happy-cli/src/api/apiSession.test.ts
+++ b/packages/happy-cli/src/api/apiSession.test.ts
@@ -343,6 +343,102 @@ describe('ApiSessionClient v3 messages API migration', () => {
         expect(typeof (sessionUser as any).content.time).toBe('number');
     });
 
+    it('sends a legacy output compatibility mirror for assistant messages', async () => {
+        const client = new ApiSessionClient('fake-token', session);
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                messages: [
+                    { id: 'msg-1', seq: 1, localId: 'local-1', createdAt: 1, updatedAt: 1 },
+                    { id: 'msg-2', seq: 2, localId: 'local-2', createdAt: 1, updatedAt: 1 },
+                    { id: 'msg-3', seq: 3, localId: 'local-3', createdAt: 1, updatedAt: 1 }
+                ]
+            }
+        });
+
+        const assistantBody = {
+            type: 'assistant',
+            uuid: 'assistant-uuid-1',
+            message: {
+                role: 'assistant',
+                model: 'claude-sonnet-4-6',
+                content: [{ type: 'text', text: 'pong' }]
+            }
+        } as any;
+
+        client.sendClaudeSessionMessage(assistantBody);
+
+        await waitForCheck(() => {
+            expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+        });
+
+        const payload = mockAxiosPost.mock.calls[0][1];
+        expect(payload.messages).toHaveLength(3);
+
+        const decryptedMessages = payload.messages.map((message: { content: string }) => decrypt(
+            session.encryptionKey,
+            session.encryptionVariant,
+            decodeBase64(message.content)
+        ));
+
+        expect(decryptedMessages).toContainEqual({
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    ...assistantBody,
+                    legacyCompat: true
+                }
+            },
+            meta: {
+                sentFrom: 'cli'
+            }
+        });
+    });
+
+    it('adds a compatibility uuid when assistant output is missing one', async () => {
+        const client = new ApiSessionClient('fake-token', session);
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                messages: [
+                    { id: 'msg-1', seq: 1, localId: 'local-1', createdAt: 1, updatedAt: 1 },
+                    { id: 'msg-2', seq: 2, localId: 'local-2', createdAt: 1, updatedAt: 1 },
+                    { id: 'msg-3', seq: 3, localId: 'local-3', createdAt: 1, updatedAt: 1 }
+                ]
+            }
+        });
+
+        const assistantBody = {
+            type: 'assistant',
+            message: {
+                role: 'assistant',
+                model: 'claude-sonnet-4-6',
+                content: [{ type: 'text', text: 'pong' }]
+            }
+        } as any;
+
+        expect(assistantBody.uuid).toBeUndefined();
+        client.sendClaudeSessionMessage(assistantBody);
+
+        await waitForCheck(() => {
+            expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+        });
+
+        const payload = mockAxiosPost.mock.calls[0][1];
+        const decryptedMessages = payload.messages.map((message: { content: string }) => decrypt(
+            session.encryptionKey,
+            session.encryptionVariant,
+            decodeBase64(message.content)
+        ));
+
+        const legacyOutput = decryptedMessages.find((message: any) => (
+            message?.role === 'agent' && message?.content?.type === 'output' && message?.content?.data?.legacyCompat === true
+        ));
+
+        expect(legacyOutput).toBeDefined();
+        expect(legacyOutput.content.data.uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+        expect(assistantBody.uuid).toBeUndefined();
+    });
+
     it('sends session protocol messages through enqueueMessage with session envelope', async () => {
         const client = new ApiSessionClient('fake-token', session);
         mockAxiosPost.mockResolvedValueOnce({
@@ -374,6 +470,59 @@ describe('ApiSessionClient v3 messages API migration', () => {
         expect(decrypted).toEqual({
             role: 'session',
             content: envelope,
+            meta: {
+                sentFrom: 'cli'
+            }
+        });
+    });
+
+    it('sends a legacy compatibility mirror for agent session envelopes', async () => {
+        const client = new ApiSessionClient('fake-token', session);
+        mockAxiosPost.mockResolvedValueOnce({
+            data: {
+                messages: [
+                    { id: 'msg-1', seq: 1, localId: 'local-1', createdAt: 1, updatedAt: 1 },
+                    { id: 'msg-2', seq: 2, localId: 'local-2', createdAt: 1, updatedAt: 1 }
+                ]
+            }
+        });
+
+        const envelope = {
+            id: 'env-compat-1',
+            time: 1003,
+            role: 'agent' as const,
+            turn: 'turn-compat-1',
+            ev: { t: 'text' as const, text: 'compat text' }
+        };
+
+        client.sendSessionProtocolMessage(envelope);
+
+        await waitForCheck(() => {
+            expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+        });
+
+        const payload = mockAxiosPost.mock.calls[0][1];
+        expect(payload.messages).toHaveLength(2);
+
+        const decryptedMessages = payload.messages.map((message: { content: string }) => decrypt(
+            session.encryptionKey,
+            session.encryptionVariant,
+            decodeBase64(message.content)
+        ));
+
+        expect(decryptedMessages).toContainEqual({
+            role: 'session',
+            content: envelope,
+            meta: {
+                sentFrom: 'cli'
+            }
+        });
+        expect(decryptedMessages).toContainEqual({
+            role: 'agent',
+            content: {
+                type: 'session',
+                data: envelope
+            },
             meta: {
                 sentFrom: 'cli'
             }

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -350,7 +350,8 @@ export class ApiSessionClient extends EventEmitter {
      * @param body - Message body (can be MessageContent or raw content for agent messages)
      */
     sendClaudeSessionMessage(body: RawJSONLines) {
-        const shouldSendLegacyOutputCompatibility = body.type === 'assistant';
+        // Only mirror real assistant messages with content; skip synthetic error messages (body.message may be absent).
+        const shouldSendLegacyOutputCompatibility = body.type === 'assistant' && body.message != null;
         if (shouldSendLegacyOutputCompatibility) {
             this.enqueueLegacyClaudeOutputCompatibility(body, false);
         }

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -350,11 +350,20 @@ export class ApiSessionClient extends EventEmitter {
      * @param body - Message body (can be MessageContent or raw content for agent messages)
      */
     sendClaudeSessionMessage(body: RawJSONLines) {
+        const shouldSendLegacyOutputCompatibility = body.type === 'assistant';
+        if (shouldSendLegacyOutputCompatibility) {
+            this.enqueueLegacyClaudeOutputCompatibility(body, false);
+        }
+
         const mapped = mapClaudeLogMessageToSessionEnvelopes(body, this.claudeSessionProtocolState);
         this.claudeSessionProtocolState.currentTurnId = mapped.currentTurnId;
         for (const envelope of mapped.envelopes) {
             this.sendSessionProtocolMessage(envelope);
         }
+        if (shouldSendLegacyOutputCompatibility && mapped.envelopes.length === 0) {
+            this.sendSync.invalidate();
+        }
+
         // Track usage from assistant messages
         if (body.type === 'assistant' && body.message?.usage) {
             try {
@@ -385,7 +394,7 @@ export class ApiSessionClient extends EventEmitter {
     }
 
     sendCodexMessage(body: any) {
-        let content = {
+        const content = {
             role: 'agent',
             content: {
                 type: 'codex',
@@ -410,14 +419,45 @@ export class ApiSessionClient extends EventEmitter {
         this.enqueueMessage(content, invalidate);
     }
 
-    sendSessionProtocolMessage(envelope: SessionEnvelope) {
-        if (envelope.role !== 'user') {
-            this.enqueueSessionProtocolEnvelope(envelope);
-            return;
-        }
+    private enqueueLegacyClaudeOutputCompatibility(body: RawJSONLines, invalidate: boolean = true) {
+        const fallbackUuid = (body as { uuid?: unknown }).uuid;
+        const content = {
+            role: 'agent',
+            content: {
+                type: 'output',
+                data: {
+                    ...body,
+                    uuid: typeof fallbackUuid === 'string' && fallbackUuid.length > 0 ? fallbackUuid : randomUUID(),
+                    legacyCompat: true
+                }
+            },
+            meta: {
+                sentFrom: 'cli'
+            }
+        };
 
-        if (envelope.ev.t !== 'text') {
-            this.enqueueSessionProtocolEnvelope(envelope);
+        this.enqueueMessage(content, invalidate);
+    }
+
+    private enqueueLegacySessionProtocolEnvelope(envelope: SessionEnvelope, invalidate: boolean = true) {
+        const content = {
+            role: 'agent',
+            content: {
+                type: 'session',
+                data: envelope
+            },
+            meta: {
+                sentFrom: 'cli'
+            }
+        };
+
+        this.enqueueMessage(content, invalidate);
+    }
+
+    sendSessionProtocolMessage(envelope: SessionEnvelope) {
+        if (envelope.role === 'agent') {
+            this.enqueueSessionProtocolEnvelope(envelope, false);
+            this.enqueueLegacySessionProtocolEnvelope(envelope, true);
             return;
         }
 
@@ -432,7 +472,7 @@ export class ApiSessionClient extends EventEmitter {
      * @param body - The message payload (type: 'message' | 'reasoning' | 'tool-call' | 'tool-result')
      */
     sendAgentMessage(provider: 'gemini' | 'codex' | 'claude' | 'opencode', body: ACPMessageData) {
-        let content = {
+        const content = {
             role: 'agent',
             content: {
                 type: 'acp',
@@ -458,7 +498,7 @@ export class ApiSessionClient extends EventEmitter {
     } | {
         type: 'ready'
     }, id?: string) {
-        let content = {
+        const content = {
             role: 'agent',
             content: {
                 id: id ?? randomUUID(),

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -334,11 +334,11 @@ export class ApiSessionClient extends EventEmitter {
         this.lastSeq = maxSeq;
     }
 
-    private enqueueMessage(content: unknown, invalidate: boolean = true) {
+    private enqueueMessage(content: unknown, invalidate: boolean = true, localId?: string) {
         const encrypted = encodeBase64(encrypt(this.encryptionKey, this.encryptionVariant, content));
         this.pendingOutbox.push({
             content: encrypted,
-            localId: randomUUID()
+            localId: localId ?? randomUUID()
         });
         if (invalidate) {
             this.sendSync.invalidate();
@@ -408,7 +408,7 @@ export class ApiSessionClient extends EventEmitter {
         this.enqueueMessage(content);
     }
 
-    private enqueueSessionProtocolEnvelope(envelope: SessionEnvelope, invalidate: boolean = true) {
+    private enqueueSessionProtocolEnvelope(envelope: SessionEnvelope, invalidate: boolean = true, localId?: string) {
         const content = {
             role: 'session',
             content: envelope,
@@ -417,7 +417,7 @@ export class ApiSessionClient extends EventEmitter {
             }
         };
 
-        this.enqueueMessage(content, invalidate);
+        this.enqueueMessage(content, invalidate, localId);
     }
 
     private enqueueLegacyClaudeOutputCompatibility(body: RawJSONLines, invalidate: boolean = true) {
@@ -440,7 +440,7 @@ export class ApiSessionClient extends EventEmitter {
         this.enqueueMessage(content, invalidate);
     }
 
-    private enqueueLegacySessionProtocolEnvelope(envelope: SessionEnvelope, invalidate: boolean = true) {
+    private enqueueLegacySessionProtocolEnvelope(envelope: SessionEnvelope, invalidate: boolean = true, localId?: string) {
         const content = {
             role: 'agent',
             content: {
@@ -452,13 +452,17 @@ export class ApiSessionClient extends EventEmitter {
             }
         };
 
-        this.enqueueMessage(content, invalidate);
+        this.enqueueMessage(content, invalidate, localId);
     }
 
     sendSessionProtocolMessage(envelope: SessionEnvelope) {
         if (envelope.role === 'agent') {
-            this.enqueueSessionProtocolEnvelope(envelope, false);
-            this.enqueueLegacySessionProtocolEnvelope(envelope, true);
+            // Send both modern and legacy formats with the same localId
+            // so the server deduplicates and only stores one copy.
+            // Legacy format is sent second with invalidate=true to trigger flush.
+            const localId = randomUUID();
+            this.enqueueSessionProtocolEnvelope(envelope, false, localId);
+            this.enqueueLegacySessionProtocolEnvelope(envelope, true, localId);
             return;
         }
 
@@ -526,10 +530,19 @@ export class ApiSessionClient extends EventEmitter {
     }
 
     /**
-     * Send session death message
+     * Send session death message and wait for server acknowledgement.
+     * Falls back to fire-and-forget if ack times out (2s).
      */
-    sendSessionDeath() {
-        this.socket.emit('session-end', { sid: this.sessionId, time: Date.now() });
+    async sendSessionDeath(): Promise<void> {
+        try {
+            await Promise.race([
+                this.socket.emitWithAck('session-end', { sid: this.sessionId, time: Date.now() }),
+                delay(2000)
+            ]);
+        } catch {
+            // Best-effort: if ack fails, the 10-minute timeout sweep will clean up
+            logger.debug('[API] session-end ack failed or timed out');
+        }
     }
 
     /**

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -65,7 +65,7 @@ export interface ClientToServerEvents {
     thinking: boolean;
     mode?: 'local' | 'remote';
   }) => void
-  'session-end': (data: { sid: string, time: number }) => void,
+  'session-end': (data: { sid: string, time: number }, cb: (response: { result: string }) => void) => void,
   'update-metadata': (data: { sid: string, expectedVersion: number, metadata: string }, cb: (answer: {
     result: 'error'
   } | {

--- a/packages/happy-cli/src/claude/claudeLocal.test.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { claudeLocal } from './claudeLocal';
 
 // Use vi.hoisted to ensure mock functions are available when vi.mock factory runs
@@ -314,5 +314,176 @@ describe('claudeLocal --continue handling', () => {
         );
         const spawnedArgs = mockSpawn.mock.calls[0][1];
         expect(spawnedArgs).not.toContain('--dangerously-skip-permissions');
+    });
+});
+
+describe('claudeLocal - environment variable stripping', () => {
+    let onSessionFound: any;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        // Reset process.env with test values
+        process.env = {
+            ...originalEnv,
+            ANTHROPIC_API_KEY: 'inherited-api-key',
+            ANTHROPIC_AUTH_TOKEN: 'inherited-auth-token',
+            CLAUDE_CODE_OAUTH_TOKEN: 'inherited-oauth-token',
+            PATH: '/usr/bin',
+            HOME: '/home/user',
+            CUSTOM_VAR: 'custom-value',
+        };
+
+        // Mock spawn to capture the env passed to it
+        mockSpawn.mockReturnValue({
+            stdio: [null, null, null, null],
+            on: vi.fn((event, callback) => {
+                if (event === 'exit') {
+                    process.nextTick(() => callback(0));
+                }
+            }),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            kill: vi.fn(),
+            stdout: { on: vi.fn() },
+            stderr: { on: vi.fn() },
+            stdin: {
+                on: vi.fn(),
+                end: vi.fn()
+            }
+        });
+
+        onSessionFound = vi.fn();
+        vi.clearAllMocks();
+        mockInitializeSandbox.mockResolvedValue(mockSandboxCleanup);
+        mockWrapCommand.mockResolvedValue('wrapped claude command');
+    });
+
+    afterEach(() => {
+        // Restore original process.env
+        process.env = originalEnv;
+    });
+
+    it('should strip inherited auth vars when not explicitly set in claudeEnvVars', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            claudeEnvVars: { CUSTOM_OVERRIDE: 'override-value' }
+        });
+
+        const spawnCall = mockSpawn.mock.calls[0];
+        const spawnedEnv = spawnCall[2].env;
+
+        // Auth vars should be stripped
+        expect(spawnedEnv.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(spawnedEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+        expect(spawnedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+
+        // Other vars should pass through
+        expect(spawnedEnv.PATH).toBe('/usr/bin');
+        expect(spawnedEnv.HOME).toBe('/home/user');
+        expect(spawnedEnv.CUSTOM_VAR).toBe('custom-value');
+
+        // Explicitly set vars should be present
+        expect(spawnedEnv.CUSTOM_OVERRIDE).toBe('override-value');
+    });
+
+    it('should preserve auth vars when explicitly set in claudeEnvVars', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            claudeEnvVars: {
+                ANTHROPIC_API_KEY: 'explicit-api-key',
+                ANTHROPIC_AUTH_TOKEN: 'explicit-auth-token'
+            }
+        });
+
+        const spawnCall = mockSpawn.mock.calls[0];
+        const spawnedEnv = spawnCall[2].env;
+
+        // Explicitly set auth vars should be present (from claudeEnvVars)
+        expect(spawnedEnv.ANTHROPIC_API_KEY).toBe('explicit-api-key');
+        expect(spawnedEnv.ANTHROPIC_AUTH_TOKEN).toBe('explicit-auth-token');
+
+        // Oauth token not explicitly set should still be stripped
+        expect(spawnedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+
+        // Other vars should pass through
+        expect(spawnedEnv.PATH).toBe('/usr/bin');
+    });
+
+    it('should handle empty claudeEnvVars gracefully', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            claudeEnvVars: undefined
+        });
+
+        const spawnCall = mockSpawn.mock.calls[0];
+        const spawnedEnv = spawnCall[2].env;
+
+        // Auth vars should be stripped with undefined claudeEnvVars
+        expect(spawnedEnv.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(spawnedEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+        expect(spawnedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+
+        // Other vars should pass through
+        expect(spawnedEnv.PATH).toBe('/usr/bin');
+        expect(spawnedEnv.CUSTOM_VAR).toBe('custom-value');
+    });
+
+    it('should strip only the auth vars, not others with similar names', async () => {
+        process.env = {
+            ...process.env,
+            ANTHROPIC_API_KEY: 'should-be-stripped',
+            ANTHROPIC_OTHER_VAR: 'should-remain',
+            AUTH_TOKEN: 'should-remain',
+            CLAUDE_OTHER: 'should-remain',
+        };
+
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+        });
+
+        const spawnCall = mockSpawn.mock.calls[0];
+        const spawnedEnv = spawnCall[2].env;
+
+        // Only exact matches should be stripped
+        expect(spawnedEnv.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(spawnedEnv.ANTHROPIC_OTHER_VAR).toBe('should-remain');
+        expect(spawnedEnv.AUTH_TOKEN).toBe('should-remain');
+        expect(spawnedEnv.CLAUDE_OTHER).toBe('should-remain');
+    });
+
+    it('should log when stripping auth vars', async () => {
+        const { logger } = await import('@/ui/logger');
+        const debugSpy = vi.spyOn(logger, 'debug');
+
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+        });
+
+        // Should have logged stripping of inherited auth vars
+        const stripLogs = debugSpy.mock.calls.filter(
+            (call: any[]) => call[0]?.includes('Stripping inherited') && call[0]?.includes('from env')
+        );
+        expect(stripLogs.length).toBeGreaterThan(0);
+        expect(stripLogs.some((call: any[]) => call[0]?.includes('ANTHROPIC_API_KEY'))).toBe(true);
     });
 });

--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -237,8 +237,23 @@ export async function claudeLocal(opts: {
             // Prepare environment variables
             // Note: Local mode uses global Claude installation with --session-id flag
             // Launcher only intercepts fetch for thinking state tracking
+            
+            // Strip inherited auth vars unless explicitly set by claudeEnvVars
+            // This prevents unintended authentication using API keys from parent process
+            const authVarsToStrip = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'];
+            const baseEnv: Record<string, string> = {};
+            for (const [key, value] of Object.entries(process.env)) {
+                if (value !== undefined) {
+                    // Skip auth vars unless explicitly provided in claudeEnvVars
+                    if (authVarsToStrip.includes(key) && !(key in (opts.claudeEnvVars || {}))) {
+                        logger.debug(`[ClaudeLocal] Stripping inherited ${key} from env (not set by configuration)`);
+                        continue;
+                    }
+                    baseEnv[key] = value;
+                }
+            }
             const env = {
-                ...process.env,
+                ...baseEnv,
                 ...opts.claudeEnvVars
             }
 

--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -11,6 +11,7 @@ import { projectPath } from "@/projectPath";
 import { systemPrompt } from "./utils/systemPrompt";
 import type { SandboxConfig } from "@/persistence";
 import { initializeSandbox, wrapCommand } from "@/sandbox/manager";
+import { buildEnvWithStrippedAuthVars } from "@/utils/stripAuthEnvVars";
 
 /**
  * Error thrown when the Claude process exits with a non-zero exit code.
@@ -238,20 +239,10 @@ export async function claudeLocal(opts: {
             // Note: Local mode uses global Claude installation with --session-id flag
             // Launcher only intercepts fetch for thinking state tracking
             
-            // Strip inherited auth vars unless explicitly set by claudeEnvVars
-            // This prevents unintended authentication using API keys from parent process
-            const authVarsToStrip = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'];
-            const baseEnv: Record<string, string> = {};
-            for (const [key, value] of Object.entries(process.env)) {
-                if (value !== undefined) {
-                    // Skip auth vars unless explicitly provided in claudeEnvVars
-                    if (authVarsToStrip.includes(key) && !(key in (opts.claudeEnvVars || {}))) {
-                        logger.debug(`[ClaudeLocal] Stripping inherited ${key} from env (not set by configuration)`);
-                        continue;
-                    }
-                    baseEnv[key] = value;
-                }
-            }
+            // Strip inherited auth vars unless explicitly set by claudeEnvVars.
+            // This prevents unintended authentication using API keys from parent process.
+            // See: https://github.com/anthropics/happy-cli/issues/120
+            const baseEnv = buildEnvWithStrippedAuthVars(process.env, opts.claudeEnvVars ?? {});
             const env = {
                 ...baseEnv,
                 ...opts.claudeEnvVars

--- a/packages/happy-cli/src/claude/claudeRemote.test.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for auth environment variable stripping in claudeRemote.
+ *
+ * Issue #120: When a local session switches to remote mode (doSwitch), or when
+ * claudeRemote is invoked directly, inherited auth env vars must be stripped from
+ * process.env before the Claude Code SDK is called.  The SDK reads process.env
+ * directly for .cjs launcher executables (sdk/query.ts:343), so if
+ * ANTHROPIC_API_KEY is still set it overrides Claude's native OAuth / Max-plan
+ * authentication.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks – must be declared before any vi.mock() calls
+// ---------------------------------------------------------------------------
+const { mockQuery } = vi.hoisted(() => ({
+    mockQuery: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock('@/claude/sdk', () => ({
+    query: mockQuery,
+    AbortError: class AbortError extends Error {},
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+        debugLargeJson: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+    },
+}));
+
+vi.mock('./utils/claudeCheckSession', () => ({
+    claudeCheckSession: vi.fn(() => true),
+}));
+
+vi.mock('./utils/path', () => ({
+    getProjectPath: vi.fn((p: string) => p),
+}));
+
+vi.mock('./utils/systemPrompt', () => ({
+    systemPrompt: 'test-system-prompt',
+}));
+
+vi.mock('@/modules/watcher/awaitFileExist', () => ({
+    awaitFileExist: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock('@/projectPath', () => ({
+    projectPath: vi.fn(() => '/fake/project'),
+}));
+
+vi.mock('@/parsers/specialCommands', () => ({
+    parseSpecialCommand: vi.fn(() => ({ type: 'none' })),
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+function makeMode() {
+    return {
+        permissionMode: 'default' as const,
+        model: undefined,
+        fallbackModel: undefined,
+        customSystemPrompt: undefined,
+        appendSystemPrompt: undefined,
+        allowedTools: undefined,
+        disallowedTools: undefined,
+    };
+}
+
+function makeBaseOpts(overrides: Record<string, unknown> = {}) {
+    const mode = makeMode();
+    return {
+        sessionId: null,
+        path: '/tmp/test-project',
+        claudeEnvVars: {} as Record<string, string>,
+        allowedTools: [],
+        hookSettingsPath: '/tmp/test-settings.json',
+        nextMessage: vi.fn().mockResolvedValueOnce({ message: 'hello', mode }).mockResolvedValue(null),
+        onReady: vi.fn(),
+        isAborted: vi.fn(() => false),
+        onSessionFound: vi.fn(),
+        onMessage: vi.fn(),
+        canCallTool: vi.fn(),
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers to set up the mock query to emit a minimal result immediately
+// ---------------------------------------------------------------------------
+async function* makeResultStream() {
+    yield {
+        type: 'system',
+        subtype: 'init',
+        session_id: 'test-session-id-abc123',
+    };
+    yield { type: 'result' };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('claudeRemote – auth env var stripping (Issue #120)', () => {
+    const AUTH_VARS = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'];
+
+    let savedEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+        // Save and restore process.env around each test
+        savedEnv = {};
+        for (const key of AUTH_VARS) {
+            savedEnv[key] = process.env[key];
+        }
+
+        // Seed the auth vars so they are definitely present
+        process.env.ANTHROPIC_API_KEY = 'sk-inherited-key';
+        process.env.ANTHROPIC_AUTH_TOKEN = 'inherited-token';
+        process.env.CLAUDE_CODE_OAUTH_TOKEN = 'inherited-oauth';
+
+        mockQuery.mockReturnValue(makeResultStream());
+    });
+
+    afterEach(() => {
+        // Restore process.env
+        for (const key of AUTH_VARS) {
+            if (savedEnv[key] === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = savedEnv[key];
+            }
+        }
+        vi.clearAllMocks();
+    });
+
+    it('strips inherited ANTHROPIC_API_KEY from process.env before SDK call when not in claudeEnvVars', async () => {
+        const { claudeRemote } = await import('./claudeRemote');
+
+        let apiKeyAtCallTime: string | undefined = 'SENTINEL_NOT_CHECKED';
+        mockQuery.mockImplementation(function* () {
+            apiKeyAtCallTime = process.env.ANTHROPIC_API_KEY;
+            yield { type: 'system', subtype: 'init', session_id: 'sess-1' };
+            yield { type: 'result' };
+        });
+
+        const opts = makeBaseOpts({ claudeEnvVars: {} });
+        await claudeRemote(opts as any);
+
+        expect(apiKeyAtCallTime).toBeUndefined();
+    });
+
+    it('strips inherited ANTHROPIC_AUTH_TOKEN from process.env before SDK call when not in claudeEnvVars', async () => {
+        const { claudeRemote } = await import('./claudeRemote');
+
+        let tokenAtCallTime: string | undefined = 'SENTINEL_NOT_CHECKED';
+        mockQuery.mockImplementation(function* () {
+            tokenAtCallTime = process.env.ANTHROPIC_AUTH_TOKEN;
+            yield { type: 'system', subtype: 'init', session_id: 'sess-2' };
+            yield { type: 'result' };
+        });
+
+        const opts = makeBaseOpts({ claudeEnvVars: {} });
+        await claudeRemote(opts as any);
+
+        expect(tokenAtCallTime).toBeUndefined();
+    });
+
+    it('strips inherited CLAUDE_CODE_OAUTH_TOKEN from process.env before SDK call when not in claudeEnvVars', async () => {
+        const { claudeRemote } = await import('./claudeRemote');
+
+        let oauthAtCallTime: string | undefined = 'SENTINEL_NOT_CHECKED';
+        mockQuery.mockImplementation(function* () {
+            oauthAtCallTime = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+            yield { type: 'system', subtype: 'init', session_id: 'sess-3' };
+            yield { type: 'result' };
+        });
+
+        const opts = makeBaseOpts({ claudeEnvVars: {} });
+        await claudeRemote(opts as any);
+
+        expect(oauthAtCallTime).toBeUndefined();
+    });
+
+    it('preserves ANTHROPIC_API_KEY when explicitly provided in claudeEnvVars', async () => {
+        const { claudeRemote } = await import('./claudeRemote');
+
+        let apiKeyAtCallTime: string | undefined = 'SENTINEL_NOT_CHECKED';
+        mockQuery.mockImplementation(function* () {
+            apiKeyAtCallTime = process.env.ANTHROPIC_API_KEY;
+            yield { type: 'system', subtype: 'init', session_id: 'sess-4' };
+            yield { type: 'result' };
+        });
+
+        const opts = makeBaseOpts({
+            claudeEnvVars: { ANTHROPIC_API_KEY: 'sk-explicit-key' },
+        });
+        await claudeRemote(opts as any);
+
+        // Inherited or explicit value should remain – either is acceptable as long as it's set
+        expect(apiKeyAtCallTime).not.toBeUndefined();
+    });
+
+    it('strips all three auth vars when none are in claudeEnvVars', async () => {
+        const { claudeRemote } = await import('./claudeRemote');
+
+        const capturedEnv: Record<string, string | undefined> = {};
+        mockQuery.mockImplementation(function* () {
+            for (const key of AUTH_VARS) {
+                capturedEnv[key] = process.env[key];
+            }
+            yield { type: 'system', subtype: 'init', session_id: 'sess-5' };
+            yield { type: 'result' };
+        });
+
+        const opts = makeBaseOpts({ claudeEnvVars: {} });
+        await claudeRemote(opts as any);
+
+        for (const key of AUTH_VARS) {
+            expect(capturedEnv[key], `${key} should be undefined`).toBeUndefined();
+        }
+    });
+
+    it('does not strip auth vars when claudeEnvVars is undefined', async () => {
+        const { claudeRemote } = await import('./claudeRemote');
+
+        // When claudeEnvVars is undefined, no auth vars were explicitly configured,
+        // so they should still be stripped (treat same as empty object).
+        let apiKeyAtCallTime: string | undefined = 'SENTINEL_NOT_CHECKED';
+        mockQuery.mockImplementation(function* () {
+            apiKeyAtCallTime = process.env.ANTHROPIC_API_KEY;
+            yield { type: 'system', subtype: 'init', session_id: 'sess-6' };
+            yield { type: 'result' };
+        });
+
+        const opts = makeBaseOpts({ claudeEnvVars: undefined });
+        await claudeRemote(opts as any);
+
+        expect(apiKeyAtCallTime).toBeUndefined();
+    });
+});

--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -12,6 +12,7 @@ import { awaitFileExist } from "@/modules/watcher/awaitFileExist";
 import { systemPrompt } from "./utils/systemPrompt";
 import { PermissionResult } from "./sdk/types";
 import type { JsRuntime } from "./runClaude";
+import { deleteAuthVarsFromProcessEnv } from "@/utils/stripAuthEnvVars";
 
 export async function claudeRemote(opts: {
 
@@ -73,6 +74,15 @@ export async function claudeRemote(opts: {
             }
         }
     }
+
+    // Strip inherited auth vars from process.env before the SDK reads it.
+    // The Claude Code SDK uses process.env directly for .cjs launcher executables
+    // (sdk/query.ts: `spawnEnv = isCommandOnly ? getCleanEnv() : process.env`).
+    // Inherited shell vars like ANTHROPIC_API_KEY would override Claude's native
+    // OAuth / Max-plan auth unless removed here.
+    // Auth vars present in opts.claudeEnvVars are explicitly configured and kept.
+    // See: https://github.com/anthropics/happy-cli/issues/120
+    deleteAuthVarsFromProcessEnv(opts.claudeEnvVars ?? {});
 
     // Set environment variables for Claude Code SDK
     if (opts.claudeEnvVars) {

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -178,12 +178,15 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         logger.debug('[START] Failed to report to daemon (may not be running):', error);
     }
 
+    // Create realtime session
+    const session = api.sessionSyncClient(response);
+
     // Extract SDK metadata in background and update session when ready
     extractSDKMetadataAsync(async (sdkMetadata) => {
         logger.debug('[start] SDK metadata extracted, updating session:', sdkMetadata);
         try {
             // Update session metadata with tools and slash commands
-            api.sessionSyncClient(response).updateMetadata((currentMetadata) => ({
+            session.updateMetadata((currentMetadata) => ({
                 ...currentMetadata,
                 tools: sdkMetadata.tools,
                 slashCommands: sdkMetadata.slashCommands
@@ -193,9 +196,6 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             logger.debug('[start] Failed to update session metadata:', error);
         }
     });
-
-    // Create realtime session
-    const session = api.sessionSyncClient(response);
 
     // Start Happy MCP server
     const happyServer = await startHappyServer(session);

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -402,8 +402,8 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
                 // Cleanup session resources (intervals, callbacks)
                 currentSession?.cleanup();
 
-                // Send session death message
-                session.sendSessionDeath();
+                // Send session death message (waits for server ack)
+                await session.sendSessionDeath();
                 await session.flush();
                 await session.close();
             }
@@ -429,6 +429,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Handle termination signals
     process.on('SIGTERM', cleanup);
     process.on('SIGINT', cleanup);
+    process.on('SIGHUP', cleanup);
 
     // Handle uncaught exceptions and rejections
     process.on('uncaughtException', (error) => {
@@ -481,8 +482,8 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Note: currentSession is set by onSessionReady callback during loop()
     (currentSession as Session | null)?.cleanup();
 
-    // Send session death message
-    session.sendSessionDeath();
+    // Send session death message (waits for server ack)
+    await session.sendSessionDeath();
 
     // Wait for socket to flush
     logger.debug('Waiting for socket to flush...');

--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -340,7 +340,10 @@ export function query(config: {
 
     // Spawn Claude Code process
     // Use clean env for global claude to avoid local node_modules/.bin taking precedence
-    const spawnEnv = isCommandOnly ? getCleanEnv() : process.env
+    // Always strip CLAUDECODE to prevent "nested session" errors when running inside Claude Code
+    const baseEnv = isCommandOnly ? getCleanEnv() : { ...process.env }
+    delete baseEnv.CLAUDECODE
+    const spawnEnv = baseEnv
     logDebug(`Spawning Claude Code process: ${spawnCommand} ${spawnArgs.join(' ')} (using ${isCommandOnly ? 'clean' : 'normal'} env)`)
 
     const child = spawn(spawnCommand, spawnArgs, {

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -293,7 +293,7 @@ export async function runCodex(opts: {
                 }));
                 
                 // Send session death message
-                session.sendSessionDeath();
+                await session.sendSessionDeath();
                 await session.flush();
                 await session.close();
             }
@@ -711,7 +711,7 @@ export async function runCodex(opts: {
 
         try {
             logger.debug('[codex]: sendSessionDeath');
-            session.sendSessionDeath();
+            await session.sendSessionDeath();
             logger.debug('[codex]: flush begin');
             await session.flush();
             logger.debug('[codex]: flush done');

--- a/packages/happy-cli/src/daemon/authEnvVarStripping.test.ts
+++ b/packages/happy-cli/src/daemon/authEnvVarStripping.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for auth environment variable stripping in daemon session spawning
+ * 
+ * Issue #120: When daemon spawns sessions, it must strip inherited auth environment
+ * variables (ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)
+ * unless explicitly set by the selected profile. This prevents unexpectedly using
+ * API key auth instead of Claude Max's native OAuth.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+/**
+ * Helper to build a clean environment with auth var stripping
+ * This mimics the logic that should be in daemon/run.ts for stripping auth vars
+ */
+function buildCleanEnvironment(
+  inheritedEnv: Record<string, string | undefined>,
+  profileEnv: Record<string, string>
+): Record<string, string> {
+  const authVarsToStrip = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'];
+  const baseEnv: Record<string, string> = {};
+  
+  for (const [key, value] of Object.entries(inheritedEnv)) {
+    if (value !== undefined) {
+      // Strip auth vars from inherited env unless the profile explicitly sets them
+      if (authVarsToStrip.includes(key) && !(key in profileEnv)) {
+        continue;
+      }
+      baseEnv[key] = value;
+    }
+  }
+  
+  return baseEnv;
+}
+
+describe('Auth Environment Variable Stripping (Issue #120)', () => {
+  let inheritedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    // Setup: daemon inherits typical shell environment with various vars
+    inheritedEnv = {
+      'PATH': '/usr/local/bin:/usr/bin',
+      'HOME': '/home/user',
+      'USER': 'testuser',
+      'ANTHROPIC_API_KEY': 'sk-test-key-12345',  // Stale API key in daemon's shell
+      'ANTHROPIC_AUTH_TOKEN': 'legacy-token',     // Should be stripped
+      'CLAUDE_CODE_OAUTH_TOKEN': 'oauth-token',   // Should be stripped
+      'CUSTOM_VAR': 'custom-value',
+      'NODE_ENV': 'production'
+    };
+  });
+
+  it('should strip inherited auth vars when profile does not set them', () => {
+    const profileEnv = {}; // Profile sets no auth vars
+
+    const result = buildCleanEnvironment(inheritedEnv, profileEnv);
+
+    // Auth vars should be stripped
+    expect(result.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(result.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(result.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+
+    // Other vars should pass through
+    expect(result.PATH).toBe('/usr/local/bin:/usr/bin');
+    expect(result.HOME).toBe('/home/user');
+    expect(result.USER).toBe('testuser');
+    expect(result.CUSTOM_VAR).toBe('custom-value');
+    expect(result.NODE_ENV).toBe('production');
+  });
+
+  it('should preserve auth vars when profile explicitly sets them', () => {
+    // Profile explicitly sets ANTHROPIC_API_KEY (e.g., for a different account/org)
+    const profileEnv = {
+      'ANTHROPIC_API_KEY': 'sk-profile-key-98765'
+    };
+
+    const result = buildCleanEnvironment(inheritedEnv, profileEnv);
+
+    // Auth var should be preserved since profile set it
+    expect(result.ANTHROPIC_API_KEY).toBe('sk-test-key-12345');
+
+    // Other auth vars still stripped (profile didn't set them)
+    expect(result.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(result.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  });
+
+  it('should allow profile to override all three auth vars', () => {
+    const profileEnv = {
+      'ANTHROPIC_API_KEY': 'sk-profile-key',
+      'ANTHROPIC_AUTH_TOKEN': 'profile-auth-token',
+      'CLAUDE_CODE_OAUTH_TOKEN': 'profile-oauth-token'
+    };
+
+    const result = buildCleanEnvironment(inheritedEnv, profileEnv);
+
+    // All auth vars from inherited env should pass through since profile set them
+    expect(result.ANTHROPIC_API_KEY).toBe('sk-test-key-12345');
+    expect(result.ANTHROPIC_AUTH_TOKEN).toBe('legacy-token');
+    expect(result.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
+  });
+
+  it('should handle undefined values gracefully', () => {
+    const mixedEnv: Record<string, string | undefined> = {
+      'PATH': '/usr/bin',
+      'ANTHROPIC_API_KEY': undefined,  // Explicitly undefined
+      'CUSTOM_VAR': 'value',
+      'ANTHROPIC_AUTH_TOKEN': 'token'
+    };
+
+    const profileEnv = {};
+
+    const result = buildCleanEnvironment(mixedEnv, profileEnv);
+
+    // Undefined should be filtered out
+    expect(result.ANTHROPIC_API_KEY).toBeUndefined();
+
+    // Other vars should be present
+    expect(result.PATH).toBe('/usr/bin');
+    expect(result.CUSTOM_VAR).toBe('value');
+
+    // Auth var should still be stripped (not set by profile)
+    expect(result.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it('should pass through non-auth environment variables unchanged', () => {
+    const profileEnv = {};
+
+    const result = buildCleanEnvironment(inheritedEnv, profileEnv);
+
+    // Verify common env vars pass through
+    expect(result.PATH).toBe('/usr/local/bin:/usr/bin');
+    expect(result.HOME).toBe('/home/user');
+    expect(result.USER).toBe('testuser');
+    expect(result.CUSTOM_VAR).toBe('custom-value');
+    expect(result.NODE_ENV).toBe('production');
+  });
+
+  it('should work with empty environment', () => {
+    const emptyEnv = {};
+    const profileEnv = {};
+
+    const result = buildCleanEnvironment(emptyEnv, profileEnv);
+
+    expect(result).toEqual({});
+  });
+
+  it('should work with only auth vars', () => {
+    const authOnlyEnv = {
+      'ANTHROPIC_API_KEY': 'key',
+      'ANTHROPIC_AUTH_TOKEN': 'token',
+      'CLAUDE_CODE_OAUTH_TOKEN': 'oauth'
+    };
+
+    const profileEnv = {};
+
+    const result = buildCleanEnvironment(authOnlyEnv, profileEnv);
+
+    // All should be stripped
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('should preserve auth var if profile sets just one of them', () => {
+    const profileEnv = {
+      'ANTHROPIC_AUTH_TOKEN': 'profile-token-override'  // Only this one
+    };
+
+    const result = buildCleanEnvironment(inheritedEnv, profileEnv);
+
+    // ANTHROPIC_AUTH_TOKEN should be preserved (profile set it)
+    expect(result.ANTHROPIC_AUTH_TOKEN).toBe('legacy-token');
+
+    // Others should be stripped (profile didn't set them)
+    expect(result.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(result.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+  });
+});

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -360,6 +360,25 @@ export async function startDaemon(): Promise<void> {
           };
         }
 
+        // Build a clean base environment from process.env.
+        // Strip auth-related env vars that weren't explicitly set by the profile or auth layer.
+        // This prevents the daemon's inherited ANTHROPIC_API_KEY from overriding Claude Code's
+        // native OAuth login (Max plan). Without this, users with both a Max plan and a stale
+        // ANTHROPIC_API_KEY in their shell would always get billed via the API key.
+        // See: https://github.com/anthropics/happy-cli/issues/120
+        const authVarsToStrip = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'];
+        const baseEnv: Record<string, string> = {};
+        for (const [key, value] of Object.entries(process.env)) {
+          if (value !== undefined) {
+            // Strip auth vars from inherited env unless the profile explicitly sets them
+            if (authVarsToStrip.includes(key) && !(key in extraEnv)) {
+              logger.debug(`[DAEMON RUN] Stripping inherited ${key} from daemon env (not set by profile) to allow native Claude Code auth`);
+              continue;
+            }
+            baseEnv[key] = value;
+          }
+        }
+
         // Check if tmux is available and should be used
         const tmuxAvailable = await isTmuxAvailable();
         let useTmux = tmuxAvailable;
@@ -391,19 +410,13 @@ export async function startDaemon(): Promise<void> {
           const fullCommand = `node --no-warnings --no-deprecation ${cliPath} ${agent} --happy-starting-mode remote --started-by daemon`;
 
           // Spawn in tmux with environment variables
-          // IMPORTANT: Pass complete environment (process.env + extraEnv) because:
+          // IMPORTANT: Pass complete environment (baseEnv + extraEnv) because:
           // 1. tmux sessions need daemon's expanded auth variables (e.g., ANTHROPIC_AUTH_TOKEN)
-          // 2. Regular spawn uses env: { ...process.env, ...extraEnv }
+          // 2. Regular spawn uses env: { ...baseEnv, ...extraEnv }
           // 3. tmux needs explicit environment via -e flags to ensure all variables are available
+          // Note: baseEnv already has auth vars stripped if not set by profile (Max plan support)
           const windowName = `happy-${Date.now()}-${agent}`;
-          const tmuxEnv: Record<string, string> = {};
-
-          // Add all daemon environment variables (filtering out undefined)
-          for (const [key, value] of Object.entries(process.env)) {
-            if (value !== undefined) {
-              tmuxEnv[key] = value;
-            }
-          }
+          const tmuxEnv: Record<string, string> = { ...baseEnv };
 
           // Add extra environment variables (these should already be filtered)
           Object.assign(tmuxEnv, extraEnv);
@@ -496,16 +509,16 @@ export async function startDaemon(): Promise<void> {
           ];
 
           // TODO: In future, sessionId could be used with --resume to continue existing sessions
-          // For now, we ignore it - each spawn creates a new session
-          const happyProcess = spawnHappyCLI(args, {
-            cwd: directory,
-            detached: true,  // Sessions stay alive when daemon stops
-            stdio: ['ignore', 'pipe', 'pipe'],  // Capture stdout/stderr for debugging
-            env: {
-              ...process.env,
-              ...extraEnv
-            }
-          });
+           // For now, we ignore it - each spawn creates a new session
+           const happyProcess = spawnHappyCLI(args, {
+             cwd: directory,
+             detached: true,  // Sessions stay alive when daemon stops
+             stdio: ['ignore', 'pipe', 'pipe'],  // Capture stdout/stderr for debugging
+             env: {
+               ...baseEnv,
+               ...extraEnv
+             }
+           });
 
           // Log output for debugging
           if (process.env.DEBUG) {

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -22,6 +22,7 @@ import { join } from 'path';
 import { projectPath } from '@/projectPath';
 import { getTmuxUtilities, isTmuxAvailable, parseTmuxSessionIdentifier, formatTmuxSessionIdentifier } from '@/utils/tmux';
 import { expandEnvironmentVariables } from '@/utils/expandEnvVars';
+import { buildEnvWithStrippedAuthVars } from '@/utils/stripAuthEnvVars';
 
 // Prepare initial metadata
 export const initialMachineMetadata: MachineMetadata = {
@@ -366,18 +367,7 @@ export async function startDaemon(): Promise<void> {
         // native OAuth login (Max plan). Without this, users with both a Max plan and a stale
         // ANTHROPIC_API_KEY in their shell would always get billed via the API key.
         // See: https://github.com/anthropics/happy-cli/issues/120
-        const authVarsToStrip = ['ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN'];
-        const baseEnv: Record<string, string> = {};
-        for (const [key, value] of Object.entries(process.env)) {
-          if (value !== undefined) {
-            // Strip auth vars from inherited env unless the profile explicitly sets them
-            if (authVarsToStrip.includes(key) && !(key in extraEnv)) {
-              logger.debug(`[DAEMON RUN] Stripping inherited ${key} from daemon env (not set by profile) to allow native Claude Code auth`);
-              continue;
-            }
-            baseEnv[key] = value;
-          }
-        }
+        const baseEnv = buildEnvWithStrippedAuthVars(process.env, extraEnv);
 
         // Check if tmux is available and should be used
         const tmuxAvailable = await isTmuxAvailable();

--- a/packages/happy-cli/src/gemini/constants.ts
+++ b/packages/happy-cli/src/gemini/constants.ts
@@ -17,7 +17,7 @@ export const GOOGLE_API_KEY_ENV = 'GOOGLE_API_KEY';
 export const GEMINI_MODEL_ENV = 'GEMINI_MODEL';
 
 /** Default Gemini model */
-export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
+export const DEFAULT_GEMINI_MODEL = 'gemini-3.1-pro-preview';
 
 /**
  * Instruction for changing chat title

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -930,6 +930,31 @@ export async function runGemini(opts: {
 
   let first = true;
 
+  /**
+   * Race a promise against the abort signal so long-running awaits
+   * (sendPrompt, waitForResponseComplete) can be interrupted when the user
+   * aborts. Without this the main loop blocks forever on the await while
+   * new messages queue up — causing the deadlock.
+   */
+  function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+    function makeAbortError(): Error {
+      const err = new Error('Aborted');
+      err.name = 'AbortError';
+      return err;
+    }
+    if (signal.aborted) {
+      return Promise.reject(makeAbortError());
+    }
+    return new Promise<T>((resolve, reject) => {
+      const onAbort = () => reject(makeAbortError());
+      signal.addEventListener('abort', onAbort, { once: true });
+      promise.then(
+        (v) => { signal.removeEventListener('abort', onAbort); resolve(v); },
+        (e) => { signal.removeEventListener('abort', onAbort); reject(e); },
+      );
+    });
+  }
+
   try {
     let currentModeHash: string | null = null;
     let pending: { message: string; mode: GeminiMode; isolate: boolean; hash: string } | null = null;
@@ -957,6 +982,10 @@ export async function runGemini(opts: {
       if (!message) {
         break;
       }
+
+      // Capture the current abort signal for this turn so sendPrompt/
+      // waitForResponseComplete can be interrupted when handleAbort fires.
+      const turnSignal = abortController.signal;
 
       // Track if we need to inject conversation history (after model change)
       let injectHistoryContext = false;
@@ -1125,13 +1154,13 @@ export async function runGemini(opts: {
         
         for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
           try {
-            await geminiBackend.sendPrompt(acpSessionId, promptToSend);
+            await withAbort(geminiBackend.sendPrompt(acpSessionId, promptToSend), turnSignal);
             logger.debug('[gemini] Prompt sent successfully');
-            
+
             // Wait for Gemini to finish responding (all chunks received + final idle)
             // This ensures we don't send task_complete until response is truly done
             if (geminiBackend.waitForResponseComplete) {
-              await geminiBackend.waitForResponseComplete(120000);
+              await withAbort(geminiBackend.waitForResponseComplete(120000), turnSignal);
               logger.debug('[gemini] Response complete');
             }
             

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -59,6 +59,10 @@ import { ConversationHistory } from '@/gemini/utils/conversationHistory';
 export async function runGemini(opts: {
   credentials: Credentials;
   startedBy?: 'daemon' | 'terminal';
+  initialPrompt?: string;
+  model?: string;
+  dangerouslySkipPermissions?: boolean;
+  resumeSessionId?: string;
 }): Promise<void> {
   //
   // Define session
@@ -883,6 +887,27 @@ export async function runGemini(opts: {
 
   // Note: Backend will be created dynamically in the main loop based on model from first message
   // This allows us to support model changes by recreating the backend
+
+  // If dangerouslySkipPermissions is set, default to 'yolo' permission mode
+  if (opts.dangerouslySkipPermissions) {
+    currentPermissionMode = 'yolo';
+    updatePermissionMode('yolo');
+    logger.debug('[Gemini] Permission mode set to yolo (dangerously-skip-permissions)');
+  }
+
+  // If an initial prompt was provided via CLI, inject it into the message queue
+  if (opts.initialPrompt) {
+    logger.debug(`[Gemini] Injecting initial prompt from CLI (length: ${opts.initialPrompt.length})`);
+    const initialMode: GeminiMode = {
+      permissionMode: currentPermissionMode || 'default',
+      model: opts.model,
+      originalUserMessage: opts.initialPrompt,
+    };
+    // Add change_title instruction for the first message (same as mobile app flow)
+    const fullInitialPrompt = opts.initialPrompt + '\n\n' + CHANGE_TITLE_INSTRUCTION;
+    isFirstMessage = false; // Mark as consumed so onUserMessage doesn't add it again
+    messageQueue.push(fullInitialPrompt, initialMode);
+  }
 
   let first = true;
 

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -201,6 +201,19 @@ export async function runGemini(opts: {
     }
   }
 
+  // Push available Gemini models to session metadata so the mobile app can display them
+  // (Without this, the app falls back to hardcoded model lists which may be stale)
+  const GEMINI_AVAILABLE_MODELS = [
+    { code: 'gemini-3.1-pro-preview', value: 'Gemini 3.1 Pro', description: 'Most capable' },
+    { code: 'gemini-3.0-flash-preview', value: 'Gemini 3.0 Flash', description: 'Fast & efficient' },
+  ];
+
+  session.updateMetadata((currentMetadata) => ({
+    ...currentMetadata,
+    models: GEMINI_AVAILABLE_MODELS,
+    currentModelCode: opts.model || getInitialGeminiModel(),
+  }));
+
   const messageQueue = new MessageQueue2<GeminiMode>((mode) => hashObject({
     permissionMode: mode.permissionMode,
     model: mode.model,
@@ -440,12 +453,18 @@ export async function runGemini(opts: {
     if (saveToConfig) {
       saveGeminiModelToConfig(model);
     }
-    
+
+    // Update session metadata so mobile app reflects the current model
+    session.updateMetadata((currentMetadata) => ({
+      ...currentMetadata,
+      currentModelCode: model,
+    }));
+
     // Trigger UI update by adding a system message with model info
     // The message will be parsed by UI to extract model name
     if (hasTTY && oldModel !== model) {
       // Add a system message that includes model info - UI will parse it
-      // Format: [MODEL:gemini-2.5-pro] to make it easy to extract
+      // Format: [MODEL:gemini-3.1-pro-preview] to make it easy to extract
       logger.debug(`[gemini] Adding model update message to buffer: [MODEL:${model}]`);
       messageBuffer.addMessage(`[MODEL:${model}]`, 'system');
     } else if (hasTTY) {
@@ -460,7 +479,7 @@ export async function runGemini(opts: {
     // We use a function component that reads displayedModel on each render
     const DisplayComponent = () => {
       // Read displayedModel from closure - it will have latest value on each render
-      const currentModelValue = displayedModel || 'gemini-2.5-pro';
+      const currentModelValue = displayedModel || DEFAULT_GEMINI_MODEL;
       // Don't log on every render to avoid spam - only log when model changes
       return React.createElement(GeminiDisplay, {
         messageBuffer,
@@ -480,7 +499,7 @@ export async function runGemini(opts: {
     });
     
     // Send initial model to UI so it displays correctly from start
-    const initialModelName = displayedModel || 'gemini-2.5-pro';
+    const initialModelName = displayedModel || DEFAULT_GEMINI_MODEL;
     logger.debug(`[gemini] Sending initial model to UI: ${initialModelName}`);
     messageBuffer.addMessage(`[MODEL:${initialModelName}]`, 'system');
   }
@@ -1058,7 +1077,7 @@ export async function runGemini(opts: {
             currentModeHash = message.hash;
             
             // Model info is already shown in status bar via updateDisplayedModel
-            logger.debug(`[gemini] Displaying model in UI: ${displayedModel || 'gemini-2.5-pro'}, displayedModel: ${displayedModel}`);
+            logger.debug(`[gemini] Displaying model in UI: ${displayedModel || DEFAULT_GEMINI_MODEL}, displayedModel: ${displayedModel}`);
           }
         }
         
@@ -1135,7 +1154,7 @@ export async function runGemini(opts: {
                 const parts = resetTimeMatch.slice(1).filter(Boolean).join('');
                 resetTimeMsg = ` Quota resets in ${parts}.`;
               }
-              const quotaMsg = `Gemini quota exceeded.${resetTimeMsg} Try using a different model (gemini-2.5-flash-lite) or wait for quota reset.`;
+              const quotaMsg = `Gemini quota exceeded.${resetTimeMsg} Try using a different model (gemini-3.0-flash-preview) or wait for quota reset.`;
               messageBuffer.addMessage(quotaMsg, 'status');
               session.sendAgentMessage('gemini', { type: 'message', message: quotaMsg });
               throw promptError; // Don't retry quota errors
@@ -1191,8 +1210,8 @@ export async function runGemini(opts: {
             // Check for 404 error (model not found)
             if (errorCode === 404 || errorDetails.includes('notFound') || errorDetails.includes('404') || 
                 errorMessage.includes('not found') || errorMessage.includes('404')) {
-              const currentModel = displayedModel || 'gemini-2.5-pro';
-              errorMsg = `Model "${currentModel}" not found. Available models: gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite`;
+              const currentModel = displayedModel || DEFAULT_GEMINI_MODEL;
+              errorMsg = `Model "${currentModel}" not found. Available models: gemini-3.1-pro-preview, gemini-3.0-flash-preview`;
             }
             // Check for empty response / internal error after retries exhausted
             else if (errorCode === -32603 || 
@@ -1217,7 +1236,7 @@ export async function runGemini(opts: {
                 const parts = resetTimeMatch.slice(1).filter(Boolean).join('');
                 resetTimeMsg = ` Quota resets in ${parts}.`;
               }
-              errorMsg = `Gemini quota exceeded.${resetTimeMsg} Try using a different model (gemini-2.5-flash-lite) or wait for quota reset.`;
+              errorMsg = `Gemini quota exceeded.${resetTimeMsg} Try using a different model (gemini-3.0-flash-preview) or wait for quota reset.`;
             }
             // Check for authentication error (Google Workspace accounts need project ID)
             else if (errorMessage.includes('Authentication required') || 

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -398,7 +398,7 @@ export async function runGemini(opts: {
           archiveReason: 'User terminated'
         }));
 
-        session.sendSessionDeath();
+        await session.sendSessionDeath();
         await session.flush();
         await session.close();
       }
@@ -1370,7 +1370,7 @@ export async function runGemini(opts: {
     }
 
     try {
-      session.sendSessionDeath();
+      await session.sendSessionDeath();
       await session.flush();
       await session.close();
     } catch (e) {

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -131,7 +131,7 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
     // Handle "happy gemini model set <model>" command
     if (geminiSubcommand === 'model' && args[2] === 'set' && args[3]) {
       const modelName = args[3];
-      const validModels = ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'];
+      const validModels = ['gemini-3.1-pro-preview', 'gemini-3.0-flash-preview'];
       
       if (!validModels.includes(modelName)) {
         console.error(`Invalid model: ${modelName}`);
@@ -307,15 +307,31 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
     // Handle gemini command (ACP-based agent)
     try {
       const { runGemini } = await import('@/gemini/runGemini');
-      
-      // Parse startedBy argument
+
+      // Parse gemini-specific arguments
       let startedBy: 'daemon' | 'terminal' | undefined = undefined;
+      let geminiModel: string | undefined = undefined;
+      let dangerouslySkipPermissions = false;
+      let resumeSessionId: string | undefined = undefined;
+      const positionalArgs: string[] = [];
+
       for (let i = 1; i < args.length; i++) {
         if (args[i] === '--started-by') {
           startedBy = args[++i] as 'daemon' | 'terminal';
+        } else if (args[i] === '--model' && args[i + 1]) {
+          geminiModel = args[++i];
+        } else if (args[i] === '--dangerously-skip-permissions' || args[i] === '--yolo') {
+          dangerouslySkipPermissions = true;
+        } else if (args[i] === '--resume' && args[i + 1]) {
+          resumeSessionId = args[++i];
+        } else if (!args[i].startsWith('-')) {
+          // Collect positional args as initial prompt
+          positionalArgs.push(args[i]);
         }
       }
-      
+
+      const initialPrompt = positionalArgs.length > 0 ? positionalArgs.join(' ') : undefined;
+
       const {
         credentials
       } = await authAndSetupMachineIfNeeded();
@@ -333,7 +349,19 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
         await new Promise(resolve => setTimeout(resolve, 200));
       }
 
-      await runGemini({credentials, startedBy});
+      // If --model is specified, set GEMINI_MODEL env var so the backend picks it up
+      if (geminiModel) {
+        process.env.GEMINI_MODEL = geminiModel;
+      }
+
+      await runGemini({
+        credentials,
+        startedBy,
+        initialPrompt,
+        model: geminiModel,
+        dangerouslySkipPermissions,
+        resumeSessionId,
+      });
     } catch (error) {
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
       if (process.env.DEBUG) {

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -208,7 +208,7 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
         } else if (process.env.GEMINI_MODEL) {
           console.log(`Current model: ${process.env.GEMINI_MODEL} (from GEMINI_MODEL env var)`);
         } else {
-          console.log('Current model: gemini-2.5-pro (default)');
+          console.log('Current model: gemini-3.1-pro-preview (default)');
         }
         process.exit(0);
       } catch (error) {

--- a/packages/happy-cli/src/utils/MessageQueue2.ts
+++ b/packages/happy-cli/src/utils/MessageQueue2.ts
@@ -184,8 +184,15 @@ export class MessageQueue2<T> {
         this.queue = [];
         this.closed = false;
 
-        // Clear waiter without calling it since we're not closing
-        this.waiter = null;
+        // Notify waiter so it doesn't hang forever on a promise that never resolves.
+        // Resolving with false tells waitForMessagesAndGetAsString to return null,
+        // which the main loop handles as "no batch, re-check".
+        if (this.waiter) {
+            logger.debug(`[MessageQueue2] reset() notifying waiter`);
+            const waiter = this.waiter;
+            this.waiter = null;
+            waiter(false);
+        }
     }
 
     /**

--- a/packages/happy-cli/src/utils/offlineSessionStub.ts
+++ b/packages/happy-cli/src/utils/offlineSessionStub.ts
@@ -39,7 +39,7 @@ export function createOfflineSessionStub(sessionTag: string): ApiSessionClient {
         sendClaudeSessionMessage: () => {},
         keepAlive: () => {},
         sendSessionEvent: () => {},
-        sendSessionDeath: () => {},
+        sendSessionDeath: async () => {},
         updateLifecycleState: () => {},
         requestControlTransfer: async () => {},
         flush: async () => {},

--- a/packages/happy-cli/src/utils/spawnHappyCLI.ts
+++ b/packages/happy-cli/src/utils/spawnHappyCLI.ts
@@ -100,6 +100,11 @@ export function spawnHappyCLI(args: string[], options: SpawnOptions = {}): Child
     throw new Error(errorMessage);
   }
   
+  // Strip CLAUDECODE env var to prevent "nested session" errors when
+  // spawned from within a Claude Code session (e.g., daemon started inside Claude Code)
+  const env = { ...(options.env || process.env) };
+  delete env.CLAUDECODE;
+
   const runtime = isBun() ? 'bun' : 'node';
-  return spawn(runtime, nodeArgs, options);
+  return spawn(runtime, nodeArgs, { ...options, env });
 }

--- a/packages/happy-cli/src/utils/stripAuthEnvVars.ts
+++ b/packages/happy-cli/src/utils/stripAuthEnvVars.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared utility for stripping auth-related environment variables.
+ *
+ * Issue #120: When Happy CLI spawns or invokes Claude Code, inherited shell auth
+ * vars (ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN) must be
+ * removed from the environment unless explicitly configured. If left in place they
+ * override Claude Code's native OAuth / Max-plan authentication, causing API-limit
+ * errors for users who rely on Claude Max.
+ *
+ * This module is used by:
+ *   - daemon/run.ts        – child process env for daemon-spawned sessions
+ *   - claude/claudeLocal.ts – child process env for local terminal sessions
+ *   - claude/claudeRemote.ts – process.env before SDK invocation for remote sessions
+ */
+
+import { logger } from '@/ui/logger';
+
+/** Auth-related env vars that Claude Code uses to select its authentication method. */
+export const AUTH_VARS_TO_STRIP = [
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_AUTH_TOKEN',
+    'CLAUDE_CODE_OAUTH_TOKEN',
+] as const;
+
+export type AuthVar = typeof AUTH_VARS_TO_STRIP[number];
+
+/**
+ * Build a clean environment by copying `inheritedEnv` and omitting auth vars that
+ * are NOT present in `explicitVars`.
+ *
+ * Used when building the `env` object for a spawned child process (daemon, local
+ * launcher). Call site example:
+ *
+ * ```ts
+ * const env = buildEnvWithStrippedAuthVars(process.env, opts.claudeEnvVars ?? {});
+ * spawn(cmd, args, { env: { ...env, ...opts.claudeEnvVars } });
+ * ```
+ *
+ * @param inheritedEnv  The environment to copy from (typically `process.env`).
+ * @param explicitVars  Vars explicitly configured by the user/profile. Auth vars
+ *                      present here are kept; others are stripped.
+ * @returns A new record with auth vars stripped (or preserved when in explicitVars).
+ */
+export function buildEnvWithStrippedAuthVars(
+    inheritedEnv: Record<string, string | undefined>,
+    explicitVars: Record<string, string> = {}
+): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(inheritedEnv)) {
+        if (value === undefined) continue;
+        if ((AUTH_VARS_TO_STRIP as readonly string[]).includes(key) && !(key in explicitVars)) {
+            logger.debug(`[stripAuthEnvVars] Stripping inherited ${key} from env (not set by configuration)`);
+            continue;
+        }
+        result[key] = value;
+    }
+    return result;
+}
+
+/**
+ * Delete auth vars directly from `process.env` when they are NOT present in
+ * `explicitVars`.
+ *
+ * Used by claudeRemote.ts, which cannot build a separate env object because the
+ * Claude Code SDK reads `process.env` directly at spawn time for `.cjs` launcher
+ * executables (see sdk/query.ts:343 – `spawnEnv = isCommandOnly ? getCleanEnv() : process.env`).
+ *
+ * @param explicitVars  Vars explicitly configured by the user/profile. Auth vars
+ *                      present here are left untouched; others are deleted.
+ */
+export function deleteAuthVarsFromProcessEnv(
+    explicitVars: Record<string, string> = {}
+): void {
+    for (const key of AUTH_VARS_TO_STRIP) {
+        if (!(key in explicitVars) && process.env[key] !== undefined) {
+            logger.debug(`[stripAuthEnvVars] Deleting inherited ${key} from process.env (not set by configuration)`);
+            delete process.env[key];
+        }
+    }
+}

--- a/packages/happy-server/sources/app/api/routes/v3SessionRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/v3SessionRoutes.ts
@@ -14,7 +14,7 @@ const sendMessagesBodySchema = z.object({
     messages: z.array(z.object({
         content: z.string(),
         localId: z.string().min(1)
-    })).min(1).max(100)
+    })).min(1).max(1000)
 });
 
 type SelectedMessage = {

--- a/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
@@ -247,17 +247,19 @@ export function sessionUpdateHandler(userId: string, socket: Socket, connection:
     socket.on('session-end', async (data: {
         sid: string;
         time: number;
-    }) => {
+    }, callback?: (response: { result: string }) => void) => {
         try {
             const { sid, time } = data;
             let t = time;
             if (typeof t !== 'number') {
+                callback?.({ result: 'error' });
                 return;
             }
             if (t > Date.now()) {
                 t = Date.now();
             }
             if (t < Date.now() - 1000 * 60 * 10) { // Ignore if time is in the past 10 minutes
+                callback?.({ result: 'error' });
                 return;
             }
 
@@ -266,6 +268,7 @@ export function sessionUpdateHandler(userId: string, socket: Socket, connection:
                 where: { id: sid, accountId: userId }
             });
             if (!session) {
+                callback?.({ result: 'error' });
                 return;
             }
 
@@ -282,8 +285,11 @@ export function sessionUpdateHandler(userId: string, socket: Socket, connection:
                 payload: sessionActivity,
                 recipientFilter: { type: 'user-scoped-only' }
             });
+
+            callback?.({ result: 'ok' });
         } catch (error) {
             log({ module: 'websocket', level: 'error' }, `Error in session-end: ${error}`);
+            callback?.({ result: 'error' });
         }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12661,7 +12661,7 @@ shell-quote@^1.6.1, shell-quote@^1.8.3:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
   integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
 
-shelljs@^0.8.5:
+shelljs@^0.8.4, shelljs@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
   integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
@@ -12669,6 +12669,14 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shx@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.3.tgz#681a88c7c10db15abe18525349ed474f0f1e7b9f"
+  integrity sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.4"
 
 shx@^0.3.3:
   version "0.3.4"
@@ -13342,8 +13350,8 @@ toidentifier@~1.0.1:
 
 tr46@~0.0.3:
   version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 ts-debounce@^4.0.0:
   version "4.0.0"
@@ -13904,8 +13912,8 @@ web-streams-polyfill@^4.1.0:
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
 webidl-conversions@^5.0.0:
   version "5.0.0"
@@ -13943,8 +13951,8 @@ whatwg-url-without-unicode@8.0.0-3:
 
 whatwg-url@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"


### PR DESCRIPTION
## Summary
- **Fix duplicate messages in web client** by sharing `localId` between modern and legacy format sends, so server dedup drops the second copy
- **Make `sendSessionDeath` async** with server ack (2s timeout fallback) for reliable session cleanup
- **Add SIGHUP handler** for graceful cleanup on terminal disconnect
- **Bump max messages per batch** from 100 to 1000
- **Fix Dockerfile**: copy `patches/` dir needed by postinstall script
- Plus: Gemini 3.1 Pro support, legacy output compat, various bug fixes

## Test plan
- [x] Verified DB stores one message per `localId` (no duplicates)
- [x] Docker image builds successfully with `patches/` fix
- [x] CLI type-checks and builds cleanly
- [x] Server container starts and serves requests

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)