### PR TITLE
feat: auto-exit CLI on session archive

### DIFF
--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -197,6 +197,12 @@ export class ApiSessionClient extends EventEmitter {
                     if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
                         this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
                         this.metadataVersion = data.body.metadata.version;
+                        // Check if session was archived from web/mobile
+                        const meta = this.metadata as any;
+                        if (meta?.lifecycleState === 'archiveRequested' || meta?.lifecycleState === 'archived') {
+                            logger.debug(`[SOCKET] Session archived (${meta.lifecycleState}), exiting...`);
+                            this.emit('archived');
+                        }
                     }
                     if (data.body.agentState && data.body.agentState.version > this.agentStateVersion) {
                         this.agentState = data.body.agentState.value ? decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.agentState.value)) : null;

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -263,6 +263,12 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     let currentAppendSystemPrompt: string | undefined = undefined; // Track current append system prompt
     let currentAllowedTools: string[] | undefined = undefined; // Track current allowed tools
     let currentDisallowedTools: string[] | undefined = undefined; // Track current disallowed tools
+    // Exit when session is archived from web/mobile
+    session.on('archived', () => {
+        logger.debug('[loop] Session archived from web/mobile, cleaning up...');
+        cleanup();
+    });
+
     session.onUserMessage((message) => {
 
         // Resolve permission mode from meta - pass through as-is, mapping happens at SDK boundary


### PR DESCRIPTION
## Summary
- When a session is archived from web or mobile, the CLI process now detects the `lifecycleState` change and automatically exits
- Listens for metadata updates in `apiSession.ts` — emits `archived` event when `archiveRequested` or `archived` state is detected
- `runClaude.ts` listens for `archived` event and calls `cleanup()` to gracefully terminate

## Problem
Previously, archiving a session from web/mobile left the CLI process running as a zombie. These accumulated over time and could cause resource exhaustion (TCP connections, memory, even kernel panics from network interface ref count overflow).

## Test plan
- [x] Archive session from web UI → CLI process exits
- [x] Normal session usage unaffected
- [x] Only applies to sessions started after the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)