### PR TITLE
feat: add Cmd+Enter and Ctrl+Enter to send messages

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -498,6 +498,14 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
             return true;
         }
 
+        // Cmd+Enter or Ctrl+Enter sends on all platforms (external keyboard support)
+        if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+            if (props.value.trim()) {
+                props.onSend();
+                return true;
+            }
+        }
+
         // Original key handling
         if (Platform.OS === 'web') {
             if (agentInputEnterToSend && event.key === 'Enter' && !event.shiftKey) {

--- a/packages/happy-app/sources/components/MultiTextInput.tsx
+++ b/packages/happy-app/sources/components/MultiTextInput.tsx
@@ -8,6 +8,8 @@ export type SupportedKey = 'Enter' | 'Escape' | 'ArrowUp' | 'ArrowDown' | 'Arrow
 export interface KeyPressEvent {
     key: SupportedKey;
     shiftKey: boolean;
+    metaKey: boolean;
+    ctrlKey: boolean;
 }
 
 export type OnKeyPressCallback = (event: KeyPressEvent) => boolean;
@@ -96,7 +98,9 @@ export const MultiTextInput = React.forwardRef<MultiTextInputHandle, MultiTextIn
         if (normalizedKey) {
             const keyEvent: KeyPressEvent = {
                 key: normalizedKey,
-                shiftKey: (nativeEvent as any).shiftKey || false
+                shiftKey: (nativeEvent as any).shiftKey || false,
+                metaKey: (nativeEvent as any).metaKey || false,
+                ctrlKey: (nativeEvent as any).ctrlKey || false,
             };
             
             const handled = onKeyPress(keyEvent);

--- a/packages/happy-app/sources/components/MultiTextInput.web.tsx
+++ b/packages/happy-app/sources/components/MultiTextInput.web.tsx
@@ -9,6 +9,8 @@ export type SupportedKey = 'Enter' | 'Escape' | 'ArrowUp' | 'ArrowDown' | 'Arrow
 export interface KeyPressEvent {
     key: SupportedKey;
     shiftKey: boolean;
+    metaKey: boolean;
+    ctrlKey: boolean;
 }
 
 export type OnKeyPressCallback = (event: KeyPressEvent) => boolean;
@@ -98,7 +100,9 @@ export const MultiTextInput = React.forwardRef<MultiTextInputHandle, MultiTextIn
         if (normalizedKey) {
             const keyEvent: KeyPressEvent = {
                 key: normalizedKey,
-                shiftKey: e.shiftKey
+                shiftKey: e.shiftKey,
+                metaKey: e.metaKey,
+                ctrlKey: e.ctrlKey,
             };
             
             const handled = onKeyPress(keyEvent);


### PR DESCRIPTION
## Summary

- Add `metaKey` and `ctrlKey` to `KeyPressEvent` interface in both native and web `MultiTextInput`
- Handle **Cmd+Enter** (macOS/iOS) and **Ctrl+Enter** (Windows/Linux) as send action in `AgentInput`
- Works across all platforms: iOS/iPad with external keyboards, and web

Closes #76
Relates to #198

## Changes

| File | Change |
|------|--------|
| `MultiTextInput.tsx` | Extract `metaKey`/`ctrlKey` from native event via `(nativeEvent as any)` (same pattern as existing `shiftKey`) |
| `MultiTextInput.web.tsx` | Pass `metaKey`/`ctrlKey` from browser `KeyboardEvent` |
| `AgentInput.tsx` | Add Cmd+Enter / Ctrl+Enter send handler before existing platform-specific key handling |

## Notes

- The native iOS `onKeyPress` event may or may not include `metaKey`/`ctrlKey` for external keyboards — this needs testing on a physical device. The web version is fully functional.
- The implementation gracefully falls back to `false` if the properties are not present in the native event.
- No new dependencies added.

## Test plan

- [ ] Web: Verify Cmd+Enter / Ctrl+Enter sends the message
- [ ] Web: Verify Shift+Enter still inserts a newline
- [ ] iOS/iPad with external keyboard: Verify Cmd+Enter sends
- [ ] Verify existing Enter-to-send setting still works on web

🤖 Generated with [Claude Code](https://claude.com/claude-code)