### PR TITLE
fix(Dockerfile.server): only install happy-server workspace deps

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -11,20 +11,18 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY scripts ./scripts
 COPY patches ./patches
 
-RUN mkdir -p packages/happy-app packages/happy-server packages/happy-cli packages/happy-wire
+RUN mkdir -p packages/happy-server packages/happy-wire
 
-COPY packages/happy-app/package.json packages/happy-app/
 COPY packages/happy-server/package.json packages/happy-server/
-COPY packages/happy-cli/package.json packages/happy-cli/
 COPY packages/happy-wire/package.json packages/happy-wire/
 
 # Workspace postinstall requirements
-COPY packages/happy-app/patches packages/happy-app/patches
 COPY packages/happy-server/prisma packages/happy-server/prisma
-COPY packages/happy-cli/scripts packages/happy-cli/scripts
-COPY packages/happy-cli/tools packages/happy-cli/tools
 
-RUN SKIP_HAPPY_WIRE_BUILD=1 pnpm install --frozen-lockfile
+# Install only the workspaces needed for happy-server (+ its workspace dep happy-wire).
+# Avoids pulling in happy-app / happy-cli / happy-agent / happy-app-logs / codium —
+# saves several GB of disk during build and shrinks the runtime image.
+RUN SKIP_HAPPY_WIRE_BUILD=1 pnpm install --filter happy-server... --frozen-lockfile
 
 # Stage 2: build the server
 FROM deps AS builder


### PR DESCRIPTION
## Problem

`Dockerfile.server`'s deps stage runs `pnpm install --frozen-lockfile` against the whole monorepo, pulling in `happy-app`, `happy-cli`, `happy-agent`, `happy-app-logs` and `codium` even though the runner only needs `happy-server` (and its workspace dep `@slopus/happy-wire`). On small self-hosted VPS deployments this routinely tips the build over the disk limit (ENOSPC during the React Native / Expo deps fetch in `happy-app`), and it bloats the deps layer with several GB of node_modules that never get used at runtime.

## Fix

Switch to `pnpm install --filter happy-server... --frozen-lockfile` so pnpm only resolves and links transitive deps for `happy-server` and `happy-wire`. Drop the now-unused workspace `COPY`s (`happy-app/`, `happy-cli/`) and their postinstall artefacts (`happy-app/patches`, `happy-cli/{scripts,tools}`).

The root `scripts/postinstall.cjs` patches stay in place — all five (`fix-pglite-prisma-bytes`, `fix-livekit-room-reuse`, `expose-pierre-diffs-style`, `force-preact-cjs`, `fix-pierre-trees-preact-hooks`) gate every file write behind `fs.existsSync`, so absent packages are silently skipped. The only one relevant to the server is `fix-pglite-prisma-bytes` (pglite-prisma-adapter is a `happy-server` dep), which still runs.

## Notes

This obsoletes my earlier yarn-era fixes on this branch (force-pushed). Those targeted the same root cause — over-broad install — but for the pre-#1033 yarn-1 setup.