### PR TITLE
fix(cli): set UTF-8 code page on Windows to fix garbled box-drawing characters

### DIFF
--- a/packages/happy-cli/scripts/claude_local_launcher.cjs
+++ b/packages/happy-cli/scripts/claude_local_launcher.cjs
@@ -1,5 +1,15 @@
 const fs = require('fs');
 
+// Fix Windows Unicode rendering (box-drawing characters)
+if (process.platform === 'win32') {
+    const { execSync } = require('child_process');
+    try {
+        execSync('chcp 65001', { stdio: 'ignore' });
+    } catch (e) {
+        // chcp not available, ignore
+    }
+}
+
 // Disable autoupdater (never works really)
 process.env.DISABLE_AUTOUPDATER = '1';
 


### PR DESCRIPTION
Fixes #904

When running `happy` on Windows, box-drawing and other Unicode characters are rendered as garbled/mojibake text during startup and in the prompt input area. This happens because the Windows console code page defaults to 437 (OEM) or 1252 (Western European) rather than 65001 (UTF-8).

When `claude` is launched directly, the terminal sets up UTF-8 encoding before spawning the process. However, when `happy-coder`'s Node.js launcher (`claude_local_launcher.cjs`) spawns Claude in-process via dynamic import, this UTF-8 setup is bypassed.

This PR adds a UTF-8 code page initialization (`chcp 65001`) in the Windows path of `scripts/claude_local_launcher.cjs` to ensure multi-byte UTF-8 sequences are interpreted correctly.