### PR TITLE
fix: resolve Windows npm shim scripts in findClaudeInPath

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -74,6 +74,20 @@ function findClaudeInPath() {
         const resolvedPath = resolvePathSafe(claudePath) || claudePath;
 
         if (resolvedPath) {
+            // On Windows, npm creates shell script shims (no extension) for global packages.
+            // These cannot be spawned directly by Node.js. When we find such a shim,
+            // resolve to the actual cli.js in the adjacent node_modules directory.
+            const isExecutable = resolvedPath.endsWith('.js') || resolvedPath.endsWith('.cjs') || resolvedPath.endsWith('.exe');
+            if (!isExecutable) {
+                const shimDir = path.dirname(claudePath);
+                const cliJsPath = path.join(shimDir, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+                if (fs.existsSync(cliJsPath)) {
+                    return { path: cliJsPath, source: 'npm' };
+                }
+                // Shim found but no cli.js next to it — skip and let other finders handle it
+                return null;
+            }
+
             // Detect source from BOTH original PATH entry and resolved path
             // Original path tells us HOW user accessed it (context)
             // Resolved path tells us WHERE it actually lives (content)


### PR DESCRIPTION
## Summary

- Fix `findClaudeInPath()` failing to spawn Claude on Windows when installed via npm global

## Problem

On Windows + nvm, `where claude` returns a shell script shim (no file extension) created by npm for global packages. Node.js cannot spawn these shims directly, causing Claude detection to fail silently.

## Solution

When the resolved path is not a recognized executable (`.js`, `.cjs`, `.exe`), treat it as an npm shim and look for the actual entry point at `node_modules/@anthropic-ai/claude-code/cli.js` adjacent to the shim. Falls back gracefully if not found.

## Test plan

- [x] Verified on Windows 11 + nvm: Claude is correctly detected and spawned
- [x] No impact on macOS/Linux where shims are not an issue