### PR TITLE
fix(docker): standalone build missing patches and runtime working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY packages/happy-app/patches packages/happy-app/patches
 COPY packages/happy-server/prisma packages/happy-server/prisma
 COPY packages/happy-cli/scripts packages/happy-cli/scripts
 COPY packages/happy-cli/tools packages/happy-cli/tools
+COPY patches ./patches
 
 RUN SKIP_HAPPY_WIRE_BUILD=1 yarn install --frozen-lockfile --ignore-engines
 


### PR DESCRIPTION
Hi! 👋 While trying to deploy the standalone docker container based on the documentation, I encountered a couple of issues. This PR fixes them:

1. **Build Fix**: The `Dockerfile` was missing the `COPY patches ./patches` step, which caused `postinstall.cjs` to fail with a `MODULE_NOT_FOUND` error for `fix-pglite-prisma-bytes.cjs`.
2. **Runtime/Docs Fix**: Updated the standalone `docker run` command in `packages/happy-server/README.md`. Without specifying the working directory (`-w /repo/packages/happy-server`) and the `yarn start` command, the container fails to find the `prisma` directory and throws a `Cannot find package '@/app'` error due to Monorepo path resolution.

Tested locally, and the standalone server boots up perfectly now without external dependencies! 🚀 Let me know if you need any changes.