### PR TITLE
feat(happy-server): add Prometheus message size histograms

### DIFF
--- a/packages/happy-server/sources/app/api/routes/v3SessionRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/v3SessionRoutes.ts
@@ -1,4 +1,5 @@
 import { buildNewMessageUpdate, eventRouter } from "@/app/events/eventRouter";
+import { messageEncryptedBytesHistogram, messageBatchSizeHistogram } from "@/app/monitoring/metrics2";
 import { db } from "@/storage/db";
 import { allocateSessionSeqBatch, allocateUserSeq } from "@/storage/seq";
 import { randomKeyNaked } from "@/utils/randomKeyNaked";
@@ -111,6 +112,12 @@ export function v3SessionRoutes(app: Fastify) {
         const userId = request.userId;
         const { sessionId } = request.params;
         const { messages } = request.body;
+
+        // Record message size metrics for compression baseline
+        messageBatchSizeHistogram.observe(messages.length);
+        for (const msg of messages) {
+            messageEncryptedBytesHistogram.observe(Buffer.byteLength(msg.content, 'utf8'));
+        }
 
         const session = await db.session.findFirst({
             where: {

--- a/packages/happy-server/sources/app/monitoring/metrics2.ts
+++ b/packages/happy-server/sources/app/monitoring/metrics2.ts
@@ -60,6 +60,21 @@ export const httpRequestDurationHistogram = new Histogram({
     registers: [register]
 });
 
+// Message size metrics (for compression baseline)
+export const messageEncryptedBytesHistogram = new Histogram({
+    name: 'happy_message_encrypted_bytes',
+    help: 'Size of encrypted message content in bytes (base64-encoded ciphertext)',
+    buckets: [64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144],
+    registers: [register]
+});
+
+export const messageBatchSizeHistogram = new Histogram({
+    name: 'happy_message_batch_count',
+    help: 'Number of messages per batch POST',
+    buckets: [1, 2, 3, 5, 10, 20, 50, 100],
+    registers: [register]
+});
+
 // Database count metrics
 export const databaseRecordCountGauge = new Gauge({
     name: 'database_records_total',


### PR DESCRIPTION
## Summary
- Adds two Prometheus histograms to the v3 message POST route for observability:
  - `happy_message_encrypted_bytes` — tracks encrypted message content size (buckets 64B–256KB)
  - `happy_message_batch_count` — tracks messages per batch POST (buckets 1–100)
- Zero overhead if Prometheus isn't scraping — just in-memory counters
- Useful baseline for anyone planning message compression or debugging payload sizes

## Test plan
- [ ] Verify server builds and starts cleanly
- [ ] Confirm new metrics appear at `/metrics` endpoint after sending messages
- [ ] Verify no performance impact on message POST route

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)