### PR TITLE
fix(happy-coder): return raw Codex approval decisions

### DIFF
--- a/packages/happy-cli/src/codex/__tests__/codexMcpClient.test.ts
+++ b/packages/happy-cli/src/codex/__tests__/codexMcpClient.test.ts
@@ -9,7 +9,9 @@ const {
     mockSandboxCleanup,
     mockClientConnect,
     mockClientClose,
+    mockClientSetRequestHandler,
     mockStdioCtor,
+    mockClients,
 } = vi.hoisted(() => ({
     mockExecSync: vi.fn(),
     mockInitializeSandbox: vi.fn(),
@@ -17,7 +19,9 @@ const {
     mockSandboxCleanup: vi.fn(),
     mockClientConnect: vi.fn(),
     mockClientClose: vi.fn(),
+    mockClientSetRequestHandler: vi.fn(),
     mockStdioCtor: vi.fn(),
+    mockClients: [] as any[],
 }));
 
 vi.mock('child_process', () => ({
@@ -40,11 +44,14 @@ vi.mock('@/ui/logger', () => ({
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
     Client: class MockClient {
         setNotificationHandler = vi.fn();
-        setRequestHandler = vi.fn();
+        setRequestHandler = mockClientSetRequestHandler;
         connect = mockClientConnect;
         close = mockClientClose;
         callTool = vi.fn();
-        constructor() {}
+        _requestHandlers = new Map();
+        constructor() {
+            mockClients.push(this);
+        }
     },
 }));
 
@@ -77,6 +84,7 @@ describe('CodexMcpClient sandbox integration', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockClients.length = 0;
         process.env.RUST_LOG = originalRustLog;
         mockExecSync.mockReturnValue('codex-cli 0.43.0');
         mockClientConnect.mockResolvedValue(undefined);
@@ -151,5 +159,54 @@ describe('CodexMcpClient sandbox integration', () => {
                 }),
             }),
         );
+    });
+
+    it('registers a raw elicitation handler for Codex approvals', async () => {
+        const client = new CodexMcpClient(sandboxConfig);
+
+        await client.connect();
+
+        const rawHandler = mockClients[0]?._requestHandlers.get('elicitation/create');
+        expect(typeof rawHandler).toBe('function');
+        expect(mockClientSetRequestHandler).not.toHaveBeenCalled();
+    });
+
+    it('normalizes approved_for_session to approved for Codex approvals', async () => {
+        const client = new CodexMcpClient(sandboxConfig);
+        client.setPermissionHandler({
+            handleToolCall: vi.fn().mockResolvedValue({ decision: 'approved_for_session' }),
+        } as any);
+
+        await client.connect();
+
+        const rawHandler = mockClients[0]?._requestHandlers.get('elicitation/create');
+        const response = await rawHandler({
+            params: {
+                codex_call_id: 'call_123',
+                codex_command: ['mkdir', '-p', '../test'],
+                codex_cwd: '/tmp/project',
+            },
+        });
+
+        expect(response).toEqual({ decision: 'approved' });
+    });
+
+    it('aborts approvals when Codex call id is missing', async () => {
+        const client = new CodexMcpClient(sandboxConfig);
+        client.setPermissionHandler({
+            handleToolCall: vi.fn(),
+        } as any);
+
+        await client.connect();
+
+        const rawHandler = mockClients[0]?._requestHandlers.get('elicitation/create');
+        const response = await rawHandler({
+            params: {
+                codex_command: ['pwd'],
+                codex_cwd: '/tmp/project',
+            },
+        });
+
+        expect(response).toEqual({ decision: 'abort' });
     });
 });

--- a/packages/happy-cli/src/codex/codexMcpClient.ts
+++ b/packages/happy-cli/src/codex/codexMcpClient.ts
@@ -7,13 +7,31 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { logger } from '@/ui/logger';
 import type { CodexSessionConfig, CodexToolResponse } from './types';
 import { z } from 'zod';
-import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { CodexPermissionHandler } from './utils/permissionHandler';
 import { execSync } from 'child_process';
 import type { SandboxConfig } from '@/persistence';
 import { initializeSandbox, wrapForMcpTransport } from '@/sandbox/manager';
 
 const DEFAULT_TIMEOUT = 14 * 24 * 60 * 60 * 1000; // 14 days, which is the half of the maximum possible timeout (~28 days for int32 value in NodeJS)
