### PR TITLE
fix: MCP title generation fails — reconnect bridge + pre-parse body (#900)

### DIFF
--- a/packages/happy-app/sources/sync/apiSocket.ts
+++ b/packages/happy-app/sources/sync/apiSocket.ts
@@ -112,32 +112,46 @@ class ApiSocket {
      * RPC call for sessions - uses session-specific encryption
      */
     async sessionRPC<R, A>(sessionId: string, method: string, params: A): Promise<R> {
-        const sessionEncryption = this.encryption!.getSessionEncryption(sessionId);
+        const socket = this.socket;
+        if (!socket) {
+            throw new Error('Socket not connected');
+        }
+        if (!this.encryption) {
+            throw new Error('Encryption not initialized');
+        }
+        const sessionEncryption = this.encryption.getSessionEncryption(sessionId);
         if (!sessionEncryption) {
             throw new Error(`Session encryption not found for ${sessionId}`);
         }
-        
-        const result = await this.socket!.emitWithAck('rpc-call', {
+
+        const result = await socket.emitWithAck('rpc-call', {
             method: `${sessionId}:${method}`,
             params: await sessionEncryption.encryptRaw(params)
         });
-        
+
         if (result.ok) {
             return await sessionEncryption.decryptRaw(result.result) as R;
         }
-        throw new Error('RPC call failed');
+        throw new Error(result.error || 'RPC call failed');
     }
 
     /**
      * RPC call for machines - uses legacy/global encryption (for now)
      */
     async machineRPC<R, A>(machineId: string, method: string, params: A): Promise<R> {
-        const machineEncryption = this.encryption!.getMachineEncryption(machineId);
+        const socket = this.socket;
+        if (!socket) {
+            throw new Error('Socket not connected');
+        }
+        if (!this.encryption) {
+            throw new Error('Encryption not initialized');
+        }
+        const machineEncryption = this.encryption.getMachineEncryption(machineId);
         if (!machineEncryption) {
             throw new Error(`Machine encryption not found for ${machineId}`);
         }
 
-        const result = await this.socket!.emitWithAck('rpc-call', {
+        const result = await socket.emitWithAck('rpc-call', {
             method: `${machineId}:${method}`,
             params: await machineEncryption.encryptRaw(params)
         });
@@ -149,7 +163,10 @@ class ApiSocket {
     }
 
     send(event: string, data: any) {
-        this.socket!.emit(event, data);
+        if (!this.socket) {
+            throw new Error('Socket not connected');
+        }
+        this.socket.emit(event, data);
         return true;
     }
 

--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -95,7 +95,11 @@ export async function startHappyServer(client: ApiSessionClient) {
         }
     });
 
-    const baseUrl = await new Promise<URL>((resolve) => {
+    const baseUrl = await new Promise<URL>((resolve, reject) => {
+        server.on('error', (err) => {
+            logger.debug("[happyMCP] server:error", err);
+            reject(err);
+        });
         server.listen(0, "127.0.0.1", () => {
             const addr = server.address() as AddressInfo;
             resolve(new URL(`http://127.0.0.1:${addr.port}`));

--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -77,17 +77,34 @@ export async function startHappyServer(client: ApiSessionClient) {
     const server = createServer(async (req, res) => {
         const mcp = createMcpServer(handler);
         try {
+            // Pre-parse body to avoid @hono/node-server stream conversion issues
+            let parsedBody: unknown;
+            if (req.method === 'POST') {
+                const chunks: Buffer[] = [];
+                for await (const chunk of req) {
+                    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+                }
+                try {
+                    parsedBody = JSON.parse(Buffer.concat(chunks).toString());
+                } catch {
+                    res.writeHead(400, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null }));
+                    mcp.close();
+                    return;
+                }
+            }
+
             const transport = new StreamableHTTPServerTransport({
                 sessionIdGenerator: undefined
             });
             await mcp.connect(transport);
-            await transport.handleRequest(req, res);
+            await transport.handleRequest(req, res, parsedBody);
             res.on('close', () => {
                 transport.close();
                 mcp.close();
             });
         } catch (error) {
-            logger.debug("Error handling request:", error);
+            logger.debug("[happyMCP] Error handling request:", error);
             if (!res.headersSent) {
                 res.writeHead(500).end();
             }

--- a/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
+++ b/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
@@ -50,14 +50,13 @@ async function main() {
     if (connectPromise) return connectPromise;
 
     connectPromise = (async () => {
+      const client = new Client(
+        { name: 'happy-stdio-bridge', version: '1.0.0' },
+        { capabilities: {} }
+      );
+      const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
       try {
-        const client = new Client(
-          { name: 'happy-stdio-bridge', version: '1.0.0' },
-          { capabilities: {} }
-        );
-        const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
         transport.onclose = () => {
-          // Reset client on transport close so next call reconnects
           if (httpClient === client) {
             httpClient = null;
           }
@@ -70,6 +69,10 @@ async function main() {
         };
         httpClient = client;
         return client;
+      } catch (error) {
+        // Clean up on connect failure to avoid leaking SSE streams/timers
+        try { await client.close(); } catch { /* ignore */ }
+        throw error;
       } finally {
         connectPromise = null;
       }

--- a/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
+++ b/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
@@ -43,18 +43,28 @@ async function main() {
   }
 
   let httpClient: Client | null = null;
+  let connectPromise: Promise<Client> | null = null;
 
   async function ensureHttpClient(): Promise<Client> {
     if (httpClient) return httpClient;
-    const client = new Client(
-      { name: 'happy-stdio-bridge', version: '1.0.0' },
-      { capabilities: {} }
-    );
+    if (connectPromise) return connectPromise;
 
-    const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
-    await client.connect(transport);
-    httpClient = client;
-    return client;
+    connectPromise = (async () => {
+      try {
+        const client = new Client(
+          { name: 'happy-stdio-bridge', version: '1.0.0' },
+          { capabilities: {} }
+        );
+        const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
+        await client.connect(transport);
+        httpClient = client;
+        return client;
+      } finally {
+        connectPromise = null;
+      }
+    })();
+
+    return connectPromise;
   }
 
   // Create STDIO MCP server

--- a/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
+++ b/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
@@ -56,7 +56,18 @@ async function main() {
           { capabilities: {} }
         );
         const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
+        transport.onclose = () => {
+          // Reset client on transport close so next call reconnects
+          if (httpClient === client) {
+            httpClient = null;
+          }
+        };
         await client.connect(transport);
+        client.onclose = () => {
+          if (httpClient === client) {
+            httpClient = null;
+          }
+        };
         httpClient = client;
         return client;
       } finally {
@@ -87,9 +98,12 @@ async function main() {
       try {
         const client = await ensureHttpClient();
         const response = await client.callTool({ name: 'change_title', arguments: args });
-        // Pass-through response from HTTP server
         return response as any;
       } catch (error) {
+        // Clean up stale client so the next invocation reconnects
+        const staleClient = httpClient;
+        httpClient = null;
+        try { await staleClient?.close(); } catch { /* ignore close errors */ }
         return {
           content: [
             { type: 'text', text: `Failed to change chat title: ${error instanceof Error ? error.message : String(error)}` },


### PR DESCRIPTION
## Summary

Fixes **"Streamable HTTP error: Error POSTing to endpoint"** that prevents session title generation. Builds on #907 (socket null guards).

- **`happyMcpStdioBridge.ts`**: Auto-reconnect when HTTP MCP client drops. `transport.onclose`/`client.onclose` reset the client reference. Failed calls close the stale client to free SSE streams/timers.
- **`startHappyServer.ts`**: Pre-parse POST body and pass as `parsedBody` to `transport.handleRequest()`, bypassing `@hono/node-server` stream conversion that causes HTTP 500. Invalid JSON now returns proper 400.

## Root cause

The SSE stream times out every ~300s. The bridge's `httpClient` becomes stale but isn't reset, so subsequent `change_title` calls fail. The server's reliance on `@hono/node-server` body stream conversion intermittently produces 500 errors.

## Depends on
- #907 (socket null guards — includes the promise lock this PR's reconnect logic builds on)

Closes #900, closes #768

## Test plan
- [ ] `change_title` works for Claude Code sessions (direct HTTP)
- [ ] `change_title` works for Codex sessions (STDIO bridge)
- [ ] Title updates survive SSE stream timeout (~5 min idle)
- [ ] Invalid JSON POST returns 400, not 500

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)