### PR TITLE
feat(voice): improve assistant voice input with provider-based architecture

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -22,6 +22,10 @@ import { hackMode, hackModes } from '@/sync/modeHacks';
 import { Theme } from '@/theme';
 import { t } from '@/text';
 import { Metadata } from '@/sync/storageTypes';
+import { AIBackendProfile, getProfileEnvironmentVariables, validateProfileForAgent } from '@/sync/settings';
+import { getBuiltInProfile } from '@/sync/profileUtils';
+
+import { SmartVoiceButton } from '@/features/custom-asr/SmartVoiceButton';
 
 interface AgentInputProps {
     value: string;
@@ -63,16 +67,17 @@ interface AgentInputProps {
     };
     alwaysShowContextSize?: boolean;
     onFileViewerPress?: () => void;
-    agentType?: 'claude' | 'codex' | 'gemini' | 'openclaw';
+    agentType?: 'claude' | 'codex' | 'gemini';
     onAgentClick?: () => void;
     machineName?: string | null;
     onMachineClick?: () => void;
     currentPath?: string | null;
     onPathClick?: () => void;
-    blockSend?: boolean;
     isSendDisabled?: boolean;
     isSending?: boolean;
     minHeight?: number;
+    profileId?: string | null;
+    onProfileClick?: () => void;
 }
 
 const MAX_CONTEXT_SIZE = 190000;
@@ -263,11 +268,6 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
     sendButtonInactive: {
         backgroundColor: theme.colors.button.primary.disabled,
     },
-    sendButtonLocked: {
-        backgroundColor: theme.colors.surfaceHigh,
-        borderWidth: 1,
-        borderColor: theme.colors.divider,
-    },
     sendButtonInner: {
         width: '100%',
         height: '100%',
@@ -301,18 +301,13 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     const styles = stylesheet;
     const { theme } = useUnistyles();
     const screenWidth = useWindowDimensions().width;
-    const isSendBlocked = props.blockSend ?? false;
 
     const hasText = props.value.trim().length > 0;
-    const canPressSendButton = !props.isSending
-        && !props.isSendDisabled
-        && (isSendBlocked ? hasText : (hasText || !!props.onMicPress));
 
-    // Check if this is a Codex, Gemini, or OpenClaw session
+    // Check if this is a Codex or Gemini session
     // Use metadata.flavor for existing sessions, agentType prop for new sessions
     const isCodex = props.metadata?.flavor === 'codex' || props.agentType === 'codex';
     const isGemini = props.metadata?.flavor === 'gemini' || props.agentType === 'gemini';
-    const isOpenClaw = props.metadata?.flavor === 'openclaw' || props.agentType === 'openclaw';
     const displayPermissionMode = React.useMemo(() => (
         props.permissionMode ? hackMode(props.permissionMode) : null
     ), [props.permissionMode]);
@@ -345,6 +340,17 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
         return label;
     }, [isSandboxEnabled]);
 
+    // Profile data
+    const profiles = useSetting('profiles');
+    const currentProfile = React.useMemo(() => {
+        if (!props.profileId) return null;
+        // Check custom profiles first
+        const customProfile = profiles.find(p => p.id === props.profileId);
+        if (customProfile) return customProfile;
+        // Check built-in profiles
+        return getBuiltInProfile(props.profileId);
+    }, [profiles, props.profileId]);
+
     // Calculate context warning
     const contextWarning = props.usageData?.contextSize
         ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme)
@@ -356,7 +362,6 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     // Abort button state
     const [isAborting, setIsAborting] = React.useState(false);
     const shakerRef = React.useRef<ShakeInstance>(null);
-    const sendBlockShakerRef = React.useRef<ShakeInstance>(null);
     const inputRef = React.useRef<MultiTextInputHandle>(null);
 
     // Forward ref to the MultiTextInput
@@ -460,27 +465,6 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
         }
     }, [props.onAbort]);
 
-    const handleBlockedSendAttempt = React.useCallback(() => {
-        if (!isSendBlocked || !hasText || props.isSending) return;
-        hapticsError();
-        sendBlockShakerRef.current?.shake();
-    }, [hasText, isSendBlocked, props.isSending]);
-
-    const handleSendPress = React.useCallback(() => {
-        if (isSendBlocked) {
-            handleBlockedSendAttempt();
-            return;
-        }
-        if (props.isSendDisabled || props.isSending) return;
-
-        hapticsLight();
-        if (hasText) {
-            props.onSend();
-        } else {
-            props.onMicPress?.();
-        }
-    }, [handleBlockedSendAttempt, hasText, isSendBlocked, props]);
-
     // Handle keyboard navigation
     const handleKeyPress = React.useCallback((event: KeyPressEvent): boolean => {
         // Handle autocomplete navigation first
@@ -518,16 +502,9 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
         // Original key handling
         if (Platform.OS === 'web') {
-            // On mobile web (touch devices), Enter should insert a newline since
-            // there's no Shift key available. Users send via the send button instead.
-            const isTouchDevice = typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0);
-            if (agentInputEnterToSend && event.key === 'Enter' && !event.shiftKey && !isTouchDevice) {
+            if (agentInputEnterToSend && event.key === 'Enter' && !event.shiftKey) {
                 if (props.value.trim()) {
-                    if (isSendBlocked) {
-                        handleBlockedSendAttempt();
-                    } else if (!props.isSendDisabled) {
-                        props.onSend();
-                    }
+                    props.onSend();
                     return true; // Key was handled
                 }
             }
@@ -542,7 +519,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
         }
         return false; // Key was not handled
-    }, [suggestions, moveUp, moveDown, selected, handleSuggestionSelect, props.showAbortButton, props.onAbort, isAborting, handleAbortPress, agentInputEnterToSend, props.value, props.onSend, props.onPermissionModeChange, availableModes, permissionModeKey, isSendBlocked, handleBlockedSendAttempt, props.isSendDisabled]);
+    }, [suggestions, moveUp, moveDown, selected, handleSuggestionSelect, props.showAbortButton, props.onAbort, isAborting, handleAbortPress, agentInputEnterToSend, props.value, props.onSend, props.onPermissionModeChange, availableModes, permissionModeKey]);
 
 
 
