### PR TITLE
fix(happy-cli): handle Windows PID reuse in daemon state check

### DIFF
--- a/packages/happy-cli/src/daemon/controlClient.ts
+++ b/packages/happy-cli/src/daemon/controlClient.ts
@@ -121,15 +121,37 @@ export async function checkIfDaemonRunningAndCleanupStaleState(): Promise<boolea
     return false;
   }
 
-  // Check if the daemon is running
+  // Check if the PID is alive
   try {
     process.kill(state.pid, 0);
-    return true;
   } catch {
     logger.debug('[DAEMON RUN] Daemon PID not running, cleaning up state');
     await cleanupDaemonState();
     return false;
   }
+
+  // PID is alive, but on Windows PIDs get reused after reboot.
+  // Verify it's actually our daemon by HTTP pinging its control server.
+  if (state.httpPort) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${state.httpPort}/list`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+        signal: AbortSignal.timeout(2000)
+      });
+      if (response.ok) {
+        return true;
+      }
+    } catch {
+      // HTTP check failed - the PID is not our daemon (likely reused by OS after reboot)
+      logger.debug(`[DAEMON RUN] PID ${state.pid} is alive but HTTP health check failed on port ${state.httpPort}, cleaning up stale state`);
+      await cleanupDaemonState();
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

- On Windows, PIDs get reused after reboot. The daemon previously only checked if a PID was alive via `process.kill(pid, 0)`, which could return `true` for a completely unrelated process that happened to receive the same PID after a system restart.
- This caused the daemon to think it was already running and skip startup, leaving the device invisible on the mobile app.
- Added an HTTP health check (`POST /list`) to the daemon's control server after the PID alive check. If the PID is alive but the HTTP ping fails, the stale state file is cleaned up, allowing a fresh daemon to start.

## Test plan

- [x] Verified on Windows 10: after a full system reboot, the daemon correctly detects the stale PID and starts a new instance
- [x] Verified the mobile app can see the device after the daemon restarts
- [ ] Verify on macOS/Linux that existing behavior is unchanged (PID reuse is less common but the HTTP check is harmless)