### PR TITLE
feat: image message TTL and inline display

### DIFF
--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { View, Text } from "react-native";
+import { View, Text, Image as RNImage, Pressable, Modal, Platform } from "react-native";
 import { StyleSheet } from 'react-native-unistyles';
 import { MarkdownView } from "./markdown/MarkdownView";
 import { t } from '@/text';
@@ -8,7 +8,7 @@ import { Metadata } from "@/sync/storageTypes";
 import { layout } from "./layout";
 import { ToolView } from "./tools/ToolView";
 import { AgentEvent } from "@/sync/typesRaw";
-import { sync } from '@/sync/sync';
+import { sync, messageImageStore } from '@/sync/sync';
 import { Option } from './markdown/MarkdownView';
 
 
@@ -73,14 +73,39 @@ function UserTextBlock(props: {
     sync.sendMessage(props.sessionId, option.title, { source: 'option' });
   }, [props.sessionId]);
 
+  // Get images from ephemeral store (keyed by localId)
+  const images = props.message.images || (props.message.localId ? messageImageStore.get(props.message.localId) : undefined);
+  const [expandedImage, setExpandedImage] = React.useState<string | null>(null);
+
   return (
     <View style={styles.userMessageContainer}>
       <View style={styles.userMessageBubble}>
+        {images && images.length > 0 && (
+          <View style={styles.messageImagesContainer}>
+            {images.map((img, index) => (
+              <Pressable key={index} onPress={() => setExpandedImage(`data:${img.mediaType};base64,${img.base64}`)}>
+                <RNImage
+                  source={{ uri: `data:${img.mediaType};base64,${img.base64}` }}
+                  style={{ width: 120, height: 120, borderRadius: 8 }}
+                />
+              </Pressable>
+            ))}
+          </View>
+        )}
         <MarkdownView markdown={props.message.displayText || props.message.text} onOptionPress={handleOptionPress} sessionId={props.sessionId} />
-        {/* {__DEV__ && (
-          <Text style={styles.debugText}>{JSON.stringify(props.message.meta)}</Text>
-        )} */}
       </View>
+      {Platform.OS === 'web' && expandedImage && (
+        <Pressable
+          style={styles.imageOverlay}
+          onPress={() => setExpandedImage(null)}
+        >
+          <RNImage
+            source={{ uri: expandedImage }}
+            style={styles.expandedImage}
+            resizeMode="contain"
+          />
+        </Pressable>
+      )}
     </View>
   );
 }
@@ -221,5 +246,26 @@ const styles = StyleSheet.create((theme) => ({
   debugText: {
     color: theme.colors.agentEventText,
     fontSize: 12,
+  },
+  messageImagesContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  imageOverlay: {
+    position: 'fixed' as any,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.85)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 9999,
+  },
+  expandedImage: {
+    width: '90%',
+    height: '90%',
   },
 }));

--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -73,8 +73,10 @@ function UserTextBlock(props: {
     sync.sendMessage(props.sessionId, option.title, { source: 'option' });
   }, [props.sessionId]);
 