@@ -550,7 +527,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     return (
         <View style={[
             styles.container,
-            { paddingHorizontal: screenWidth > 700 ? 12 : 8 }
+            { paddingHorizontal: screenWidth > 700 ? 16 : 8 }
         ]}>
             <View style={[
                 styles.innerContainer,
@@ -743,7 +720,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                 )}
 
                 {/* Connection status, context warning, and permission mode */}
-                {(props.connectionStatus || contextWarning || (displayPermissionMode && permissionModeKey !== 'default')) && (
+                {(props.connectionStatus || contextWarning || displayPermissionMode || props.modelMode) && (
                     <View style={{
                         flexDirection: 'row',
                         alignItems: 'center',
@@ -849,32 +826,37 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                 </Text>
                             )}
                         </View>
-                        {/* Permission badge — only shown when non-default */}
-                        {displayPermissionMode && permissionModeKey !== 'default' && (() => {
-                            const permColor = isSandboxedYoloMode ? '#4169E1' :
-                                permissionModeKey === 'acceptEdits' ? theme.colors.permission.acceptEdits :
-                                    permissionModeKey === 'bypassPermissions' ? theme.colors.permission.bypass :
-                                        permissionModeKey === 'plan' ? theme.colors.permission.plan :
-                                            permissionModeKey === 'read-only' ? theme.colors.permission.readOnly :
-                                                permissionModeKey === 'safe-yolo' ? theme.colors.permission.safeYolo :
-                                                    permissionModeKey === 'yolo' ? theme.colors.permission.yolo :
-                                                        theme.colors.textSecondary;
-                            const permIcon: 'play-forward' | 'pause' =
-                                permissionModeKey === 'plan' || permissionModeKey === 'read-only'
-                                    ? 'pause' : 'play-forward';
-                            return (
-                                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                                    <Ionicons name={permIcon} size={11} color={permColor} />
-                                    <Text style={{
-                                        fontSize: 11,
-                                        color: permColor,
-                                        ...Typography.default()
-                                    }}>
-                                        {withSandboxSuffix(displayPermissionMode.name, permissionModeKey)}
-                                    </Text>
-                                </View>
-                            );
-                        })()}
+                        <View style={{
+                            flexDirection: 'column',
+                            alignItems: 'flex-end',
+                            minWidth: 150, // Fixed minimum width to prevent layout shift
+                        }}>
+                            {displayPermissionMode && (
+                                <Text style={{
+                                    fontSize: 11,
+                                    color: isSandboxedYoloMode ? '#4169E1' :
+                                        permissionModeKey === 'acceptEdits' ? theme.colors.permission.acceptEdits :
+                                            permissionModeKey === 'bypassPermissions' ? theme.colors.permission.bypass :
+                                                permissionModeKey === 'plan' ? theme.colors.permission.plan :
+                                                    permissionModeKey === 'read-only' ? theme.colors.permission.readOnly :
+                                                        permissionModeKey === 'safe-yolo' ? theme.colors.permission.safeYolo :
+                                                            permissionModeKey === 'yolo' ? theme.colors.permission.yolo :
+                                                                theme.colors.textSecondary, // Use secondary text color for default
+                                    ...Typography.default()
+                                }}>
+                                    {withSandboxSuffix(displayPermissionMode.name, permissionModeKey)}
+                                </Text>
+                            )}
+                            {props.modelMode && (
+                                <Text style={{
+                                    fontSize: 11,
+                                    color: theme.colors.textSecondary,
+                                    ...Typography.default()
+                                }}>
+                                    {props.modelMode.name}
+                                </Text>
+                            )}
+                        </View>
                     </View>
                 )}
 
@@ -960,7 +942,6 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                 )}
 
                 {/* Box 2: Action Area (Input + Send) */}
-                <Shaker ref={sendBlockShakerRef}>
                 <View style={styles.unifiedPanel}>
                     {/* Input field */}
                     <View style={[styles.inputContainer, props.minHeight ? { minHeight: props.minHeight } : undefined]}>
@@ -1008,6 +989,42 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                     </Pressable>
                                 )}
 
