### PR TITLE
fix(happy-app): include server error details in RPC failure messages

### DIFF
--- a/packages/happy-app/sources/sync/apiSocket.ts
+++ b/packages/happy-app/sources/sync/apiSocket.ts
@@ -125,7 +125,7 @@ class ApiSocket {
         if (result.ok) {
             return await sessionEncryption.decryptRaw(result.result) as R;
         }
-        throw new Error('RPC call failed');
+        throw new Error(`RPC call failed: ${result.error || 'unknown error'}`);
     }
 
     /**
@@ -145,7 +145,7 @@ class ApiSocket {
         if (result.ok) {
             return await machineEncryption.decryptRaw(result.result) as R;
         }
-        throw new Error('RPC call failed');
+        throw new Error(`RPC call failed: ${result.error || 'unknown error'}`);
     }
 
     send(event: string, data: any) {


### PR DESCRIPTION
## Summary
- Surfaces server error details in RPC failure messages instead of swallowing them
- One-line change in apiSocket.ts — appends the server's error message to the thrown error

## Test plan
- [ ] Verify RPC errors now include the server's error message in the client-side error
- [ ] Verify normal (non-error) RPC calls are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)