+
+type CodexApprovalDecision = 'approved' | 'abort';
+
+type CodexElicitationParams = {
+    message?: string;
+    codex_elicitation?: string;
+    codex_mcp_tool_call_id?: string;
+    codex_event_id?: string;
+    codex_call_id?: string;
+    codex_command?: string[] | string;
+    codex_cwd?: string;
+};
+
+type CodexRawRequestClient = {
+    _requestHandlers?: Map<
+        string,
+        (request: { params: CodexElicitationParams }) => Promise<{ decision: CodexApprovalDecision }>
+    >;
+};
 
 /**
  * Get the correct MCP subcommand based on installed codex version
@@ -186,56 +204,53 @@ export class CodexMcpClient {
     }
 
     private registerPermissionHandlers(): void {
-        // Register handler for exec command approval requests
-        this.client.setRequestHandler(
-            ElicitRequestSchema,
-            async (request) => {
-                console.log('[CodexMCP] Received elicitation request:', request.params);
+        const rawClient = this.client as unknown as CodexRawRequestClient;
+        const requestHandlers = rawClient._requestHandlers;
 
-                // Load params
-                const params = request.params as unknown as {
-                    message: string,
-                    codex_elicitation: string,
-                    codex_mcp_tool_call_id: string,
-                    codex_event_id: string,
-                    codex_call_id: string,
-                    codex_command: string[],
-                    codex_cwd: string
-                }
-                const toolName = 'CodexBash';
+        if (!(requestHandlers instanceof Map)) {
+            throw new Error('Codex MCP client does not expose raw request handlers');
+        }
 
-                // If no permission handler set, deny by default
-                if (!this.permissionHandler) {
-                    logger.debug('[CodexMCP] No permission handler set, denying by default');
-                    return {
-                        decision: 'denied' as const,
-                    };
-                }
+        // Codex expects a non-standard top-level `{ decision }` approval payload.
+        requestHandlers.set('elicitation/create', async (request: { params: CodexElicitationParams }) => {
+            logger.debug('[CodexMCP] Received elicitation request:', request.params);
 
-                try {
-                    // Request permission through the handler
-                    const result = await this.permissionHandler.handleToolCall(
-                        params.codex_call_id,
-                        toolName,
-                        {
-                            command: params.codex_command,
-                            cwd: params.codex_cwd
-                        }
-                    );
+            const params = request.params ?? {};
+            const toolName = 'CodexBash';
+            const toolCallId = params.codex_call_id;
 
-                    logger.debug('[CodexMCP] Permission result:', result);
-                    return {
-                        decision: result.decision
-                    }
-                } catch (error) {
-                    logger.debug('[CodexMCP] Error handling permission request:', error);
-                    return {
-                        decision: 'denied' as const,
-                        reason: error instanceof Error ? error.message : 'Permission request failed'
-                    };
-                }
+            if (!toolCallId) {
+                logger.debug('[CodexMCP] Missing codex_call_id, aborting request');
+                return { decision: 'abort' };
             }
-        );
+
+            if (!this.permissionHandler) {
+                logger.debug('[CodexMCP] No permission handler set, aborting by default');
+                return { decision: 'abort' };
+            }
+
+            try {
+                const result = await this.permissionHandler.handleToolCall(
+                    toolCallId,
+                    toolName,
+                    {
+                        command: params.codex_command,
+                        cwd: params.codex_cwd,
+                    },
+                );
+
+                const decision: CodexApprovalDecision =
+                    result.decision === 'approved' || result.decision === 'approved_for_session'
+                        ? 'approved'
+                        : 'abort';
+
+                logger.debug('[CodexMCP] Elicitation response:', { decision });
+                return { decision };
+            } catch (error) {
+                logger.debug('[CodexMCP] Error handling permission request:', error);
+                return { decision: 'abort' };
+            }
+        });
 
         logger.debug('[CodexMCP] Permission handlers registered');
     }


### PR DESCRIPTION
## Summary
- register the Codex approval handler on the raw `elicitation/create` method instead of `setRequestHandler(ElicitRequestSchema, ...)`
- return the top-level `{ decision }` shape that `codex mcp-server` expects
- normalize `approved_for_session` to `approved` and reject unsupported / incomplete requests with `abort`
- add coverage for raw handler registration and Codex decision normalization

## Why
I was reproducing the Android permission flow issue from [#229](https://github.com/slopus/happy/issues/229) with Codex sessions.

In practice, `codex mcp-server` currently expects a non-standard top-level approval response like:

```json
{ "decision": "approved" }
```

Using the MCP SDK's standard elicitation handler path returns the SDK-shaped payload instead, which causes Codex to reject the approval response and the command stays stuck or ends up rejected after approval.

This patch keeps the existing Happy permission flow, but installs the Codex approval handler on the raw request map so the response shape matches what Codex actually consumes today.

## Testing
- `PATH=/Users/kinocode/.nvm/versions/node/v22.19.0/bin:$PATH yarn install`
- `PATH=/Users/kinocode/.nvm/versions/node/v22.19.0/bin:$PATH yarn workspace happy-coder build`
- `PATH=/Users/kinocode/.nvm/versions/node/v22.19.0/bin:$PATH ./node_modules/.bin/vitest run packages/happy-cli/src/codex/__tests__/codexMcpClient.test.ts`
- Manual validation against `codex mcp-server 0.106.0`
  - SDK-standard `{ action, content }` approval responses failed with `missing field decision`
  - raw `{ decision: "approved" }` resumed the command successfully
  - raw `{ decision: "abort" }` produced the expected `rejected by user`
