### PR TITLE
fix(happy-app): don't intercept Enter on mobile web touch devices

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -500,7 +500,10 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
         // Original key handling
         if (Platform.OS === 'web') {
-            if (agentInputEnterToSend && event.key === 'Enter' && !event.shiftKey) {
+            // On mobile web (touch devices), Enter should insert a newline since
+            // there's no Shift key available. Users send via the send button instead.
+            const isTouchDevice = typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+            if (agentInputEnterToSend && event.key === 'Enter' && !event.shiftKey && !isTouchDevice) {
                 if (props.value.trim()) {
                     props.onSend();
                     return true; // Key was handled


### PR DESCRIPTION
## Summary
- On mobile web, the on-screen keyboard has no Shift key, so Enter-to-send made it impossible to insert newlines in messages
- Enter now falls through to default textarea behavior on touch devices — users send via the send button instead
- Desktop web behavior is unchanged (Enter still sends, Shift+Enter for newline)

## Test plan
- [ ] On mobile web (phone), pressing Enter in the input should insert a newline
- [ ] On mobile web, tapping the send button should send the message
- [ ] On desktop web, Enter should still send and Shift+Enter should still insert a newline

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)