### PR TITLE
fix(happy-app): block voice session when microphone permission is denied

### DIFF
--- a/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
@@ -4,6 +4,7 @@ import { registerVoiceSession } from './RealtimeSession';
 import { storage } from '@/sync/storage';
 import { realtimeClientTools } from './realtimeClientTools';
 import { getElevenLabsCodeFromPreference } from '@/constants/Languages';
+import { checkMicrophonePermission } from '@/utils/microphonePermissions';
 import type { VoiceSession, VoiceSessionConfig } from './types';
 
 // Static reference to the conversation hook instance
@@ -15,6 +16,13 @@ class RealtimeVoiceSessionImpl implements VoiceSession {
     async startSession(config: VoiceSessionConfig): Promise<void> {
         if (!conversationInstance) {
             console.warn('Realtime voice session not initialized');
+            return;
+        }
+
+        const permission = await checkMicrophonePermission();
+        if (!permission.granted) {
+            console.warn('Microphone permission not granted, aborting voice session');
+            storage.getState().setRealtimeStatus('disconnected');
             return;
         }
 


### PR DESCRIPTION
Fixes slopus/happy#860

## Summary
- Add secondary `checkMicrophonePermission()` verification in `RealtimeVoiceSessionImpl.startSession()` right before the ElevenLabs SDK call
- If permission is not granted, abort the session and set status to `disconnected`

## Context
The ElevenLabs SDK sends a TTS greeting from the server immediately upon WebSocket connection. Speaker output works regardless of `RECORD_AUDIO` permission, so in edge cases where the existing permission check in `startRealtimeSession()` is bypassed, the greeting plays even when the user denied microphone access.

## Test plan
- [ ] Android: tap voice button → deny permission → verify TTS greeting does NOT play
- [ ] Android: tap voice button → grant permission → verify normal operation
- [ ] iOS: same scenarios