+                                {/* Profile selector button - FIRST */}
+                                {props.profileId && props.onProfileClick && (
+                                    <Pressable
+                                        onPress={() => {
+                                            hapticsLight();
+                                            props.onProfileClick?.();
+                                        }}
+                                        hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
+                                        style={(p) => ({
+                                            flexDirection: 'row',
+                                            alignItems: 'center',
+                                            borderRadius: Platform.select({ default: 16, android: 20 }),
+                                            paddingHorizontal: 10,
+                                            paddingVertical: 6,
+                                            justifyContent: 'center',
+                                            height: 32,
+                                            opacity: p.pressed ? 0.7 : 1,
+                                            gap: 6,
+                                        })}
+                                    >
+                                        <Ionicons
+                                            name="person-outline"
+                                            size={14}
+                                            color={theme.colors.button.secondary.tint}
+                                        />
+                                        <Text style={{
+                                            fontSize: 13,
+                                            color: theme.colors.button.secondary.tint,
+                                            fontWeight: '600',
+                                            ...Typography.default('semiBold'),
+                                        }}>
+                                            {currentProfile?.name || 'Select Profile'}
+                                        </Text>
+                                    </Pressable>
+                                )}
+
                                 {/* Agent selector button */}
                                 {props.agentType && props.onAgentClick && (
                                     <Pressable
@@ -1039,7 +1056,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                             fontWeight: '600',
                                             ...Typography.default('semiBold'),
                                         }}>
-                                            {props.agentType === 'claude' ? t('agentInput.agent.claude') : props.agentType === 'codex' ? t('agentInput.agent.codex') : props.agentType === 'openclaw' ? t('agentInput.agent.openclaw') : t('agentInput.agent.gemini')}
+                                            {props.agentType === 'claude' ? t('agentInput.agent.claude') : props.agentType === 'codex' ? t('agentInput.agent.codex') : t('agentInput.agent.gemini')}
                                         </Text>
                                     </Pressable>
                                 )}
@@ -1083,75 +1100,23 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                 </View>
 
                                 {/* Send/Voice button - aligned with first row */}
-                                <View
-                                    style={[
-                                        styles.sendButton,
-                                        isSendBlocked ? styles.sendButtonLocked :
-                                        (hasText || props.isSending || (props.onMicPress && !props.isMicActive))
-                                            ? styles.sendButtonActive
-                                            : styles.sendButtonInactive
-                                    ]}
-                                >
-                                    <Pressable
-                                        style={(p) => ({
-                                            width: '100%',
-                                            height: '100%',
-                                            alignItems: 'center',
-                                            justifyContent: 'center',
-                                            opacity: p.pressed ? 0.7 : 1,
-                                        })}
-                                        hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
-                                        onPress={handleSendPress}
-                                        disabled={!canPressSendButton}
-                                    >
-                                        {props.isSending ? (
-                                            <ActivityIndicator
-                                                size="small"
-                                                color={theme.colors.button.primary.tint}
-                                            />
-                                        ) : isSendBlocked ? (
-                                            <Ionicons
-                                                name="lock-closed"
-                                                size={15}
-                                                color={theme.colors.textSecondary}
-                                            />
-                                        ) : hasText ? (
-                                            <Octicons
-                                                name="arrow-up"
-                                                size={16}
-                                                color={theme.colors.button.primary.tint}
-                                                style={[
-                                                    styles.sendButtonIcon,
-                                                    { marginTop: Platform.OS === 'web' ? 2 : 0 }
-                                                ]}
-                                            />
-                                        ) : props.onMicPress && !props.isMicActive ? (
-                                            <Image
-                                                source={require('@/assets/images/icon-voice-white.png')}
-                                                style={{
-                                                    width: 24,
-                                                    height: 24,
-                                                }}
-                                                tintColor={theme.colors.button.primary.tint}
-                                            />
-                                        ) : (
-                                            <Octicons
-                                                name="arrow-up"
-                                                size={16}
-                                                color={theme.colors.button.primary.tint}
-                                                style={[
-                                                    styles.sendButtonIcon,
-                                                    { marginTop: Platform.OS === 'web' ? 2 : 0 }
-                                                ]}
-                                            />
-                                        )}
-                                    </Pressable>
+                                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                                    <SmartVoiceButton
+                                        hasText={hasText}
+                                        isSending={props.isSending}
+                                        isSendDisabled={props.isSendDisabled}
+                                        onSend={props.onSend}
+                                        onMicPress={props.onMicPress}
+                                        isMicActive={props.isMicActive}
+                                        styles={styles}
+                                        sessionId={props.sessionId}
+                                        onTextUpdate={props.onChangeText}
+                                    />
                                 </View>
                             </View>
                         </View>
                     </View>
                 </View>
-                </Shaker>
             </View>
         </View>
     );

