### PR TITLE
fix(docker): make happy-server Dockerfile buildable & runnable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /repo
 
 COPY package.json yarn.lock ./
 COPY scripts ./scripts
+COPY patches ./patches
 
 RUN mkdir -p packages/happy-app packages/happy-server packages/happy-cli packages/happy-agent packages/happy-wire
 
@@ -54,4 +55,4 @@ COPY --from=builder /repo/packages/happy-server /repo/packages/happy-server
 VOLUME /data
 EXPOSE 3005
 
-CMD ["sh", "-c", "node_modules/.bin/tsx packages/happy-server/sources/standalone.ts migrate && exec node_modules/.bin/tsx packages/happy-server/sources/standalone.ts serve"]
+CMD ["sh", "-c", "cd /repo/packages/happy-server && node /repo/node_modules/.bin/tsx sources/standalone.ts migrate && exec node /repo/node_modules/.bin/tsx sources/standalone.ts serve"]


### PR DESCRIPTION
**Description**
This patch fixes the Docker build and runtime of *happy‑server* so it can be built and run without manual intervention.

**What changed**

- **Pre‑install patches** – The Dockerfile now copies the required patch files **before** running `yarn install`. This prevents the build from failing due to missing modules.
- **Correct working directory** – The `CMD` is updated to set the correct working directory. This ensures that imports like `@/app` and `path.join(process.cwd(), "prisma", "migrations")` resolve properly when the container runs in standalone mode.

**Result**

After applying this patch, you can simply run:

```bash
docker build -t happy-server -f Dockerfile .
docker run -p 3005:3005 \
  -e HANDY_MASTER_SECRET=<your-secret> \
  -v happy-data:/data \
  happy-server
```

and the container starts successfully, with all imports resolved correctly.