### PR TITLE
fix(mcp): use stateful transport to prevent 500 errors on Happy MCP server

### DIFF
--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -72,10 +72,13 @@ export async function startHappyServer(client: ApiSessionClient) {
         }
     });
 
+    // Use a fixed session ID so the transport operates in stateful mode.
+    // Stateless mode (sessionIdGenerator: undefined) throws on the second request
+    // because StreamableHTTPServerTransport refuses to be reused, causing Claude Code
+    // to see a 500 error and mark the MCP server as "failed".
+    const sessionId = randomUUID();
     const transport = new StreamableHTTPServerTransport({
-        // NOTE: Returning session id here will result in claude
-        // sdk spawn to fail with `Invalid Request: Server already initialized`
-        sessionIdGenerator: undefined
+        sessionIdGenerator: () => sessionId,
     });
     await mcp.connect(transport);
 


### PR DESCRIPTION
## Summary

- The `StreamableHTTPServerTransport` in `startHappyServer.ts` was configured with `sessionIdGenerator: undefined` (stateless mode)
- In MCP SDK v1.25+, stateless mode throws `"Stateless transport cannot be reused across requests"` on any request after the first one
- This caused Claude Code to receive HTTP 500 errors when trying to discover tools (e.g. `tools/list`) after initialization, marking the Happy MCP server as `"failed"` and making `mcp__happy__change_title` unavailable
- Fix: use a fixed session ID generator so the transport operates in stateful mode, allowing the single-client local connection to handle multiple requests

## Root cause analysis

1. Happy starts an HTTP MCP server on a random local port and passes it to Claude Code via `--mcp-config`
2. Claude Code connects and sends `initialize` → succeeds (first request)
3. Claude Code sends `tools/list` → the transport throws because stateless mode prohibits reuse → caught by the HTTP handler → returns 500
4. Claude Code marks the MCP server as `"failed"`
5. All `mcp__happy__*` tools become unavailable

## Test plan

- [x] Verified the 500 error by manually `curl`-ing the running MCP server
- [ ] Build and install the fixed version, start a happy session, and verify `mcp__happy__change_title` is available and functional

🤖 Generated with [Claude Code](https://claude.ai/code)