### PR TITLE
feat: image paste support for web UI

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -301,6 +301,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
     const deviceType = useDeviceType();
     const isTablet = useIsTablet();
     const [message, setMessage] = React.useState('');
+    const [images, setImages] = React.useState<Array<{ base64: string; mediaType: string }>>([]);
     const realtimeStatus = useRealtimeStatus();
     const { messages, isLoaded } = useSessionMessages(sessionId);
     const acknowledgedCliVersions = useLocalSetting('acknowledgedCliVersions');
@@ -500,11 +501,16 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                 isPulsing: sessionStatus.isPulsing
             }}
             blockSend={false}
+            images={images}
+            onImagePaste={(img) => setImages(prev => [...prev, img])}
+            onRemoveImage={(index) => setImages(prev => prev.filter((_, i) => i !== index))}
             onSend={() => {
-                if (message.trim()) {
+                if (message.trim() || images.length > 0) {
+                    const currentImages = images.length > 0 ? images : undefined;
                     setMessage('');
+                    setImages([]);
                     clearDraft();
-                    sync.sendMessage(sessionId, message, { source: 'chat' });
+                    sync.sendMessage(sessionId, message, { source: 'chat', images: currentImages });
                 }
             }}
             onMicPress={isDisconnected ? undefined : micButtonState.onMicPress}

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -77,6 +77,9 @@ interface AgentInputProps {
     isSendDisabled?: boolean;
     isSending?: boolean;
     minHeight?: number;
+    images?: Array<{ base64: string; mediaType: string }>;
+    onImagePaste?: (image: { base64: string; mediaType: string }) => void;
+    onRemoveImage?: (index: number) => void;
 }
 
 const MAX_CONTEXT_SIZE = 190000;
@@ -284,6 +287,30 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
     sendButtonIcon: {
         color: theme.colors.button.primary.tint,
     },
+    imagePreviewContainer: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        paddingHorizontal: 8,
+        paddingTop: 8,
+        gap: 8,
+    },
+    imagePreviewWrapper: {
+        position: 'relative',
+    },
+    imagePreview: {
+        width: 80,
+        height: 80,
+        borderRadius: 8,
+    },
+    imageRemoveButton: {
+        position: 'absolute',
+        top: -6,
+        right: -6,
+        backgroundColor: 'rgba(0,0,0,0.6)',
+        borderRadius: 10,
+        width: 20,
+        height: 20,
+    },
 }));
 
 const getContextWarning = (contextSize: number, alwaysShow: boolean = false, theme: Theme) => {
@@ -307,7 +334,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     const screenWidth = useWindowDimensions().width;
     const isSendBlocked = props.blockSend ?? false;
 
-    const hasText = props.value.trim().length > 0;
+    const hasText = props.value.trim().length > 0 || (props.images && props.images.length > 0);
     const canPressSendButton = !props.isSending
         && !props.isSendDisabled
         && (isSendBlocked ? hasText : (hasText || !!props.onMicPress));
@@ -529,7 +556,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
             // to avoid false positives on Windows touch-screen laptops with keyboards.
             const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
             if (agentInputEnterToSend && event.key === 'Enter' && !event.shiftKey && !isTouchDevice) {
-                if (props.value.trim()) {
+                if (props.value.trim() || (props.images && props.images.length > 0)) {
                     if (isSendBlocked) {
                         handleBlockedSendAttempt();
                     } else if (!props.isSendDisabled) {
@@ -1058,6 +1085,25 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                 {/* Box 2: Action Area (Input + Send) */}
                 <Shaker ref={sendBlockShakerRef}>
                 <View style={styles.unifiedPanel}>
+                    {/* Image previews */}
+                    {props.images && props.images.length > 0 && (
+                        <View style={styles.imagePreviewContainer}>
+                            {props.images.map((img, index) => (
+                                <View key={index} style={styles.imagePreviewWrapper}>
+                                    <RNImage
+                                        source={{ uri: `data:${img.mediaType};base64,${img.base64}` }}
+                                        style={styles.imagePreview}
+                                    />
+                                    <Pressable
+                                        style={styles.imageRemoveButton}
+                                        onPress={() => props.onRemoveImage?.(index)}
+                                    >
+                                        <Ionicons name="close-circle" size={20} color="#fff" />
+                                    </Pressable>
+                                </View>
+                            ))}
+                        </View>
+                    )}
                     {/* Input field */}
                     <View style={[styles.inputContainer, props.minHeight ? { minHeight: props.minHeight } : undefined]}>
                         <MultiTextInput
@@ -1070,6 +1116,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                             onKeyPress={handleKeyPress}
                             onStateChange={handleInputStateChange}
                             maxHeight={120}
+                            onImagePaste={props.onImagePaste}
                         />
                     </View>
 

--- a/packages/happy-app/sources/components/MultiTextInput.tsx
+++ b/packages/happy-app/sources/components/MultiTextInput.tsx
@@ -43,6 +43,7 @@ interface MultiTextInputProps {
     onKeyPress?: OnKeyPressCallback;
     onSelectionChange?: (selection: { start: number; end: number }) => void;
     onStateChange?: (state: TextInputState) => void;
+    onImagePaste?: (image: { base64: string; mediaType: string }) => void;
 }
 
 export const MultiTextInput = React.forwardRef<MultiTextInputHandle, MultiTextInputProps>((props, ref) => {

--- a/packages/happy-app/sources/components/MultiTextInput.web.tsx
+++ b/packages/happy-app/sources/components/MultiTextInput.web.tsx
@@ -43,6 +43,7 @@ interface MultiTextInputProps {
     onKeyPress?: OnKeyPressCallback;
     onSelectionChange?: (selection: { start: number; end: number }) => void;
     onStateChange?: (state: TextInputState) => void;
+    onImagePaste?: (image: { base64: string; mediaType: string }) => void;
 }
 
 export const MultiTextInput = React.forwardRef<MultiTextInputHandle, MultiTextInputProps>((props, ref) => {
@@ -129,6 +130,33 @@ export const MultiTextInput = React.forwardRef<MultiTextInputHandle, MultiTextIn
         }
     }, [onChangeText, onStateChange, onSelectionChange]);
 
+    const handlePaste = React.useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+        if (!props.onImagePaste) return;
+
+        const items = e.clipboardData?.items;
+        if (!items) return;
+
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (item.type.startsWith('image/')) {
+                e.preventDefault();
+                const mediaType = item.type; // Capture before async — DataTransferItem invalidates after event
+                const file = item.getAsFile();
+                if (!file) continue;
+
+                const reader = new FileReader();
+                reader.onload = () => {
+                    const dataUrl = reader.result as string;
+                    const commaIndex = dataUrl.indexOf(',');
+                    const base64 = dataUrl.substring(commaIndex + 1);
+                    props.onImagePaste!({ base64, mediaType });
+                };
+                reader.readAsDataURL(file);
+                return;
+            }
+        }
+    }, [props.onImagePaste]);
+
     const handleSelect = React.useCallback((e: React.SyntheticEvent<HTMLTextAreaElement>) => {
         const target = e.target as HTMLTextAreaElement;
         const selection = { 
@@ -200,6 +228,7 @@ export const MultiTextInput = React.forwardRef<MultiTextInputHandle, MultiTextIn
                 onChange={handleChange}
                 onSelect={handleSelect}
                 onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
                 maxRows={maxRows}
                 autoCapitalize="sentences"
                 autoCorrect="on"

--- a/packages/happy-app/sources/encryption/aes.web.ts
+++ b/packages/happy-app/sources/encryption/aes.web.ts
@@ -1,0 +1,36 @@
+import { decodeBase64, encodeBase64 } from '@/encryption/base64';
+
+async function importAESKey(key64: string): Promise<CryptoKey> {
+    const raw = Uint8Array.from(atob(key64), c => c.charCodeAt(0));
+    return await crypto.subtle.importKey('raw', raw, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']);
+}
+
+export async function encryptAESGCMString(data: string, key64: string): Promise<string> {
+    const key = await importAESKey(key64);
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const encoded = new TextEncoder().encode(data);
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded);
+    const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+    combined.set(iv);
+    combined.set(new Uint8Array(ciphertext), iv.length);
+    return encodeBase64(combined);
+}
+
+export async function decryptAESGCMString(data: string, key64: string): Promise<string | null> {
+    const key = await importAESKey(key64);
+    const combined = decodeBase64(data);
+    const iv = combined.slice(0, 12);
+    const ciphertext = combined.slice(12);
+    const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+    return new TextDecoder().decode(plaintext);
+}
+
+export async function encryptAESGCM(data: Uint8Array, key64: string): Promise<Uint8Array> {
+    const encrypted = await encryptAESGCMString(new TextDecoder().decode(data), key64);
+    return decodeBase64(encrypted);
+}
+
+export async function decryptAESGCM(data: Uint8Array, key64: string): Promise<Uint8Array | null> {
+    const decrypted = await decryptAESGCMString(encodeBase64(data), key64);
+    return decrypted ? new TextEncoder().encode(decrypted) : null;
+}

--- a/packages/happy-app/sources/encryption/base64.ts
+++ b/packages/happy-app/sources/encryption/base64.ts
@@ -24,7 +24,14 @@ export function decodeBase64(base64: string, encoding: 'base64' | 'base64url' = 
 }
 
 export function encodeBase64(buffer: Uint8Array, encoding: 'base64' | 'base64url' = 'base64'): string {
-    const binaryString = String.fromCharCode.apply(null, Array.from(buffer));
+    // Process in chunks to avoid stack overflow with large buffers (e.g. images)
+    const chunks: string[] = [];
+    const chunkSize = 8192;
+    for (let i = 0; i < buffer.length; i += chunkSize) {
+        const chunk = buffer.subarray(i, Math.min(i + chunkSize, buffer.length));
+        chunks.push(String.fromCharCode.apply(null, Array.from(chunk)));
+    }
+    const binaryString = chunks.join('');
     const base64 = btoa(binaryString);
     
     if (encoding === 'base64url') {

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -74,6 +74,7 @@ type OutboxMessage = {
 type SendMessageOptions = {
     displayText?: string;
     source?: MessageSentSource;
+    images?: Array<{ base64: string; mediaType: string }>;
 };
 
 class Sync {
@@ -471,7 +472,7 @@ class Sync {
         }
 
         const { permissionMode, model } = resolveMessageModeMeta(session);
-        const { displayText, source = 'chat' } = options ?? {};
+        const { displayText, source = 'chat', images } = options ?? {};
 
         // Generate local ID
         const localId = randomUUID();
@@ -500,7 +501,8 @@ class Sync {
             role: 'user',
             content: {
                 type: 'text',
-                text
+                text,
+                ...(images && images.length > 0 && { images }),
             },
             meta: {
                 sentFrom,

--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -433,7 +433,11 @@ const rawRecordSchema = z.preprocess(
             role: z.literal('user'),
             content: z.object({
                 type: z.literal('text'),
-                text: z.string()
+                text: z.string(),
+                images: z.array(z.object({
+                    base64: z.string(),
+                    mediaType: z.string(),
+                })).optional(),
             }),
             meta: MessageMetaSchema.optional()
         }),
@@ -505,6 +509,7 @@ export type NormalizedMessage = ({
     content: {
         type: 'text';
         text: string;
+        images?: Array<{ base64: string; mediaType: string }>;
     }
 } | {
     role: 'agent'

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -222,7 +222,11 @@ export const UserMessageSchema = z.object({
   role: z.literal('user'),
   content: z.object({
     type: z.literal('text'),
-    text: z.string()
+    text: z.string(),
+    images: z.array(z.object({
+      base64: z.string(),
+      mediaType: z.string(),
+    })).optional(),
   }),
   localKey: z.string().optional(), // Mobile messages include this
   meta: MessageMetaSchema.optional()

--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -1,4 +1,5 @@
 import { EnhancedMode } from "./loop";
+import { ImageAttachment } from "@/utils/MessageQueue2";
 import { query, type QueryOptions, type SDKMessage, type SDKSystemMessage, AbortError, SDKUserMessage } from '@/claude/sdk'
 import { mapToClaudeMode } from "./utils/permissionMode";
 import { claudeCheckSession } from "./utils/claudeCheckSession";
@@ -31,7 +32,7 @@ export async function claudeRemote(opts: {
     jsRuntime?: JsRuntime,
 
     // Dynamic parameters
-    nextMessage: () => Promise<{ message: string, mode: EnhancedMode } | null>,
+    nextMessage: () => Promise<{ message: string, images?: ImageAttachment[], mode: EnhancedMode } | null>,
     onReady: () => void,
     isAborted: (toolCallId: string) => boolean,
 
@@ -143,6 +144,20 @@ export async function claudeRemote(opts: {
         }
     };
 
+    // Build SDK content: plain string when no images, content array when images are present
+    function buildContent(text: string, images?: ImageAttachment[]): string | Array<{ type: string; [key: string]: unknown }> {
+        const validImages = images?.filter(img => img.base64);
+        if (!validImages || validImages.length === 0) return text;
+        logger.debug(`[claudeRemote] Building content with ${validImages.length} image(s)`);
+        return [
+            ...validImages.map(img => ({
+                type: 'image' as const,
+                source: { type: 'base64' as const, media_type: img.mediaType || 'image/png', data: img.base64 },
+            })),
+            { type: 'text' as const, text },
+        ];
+    }
+
     // Push initial message
     let messages = new PushableAsyncIterable<SDKUserMessage>();
     messages.push({
@@ -150,7 +165,7 @@ export async function claudeRemote(opts: {
         parent_tool_use_id: null,
         message: {
             role: 'user',
-            content: initial.message,
+            content: buildContent(initial.message, initial.images),
         },
     });
 
@@ -232,7 +247,7 @@ export async function claudeRemote(opts: {
                         messages.end();
                     } else {
                         mode = next.mode;
-                        messages.push({ type: 'user', parent_tool_use_id: null, message: { role: 'user', content: next.message } });
+                        messages.push({ type: 'user', parent_tool_use_id: null, message: { role: 'user', content: buildContent(next.message, next.images) } });
                     }
                 }).catch(() => {
                     messages.end();

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -264,6 +264,7 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
     try {
         let pending: {
             message: string;
+            images?: import("@/utils/MessageQueue2").ImageAttachment[];
             mode: EnhancedMode;
         } | null = null;
 
@@ -329,6 +330,7 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                             permissionHandler.handleModeChange(mode.permissionMode);
                             return {
                                 message: msg.message,
+                                images: msg.images,
                                 mode: msg.mode
                             }
                         }

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -450,7 +450,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             allowedTools: messageAllowedTools,
             disallowedTools: messageDisallowedTools
         };
-        messageQueue.push(message.content.text, enhancedMode);
+        messageQueue.push(message.content.text, enhancedMode, (message.content as any).images);
         logger.debugLargeJson('User message pushed to queue:', message)
     });
 

--- a/packages/happy-cli/src/utils/MessageQueue2.ts
+++ b/packages/happy-cli/src/utils/MessageQueue2.ts
@@ -1,7 +1,13 @@
 import { logger } from "@/ui/logger";
 
+export interface ImageAttachment {
+    base64: string;
+    mediaType: string;
+}
+
 interface QueueItem<T> {
     message: string;
+    images?: ImageAttachment[];
     mode: T;
     modeHash: string;
     isolate?: boolean; // If true, this message must be processed alone
@@ -37,7 +43,7 @@ export class MessageQueue2<T> {
     /**
      * Push a message to the queue with a mode.
      */
-    push(message: string, mode: T): void {
+    push(message: string, mode: T, images?: ImageAttachment[]): void {
         if (this.closed) {
             throw new Error('Cannot push to closed queue');
         }
@@ -47,6 +53,7 @@ export class MessageQueue2<T> {
 
         this.queue.push({
             message,
+            images,
             mode,
             modeHash,
             isolate: false
@@ -221,7 +228,7 @@ export class MessageQueue2<T> {
      * Wait for messages and return all messages with the same mode as a single string
      * Returns { message: string, mode: T } or null if aborted/closed
      */
-    async waitForMessagesAndGetAsString(abortSignal?: AbortSignal): Promise<{ message: string, mode: T, isolate: boolean, hash: string } | null> {
+    async waitForMessagesAndGetAsString(abortSignal?: AbortSignal): Promise<{ message: string, images?: ImageAttachment[], mode: T, isolate: boolean, hash: string } | null> {
         // If we have messages, return them immediately
         if (this.queue.length > 0) {
             return this.collectBatch();
@@ -245,13 +252,14 @@ export class MessageQueue2<T> {
     /**
      * Collect a batch of messages with the same mode, respecting isolation requirements
      */
-    private collectBatch(): { message: string, mode: T, hash: string, isolate: boolean } | null {
+    private collectBatch(): { message: string, images?: ImageAttachment[], mode: T, hash: string, isolate: boolean } | null {
         if (this.queue.length === 0) {
             return null;
         }
 
         const firstItem = this.queue[0];
         const sameModeMessages: string[] = [];
+        const allImages: ImageAttachment[] = [];
         let mode = firstItem.mode;
         let isolate = firstItem.isolate ?? false;
         const targetModeHash = firstItem.modeHash;
@@ -260,6 +268,7 @@ export class MessageQueue2<T> {
         if (firstItem.isolate) {
             const item = this.queue.shift()!;
             sameModeMessages.push(item.message);
+            if (item.images) allImages.push(...item.images);
             logger.debug(`[MessageQueue2] Collected isolated message with mode hash: ${targetModeHash}`);
         } else {
             // Collect all messages with the same mode until we hit an isolated message
@@ -268,6 +277,7 @@ export class MessageQueue2<T> {
                 !this.queue[0].isolate) {
                 const item = this.queue.shift()!;
                 sameModeMessages.push(item.message);
+                if (item.images) allImages.push(...item.images);
             }
             logger.debug(`[MessageQueue2] Collected batch of ${sameModeMessages.length} messages with mode hash: ${targetModeHash}`);
         }
@@ -277,6 +287,7 @@ export class MessageQueue2<T> {
 
         return {
             message: combinedMessage,
+            images: allImages.length > 0 ? allImages : undefined,
             mode,
             hash: targetModeHash,
             isolate


### PR DESCRIPTION
## Summary
- Web UI image paste: clipboard image handling in `MultiTextInput.web.tsx`, thumbnail preview in `AgentInput.tsx`, state management in `SessionView.tsx`
- Sync transport: `images` field added to `sync.ts` sendMessage and `typesRaw.ts` schema
- CLI pipeline: `ImageAttachment` type in `MessageQueue2`, `buildContent()` in `claudeRemote.ts` converts images to base64 content blocks for Claude API, passthrough in `claudeRemoteLauncher.ts` and `runClaude.ts`
- Web Crypto AES encryption (`aes.web.ts`) for large image data — prevents stack overflow from `rn-encryption` on web platform
- `base64.ts` chunked encoding to avoid stack overflow on large buffers
- `mediaType` captured synchronously before `DataTransferItem` invalidates after paste event

## How it works
1. User pastes image in web chat input → `onPaste` handler reads as base64
2. Thumbnail preview shown with remove button
3. On send, images array passed through `sync.sendMessage()` → encrypted → server
4. CLI receives message with `images` field → `MessageQueue2` batches with images → `claudeRemote.buildContent()` builds content array with image blocks + text
5. Claude API receives images as `base64` source type content blocks

## Test plan
- [x] Paste image in web UI → thumbnail appears
- [x] Remove image via X button
- [x] Send image + text → Claude responds with image understanding
- [x] Send text only → works as before (no regression)
- [x] Large images don't cause stack overflow
- [x] Mobile app compatibility maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)