--- a/packages/happy-app/sources/features/custom-asr/SmartVoiceButton.tsx
+++ b/packages/happy-app/sources/features/custom-asr/SmartVoiceButton.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { Platform, Pressable, View, ActivityIndicator } from 'react-native';
+import { Image } from 'expo-image';
+import { Octicons } from '@expo/vector-icons';
+import { useUnistyles } from 'react-native-unistyles';
+import { hapticsLight } from '@/components/haptics';
+import { CustomASRButton } from './CustomASRButton';
+import { useVoiceInputController } from '@/features/voice-input';
+
+interface SmartVoiceButtonProps {
+    hasText: boolean;
+    isSending?: boolean;
+    isSendDisabled?: boolean;
+    onSend: () => void;
+    onMicPress?: () => void;
+    isMicActive?: boolean;
+    styles: any;
+    sessionId?: string;
+    onTextUpdate?: (text: string) => void;
+    forceMode?: 'elevenlabs_call' | 'streaming_asr';
+}
+
+export const SmartVoiceButton = React.memo((props: SmartVoiceButtonProps) => {
+    const { theme } = useUnistyles();
+    const { buttonDecision, legacyVoice, customAsrProps } = useVoiceInputController({
+        hasText: props.hasText,
+        isSending: props.isSending,
+        isSendDisabled: props.isSendDisabled,
+        onSend: props.onSend,
+        onMicPress: props.onMicPress,
+        isMicActive: props.isMicActive,
+        sessionId: props.sessionId,
+        onTextUpdate: props.onTextUpdate,
+        forceMode: props.forceMode
+    });
+    
+    if (buttonDecision.showStreamingAsrButton) {
+        return (
+            <CustomASRButton 
+                styles={props.styles} 
+                onTextUpdate={customAsrProps.onTextUpdate}
+                sessionId={customAsrProps.sessionId}
+                hasText={customAsrProps.hasText}
+                isSending={customAsrProps.isSending}
+                isSendDisabled={customAsrProps.isSendDisabled}
+                onSend={customAsrProps.onSend}
+            />
+        );
+    }
+
+    return (
+        <View
+            style={[
+                props.styles.sendButton,
+                (buttonDecision.showSendButton || buttonDecision.showLegacyMicButton)
+                    ? props.styles.sendButtonActive
+                    : props.styles.sendButtonInactive
+            ]}
+        >
+            <Pressable
+                style={(p) => ({
+                    width: '100%',
+                    height: '100%',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    opacity: p.pressed ? 0.7 : 1,
+                })}
+                hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
+                onPress={() => {
+                    hapticsLight();
+                    legacyVoice.onPress();
+                }}
+                disabled={legacyVoice.disabled}
+            >
+                {legacyVoice.iconType === 'sending' ? (
+                    <ActivityIndicator
+                        size="small"
+                        color={theme.colors.button.primary.tint}
+                    />
+                ) : legacyVoice.iconType === 'send' ? (
+                    <Octicons
+                        name="arrow-up"
+                        size={16}
+                        color={theme.colors.button.primary.tint}
+                        style={[
+                            props.styles.sendButtonIcon,
+                            { marginTop: Platform.OS === 'web' ? 2 : 0 }
+                        ]}
+                    />
+                ) : (
+                    <Image
+                        source={require('@/assets/images/icon-voice-white.png')}
+                        style={{
+                            width: 24,
+                            height: 24,
+                        }}
+                        tintColor={theme.colors.button.primary.tint}
+                    />
+                )}
+            </Pressable>
+        </View>
+    );
+});

--- a/packages/happy-app/sources/features/custom-asr/useCustomASR.ts
+++ b/packages/happy-app/sources/features/custom-asr/useCustomASR.ts
@@ -1,0 +1,10 @@
+import { useStreamingAsrProvider } from '@/features/voice-input';
+
+interface UseCustomASRProps {
+    onTextUpdate?: (text: string) => void;
+    sessionId?: string;
+}
+
+export function useCustomASR({ onTextUpdate, sessionId }: UseCustomASRProps) {
+    return useStreamingAsrProvider({ onTextUpdate, sessionId });
+}

--- a/packages/happy-app/sources/features/voice-input/index.ts
+++ b/packages/happy-app/sources/features/voice-input/index.ts
@@ -1,0 +1,3 @@
+export { useVoiceInputController } from './useVoiceInputController';
+export { resolveVoiceInputMode, getVoiceModeStrategy, decideVoiceButton, useLegacyVoiceProvider, useStreamingAsrProvider } from './providers';
+export type { VoiceInputMode, VoiceButtonState, VoiceButtonDecision, VoiceModeStrategy, StreamingAsrProviderProps } from './providers';

--- a/packages/happy-app/sources/features/voice-input/providers/index.ts
+++ b/packages/happy-app/sources/features/voice-input/providers/index.ts
@@ -1,0 +1,5 @@
+export { resolveVoiceInputMode, getVoiceModeStrategy, decideVoiceButton } from './providerFactory';
+export type { VoiceInputMode, VoiceButtonState, VoiceButtonDecision, VoiceModeStrategy } from './types';
+export { useLegacyVoiceProvider } from './useLegacyVoiceProvider';
+export { useStreamingAsrProvider } from './useStreamingAsrProvider';
+export type { StreamingAsrProviderProps } from './useStreamingAsrProvider';

