### PR TITLE
fix(happy-app): add error boundaries to contain render crashes

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -29,6 +29,7 @@ import { isRunningOnMac } from '@/utils/platform';
 import { useDeviceType, useHeaderHeight, useIsLandscape, useIsTablet } from '@/utils/responsive';
 import { formatPathRelativeToHome, getSessionAvatarId, getSessionName, useSessionStatus } from '@/utils/sessionUtils';
 import { isVersionSupported, MINIMUM_CLI_VERSION } from '@/utils/versionUtils';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import * as React from 'react';
@@ -148,8 +149,12 @@ export const SessionView = React.memo((props: { id: string }) => {
                         <Text style={{ color: theme.colors.textSecondary, fontSize: 15, marginTop: 8, textAlign: 'center', paddingHorizontal: 32 }}>{t('errors.sessionDeletedDescription')}</Text>
                     </View>
                 ) : (
-                    // Normal session view
-                    <SessionViewLoaded key={sessionId} sessionId={sessionId} session={session} />
+                    // Normal session view — error boundary keeps header/navigation usable on crash
+                    <ErrorBoundary fallback={({ error, retry }) => (
+                        <SessionErrorFallback error={error} retry={retry} />
+                    )}>
+                        <SessionViewLoaded key={sessionId} sessionId={sessionId} session={session} />
+                    </ErrorBoundary>
                 )}
             </View>
         </>
@@ -434,4 +439,34 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
             }
         </>
     )
+}
+
+/** Fallback shown when session content crashes. Header and navigation remain functional. */
+function SessionErrorFallback({ error, retry }: { error: Error; retry: () => void }) {
+    const { theme } = useUnistyles();
+    return (
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 32 }}>
+            <Ionicons name="warning-outline" size={48} color={theme.colors.textSecondary} />
+            <Text style={{ color: theme.colors.text, fontSize: 18, fontWeight: '600', marginTop: 16, textAlign: 'center' }}>
+                {t('errors.chatRenderFailed')}
+            </Text>
+            <Text style={{ color: theme.colors.textSecondary, fontSize: 14, marginTop: 8, textAlign: 'center', lineHeight: 20 }}>
+                {t('errors.chatRenderFailedDescription')}
+            </Text>
+            <Pressable
+                onPress={retry}
+                style={{
+                    marginTop: 24,
+                    paddingHorizontal: 24,
+                    paddingVertical: 12,
+                    backgroundColor: theme.colors.button.primary.background,
+                    borderRadius: 8,
+                }}
+            >
+                <Text style={{ color: theme.colors.button.primary.tint, fontSize: 15, fontWeight: '600' }}>
+                    {t('errors.tryAgain')}
+                </Text>
+            </Pressable>
+        </View>
+    );
 }

--- a/packages/happy-app/sources/components/ActiveSessionsGroup.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroup.tsx
@@ -7,6 +7,7 @@ import { Session, Machine } from '@/sync/storageTypes';
 import { Ionicons } from '@expo/vector-icons';
 import { getSessionName, useSessionStatus, getSessionAvatarId, formatPathRelativeToHome } from '@/utils/sessionUtils';
 import { Avatar } from './Avatar';
+import { ErrorBoundary } from './ErrorBoundary';
 import { Typography } from '@/constants/Typography';
 import { StatusDot } from './StatusDot';
 import { useAllMachines, useSetting } from '@/sync/storage';
@@ -316,13 +317,14 @@ export function ActiveSessionsGroup({ sessions, selectedSessionId }: ActiveSessi
                                 .map(([machineId, machineGroup]) => (
                                     <View key={`${projectPath}-${machineId}`}>
                                         {machineGroup.sessions.map((session, index) => (
-                                            <CompactSessionRow
-                                                key={session.id}
-                                                session={session}
-                                                selected={selectedSessionId === session.id}
-                                                showBorder={index < machineGroup.sessions.length - 1 ||
-                                                    Array.from(projectGroup.machines.keys()).indexOf(machineId) < projectGroup.machines.size - 1}
-                                            />
+                                            <ErrorBoundary key={session.id}>
+                                                <CompactSessionRow
+                                                    session={session}
+                                                    selected={selectedSessionId === session.id}
+                                                    showBorder={index < machineGroup.sessions.length - 1 ||
+                                                        Array.from(projectGroup.machines.keys()).indexOf(machineId) < projectGroup.machines.size - 1}
+                                                />
+                                            </ErrorBoundary>
                                         ))}
                                     </View>
                                 ))}
