### PR TITLE
chore: add block-no-verify hook to Claude Code settings

### DIFF
--- a/packages/happy-app/.claude/settings.json
+++ b/packages/happy-app/.claude/settings.json
@@ -4,5 +4,15 @@
         "Bash(npx tsx sources/scripts/parseChangelog.ts)"
       ],
       "deny": []
+    },
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [
+            { "type": "command", "command": "npx --yes block-no-verify@1.1.2" }
+          ]
+        }
+      ]
     }
   }


### PR DESCRIPTION
Closes #890\n\nAdds block-no-verify@1.1.2 as a PreToolUse hook in Claude Code settings to prevent AI agents from bypassing git hooks.\n\nblock-no-verify intercepts git commit or push commands that attempt to skip pre-commit hooks and blocks them before execution. This protects the lint, typecheck, and test workflows in this repo from being bypassed when Claude Code runs autonomously.\n\nPackage: https://github.com/tupe12334/block-no-verify\n\nDisclosure: I am the author and maintainer of block-no-verify.