--- a/packages/happy-app/sources/features/voice-input/providers/providerFactory.test.ts
+++ b/packages/happy-app/sources/features/voice-input/providers/providerFactory.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { decideVoiceButton, getVoiceModeStrategy, resolveVoiceInputMode } from './providerFactory';
+
+describe('resolveVoiceInputMode', () => {
+    it('returns streaming_asr for streaming mode', () => {
+        expect(resolveVoiceInputMode('streaming_asr')).toBe('streaming_asr');
+    });
+
+    it('falls back to elevenlabs_call for unknown values', () => {
+        expect(resolveVoiceInputMode('unknown')).toBe('elevenlabs_call');
+        expect(resolveVoiceInputMode(undefined)).toBe('elevenlabs_call');
+        expect(resolveVoiceInputMode(null)).toBe('elevenlabs_call');
+    });
+});
+
+describe('decideVoiceButton', () => {
+    it('always shows streaming button in streaming_asr mode', () => {
+        expect(decideVoiceButton('streaming_asr', {
+            hasText: false,
+            isSending: false,
+            hasMicAction: true,
+            isMicActive: false
+        })).toEqual({
+            showStreamingAsrButton: true,
+            showSendButton: false,
+            showLegacyMicButton: false
+        });
+    });
+
+    it('shows send button when text exists in elevenlabs mode', () => {
+        expect(decideVoiceButton('elevenlabs_call', {
+            hasText: true,
+            isSending: false,
+            hasMicAction: true,
+            isMicActive: false
+        })).toEqual({
+            showStreamingAsrButton: false,
+            showSendButton: true,
+            showLegacyMicButton: false
+        });
+    });
+
+    it('shows send button when mic is active in elevenlabs mode', () => {
+        expect(decideVoiceButton('elevenlabs_call', {
+            hasText: false,
+            isSending: false,
+            hasMicAction: true,
+            isMicActive: true
+        })).toEqual({
+            showStreamingAsrButton: false,
+            showSendButton: true,
+            showLegacyMicButton: false
+        });
+    });
+
+    it('shows legacy mic button when idle and mic action is available', () => {
+        expect(decideVoiceButton('elevenlabs_call', {
+            hasText: false,
+            isSending: false,
+            hasMicAction: true,
+            isMicActive: false
+        })).toEqual({
+            showStreamingAsrButton: false,
+            showSendButton: false,
+            showLegacyMicButton: true
+        });
+    });
+
+    it('shows inactive state when idle and mic action is unavailable', () => {
+        expect(decideVoiceButton('elevenlabs_call', {
+            hasText: false,
+            isSending: false,
+            hasMicAction: false,
+            isMicActive: false
+        })).toEqual({
+            showStreamingAsrButton: false,
+            showSendButton: false,
+            showLegacyMicButton: false
+        });
+    });
+});
+
+describe('getVoiceModeStrategy', () => {
+    it('returns streaming strategy for streaming mode', () => {
+        expect(getVoiceModeStrategy('streaming_asr').mode).toBe('streaming_asr');
+    });
+
+    it('returns fallback strategy for unknown mode', () => {
+        expect(getVoiceModeStrategy('other').mode).toBe('elevenlabs_call');
+    });
+});

--- a/packages/happy-app/sources/features/voice-input/providers/providerFactory.ts
+++ b/packages/happy-app/sources/features/voice-input/providers/providerFactory.ts
@@ -1,0 +1,40 @@
+import { VoiceButtonDecision, VoiceButtonState, VoiceInputMode, VoiceModeStrategy } from './types';
+
+const streamingAsrStrategy: VoiceModeStrategy = {
+    mode: 'streaming_asr',
+    decideButton: () => ({
+        showStreamingAsrButton: true,
+        showSendButton: false,
+        showLegacyMicButton: false
+    })
+};
+
+const elevenlabsCallStrategy: VoiceModeStrategy = {
+    mode: 'elevenlabs_call',
+    decideButton: (state) => {
+        const showSendButton = state.hasText || !!state.isSending || !!state.isMicActive;
+        const showLegacyMicButton = !showSendButton && state.hasMicAction && !state.isMicActive;
+        return {
+            showStreamingAsrButton: false,
+            showSendButton,
+            showLegacyMicButton
+        };
+    }
+};
+
+const strategyByMode: Record<VoiceInputMode, VoiceModeStrategy> = {
+    streaming_asr: streamingAsrStrategy,
+    elevenlabs_call: elevenlabsCallStrategy
+};
+
+export function resolveVoiceInputMode(mode?: string | null): VoiceInputMode {
+    return mode === 'streaming_asr' ? 'streaming_asr' : 'elevenlabs_call';
+}
+
+export function getVoiceModeStrategy(mode?: string | null): VoiceModeStrategy {
+    return strategyByMode[resolveVoiceInputMode(mode)];
+}
+
+export function decideVoiceButton(mode: VoiceInputMode, state: VoiceButtonState): VoiceButtonDecision {
+    return strategyByMode[mode].decideButton(state);
+}

