### PR TITLE
fix: add windowsHide to all spawn/execSync calls to prevent console popups on Windows

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -292,6 +292,7 @@ export async function claudeLocal(opts: {
                         cwd: opts.path,
                         env,
                         shell: spawnWithShell,
+                        windowsHide: true,
                     },
                 );
 

--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -349,7 +349,8 @@ export function query(config: {
         signal: config.options?.abort,
         env: spawnEnv,
         // Use shell on Windows for global binaries and command-only mode
-        shell: !isJsFile && process.platform === 'win32'
+        shell: !isJsFile && process.platform === 'win32',
+        windowsHide: true,
     }) as ChildProcessWithoutNullStreams
 
     // Handle stdin

--- a/packages/happy-cli/src/claude/sdk/utils.ts
+++ b/packages/happy-cli/src/claude/sdk/utils.ts
@@ -24,11 +24,12 @@ const __dirname = join(__filename, '..')
 function getGlobalClaudeVersion(): string | null {
     try {
         const cleanEnv = getCleanEnv()
-        const output = execSync('claude --version', { 
-            encoding: 'utf8', 
+        const output = execSync('claude --version', {
+            encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
             cwd: homedir(),
-            env: cleanEnv
+            env: cleanEnv,
+            windowsHide: true,
         }).trim()
         // Output format: "2.0.54 (Claude Code)" or similar
         const match = output.match(/(\d+\.\d+\.\d+)/)
@@ -92,11 +93,12 @@ function findGlobalClaudePath(): string | null {
     
     // PRIMARY: Check if 'claude' command works directly from home dir with clean PATH
     try {
-        execSync('claude --version', { 
-            encoding: 'utf8', 
+        execSync('claude --version', {
+            encoding: 'utf8',
             stdio: ['pipe', 'pipe', 'pipe'],
             cwd: homeDir,
-            env: cleanEnv
+            env: cleanEnv,
+            windowsHide: true,
         })
         logger.debug('[Claude SDK] Global claude command available (checked with clean PATH)')
         return 'claude'
@@ -107,11 +109,12 @@ function findGlobalClaudePath(): string | null {
     // FALLBACK for Unix: try which to get actual path
     if (process.platform !== 'win32') {
         try {
-            const result = execSync('which claude', { 
-                encoding: 'utf8', 
+            const result = execSync('which claude', {
+                encoding: 'utf8',
                 stdio: ['pipe', 'pipe', 'pipe'],
                 cwd: homeDir,
-                env: cleanEnv
+                env: cleanEnv,
+                windowsHide: true,
             }).trim()
             if (result && existsSync(result)) {
                 logger.debug(`[Claude SDK] Found global claude path via which: ${result}`)

--- a/packages/happy-cli/src/claude/utils/sdkToLogConverter.ts
+++ b/packages/happy-cli/src/claude/utils/sdkToLogConverter.ts
@@ -33,7 +33,8 @@ function getGitBranch(cwd: string): string | undefined {
         const branch = execSync('git rev-parse --abbrev-ref HEAD', {
             cwd,
             encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'ignore']
+            stdio: ['ignore', 'pipe', 'ignore'],
+            windowsHide: true,
         }).trim()
         return branch || undefined
     } catch {

--- a/packages/happy-cli/src/codex/codexAppServerClient.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.ts
@@ -58,7 +58,7 @@ export type ApprovalHandler = (params: {
  */
 function isAppServerAvailable(): boolean {
     try {
-        const version = execSync('codex --version', { encoding: 'utf8' }).trim();
+        const version = execSync('codex --version', { encoding: 'utf8', windowsHide: true }).trim();
         const match = version.match(/codex-cli\s+(\d+\.\d+\.\d+)/);
         if (!match) return false;
         const [, ver] = match;
@@ -422,6 +422,7 @@ export class CodexAppServerClient {
         const proc = spawn(command, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
             env,
+            windowsHide: true,
         });
         this.process = proc;
 

--- a/packages/happy-cli/src/gemini/utils/config.ts
+++ b/packages/happy-cli/src/gemini/utils/config.ts
@@ -89,10 +89,11 @@ export function readGeminiLocalConfig(): GeminiLocalConfig {
   // Gemini CLI might use gcloud auth application-default print-access-token
   if (!token) {
     try {
-      const gcloudToken = execSync('gcloud auth application-default print-access-token', { 
+      const gcloudToken = execSync('gcloud auth application-default print-access-token', {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'ignore'],
-        timeout: 5000
+        timeout: 5000,
+        windowsHide: true,
       }).trim();
       if (gcloudToken && gcloudToken.length > 0) {
         token = gcloudToken;

--- a/packages/happy-cli/src/modules/difftastic/index.ts
+++ b/packages/happy-cli/src/modules/difftastic/index.ts
@@ -39,6 +39,7 @@ export function run(args: string[], options?: DifftasticOptions): Promise<Diffta
         const child = spawn(binaryPath, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
             cwd: options?.cwd,
+            windowsHide: true,
             env: {
                 ...process.env,
                 // Force color output when needed

--- a/packages/happy-cli/src/modules/ripgrep/index.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.ts
@@ -27,7 +27,8 @@ export function run(args: string[], options?: RipgrepOptions): Promise<RipgrepRe
     return new Promise((resolve, reject) => {
         const child = spawn('node', [RUNNER_PATH, JSON.stringify(args)], {
             stdio: ['pipe', 'pipe', 'pipe'],
-            cwd: options?.cwd
+            cwd: options?.cwd,
+            windowsHide: true,
         });
 
         let stdout = '';

--- a/packages/happy-cli/src/utils/detectCLI.ts
+++ b/packages/happy-cli/src/utils/detectCLI.ts
@@ -50,7 +50,7 @@ function detectPosix(): CLIAvailability {
 function detectWindows(): CLIAvailability {
   const checkCommand = (name: string): boolean => {
     try {
-      execSync(`powershell -NoProfile -Command "Get-Command ${name} -ErrorAction SilentlyContinue"`, { stdio: 'ignore' });
+      execSync(`powershell -NoProfile -Command "Get-Command ${name} -ErrorAction SilentlyContinue"`, { stdio: 'ignore', windowsHide: true });
       return true;
     } catch {
       return false;

--- a/packages/happy-cli/src/utils/spawnHappyCLI.ts
+++ b/packages/happy-cli/src/utils/spawnHappyCLI.ts
@@ -101,5 +101,8 @@ export function spawnHappyCLI(args: string[], options: SpawnOptions = {}): Child
   }
   
   const runtime = isBun() ? 'bun' : 'node';
-  return spawn(runtime, nodeArgs, options);
+  return spawn(runtime, nodeArgs, {
+    windowsHide: true,
+    ...options,
+  });
 }

--- a/packages/happy-cli/src/utils/tmux.ts
+++ b/packages/happy-cli/src/utils/tmux.ts
@@ -486,6 +486,7 @@ export class TmuxUtilities {
                 stdio: ['ignore', 'pipe', 'pipe'],
                 timeout: 5000,
                 shell: false,
+                windowsHide: true,
                 ...options
             });
 


### PR DESCRIPTION
## Summary

- Add `windowsHide: true` to all `spawn()` and `execSync()` call sites in happy-cli
- Prevents persistent black cmd window popups when the CLI invokes subprocesses (claude, ripgrep, difftastic, tmux, etc.)
- This option is ignored on non-Windows platforms, so no impact to macOS/Linux

## Problem

On Windows, `child_process.spawn()` and `execSync()` open a visible console window by default. This causes repeated black cmd popups flashing on screen whenever the CLI runs background processes, which is a poor user experience.

## Changes

11 files updated across these areas:
- `claude/claudeLocal.ts` — claude process spawning
- `claude/sdk/query.ts` — SDK query execution
- `claude/sdk/utils.ts` — SDK utility exec calls
- `claude/utils/sdkToLogConverter.ts` — log converter exec
- `codex/codexAppServerClient.ts` — codex server spawning
- `gemini/utils/config.ts` — gemini config detection
- `modules/difftastic/index.ts` — difftastic spawning
- `modules/ripgrep/index.ts` — ripgrep spawning
- `utils/detectCLI.ts` — CLI detection exec
- `utils/spawnHappyCLI.ts` — CLI spawning utility
- `utils/tmux.ts` — tmux spawning

## Test plan

- [x] Verified on Windows 11: no more console popups when running happy-cli
- [x] `windowsHide` is a no-op on macOS/Linux, no regressions expected