### PR TITLE
fix: type safety for nullable content fields

### DIFF
--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -854,7 +854,7 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
                             content.push({
                                 ...c,  // WOLOG: Preserve all fields including unknown ones
                                 type: 'tool-result',
-                                content: raw.content.data.toolUseResult ? raw.content.data.toolUseResult : (typeof c.content === 'string' ? c.content : c.content[0].text),
+                                content: raw.content.data.toolUseResult ? raw.content.data.toolUseResult : (typeof c.content === 'string' ? c.content : c.content?.[0]?.text ?? ''),
                                 is_error: c.is_error || false,
                                 uuid: raw.content.data.uuid,
                                 parentUUID: raw.content.data.parentUuid ?? null,


### PR DESCRIPTION
## Summary
- Fixes a crash caused by empty tool_result content arrays triggering an infinite re-fetch loop
- Adds proper type narrowing for nullable content fields in typesRaw.ts and runAcp.ts

## Test plan
- [ ] Verify tool results with empty content arrays no longer cause infinite re-fetch
- [ ] Verify normal tool results with content still render correctly
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)