--- a/packages/happy-app/sources/features/voice-input/providers/types.ts
+++ b/packages/happy-app/sources/features/voice-input/providers/types.ts
@@ -1,0 +1,19 @@
+export type VoiceInputMode = 'elevenlabs_call' | 'streaming_asr';
+
+export interface VoiceButtonState {
+    hasText: boolean;
+    isSending?: boolean;
+    hasMicAction: boolean;
+    isMicActive?: boolean;
+}
+
+export interface VoiceButtonDecision {
+    showStreamingAsrButton: boolean;
+    showSendButton: boolean;
+    showLegacyMicButton: boolean;
+}
+
+export interface VoiceModeStrategy {
+    mode: VoiceInputMode;
+    decideButton: (state: VoiceButtonState) => VoiceButtonDecision;
+}

--- a/packages/happy-app/sources/features/voice-input/providers/useLegacyVoiceProvider.ts
+++ b/packages/happy-app/sources/features/voice-input/providers/useLegacyVoiceProvider.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+
+interface UseLegacyVoiceProviderProps {
+    hasText: boolean;
+    isSending?: boolean;
+    isSendDisabled?: boolean;
+    hasMicAction: boolean;
+    isMicActive?: boolean;
+    onSend: () => void;
+    onMicPress?: () => void;
+}
+
+export function useLegacyVoiceProvider(props: UseLegacyVoiceProviderProps) {
+    const disabled = useMemo(() => {
+        return !!props.isSendDisabled || !!props.isSending || (!props.hasText && !props.hasMicAction);
+    }, [props.hasMicAction, props.hasText, props.isSendDisabled, props.isSending]);
+
+    const onPress = useMemo(() => {
+        return () => {
+            if (props.hasText) {
+                props.onSend();
+                return;
+            }
+            if (props.onMicPress) {
+                props.onMicPress();
+            }
+        };
+    }, [props.hasText, props.onMicPress, props.onSend]);
+
+    const iconType = useMemo<'sending' | 'send' | 'mic'>(() => {
+        if (props.isSending) {
+            return 'sending';
+        }
+        if (props.hasText || props.isMicActive) {
+            return 'send';
+        }
+        return 'mic';
+    }, [props.hasText, props.isMicActive, props.isSending]);
+
+    return {
+        disabled,
+        onPress,
+        iconType
+    };
+}

