### PR TITLE
fix(happy-cli): use stateful StreamableHTTPServerTransport to prevent 500 errors

### DIFF
--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -75,9 +75,7 @@ export async function startHappyServer(client: ApiSessionClient) {
     });
 
     const transport = new StreamableHTTPServerTransport({
-        // NOTE: Returning session id here will result in claude
-        // sdk spawn to fail with `Invalid Request: Server already initialized`
-        sessionIdGenerator: undefined
+        sessionIdGenerator: () => randomUUID()
     });
     await mcp.connect(transport);
 


### PR DESCRIPTION
## Summary

The MCP server in `startHappyServer.ts` uses `StreamableHTTPServerTransport` with `sessionIdGenerator: undefined` (stateless mode). Since MCP SDK `@modelcontextprotocol/sdk` >= 1.27.x, stateless transports throw `"Stateless transport cannot be reused across requests"` after the first request.

Because `startHappyServer` creates a single transport and reuses it for all incoming HTTP requests, every request after the initial `initialize` silently returns HTTP 500. This breaks the `change_title` MCP tool — Claude Code cannot rename chat sessions.

### Fix

Switch from stateless to stateful mode:

\`\`\`diff
- sessionIdGenerator: undefined
+ sessionIdGenerator: () => randomUUID()
\`\`\`

`randomUUID` is already imported from `node:crypto` in the same file.

### How to reproduce

1. Start a happy session (`happy`)
2. Claude Code launches with `--mcp-config {"mcpServers":{"happy":{"type":"http","url":"http://127.0.0.1:{port}/"}}}`
3. Try to call `mcp__happy__change_title` → fails with 500
4. Directly test: `curl -X POST http://127.0.0.1:{port}/ -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'` → HTTP 500

### Tested

- `yarn build` ✅
- `yarn typecheck` ✅
- `yarn test` — 1 pre-existing failure in `runAcp.test.ts` (unrelated log format mismatch)
- Manual verification: after patch, new happy sessions can successfully call `change_title`