### PR TITLE
fix(happy-app): prevent message and table content from overflowing on mobile web

### DIFF
--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -180,6 +180,7 @@ const styles = StyleSheet.create((theme) => ({
     flexDirection: 'column',
     flexGrow: 1,
     flexBasis: 0,
+    minWidth: 0,
     maxWidth: layout.maxWidth,
   },
   userMessageContainer: {

--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -182,6 +182,7 @@ const styles = StyleSheet.create((theme) => ({
     flexBasis: 0,
     minWidth: 0,
     maxWidth: layout.maxWidth,
+    overflow: 'hidden',
   },
   userMessageContainer: {
     maxWidth: '100%',
@@ -202,7 +203,6 @@ const styles = StyleSheet.create((theme) => ({
     marginHorizontal: 16,
     marginBottom: 12,
     borderRadius: 16,
-    alignSelf: 'flex-start',
   },
   agentEventContainer: {
     marginHorizontal: 8,

--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -504,7 +504,7 @@ const style = StyleSheet.create((theme) => ({
         borderColor: theme.colors.divider,
         borderRadius: 8,
         overflow: 'hidden',
-        alignSelf: 'flex-start',
+        maxWidth: '100%',
     },
     tableScrollView: {
         flexGrow: 0,

--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -505,9 +505,12 @@ const style = StyleSheet.create((theme) => ({
         borderRadius: 8,
         overflow: 'hidden',
         maxWidth: '100%',
+        flexGrow: 0,
+        flexShrink: 1,
     },
     tableScrollView: {
         flexGrow: 0,
+        flexShrink: 1,
     },
     tableContent: {
         flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Adds `minWidth: 0` to the message content flex container so text wraps properly on narrow viewports
- Removes `alignSelf: 'flex-start'` from agent message container so it stretches to fill available width instead of sizing to content
- Adds `overflow: hidden` and flex constraints to table containers to prevent wide tables from pushing the message area beyond the viewport

## Test plan
- [ ] On mobile web, long text messages should wrap within the viewport — no horizontal scrolling
- [ ] Wide tables (many columns) should clip/scroll within the message bubble, not overflow the page
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)