### PR TITLE
fix(mcp): handle OAuth discovery endpoint to prevent 500 from MCP SDK

### DIFF
--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -86,6 +86,13 @@ export async function startHappyServer(client: ApiSessionClient) {
     //
 
     const server = createServer(async (req, res) => {
+        // Claude Code 2.1.70+ requires HTTP MCP servers to implement OAuth discovery.
+        // The MCP SDK does not handle this endpoint, returning 500 instead of 404,
+        // which causes Claude Code to fail. Returning 404 signals "no OAuth required".
+        if (req.url === '/.well-known/oauth-authorization-server') {
+            res.writeHead(404).end();
+            return;
+        }
         try {
             await transport.handleRequest(req, res);
         } catch (error) {


### PR DESCRIPTION
## Problem

Claude Code 2.1.70+ probes `/.well-known/oauth-authorization-server` on HTTP MCP servers as part of its OAuth discovery flow.

The MCP TypeScript SDK does not implement this endpoint — instead of returning 404, it throws an unhandled exception that gets caught and turned into a **500 Internal Server Error**.

Claude Code treats the 500 as a fatal error and refuses to connect to the MCP server entirely.

## Fix

Intercept the `/.well-known/oauth-authorization-server` request before passing it to the MCP SDK transport, and return **404** explicitly. This correctly signals to Claude Code that no OAuth is required, and the connection proceeds normally.

This is a client-side workaround until the MCP TypeScript SDK handles this endpoint properly upstream.

## Impact

- Fixes MCP server connectivity with Claude Code >= 2.1.70
- No behavior change for any other endpoints