--- a/packages/happy-app/sources/features/voice-input/providers/useStreamingAsrProvider.ts
+++ b/packages/happy-app/sources/features/voice-input/providers/useStreamingAsrProvider.ts
@@ -1,0 +1,238 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { Platform } from 'react-native';
+import { apiSocket } from '@/sync/apiSocket';
+import { requestMicrophonePermission, showMicrophonePermissionDeniedAlert } from '@/utils/microphonePermissions';
+import { encodeBase64 } from '@/encryption/base64';
+
+export interface StreamingAsrProviderProps {
+    onTextUpdate?: (text: string) => void;
+    sessionId?: string;
+}
+
+export function useStreamingAsrProvider({ onTextUpdate, sessionId }: StreamingAsrProviderProps) {
+    const [isListening, setIsListening] = useState(false);
+    const audioContextRef = useRef<any>(null);
+    const mediaStreamSourceRef = useRef<any>(null);
+    const scriptProcessorRef = useRef<any>(null);
+    const streamRef = useRef<MediaStream | null>(null);
+    const chunkCountRef = useRef<number>(0);
+    const nativeRecorderRef = useRef<any>(null);
+    const resultTextArrayRef = useRef<string[]>([]);
+    const onTextUpdateRef = useRef(onTextUpdate);
+
+    useEffect(() => {
+        onTextUpdateRef.current = onTextUpdate;
+    }, [onTextUpdate]);
+
+    const toPcmBase64 = useCallback((pcmData: Int16Array) => {
+        return encodeBase64(new Uint8Array(pcmData.buffer));
+    }, []);
+
+    const cleanupLegacyRecorder = useCallback(() => {
+        if (nativeRecorderRef.current) {
+            try {
+                if (nativeRecorderRef.current.markAsStopped) {
+                    nativeRecorderRef.current.markAsStopped();
+                }
+                nativeRecorderRef.current.stop();
+                console.log('[ASR Frontend] Native Audio Recorder stopped');
+                if (typeof nativeRecorderRef.current.disconnect === 'function') {
+                    nativeRecorderRef.current.disconnect();
+                    console.log('[ASR Frontend] Native Audio Recorder disconnected');
+                }
+            } catch (e) {
+                console.warn('[ASR Frontend] Error stopping native recorder:', e);
+            }
+            nativeRecorderRef.current = null;
+        }
+    }, []);
+
+    const cleanupBrowserAudio = useCallback(() => {
+        if (scriptProcessorRef.current) {
+            scriptProcessorRef.current.disconnect();
+            scriptProcessorRef.current = null;
+        }
+        if (mediaStreamSourceRef.current) {
+            mediaStreamSourceRef.current.disconnect();
+            mediaStreamSourceRef.current = null;
+        }
+        if (audioContextRef.current && audioContextRef.current.state !== 'closed') {
+            audioContextRef.current.close();
+            audioContextRef.current = null;
+        }
+        if (streamRef.current) {
+            streamRef.current.getTracks().forEach(track => track.stop());
+            streamRef.current = null;
+        }
+    }, []);
+
+    const stopListening = useCallback(async (options?: { skipNativeStop?: boolean; skipBackendStop?: boolean }) => {
+        console.log('[ASR Frontend] stopListening() 被调用，准备清理资源');
+        setIsListening(false);
+        chunkCountRef.current = 0;
+
+        cleanupLegacyRecorder();
+        cleanupBrowserAudio();
+
+        if (!options?.skipBackendStop) {
+            console.log('[ASR Frontend] 发送 asr_stop 到后端');
+            apiSocket.send('asr_stop', { sessionId });
+        }
+    }, [cleanupBrowserAudio, cleanupLegacyRecorder, sessionId]);
+
+    const startLegacyStreaming = useCallback(async () => {
+        setIsListening(true);
+        console.log('[ASR Frontend] 发送 asr_start 到后端');
+        apiSocket.send('asr_start', { sessionId });
+
+        if (Platform.OS === 'web') {
+            console.log('[ASR Frontend] 正在获取 Web 麦克风音频流...');
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            console.log('[ASR Frontend] 麦克风权限已获取，获得音频流:', stream.id);
+            streamRef.current = stream;
+
+            const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+            audioContextRef.current = new AudioContextClass({
+                sampleRate: 16000
+            });
+            console.log(`[ASR Frontend] AudioContext 初始化完成, 采样率: ${audioContextRef.current.sampleRate}`);
+
+            mediaStreamSourceRef.current = audioContextRef.current.createMediaStreamSource(stream);
+            scriptProcessorRef.current = audioContextRef.current.createScriptProcessor(1024, 1, 1);
+
+            mediaStreamSourceRef.current.connect(scriptProcessorRef.current);
+            scriptProcessorRef.current.connect(audioContextRef.current.destination);
+
+            scriptProcessorRef.current.onaudioprocess = (e: any) => {
+                const inputData = e.inputBuffer.getChannelData(0);
+                const pcmData = new Int16Array(inputData.length);
+                for (let i = 0; i < inputData.length; i++) {
+                    const s = Math.max(-1, Math.min(1, inputData[i]));
+                    pcmData[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
+                }
+
+                chunkCountRef.current++;
+                if (chunkCountRef.current % 50 === 1) {
+                    console.log(`[ASR Frontend] Web: 正在持续发送音频数据块... 当前第 ${chunkCountRef.current} 块, 大小: ${pcmData.buffer.byteLength} bytes`);
+                }
+
+                apiSocket.send('asr_audio_chunk', {
+                    audioBase64: toPcmBase64(pcmData),
+                    chunkByteLength: pcmData.buffer.byteLength,
+                    sessionId
+                });
+            };
+            return;
+        }
+
+        console.log('[ASR Frontend] 正在初始化 Native 麦克风录音...');
+        const { AudioRecorder } = require('react-native-audio-api');
+        const recorder = new AudioRecorder({
+            sampleRate: 16000,
+            bufferLengthInSamples: 1024
+        });
+
+        let isAudioStopped = false;
+
+        recorder.onAudioReady((event: any) => {
+            if (isAudioStopped) {
+                return;
+            }
+
+            const inputData = event.buffer.getChannelData(0);
+            const pcmData = new Int16Array(inputData.length);
+            for (let i = 0; i < inputData.length; i++) {
+                const s = Math.max(-1, Math.min(1, inputData[i]));
+                pcmData[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
+            }
+
+            chunkCountRef.current++;
+            if (chunkCountRef.current % 50 === 1) {
+                console.log(`[ASR Frontend] Native: 正在持续发送音频数据块... 当前第 ${chunkCountRef.current} 块, 大小: ${pcmData.buffer.byteLength} bytes`);
+            }
+
+            apiSocket.send('asr_audio_chunk', {
+                audioBase64: toPcmBase64(pcmData),
+                chunkByteLength: pcmData.buffer.byteLength,
+                sessionId
+            });
+        });
+
+        nativeRecorderRef.current = recorder;
+        nativeRecorderRef.current.markAsStopped = () => {
+            isAudioStopped = true;
+        };
+        recorder.start();
+        console.log('[ASR Frontend] Native Audio Recorder 已启动');
+    }, [sessionId, toPcmBase64]);
+
+    useEffect(() => {
+        const cleanupText = apiSocket.onMessage('asr_text', (data: any) => {
+            console.log('[ASR Frontend] 收到后端发来的 asr_text:', data);
+            if (data && data.text) {
+                let joinedText = '';
+                if (data.pgs === 'rpl') {
+                    joinedText = data.text;
+                    resultTextArrayRef.current = [joinedText];
+                } else {
+                    resultTextArrayRef.current.push(data.text);
+                    joinedText = resultTextArrayRef.current.join('');
+                }
+                console.log(`[ASR Frontend] 准备调用 onTextUpdate (sn:${data.sn}, pgs:${data.pgs}), 文本: "${joinedText}", onTextUpdate 是否存在: ${!!onTextUpdateRef.current}`);
+                if (onTextUpdateRef.current) {
+                    onTextUpdateRef.current(joinedText);
+                }
+            }
+        });
+
+        const cleanupEnd = apiSocket.onMessage('asr_end', () => {
+            console.log('[ASR Frontend] 收到后端发来的 asr_end，停止录音');
+            void stopListening({ skipBackendStop: true });
+        });
+
+        const cleanupError = apiSocket.onMessage('asr_error', (err: any) => {
+            console.error('[ASR Frontend] 收到后端发来的 asr_error:', err);
+            void stopListening({ skipBackendStop: true });
+        });
+
+        return () => {
+            cleanupText();
+            cleanupEnd();
+            cleanupError();
+        };
+    }, [stopListening]);
+
+    const startListening = useCallback(async () => {
+        console.log('[ASR Frontend] startListening() 被调用');
+
+        try {
+            const permissionResult = await requestMicrophonePermission();
+            if (!permissionResult.granted) {
+                showMicrophonePermissionDeniedAlert(permissionResult.canAskAgain);
+                return;
+            }
+
+            resultTextArrayRef.current = [];
+            chunkCountRef.current = 0;
+            if (onTextUpdate) {
+                console.log('[ASR Frontend] 清空输入框');
+                onTextUpdate('');
+            } else {
+                console.warn('[ASR Frontend] 警告: onTextUpdate 回调函数未传入！');
+            }
+
+            await startLegacyStreaming();
+
+        } catch (error) {
+            console.error('[ASR Frontend] Failed to start recording:', error);
+            setIsListening(false);
+            void stopListening();
+        }
+    }, [onTextUpdate, startLegacyStreaming, stopListening]);
+
+    return {
+        isListening,
+        startListening,
+        stopListening
+    };
+}

--- a/packages/happy-app/sources/features/voice-input/useVoiceInputController.ts
+++ b/packages/happy-app/sources/features/voice-input/useVoiceInputController.ts
@@ -1,0 +1,51 @@
+import { useLocalSetting } from '@/sync/storage';
+import { getVoiceModeStrategy, resolveVoiceInputMode, useLegacyVoiceProvider } from './providers';
+
+interface UseVoiceInputControllerProps {
+    hasText: boolean;
+    isSending?: boolean;
+    isSendDisabled?: boolean;
+    onSend: () => void;
+    onMicPress?: () => void;
+    isMicActive?: boolean;
+    sessionId?: string;
+    onTextUpdate?: (text: string) => void;
+    forceMode?: 'elevenlabs_call' | 'streaming_asr';
+}
+
+export function useVoiceInputController(props: UseVoiceInputControllerProps) {
+    const systemVoiceInputMode = useLocalSetting('voiceInputMode');
+    const voiceInputMode = resolveVoiceInputMode(props.forceMode || systemVoiceInputMode);
+    const modeStrategy = getVoiceModeStrategy(voiceInputMode);
+
+    const buttonDecision = modeStrategy.decideButton({
+        hasText: props.hasText,
+        isSending: props.isSending,
+        hasMicAction: !!props.onMicPress,
+        isMicActive: props.isMicActive
+    });
+
+    const legacyVoice = useLegacyVoiceProvider({
+        hasText: props.hasText,
+        isSending: props.isSending,
+        isSendDisabled: props.isSendDisabled,
+        hasMicAction: !!props.onMicPress,
+        isMicActive: props.isMicActive,
+        onSend: props.onSend,
+        onMicPress: props.onMicPress
+    });
+
+    return {
+        voiceInputMode,
+        buttonDecision,
+        legacyVoice,
+        customAsrProps: {
+            sessionId: props.sessionId,
+            onTextUpdate: props.onTextUpdate,
+            hasText: props.hasText,
+            isSending: props.isSending,
+            isSendDisabled: props.isSendDisabled,
+            onSend: props.onSend
+        }
+    };
+}


### PR DESCRIPTION
## Background
This PR improves voice input stability and maintainability in Happy App.

## What changed
- Consolidated voice entry behavior to avoid conflicting button states
- Refactored voice input logic into a provider-based structure
- Added strategy-based mode boundary for future extension
- Added tests for voice mode decision logic

## Scope
- packages/happy-app/sources/components/AgentInput.tsx
- packages/happy-app/sources/features/custom-asr/SmartVoiceButton.tsx
- packages/happy-app/sources/features/custom-asr/useCustomASR.ts
- packages/happy-app/sources/features/voice-input/*

## Validation
- `yarn workspace happy-app test run sources/features/voice-input/providers/providerFactory.test.ts` ✅ (9/9 passed)
- Manual test on mobile completed: streaming voice input updates continuously and send/voice behavior is correct
- `yarn workspace happy-app typecheck` currently reports additional errors on top of latest `upstream/main` (outside this PR’s core change path)

## Notes
- No intentional changes to unrelated RPC flow
- External UX remains consistent while internals are decoupled for future extension