@@ -436,7 +438,7 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder }: { sessi
                         {/* No longer showing git status per item - it's in the header */}
 
                         {/* Task status indicator */}
-                        {session.todos && session.todos.length > 0 && (() => {
+                        {Array.isArray(session.todos) && session.todos.length > 0 && (() => {
                             const totalTasks = session.todos.length;
                             const completedTasks = session.todos.filter(t => t.status === 'completed').length;
 

--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -7,6 +7,7 @@ import { Session, Machine } from '@/sync/storageTypes';
 import { Ionicons } from '@expo/vector-icons';
 import { getSessionName, useSessionStatus, getSessionAvatarId, formatPathRelativeToHome } from '@/utils/sessionUtils';
 import { Avatar } from './Avatar';
+import { ErrorBoundary } from './ErrorBoundary';
 import { Typography } from '@/constants/Typography';
 import { StatusDot } from './StatusDot';
 import { useAllMachines, useSetting } from '@/sync/storage';
@@ -270,13 +271,14 @@ export function ActiveSessionsGroupCompact({ sessions, selectedSessionId }: Acti
                                 .map(([machineId, machineGroup]) => (
                                     <View key={`${projectPath}-${machineId}`}>
                                         {machineGroup.sessions.map((session, index) => (
-                                            <CompactSessionRow
-                                                key={session.id}
-                                                session={session}
-                                                selected={selectedSessionId === session.id}
-                                                showBorder={index < machineGroup.sessions.length - 1 ||
-                                                    Array.from(projectGroup.machines.keys()).indexOf(machineId) < projectGroup.machines.size - 1}
-                                            />
+                                            <ErrorBoundary key={session.id}>
+                                                <CompactSessionRow
+                                                    session={session}
+                                                    selected={selectedSessionId === session.id}
+                                                    showBorder={index < machineGroup.sessions.length - 1 ||
+                                                        Array.from(projectGroup.machines.keys()).indexOf(machineId) < projectGroup.machines.size - 1}
+                                                />
+                                            </ErrorBoundary>
                                         ))}
                                     </View>
                                 ))}

--- a/packages/happy-app/sources/components/ChatList.tsx
+++ b/packages/happy-app/sources/components/ChatList.tsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import { useHeaderHeight } from '@/utils/responsive';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MessageView } from './MessageView';
+import { ErrorBoundary } from './ErrorBoundary';
 import { Metadata, Session } from '@/sync/storageTypes';
 import { ChatFooter } from './ChatFooter';
 import { Message } from '@/sync/typesMessage';
@@ -40,7 +41,9 @@ const ChatListInternal = React.memo((props: {
 }) => {
     const keyExtractor = useCallback((item: any) => item.id, []);
     const renderItem = useCallback(({ item }: { item: any }) => (
-        <MessageView message={item} metadata={props.metadata} sessionId={props.sessionId} />
+        <ErrorBoundary>
+            <MessageView message={item} metadata={props.metadata} sessionId={props.sessionId} />
+        </ErrorBoundary>
     ), [props.metadata, props.sessionId]);
     return (
         <FlatList

--- a/packages/happy-app/sources/components/ErrorBoundary.tsx
+++ b/packages/happy-app/sources/components/ErrorBoundary.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface ErrorBoundaryProps {
+    children: React.ReactNode;
+    /** Fallback to render on error. If not provided, uses a default inline error message. */
+    fallback?: (props: { error: Error; retry: () => void }) => React.ReactNode;
+    /** Called when an error is caught */
+    onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+    error: Error | null;
+}
+
+/**
+ * Generic React error boundary. Catches render errors in children and shows a fallback.
+ * Use `fallback` prop to customize the error UI for different contexts (session-level vs widget-level).
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    state: ErrorBoundaryState = { error: null };
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { error };
+    }
+
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+        console.error('[ErrorBoundary]', error, errorInfo);
+        this.props.onError?.(error, errorInfo);
+    }
+
+    retry = () => {
+        this.setState({ error: null });
+    };
+
+    render() {
+        if (this.state.error) {
+            if (this.props.fallback) {
+                return this.props.fallback({ error: this.state.error, retry: this.retry });
+            }
+            return <InlineErrorFallback error={this.state.error} retry={this.retry} />;
+        }
+        return this.props.children;
+    }
+}
+
+/** Small inline error indicator — used for widget-level failures (tool views, etc.) */
+function InlineErrorFallback({ error, retry }: { error: Error; retry: () => void }) {
+    return (
+        <Pressable
+            onPress={retry}
+            style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                padding: 12,
+                gap: 8,
+                opacity: 0.6,
+            }}
+        >
+            <Ionicons name="alert-circle-outline" size={16} color="#FF3B30" />
+            <Text style={{ fontSize: 13, color: '#FF3B30', flex: 1 }}>
+                Failed to render. Tap to retry.
+            </Text>
+        </Pressable>
+    );
+}

--- a/packages/happy-app/sources/components/MainView.tsx
+++ b/packages/happy-app/sources/components/MainView.tsx
@@ -18,6 +18,7 @@ import { VoiceAssistantStatusBar } from './VoiceAssistantStatusBar';
 import { StatusDot } from './StatusDot';
 import { Ionicons } from '@expo/vector-icons';
 import { Typography } from '@/constants/Typography';
+import { ErrorBoundary } from './ErrorBoundary';
 import { t } from '@/text';
 import { isUsingCustomServer } from '@/sync/serverConfig';
 import { trackFriendsSearch } from '@/track';
@@ -247,12 +248,12 @@ export const MainView = React.memo(({ variant }: MainViewProps) => {
     const renderTabContent = React.useCallback(() => {
         switch (activeTab) {
             case 'inbox':
-                return <InboxView />;
+                return <ErrorBoundary><InboxView /></ErrorBoundary>;
             case 'settings':
-                return <SettingsViewWrapper />;
+                return <ErrorBoundary><SettingsViewWrapper /></ErrorBoundary>;
             case 'sessions':
             default:
-                return <SessionsListWrapper />;
+                return <ErrorBoundary><SessionsListWrapper /></ErrorBoundary>;
         }
     }, [activeTab]);
 

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -9,6 +9,7 @@ import { getSessionName, useSessionStatus, getSessionSubtitle, getSessionAvatarI
 import { Avatar } from './Avatar';
 import { ActiveSessionsGroup } from './ActiveSessionsGroup';
 import { ActiveSessionsGroupCompact } from './ActiveSessionsGroupCompact';
+import { ErrorBoundary } from './ErrorBoundary';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSetting } from '@/sync/storage';
 import { useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
@@ -256,10 +257,12 @@ export function SessionsList() {
 
                 const ActiveComponent = compactSessionView ? ActiveSessionsGroupCompact : ActiveSessionsGroup;
                 return (
-                    <ActiveComponent
-                        sessions={item.sessions}
-                        selectedSessionId={selectedId}
-                    />
+                    <ErrorBoundary>
+                        <ActiveComponent
+                            sessions={item.sessions}
+                            selectedSessionId={selectedId}
+                        />
+                    </ErrorBoundary>
                 );
 
             case 'project-group':
@@ -284,13 +287,15 @@ export function SessionsList() {
                 const isSingle = isFirst && isLast;
 
                 return (
-                    <SessionItem
-                        session={item.session}
-                        selected={item.selected}
-                        isFirst={isFirst}
-                        isLast={isLast}
-                        isSingle={isSingle}
-                    />
+                    <ErrorBoundary>
+                        <SessionItem
+                            session={item.session}
+                            selected={item.selected}
+                            isFirst={isFirst}
+                            isLast={isLast}
+                            isSingle={isSingle}
+                        />
+                    </ErrorBoundary>
                 );
         }
     }, [pathname, dataWithSelected, compactSessionView]);

--- a/packages/happy-app/sources/components/tools/ToolView.tsx
+++ b/packages/happy-app/sources/components/tools/ToolView.tsx
@@ -3,6 +3,7 @@ import { Text, View, TouchableOpacity, ActivityIndicator, Platform } from 'react
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Ionicons, Octicons } from '@expo/vector-icons';
 import { getToolViewComponent } from './views/_all';
+import { ErrorBoundary } from '../ErrorBoundary';
 import { Message, ToolCall } from '@/sync/typesMessage';
 import { CodeView } from '../CodeView';
 import { ToolSectionView } from './ToolSectionView';
@@ -216,7 +217,9 @@ export const ToolView = React.memo<ToolViewProps>((props) => {
                 if (SpecificToolView) {
                     return (
                         <View style={styles.content}>
-                            <SpecificToolView tool={tool} metadata={props.metadata} messages={props.messages ?? []} sessionId={sessionId} />
+                            <ErrorBoundary>
+                                <SpecificToolView tool={tool} metadata={props.metadata} messages={props.messages ?? []} sessionId={sessionId} />
+                            </ErrorBoundary>
                             {tool.state === 'error' && tool.result &&
                                 !(tool.permission && (tool.permission.status === 'denied' || tool.permission.status === 'canceled')) &&
                                 !hideDefaultError && (

--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -182,6 +182,17 @@ export function createReducer(): ReducerState {
     }
 };
 
+type TodoItem = { content: string; status: 'pending' | 'in_progress' | 'completed'; priority: 'high' | 'medium' | 'low'; id: string };
+
+// Safely extract todos array — handles cases where Claude sends it as a JSON string
+function parseTodos(raw: unknown): TodoItem[] | null {
+    let parsed = raw;
+    if (typeof parsed === 'string') {
+        try { parsed = JSON.parse(parsed); } catch { return null; }
+    }
+    return Array.isArray(parsed) ? parsed as TodoItem[] : null;
+}
+
 const ENABLE_LOGGING = false;
 
 export type ReducerResult = {
@@ -690,10 +701,11 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
 
                             // Track TodoWrite tool inputs when updating existing messages
                             if (message.tool.name === 'TodoWrite' && message.tool.state === 'running' && message.tool.input?.todos) {
+                                const todos = parseTodos(message.tool.input.todos);
                                 // Only update if this is newer than existing todos
-                                if (!state.latestTodos || message.tool.createdAt > state.latestTodos.timestamp) {
+                                if (todos && (!state.latestTodos || message.tool.createdAt > state.latestTodos.timestamp)) {
                                     state.latestTodos = {
-                                        todos: message.tool.input.todos,
+                                        todos,
                                         timestamp: message.tool.createdAt
                                     };
                                 }
@@ -758,10 +770,11 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
 
                         // Track TodoWrite tool inputs
                         if (toolCall.name === 'TodoWrite' && toolCall.state === 'running' && toolCall.input?.todos) {
+                            const todos = parseTodos(toolCall.input.todos);
                             // Only update if this is newer than existing todos
-                            if (!state.latestTodos || toolCall.createdAt > state.latestTodos.timestamp) {
+                            if (todos && (!state.latestTodos || toolCall.createdAt > state.latestTodos.timestamp)) {
                                 state.latestTodos = {
-                                    todos: toolCall.input.todos,
+                                    todos,
                                     timestamp: toolCall.createdAt
                                 };
                             }

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -254,6 +254,8 @@ export const en = {
         failedToRemoveFriend: 'Failed to remove friend',
         searchFailed: 'Search failed. Please try again.',
         failedToSendRequest: 'Failed to send friend request',
+        chatRenderFailed: 'This chat couldn\'t load',
+        chatRenderFailedDescription: 'Something went wrong displaying this chat. You can try again or go back to your other chats.',
     },
 
     newSession: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -235,6 +235,8 @@ export const ca: TranslationStructure = {
         userNotFound: 'Usuari no trobat',
         sessionDeleted: 'La sessió s\'ha eliminat',
         sessionDeletedDescription: 'Aquesta sessió s\'ha eliminat permanentment',
+        chatRenderFailed: 'No s\'ha pogut carregar el xat',
+        chatRenderFailedDescription: 'S\'ha produït un error en mostrar aquest xat. Pots tornar-ho a provar o tornar als altres xats.',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -250,6 +250,8 @@ export const en: TranslationStructure = {
         userNotFound: 'User not found',
         sessionDeleted: 'Session has been deleted',
         sessionDeletedDescription: 'This session has been permanently removed',
+        chatRenderFailed: 'This chat couldn\'t load',
+        chatRenderFailedDescription: 'Something went wrong displaying this chat. You can try again or go back to your other chats.',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -235,6 +235,8 @@ export const es: TranslationStructure = {
         userNotFound: 'Usuario no encontrado',
         sessionDeleted: 'La sesión ha sido eliminada',
         sessionDeletedDescription: 'Esta sesión ha sido eliminada permanentemente',
+        chatRenderFailed: 'No se pudo cargar el chat',
+        chatRenderFailedDescription: 'Algo salió mal al mostrar este chat. Puedes intentar de nuevo o volver a tus otros chats.',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -264,6 +264,8 @@ export const it: TranslationStructure = {
         userNotFound: 'Utente non trovato',
         sessionDeleted: 'La sessione è stata eliminata',
         sessionDeletedDescription: 'Questa sessione è stata rimossa definitivamente',
+        chatRenderFailed: 'Impossibile caricare la chat',
+        chatRenderFailedDescription: 'Si è verificato un errore durante la visualizzazione di questa chat. Puoi riprovare o tornare alle altre chat.',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -267,6 +267,8 @@ export const ja: TranslationStructure = {
         userNotFound: 'ユーザーが見つかりません',
         sessionDeleted: 'セッションは削除されました',
         sessionDeletedDescription: 'このセッションは完全に削除されました',
+        chatRenderFailed: 'チャットを読み込めませんでした',
+        chatRenderFailedDescription: 'このチャットの表示中にエラーが発生しました。もう一度お試しいただくか、他のチャットに戻ってください。',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -246,6 +246,8 @@ export const pl: TranslationStructure = {
         userNotFound: 'Użytkownik nie został znaleziony',
         sessionDeleted: 'Sesja została usunięta',
         sessionDeletedDescription: 'Ta sesja została trwale usunięta',
+        chatRenderFailed: 'Nie udało się załadować czatu',
+        chatRenderFailedDescription: 'Wystąpił błąd podczas wyświetlania tego czatu. Spróbuj ponownie lub wróć do innych czatów.',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -235,6 +235,8 @@ export const pt: TranslationStructure = {
         userNotFound: 'Usuário não encontrado',
         sessionDeleted: 'A sessão foi excluída',
         sessionDeletedDescription: 'Esta sessão foi removida permanentemente',
+        chatRenderFailed: 'Não foi possível carregar o chat',
+        chatRenderFailedDescription: 'Algo deu errado ao exibir este chat. Tente novamente ou volte para seus outros chats.',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -217,6 +217,8 @@ export const ru: TranslationStructure = {
         userNotFound: 'Пользователь не найден',
         sessionDeleted: 'Сессия была удалена',
         sessionDeletedDescription: 'Эта сессия была окончательно удалена',
+        chatRenderFailed: 'Не удалось загрузить чат',
+        chatRenderFailedDescription: 'Произошла ошибка при отображении этого чата. Попробуйте снова или вернитесь к другим чатам.',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -237,6 +237,8 @@ export const zhHans: TranslationStructure = {
         userNotFound: '未找到用户',
         sessionDeleted: '会话已被删除',
         sessionDeletedDescription: '此会话已被永久删除',
+        chatRenderFailed: '无法加载聊天',
+        chatRenderFailedDescription: '显示此聊天时出现问题。您可以重试或返回其他聊天。',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -236,6 +236,8 @@ export const zhHant: TranslationStructure = {
         userNotFound: '未找到使用者',
         sessionDeleted: '工作階段已被刪除',
         sessionDeletedDescription: '此工作階段已被永久刪除',
+        chatRenderFailed: '無法載入聊天',
+        chatRenderFailedDescription: '顯示此聊天時出現問題。您可以重試或返回其他聊天。',
 
         // Error functions with context
         fieldError: ({ field, reason }: { field: string; reason: string }) =>


### PR DESCRIPTION
## Summary
- Adds an `ErrorBoundary` component with two granularity levels: session-wide (chat view) and widget-level (individual tool views)
- Session-level boundary keeps the header/back button functional when a chat crashes, so users can navigate away instead of being stuck
- Widget-level boundaries wrap each tool view (TodoView, EditView, etc.) so a broken widget shows an inline error instead of crashing the whole chat
- Hardens todos reducer to handle edge cases (null/undefined items) that were causing render crashes
- Expands error boundaries to cover ChatList and MainView tabs
- Includes properly translated error strings for all 10 supported languages

## Test plan
- [ ] Verify app builds and typechecks cleanly
- [ ] Simulate a render crash in a tool view — should show inline error, not crash the chat
- [ ] Simulate a render crash in chat content — should show error with back button still functional
- [ ] Verify error strings display correctly in non-English locales

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)