### PR TITLE
fix(happy-app): disable overscroll bounce and pull-to-refresh on web

### DIFF
--- a/packages/happy-app/sources/theme.css
+++ b/packages/happy-app/sources/theme.css
@@ -1,3 +1,9 @@
+/* Disable overscroll bounce / pull-to-refresh on the whole page.
+   Prevents scroll-chaining from inner scrollable elements to the body. */
+html, body {
+    overscroll-behavior: none;
+}
+
 /* Theme-aware scrollbar styles using Unistyles CSS variables */
 
 /* Webkit Scrollbars (Chrome, Safari, Edge) */


### PR DESCRIPTION
## Summary
- Adds `overscroll-behavior: none` to html/body in theme.css
- Prevents scroll-chaining from inner scrollable elements to the page body on mobile browsers
- Eliminates ambiguous pull-to-refresh and bounce behavior that interferes with chat scrolling

## Test plan
- [ ] On mobile Safari/Chrome, scroll to top of chat — should not trigger pull-to-refresh
- [ ] Inner scrollable areas (code blocks, tables) should still scroll normally
- [ ] Desktop browser behavior unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)