### PR TITLE
fix: voice assistant disconnects after greeting with no error shown (#878)

### DIFF
--- a/packages/happy-app/sources/components/VoiceAssistantStatusBar.tsx
+++ b/packages/happy-app/sources/components/VoiceAssistantStatusBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useRealtimeStatus, useRealtimeMode } from '@/sync/storage';
+import { useRealtimeStatus, useRealtimeMode, storage } from '@/sync/storage';
 import { StatusDot } from './StatusDot';
 import { Typography } from '@/constants/Typography';
 import { Ionicons } from '@expo/vector-icons';
@@ -50,7 +50,7 @@ export const VoiceAssistantStatusBar = React.memo(({ variant = 'full', style }: 
                     color: theme.colors.status.error,
                     backgroundColor: theme.colors.surfaceHighest,
                     isPulsing: false,
-                    text: 'Connection Error',
+                    text: 'Voice disconnected — tap to dismiss',
                     textColor: theme.colors.text
                 };
             default:
@@ -73,6 +73,9 @@ export const VoiceAssistantStatusBar = React.memo(({ variant = 'full', style }: 
             } catch (error) {
                 console.error('Error stopping voice session:', error);
             }
+        } else if (realtimeStatus === 'error') {
+            // Dismiss the error bar
+            storage.getState().setRealtimeStatus('disconnected');
         }
     };
 

--- a/packages/happy-app/sources/components/VoiceAssistantStatusBar.tsx
+++ b/packages/happy-app/sources/components/VoiceAssistantStatusBar.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { useRealtimeStatus, useRealtimeMode, storage } from '@/sync/storage';
 import { StatusDot } from './StatusDot';
 import { Typography } from '@/constants/Typography';
