### PR TITLE
fix(cli): close stateless Happy MCP server on response close

### DIFF
--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -32,64 +32,92 @@ export async function startHappyServer(client: ApiSessionClient) {
         }
     };
 
-    //
-    // Create the MCP server
-    //
+    const createMcpServer = () => {
+        const mcp = new McpServer({
+            name: "Happy MCP",
+            version: "1.0.0",
+        });
 
-    const mcp = new McpServer({
-        name: "Happy MCP",
-        version: "1.0.0",
-    });
+        mcp.registerTool('change_title', {
+            description: 'Change the title of the current chat session',
+            title: 'Change Chat Title',
+            inputSchema: {
+                title: z.string().describe('The new title for the chat session'),
+            },
+        }, async (args) => {
+            const response = await handler(args.title);
+            logger.debug('[happyMCP] Response:', response);
+            
+            if (response.success) {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Successfully changed chat title to: "${args.title}"`,
+                        },
+                    ],
+                    isError: false,
+                };
+            } else {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Failed to change chat title: ${response.error || 'Unknown error'}`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+        });
 
-    mcp.registerTool('change_title', {
-        description: 'Change the title of the current chat session',
-        title: 'Change Chat Title',
-        inputSchema: {
-            title: z.string().describe('The new title for the chat session'),
-        },
-    }, async (args) => {
-        const response = await handler(args.title);
-        logger.debug('[happyMCP] Response:', response);
-        
-        if (response.success) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Successfully changed chat title to: "${args.title}"`,
-                    },
-                ],
-                isError: false,
-            };
-        } else {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Failed to change chat title: ${response.error || 'Unknown error'}`,
-                    },
-                ],
-                isError: true,
-            };
-        }
-    });
-
-    const transport = new StreamableHTTPServerTransport({
-        // NOTE: Returning session id here will result in claude
-        // sdk spawn to fail with `Invalid Request: Server already initialized`
-        sessionIdGenerator: undefined
-    });
-    await mcp.connect(transport);
+        return mcp;
+    };
 
     //
     // Create the HTTP server
     //
 
     const server = createServer(async (req, res) => {
+        let mcp: McpServer | undefined;
+        let transport: StreamableHTTPServerTransport | undefined;
         try {
-            await transport.handleRequest(req, res);
+            // StreamableHTTPServerTransport in stateless mode must not be reused
+            // across requests. Create a fresh transport per request. Also create a
+            // fresh MCP server instance per request because a connected Protocol
+            // cannot be re-connected to another transport.
+            transport = new StreamableHTTPServerTransport({
+                // NOTE: Returning session id here will result in claude
+                // sdk spawn to fail with `Invalid Request: Server already initialized`
+                sessionIdGenerator: undefined
+            });
+            mcp = createMcpServer();
+            await mcp.connect(transport);
+
+            let parsedBody: unknown = undefined;
+            if (req.method === 'POST') {
+                const chunks: Buffer[] = [];
+                for await (const chunk of req) {
+                    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+                }
+                const rawBody = Buffer.concat(chunks).toString('utf8');
+                if (rawBody.length > 0) {
+                    parsedBody = JSON.parse(rawBody);
+                }
+            }
+
+            res.on('close', () => {
+                transport?.close().catch(() => { });
+                mcp?.close();
+            });
+
+            await transport.handleRequest(req, res, parsedBody);
         } catch (error) {
             logger.debug("Error handling request:", error);
+            try {
+                await transport?.close();
+            } catch { }
+            mcp?.close();
             if (!res.headersSent) {
                 res.writeHead(500).end();
             }


### PR DESCRIPTION
## Summary

Fix the built-in Happy MCP bridge for stateless HTTP mode by aligning its lifecycle with the MCP SDK example:

- create a fresh `StreamableHTTPServerTransport` per request
- create a fresh `McpServer` per request
- close both on `res.close` instead of reusing them across requests

## Problem

On Linux/NAS environments, Happy's built-in `mcp__happy__change_title` tool could fail with errors like:

- `No matching deferred tools found`
- `No such tool available: mcp__happy__change_title`

The root cause is that the stateless HTTP MCP implementation in `startHappyServer` was reusing a single `StreamableHTTPServerTransport` (and connected MCP server state) across multiple HTTP requests.

## Why this fix

The MCP SDK's stateless Streamable HTTP example creates a new server/transport for each request and performs cleanup on response close. This PR makes Happy follow the same lifecycle pattern.

## Validation

Tested on a Synology NAS / Linux environment where the bug was reproducible:

- before: `mcp__happy__change_title` failed reliably
- after: title updates succeed again
- takeover UI still works as expected after remote control is attached

Also discussed in #564.