-  // Get images from ephemeral store (keyed by localId)
-  const images = props.message.images || (props.message.localId ? messageImageStore.get(props.message.localId) : undefined);
+  // Get images from ephemeral store (keyed by localId or id)
+  const images = props.message.images
+    || (props.message.localId ? messageImageStore.get(props.message.localId) : undefined)
+    || messageImageStore.get(props.message.id);
   const [expandedImage, setExpandedImage] = React.useState<string | null>(null);
 
   return (

--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -1160,7 +1160,7 @@ function convertReducerMessageToMessage(reducerMsg: ReducerMessage, state: Reduc
     if (reducerMsg.role === 'user' && reducerMsg.text !== null) {
         return {
             id: reducerMsg.id,
-            localId: null,
+            localId: reducerMsg.realID,
             createdAt: reducerMsg.createdAt,
             kind: 'user-text',
             text: reducerMsg.text,

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -541,6 +541,11 @@ class Sync {
         };
         const encryptedRawRecord = await encryption.encryptRawRecord(content);
 
+        // Store images for UI display (keyed by message localId)
+        if (images && images.length > 0) {
+            messageImageStore.set(localId, images);
+        }
+
         // Add to messages - normalize the raw record (show text message in UI)
         const createdAt = Date.now();
         const normalizedMessage = normalizeRawMessage(localId, localId, createdAt, content);
@@ -2316,6 +2321,9 @@ class Sync {
 
 // Global singleton instance
 export const sync = new Sync();
+
+// Ephemeral store for message images (keyed by message localId, used for UI rendering)
+export const messageImageStore = new Map<string, Array<{ base64: string; mediaType: string }>>();
 
 //
 // Init sequence

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -69,6 +69,7 @@ type V3PostSessionMessagesResponse = {
 type OutboxMessage = {
     localId: string;
     content: string;
+    expiresIn?: number;
 };
 
 type SendMessageOptions = {
@@ -495,12 +496,39 @@ class Sync {
 
         const fallbackModel: string | null = null;
 
+        let pending = this.pendingOutbox.get(sessionId);
+        if (!pending) {
+            pending = [];
+            this.pendingOutbox.set(sessionId, pending);
+        }
+
+        // Send images as separate ephemeral message with TTL (deleted from server after 5 min)
+        const groupId = images && images.length > 0 ? randomUUID() : undefined;
+        if (images && images.length > 0 && groupId) {
+            const imageContent: RawRecord = {
+                role: 'user',
+                content: {
+                    type: 'images',
+                    groupId,
+                    images,
+                },
+                meta: { sentFrom }
+            };
+            const encryptedImageRecord = await encryption.encryptRawRecord(imageContent);
+            pending.push({
+                localId: randomUUID(),
+                content: encryptedImageRecord,
+                expiresIn: 300
+            });
+        }
+
         // Create user message content with metadata
         const content: RawRecord = {
             role: 'user',
             content: {
                 type: 'text',
-                text
+                text,
+                ...(groupId && { imageGroupId: groupId }),
             },
             meta: {
                 sentFrom,
@@ -513,18 +541,13 @@ class Sync {
         };
         const encryptedRawRecord = await encryption.encryptRawRecord(content);
 
-        // Add to messages - normalize the raw record
+        // Add to messages - normalize the raw record (show text message in UI)
         const createdAt = Date.now();
         const normalizedMessage = normalizeRawMessage(localId, localId, createdAt, content);
         if (normalizedMessage) {
             this.enqueueMessages(sessionId, [normalizedMessage]);
         }
 
-        let pending = this.pendingOutbox.get(sessionId);
-        if (!pending) {
-            pending = [];
-            this.pendingOutbox.set(sessionId, pending);
-        }
         pending.push({
             localId,
             content: encryptedRawRecord
@@ -1590,7 +1613,8 @@ class Sync {
                 body: JSON.stringify({
                     messages: batch.map((message) => ({
                         localId: message.localId,
-                        content: message.content
+                        content: message.content,
+                        ...(message.expiresIn && { expiresIn: message.expiresIn })
                     }))
                 }),
                 headers: {

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -518,7 +518,7 @@ class Sync {
             pending.push({
                 localId: randomUUID(),
                 content: encryptedImageRecord,
-                expiresIn: 300
+                expiresIn: 259200
             });
         }
 

--- a/packages/happy-app/sources/sync/typesMessage.ts
+++ b/packages/happy-app/sources/sync/typesMessage.ts
@@ -29,6 +29,7 @@ export type UserTextMessage = {
     createdAt: number;
     text: string;
     displayText?: string; // Optional text to display in UI instead of actual text
+    images?: Array<{ base64: string; mediaType: string }>;
     meta?: MessageMeta;
 }
 

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -259,7 +259,28 @@ export class ApiSessionClient extends EventEmitter {
         };
     }
 
+    private imageBuffer = new Map<string, Array<{ base64: string; mediaType: string }>>();
+
     private routeIncomingMessage(message: unknown) {
+        const msg = message as any;
+
+        // Buffer ephemeral image messages (sent separately with TTL)
+        if (msg?.role === 'user' && msg?.content?.type === 'images' && msg?.content?.groupId) {
+            this.imageBuffer.set(msg.content.groupId, msg.content.images);
+            setTimeout(() => this.imageBuffer.delete(msg.content.groupId), 60000);
+            return;
+        }
+
+        // Attach buffered images to matching text message
+        if (msg?.role === 'user' && msg?.content?.type === 'text' && msg?.content?.imageGroupId) {
+            const images = this.imageBuffer.get(msg.content.imageGroupId);
+            if (images) {
+                msg.content.images = images;
+                this.imageBuffer.delete(msg.content.imageGroupId);
+            }
+            delete msg.content.imageGroupId;
+        }
+
         const userResult = UserMessageSchema.safeParse(message);
         if (userResult.success) {
             if (this.pendingMessageCallback) {

--- a/packages/happy-server/prisma/schema.prisma
+++ b/packages/happy-server/prisma/schema.prisma
@@ -115,18 +115,20 @@ model Session {
 }
 
 model SessionMessage {
-    id        String   @id @default(cuid())
+    id        String    @id @default(cuid())
     sessionId String
-    session   Session  @relation(fields: [sessionId], references: [id])
+    session   Session   @relation(fields: [sessionId], references: [id])
     localId   String?
     seq       Int
     /// [SessionMessageContent]
     content   Json
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
+    expiresAt DateTime?
+    createdAt DateTime  @default(now())
+    updatedAt DateTime  @updatedAt
 
     @@unique([sessionId, localId])
     @@index([sessionId, seq])
+    @@index([expiresAt])
 }
 
 //

--- a/packages/happy-server/sources/app/api/routes/v3SessionRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/v3SessionRoutes.ts
@@ -13,7 +13,8 @@ const getMessagesQuerySchema = z.object({
 const sendMessagesBodySchema = z.object({
     messages: z.array(z.object({
         content: z.string(),
-        localId: z.string().min(1)
+        localId: z.string().min(1),
+        expiresIn: z.number().int().min(1).optional()
     })).min(1).max(100)
 });
 
@@ -124,7 +125,7 @@ export function v3SessionRoutes(app: Fastify) {
             return reply.code(404).send({ error: 'Session not found' });
         }
 
-        const firstMessageByLocalId = new Map<string, { localId: string; content: string }>();
+        const firstMessageByLocalId = new Map<string, { localId: string; content: string; expiresIn?: number }>();
         for (const message of messages) {
             if (!firstMessageByLocalId.has(message.localId)) {
                 firstMessageByLocalId.set(message.localId, message);
@@ -163,6 +164,9 @@ export function v3SessionRoutes(app: Fastify) {
             const createdMessages: Omit<SelectedMessage, 'content'>[] = [];
             for (let i = 0; i < newMessages.length; i += 1) {
                 const message = newMessages[i];
+                const expiresAt = message.expiresIn
+                    ? new Date(Date.now() + message.expiresIn * 1000)
+                    : undefined;
                 const createdMessage = await tx.sessionMessage.create({
                     data: {
                         sessionId,
@@ -171,7 +175,8 @@ export function v3SessionRoutes(app: Fastify) {
                             t: 'encrypted',
                             c: message.content
                         },
-                        localId: message.localId
+                        localId: message.localId,
+                        expiresAt
                     },
                     select: {
                         id: true,

--- a/packages/happy-server/sources/main.ts
+++ b/packages/happy-server/sources/main.ts
@@ -42,6 +42,22 @@ async function main() {
     startDatabaseMetricsUpdater();
     startTimeout();
 
+    // TTL cleanup: delete expired messages every 5 minutes
+    const ttlCleanup = async () => {
+        try {
+            const result = await db.sessionMessage.deleteMany({
+                where: { expiresAt: { lt: new Date() } }
+            });
+            if (result.count > 0) {
+                log({ module: 'ttl-cleanup' }, `Deleted ${result.count} expired messages`);
+            }
+        } catch (error) {
+            log({ module: 'ttl-cleanup', level: 'error' }, `TTL cleanup failed: ${error}`);
+        }
+    };
+    ttlCleanup();
+    setInterval(ttlCleanup, 5 * 60 * 1000);
+
     //
     // Ready
     //


### PR DESCRIPTION
## Summary
- **Image TTL**: Images are sent as separate encrypted messages with `expiresIn` (outside encryption). Server stores `expiresAt` and auto-deletes expired messages every 5 minutes. Default TTL is 3 days.
- **Server**: `expiresAt` nullable field on `SessionMessage`, index for efficient cleanup, v3 POST accepts `expiresIn` per message
- **Web**: `sendMessage()` splits images into separate ephemeral messages with `groupId` (inside encryption) linking to text message
- **CLI**: `routeIncomingMessage()` buffers image messages by `groupId`, attaches to matching text message
- **Inline display**: Image thumbnails (120x120) shown in user message bubbles, click to expand full-size with dark overlay

## How it works
1. Web sends image as separate message: `{role: 'user', content: {type: 'images', groupId, images}}` with `expiresIn: 259200` (3 days)
2. Text message includes `imageGroupId` inside encrypted payload
3. Server sees `expiresIn` → sets `expiresAt` → cleanup job deletes after TTL
4. CLI buffers image message by `groupId` → when text arrives, merges images → sends to Claude
5. Server can't read content (E2E encrypted) but can act on TTL metadata

## Test plan
- [x] Send image from web → CLI receives and passes to Claude
- [x] Image thumbnails display in chat bubbles
- [x] Click thumbnail → full-size overlay
- [x] Server auto-deletes image messages after TTL
- [x] Mobile app ignores unknown message types gracefully
- [x] Text-only messages work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)