### PR TITLE
docs: add yarn install step to Run From Source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run From Source (Repo Checkout)
 ```bash
 # from repository root
 yarn install
+yarn workspace happy-coder build
 yarn cli --help
 yarn cli codex
 ```

--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -16,9 +16,13 @@ From a repo checkout:
 
 ```bash
 # repository root
+yarn install
+yarn workspace happy-coder build
 yarn cli --help
 
 # package directory
+yarn install
+yarn build
 yarn cli --help
 ```
 


### PR DESCRIPTION
## Summary
- Adds `yarn install` as the first step in the "Run From Source" section of the README
- Without it, `yarn cli` fails with `ERR_MODULE_NOT_FOUND` because dependencies aren't installed

## Test plan
- [x] Verified `yarn cli --help` fails without `yarn install`
- [x] Verified `yarn cli --help` works after `yarn install`