### PR TITLE
fix(happy-cli): return 404 for OAuth metadata discovery paths

### DIFF
--- a/packages/happy-cli/src/claude/utils/startHappyServer.test.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getRequestPath, isOAuthMetadataDiscoveryPath } from './startHappyServer';
+
+describe('startHappyServer request path helpers', () => {
+    it('parses request paths from relative and absolute URLs', () => {
+        expect(getRequestPath('/.well-known/oauth-authorization-server')).toBe('/.well-known/oauth-authorization-server');
+        expect(getRequestPath('http://127.0.0.1:1234/.well-known/oauth-protected-resource/mcp')).toBe('/.well-known/oauth-protected-resource/mcp');
+    });
+
+    it('falls back to root path when request URL is missing', () => {
+        expect(getRequestPath(undefined)).toBe('/');
+    });
+
+    it('detects OAuth metadata discovery paths', () => {
+        expect(isOAuthMetadataDiscoveryPath('/.well-known/oauth-authorization-server')).toBe(true);
+        expect(isOAuthMetadataDiscoveryPath('/.well-known/oauth-authorization-server/')).toBe(true);
+        expect(isOAuthMetadataDiscoveryPath('/.well-known/oauth-protected-resource')).toBe(true);
+        expect(isOAuthMetadataDiscoveryPath('/.well-known/oauth-protected-resource/mcp')).toBe(true);
+    });
+
+    it('does not match non OAuth discovery paths', () => {
+        expect(isOAuthMetadataDiscoveryPath('/')).toBe(false);
+        expect(isOAuthMetadataDiscoveryPath('/mcp')).toBe(false);
+        expect(isOAuthMetadataDiscoveryPath('/.well-known/openid-configuration')).toBe(false);
+    });
+});

--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -12,6 +12,21 @@ import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
 import { randomUUID } from "node:crypto";
 
+const OAUTH_AUTHORIZATION_SERVER_PATH = /^\/\.well-known\/oauth-authorization-server\/?$/;
+const OAUTH_PROTECTED_RESOURCE_PATH = /^\/\.well-known\/oauth-protected-resource(?:\/.*)?$/;
+
+export function getRequestPath(reqUrl: string | undefined): string {
+    try {
+        return new URL(reqUrl ?? "/", "http://127.0.0.1").pathname;
+    } catch {
+        return "/";
+    }
+}
+
+export function isOAuthMetadataDiscoveryPath(pathname: string): boolean {
+    return OAUTH_AUTHORIZATION_SERVER_PATH.test(pathname) || OAUTH_PROTECTED_RESOURCE_PATH.test(pathname);
+}
+
 export async function startHappyServer(client: ApiSessionClient) {
     logger.debug(`[happyMCP] server:start sessionId=${client.sessionId}`);
 
@@ -86,6 +101,21 @@ export async function startHappyServer(client: ApiSessionClient) {
     //
 
     const server = createServer(async (req, res) => {
+        const pathname = getRequestPath(req.url);
+
+        // MCP OAuth discovery clients treat 404 as "no OAuth" and continue.
+        // Return 404 explicitly so local authless servers don't fail tool startup.
+        if (isOAuthMetadataDiscoveryPath(pathname)) {
+            res.writeHead(404).end();
+            return;
+        }
+
+        // This server only exposes MCP on the root path.
+        if (pathname !== "/") {
+            res.writeHead(404).end();
+            return;
+        }
+
         try {
             await transport.handleRequest(req, res);
         } catch (error) {


### PR DESCRIPTION
## Summary
- return HTTP 404 for `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource*` on the local Happy MCP server
- return 404 for non-root paths so unsupported probes do not surface as 500
- add unit tests for request-path parsing and OAuth discovery path detection

## Why
Codex MCP OAuth discovery treats 404 as "no OAuth" and continues, but non-404 (like 500) aborts startup. This change prevents local authless Happy MCP from failing with: `HTTP 500 trying to load OAuth metadata`.

## Testing
- Added: `src/claude/utils/startHappyServer.test.ts`
- Not run in this environment (missing `yarn`/`corepack` binaries).