@@ -50,7 +49,7 @@ export const VoiceAssistantStatusBar = React.memo(({ variant = 'full', style }: 
                     color: theme.colors.status.error,
                     backgroundColor: theme.colors.surfaceHighest,
                     isPulsing: false,
-                    text: 'Voice disconnected — tap to dismiss',
+                    text: 'Voice disconnected',
                     textColor: theme.colors.text
                 };
             default:
@@ -131,7 +130,7 @@ export const VoiceAssistantStatusBar = React.memo(({ variant = 'full', style }: 
                                 />
                             )}
                             <Text style={[styles.tapToEndText, { color: statusInfo.textColor, marginLeft: isVoiceSpeaking ? 8 : 0 }]}>
-                                Tap to end
+                                {realtimeStatus === 'error' ? 'Tap to dismiss' : 'Tap to end'}
                             </Text>
                         </View>
                     </View>

--- a/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
@@ -90,16 +90,25 @@ class RealtimeVoiceSessionImpl implements VoiceSession {
 }
 
 export const RealtimeVoiceSession: React.FC = () => {
+    // Track whether a session was successfully connected to distinguish
+    // initialization errors (silent) from runtime errors (show to user)
+    const wasConnected = useRef(false);
+
     const conversation = useConversation({
         clientTools: realtimeClientTools,
         onConnect: (data) => {
             console.log('Realtime session connected:', data);
+            wasConnected.current = true;
             storage.getState().setRealtimeStatus('connected');
             storage.getState().setRealtimeMode('idle');
         },
         onDisconnect: () => {
             console.log('Realtime session disconnected');
-            storage.getState().setRealtimeStatus('disconnected');
+            wasConnected.current = false;
+            // Preserve 'error' status if onError already fired — don't overwrite
+            if (storage.getState().realtimeStatus !== 'error') {
+                storage.getState().setRealtimeStatus('disconnected');
+            }
             storage.getState().setRealtimeMode('idle', true); // immediate mode change
             storage.getState().clearRealtimeModeDebounce();
         },
@@ -107,24 +116,32 @@ export const RealtimeVoiceSession: React.FC = () => {
             console.log('Realtime message:', data);
         },
         onError: (error) => {
-            // Log but don't block app - voice features will be unavailable
-            // This prevents initialization errors from showing "Terminals error" on startup
-            console.warn('Realtime voice not available:', error);
-            // Don't set error status during initialization - just set disconnected
-            // This allows the app to continue working without voice features
-            storage.getState().setRealtimeStatus('disconnected');
-            storage.getState().setRealtimeMode('idle', true); // immediate mode change
+            console.warn('Realtime voice error:', error);
+
+            if (wasConnected.current) {
+                // Runtime error after connection was established — inform the user
+                // This catches the "greeting plays then disconnects" scenario
+                console.error('Voice session error after connection:', error);
+                wasConnected.current = false;
+                storage.getState().setRealtimeStatus('error');
+                storage.getState().setRealtimeMode('idle', true);
+            } else {
+                // Initialization error — silent degradation
+                // This prevents startup errors from showing "Terminals error"
+                storage.getState().setRealtimeStatus('disconnected');
+                storage.getState().setRealtimeMode('idle', true);
+            }
         },
         onStatusChange: (data) => {
             console.log('Realtime status change:', data);
         },
         onModeChange: (data) => {
             console.log('Realtime mode change:', data);
-            
+
             // Only animate when speaking
             const mode = data.mode as string;
             const isSpeaking = mode === 'speaking';
-            
+
             // Use centralized debounce logic from storage
             storage.getState().setRealtimeMode(isSpeaking ? 'speaking' : 'idle');
         },

--- a/packages/happy-app/sources/realtime/RealtimeVoiceSession.web.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeVoiceSession.web.tsx
@@ -95,16 +95,25 @@ class RealtimeVoiceSessionImpl implements VoiceSession {
 }
 
 export const RealtimeVoiceSession: React.FC = () => {
+    // Track whether a session was successfully connected to distinguish
+    // initialization errors (silent) from runtime errors (show to user)
+    const wasConnected = useRef(false);
+
     const conversation = useConversation({
         clientTools: realtimeClientTools,
         onConnect: () => {
             console.log('Realtime session connected');
+            wasConnected.current = true;
             storage.getState().setRealtimeStatus('connected');
             storage.getState().setRealtimeMode('idle');
         },
         onDisconnect: () => {
             console.log('Realtime session disconnected');
-            storage.getState().setRealtimeStatus('disconnected');
+            wasConnected.current = false;
+            // Preserve 'error' status if onError already fired — don't overwrite
+            if (storage.getState().realtimeStatus !== 'error') {
+                storage.getState().setRealtimeStatus('disconnected');
+            }
             storage.getState().setRealtimeMode('idle', true); // immediate mode change
             storage.getState().clearRealtimeModeDebounce();
         },
@@ -112,24 +121,30 @@ export const RealtimeVoiceSession: React.FC = () => {
             console.log('Realtime message:', data);
         },
         onError: (error) => {
-            // Log but don't block app - voice features will be unavailable
-            // This prevents initialization errors from showing "Terminals error" on startup
-            console.warn('Realtime voice not available:', error);
-            // Don't set error status during initialization - just set disconnected
-            // This allows the app to continue working without voice features
-            storage.getState().setRealtimeStatus('disconnected');
-            storage.getState().setRealtimeMode('idle', true); // immediate mode change
+            console.warn('Realtime voice error:', error);
+
+            if (wasConnected.current) {
+                // Runtime error after connection was established — inform the user
+                console.error('Voice session error after connection:', error);
+                wasConnected.current = false;
+                storage.getState().setRealtimeStatus('error');
+                storage.getState().setRealtimeMode('idle', true);
+            } else {
+                // Initialization error — silent degradation
+                storage.getState().setRealtimeStatus('disconnected');
+                storage.getState().setRealtimeMode('idle', true);
+            }
         },
         onStatusChange: (data) => {
             console.log('Realtime status change:', data);
         },
         onModeChange: (data) => {
             console.log('Realtime mode change:', data);
-            
+
             // Only animate when speaking
             const mode = data.mode as string;
             const isSpeaking = mode === 'speaking';
-            
+
             // Use centralized debounce logic from storage
             storage.getState().setRealtimeMode(isSpeaking ? 'speaking' : 'idle');
         },


### PR DESCRIPTION
## Summary

Fixes the voice assistant silently disconnecting after "Hi, Happy here" with no feedback to the user. 4+ users reported this (#878).

- **`RealtimeVoiceSession.tsx` + `.web.tsx`**: Track `wasConnected` ref to distinguish initialization errors (silent — prevents startup "Terminals error") from post-connection errors (set status to `'error'`). `onDisconnect` now preserves `'error'` status instead of overwriting it.
- **`VoiceAssistantStatusBar.tsx`**: Error state shows "Voice disconnected — tap to dismiss" instead of being stuck. Tapping dismisses the bar.

## Root cause

The `onError` handler silently set status to `'disconnected'` for ALL errors, including runtime WebRTC failures after the greeting played. Then `onDisconnect` (which fires immediately after) would overwrite any error state. Users saw the UI return to idle with no explanation.

**Note:** This fix makes the disconnect *visible* but doesn't prevent it. The underlying disconnect is likely in the `@elevenlabs/react-native` SDK's WebRTC layer.

Addresses #878

## Test plan
- [ ] Voice assistant greeting + listening works normally when connection is stable
- [ ] When connection drops after greeting, error bar appears with "Voice disconnected — tap to dismiss"
- [ ] Tapping the error bar dismisses it
- [ ] Startup initialization errors (no ElevenLabs) still degrade silently

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)