### PR TITLE
fix: guard against null socket/encryption — 'undefined is not a function'

### DIFF
--- a/packages/happy-app/sources/sync/apiSocket.ts
+++ b/packages/happy-app/sources/sync/apiSocket.ts
@@ -112,32 +112,46 @@ class ApiSocket {
      * RPC call for sessions - uses session-specific encryption
      */
     async sessionRPC<R, A>(sessionId: string, method: string, params: A): Promise<R> {
-        const sessionEncryption = this.encryption!.getSessionEncryption(sessionId);
+        const socket = this.socket;
+        if (!socket) {
+            throw new Error('Socket not connected');
+        }
+        if (!this.encryption) {
+            throw new Error('Encryption not initialized');
+        }
+        const sessionEncryption = this.encryption.getSessionEncryption(sessionId);
         if (!sessionEncryption) {
             throw new Error(`Session encryption not found for ${sessionId}`);
         }
-        
-        const result = await this.socket!.emitWithAck('rpc-call', {
+
+        const result = await socket.emitWithAck('rpc-call', {
             method: `${sessionId}:${method}`,
             params: await sessionEncryption.encryptRaw(params)
         });
-        
+
         if (result.ok) {
             return await sessionEncryption.decryptRaw(result.result) as R;
         }
-        throw new Error('RPC call failed');
+        throw new Error(result.error || 'RPC call failed');
     }
 
     /**
      * RPC call for machines - uses legacy/global encryption (for now)
      */
     async machineRPC<R, A>(machineId: string, method: string, params: A): Promise<R> {
-        const machineEncryption = this.encryption!.getMachineEncryption(machineId);
+        const socket = this.socket;
+        if (!socket) {
+            throw new Error('Socket not connected');
+        }
+        if (!this.encryption) {
+            throw new Error('Encryption not initialized');
+        }
+        const machineEncryption = this.encryption.getMachineEncryption(machineId);
         if (!machineEncryption) {
             throw new Error(`Machine encryption not found for ${machineId}`);
         }
 
-        const result = await this.socket!.emitWithAck('rpc-call', {
+        const result = await socket.emitWithAck('rpc-call', {
             method: `${machineId}:${method}`,
             params: await machineEncryption.encryptRaw(params)
         });
@@ -149,7 +163,10 @@ class ApiSocket {
     }
 
     send(event: string, data: any) {
-        this.socket!.emit(event, data);
+        if (!this.socket) {
+            throw new Error('Socket not connected');
+        }
+        this.socket.emit(event, data);
         return true;
     }
 

--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -95,7 +95,11 @@ export async function startHappyServer(client: ApiSessionClient) {
         }
     });
 
-    const baseUrl = await new Promise<URL>((resolve) => {
+    const baseUrl = await new Promise<URL>((resolve, reject) => {
+        server.on('error', (err) => {
+            logger.debug("[happyMCP] server:error", err);
+            reject(err);
+        });
         server.listen(0, "127.0.0.1", () => {
             const addr = server.address() as AddressInfo;
             resolve(new URL(`http://127.0.0.1:${addr.port}`));

--- a/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
+++ b/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
@@ -43,18 +43,28 @@ async function main() {
   }
 
   let httpClient: Client | null = null;
+  let connectPromise: Promise<Client> | null = null;
 
   async function ensureHttpClient(): Promise<Client> {
     if (httpClient) return httpClient;
-    const client = new Client(
-      { name: 'happy-stdio-bridge', version: '1.0.0' },
-      { capabilities: {} }
-    );
+    if (connectPromise) return connectPromise;
 
-    const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
-    await client.connect(transport);
-    httpClient = client;
-    return client;
+    connectPromise = (async () => {
+      try {
+        const client = new Client(
+          { name: 'happy-stdio-bridge', version: '1.0.0' },
+          { capabilities: {} }
+        );
+        const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
+        await client.connect(transport);
+        httpClient = client;
+        return client;
+      } finally {
+        connectPromise = null;
+      }
+    })();
+
+    return connectPromise;
   }
 
   // Create STDIO MCP server


### PR DESCRIPTION
## Summary

Fixes intermittent **"undefined is not a function"** crashes caused by calling methods on null socket/encryption references after WebSocket disconnects.

- **`apiSocket.ts`**: Replace `this.socket!` / `this.encryption!` non-null assertions with explicit null guards using local variable capture to prevent TOCTOU races across `await` yield points
- **`happyMcpStdioBridge.ts`**: Add promise lock with `try/finally` to prevent concurrent `ensureHttpClient()` calls from creating duplicate MCP clients
- **`startHappyServer.ts`**: Add `server.on('error')` handler with logging so port conflicts reject instead of hanging

## Test plan
- [ ] `change_title` MCP tool works normally
- [ ] App shows "Socket not connected" error instead of crashing on disconnect
- [ ] Concurrent `change_title` calls don't create duplicate clients

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)