### PR TITLE
fix(happy-cli,happy-server): avoid false vendor token timeouts during connect

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -86,6 +86,10 @@ Auth flows:
 - `POST /v1/connect/github/webhook`
 - `DELETE /v1/connect/github`
 - `POST /v1/connect/:vendor/register` (`vendor` in `openai | anthropic | gemini`)
+  - Returns `202 Accepted` for long-running registration work with `{ taskId, state, stage, pollAfterMs, heartbeatAt, updatedAt }`
+  - Clients should poll task status until `state` becomes `succeeded` or `failed`
+- `GET /v1/tasks/:taskId`
+  - Returns current long-task status `{ taskId, state, stage, pollAfterMs, heartbeatAt, updatedAt, error? }`
 - `GET /v1/connect/:vendor/token`
 - `DELETE /v1/connect/:vendor`
 - `GET /v1/connect/tokens`

--- a/packages/happy-app/sources/sync/apiServices.spec.ts
+++ b/packages/happy-app/sources/sync/apiServices.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { connectService } from './apiServices';
+import { AuthCredentials } from '@/auth/tokenStorage';
+
+vi.mock('./serverConfig', () => ({
+    getServerUrl: () => 'https://api.test.com'
+}));
+
+vi.mock('@/utils/time', () => ({
+    backoff: vi.fn((fn) => fn())
+}));
+
+describe('apiServices', () => {
+    const mockCredentials: AuthCredentials = {
+        token: 'test-token',
+        secret: 'test-secret'
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('supports the legacy immediate success response', async () => {
+        global.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: vi.fn().mockResolvedValue({ success: true })
+        });
+
+        await expect(connectService(mockCredentials, 'openai', { oauth: true })).resolves.toBeUndefined();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits for the long-task response to complete', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 202,
+                json: vi.fn().mockResolvedValue({
+                    taskId: 'task-1',
+                    state: 'accepted',
+                    stage: 'accepted',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.000Z',
+                    updatedAt: '2026-01-01T00:00:00.000Z'
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: vi.fn().mockResolvedValue({
+                    taskId: 'task-1',
+                    state: 'succeeded',
+                    stage: 'succeeded',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.100Z',
+                    updatedAt: '2026-01-01T00:00:00.100Z'
+                })
+            });
+
+        await expect(connectService(mockCredentials, 'anthropic', { oauth: true })).resolves.toBeUndefined();
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(global.fetch).toHaveBeenNthCalledWith(
+            2,
+            'https://api.test.com/v1/tasks/task-1',
+            {
+                method: 'GET',
+                headers: {
+                    'Authorization': 'Bearer test-token',
+                    'Content-Type': 'application/json'
+                }
+            }
+        );
+    });
+
+    it('surfaces a clearer error when the long-task record is lost', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 202,
+                json: vi.fn().mockResolvedValue({
+                    taskId: 'task-2',
+                    state: 'accepted',
+                    stage: 'accepted',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.000Z',
+                    updatedAt: '2026-01-01T00:00:00.000Z'
+                })
+            })
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                json: vi.fn()
+            });
+
+        await expect(connectService(mockCredentials, 'gemini', { oauth: true }))
+            .rejects.toThrow('Service connection task was lost before completion. Please retry.');
+    });
+});

--- a/packages/happy-app/sources/sync/apiServices.ts
+++ b/packages/happy-app/sources/sync/apiServices.ts
@@ -2,6 +2,57 @@ import { AuthCredentials } from '@/auth/tokenStorage';
 import { backoff } from '@/utils/time';
 import { getServerUrl } from './serverConfig';
 
+type RegisterSuccessResponse = { success: true };
+
+type RegisterTaskResponse = {
+    taskId: string;
+    state: 'accepted' | 'running' | 'succeeded' | 'failed';
+    stage: string;
+    pollAfterMs: number;
+    heartbeatAt: string;
+    updatedAt: string;
+    error?: string;
+};
+
+function isRegisterTaskResponse(data: unknown): data is RegisterTaskResponse {
+    return Boolean(
+        data &&
+        typeof data === 'object' &&
+        'taskId' in data &&
+        typeof (data as RegisterTaskResponse).taskId === 'string'
+    );
+}
+
+async function waitForRegisterTask(credentials: AuthCredentials, initialTask: RegisterTaskResponse, apiEndpoint: string): Promise<void> {
+    while (true) {
+        const response = await fetch(`${apiEndpoint}/v1/tasks/${initialTask.taskId}`, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${credentials.token}`,
+                'Content-Type': 'application/json'
+            }
+        });
+
+        if (response.status === 404) {
+            throw new Error('Service connection task was lost before completion. Please retry.');
+        }
+
+        if (!response.ok) {
+            throw new Error(`Failed to poll service connection task: ${response.status}`);
+        }
+
+        const status = await response.json() as RegisterTaskResponse;
+        if (status.state === 'succeeded') {
+            return;
+        }
+        if (status.state === 'failed') {
+            throw new Error(status.error || 'Failed to connect service account');
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, status.pollAfterMs || 500));
+    }
+}
+
 /**
  * Connect a service to the user's account
  */
@@ -26,7 +77,12 @@ export async function connectService(
             throw new Error(`Failed to connect ${service}: ${response.status}`);
         }
 
-        const data = await response.json() as { success: true };
+        const data = await response.json() as RegisterSuccessResponse | RegisterTaskResponse;
+        if (isRegisterTaskResponse(data)) {
+            await waitForRegisterTask(credentials, data, API_ENDPOINT);
+            return;
+        }
+
         if (!data.success) {
             throw new Error(`Failed to connect ${service} account`);
         }

--- a/packages/happy-cli/src/api/api.test.ts
+++ b/packages/happy-cli/src/api/api.test.ts
@@ -4,23 +4,45 @@ import axios from 'axios';
 import { connectionState } from '@/utils/serverConnectionErrors';
 
 // Use vi.hoisted to ensure mock functions are available when vi.mock factory runs
-const { mockPost, mockIsAxiosError } = vi.hoisted(() => ({
+const { mockPost, mockGet, mockIsAxiosError } = vi.hoisted(() => ({
     mockPost: vi.fn(),
+    mockGet: vi.fn(),
     mockIsAxiosError: vi.fn(() => true)
 }));
 
 vi.mock('axios', () => ({
     default: {
         post: mockPost,
+        get: mockGet,
         isAxiosError: mockIsAxiosError
     },
     isAxiosError: mockIsAxiosError
+}));
+
+vi.mock('chalk', () => ({
+    default: new Proxy({}, {
+        get: () => (value: string) => value
+    })
 }));
 
 vi.mock('@/ui/logger', () => ({
     logger: {
         debug: vi.fn()
     }
+}));
+
+vi.mock('./apiSession', () => ({
+    ApiSessionClient: vi.fn()
+}));
+
+vi.mock('./apiMachine', () => ({
+    ApiMachineClient: vi.fn()
+}));
+
+vi.mock('./pushNotifications', () => ({
+    PushNotificationClient: vi.fn(function PushNotificationClient() {
+        return {};
+    })
 }));
 
 // Mock encryption utilities
@@ -308,6 +330,115 @@ describe('Api server error handling', () => {
             );
 
             consoleSpy.mockRestore();
+        });
+    });
+
+    describe('registerVendorToken', () => {
+        it('waits for long-task completion while progress continues', async () => {
+            mockPost.mockResolvedValue({
+                status: 202,
+                data: {
+                    taskId: 'task-1',
+                    state: 'accepted',
+                    stage: 'accepted',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.000Z',
+                    updatedAt: '2026-01-01T00:00:00.000Z'
+                }
+            });
+            mockGet
+                .mockResolvedValueOnce({
+                    data: {
+                        taskId: 'task-1',
+                        state: 'running',
+                        stage: 'persisting',
+                        pollAfterMs: 1,
+                        heartbeatAt: '2026-01-01T00:00:00.100Z',
+                        updatedAt: '2026-01-01T00:00:00.100Z'
+                    }
+                })
+                .mockResolvedValueOnce({
+                    data: {
+                        taskId: 'task-1',
+                        state: 'succeeded',
+                        stage: 'succeeded',
+                        pollAfterMs: 1,
+                        heartbeatAt: '2026-01-01T00:00:00.200Z',
+                        updatedAt: '2026-01-01T00:00:00.200Z'
+                    }
+                });
+
+            const seenStages: string[] = [];
+            await expect(api.registerVendorToken('openai', { oauth: true }, {
+                pollIntervalMs: 1,
+                idleTimeoutMs: 50,
+                absoluteTimeoutMs: 500,
+                onProgress: (status) => seenStages.push(status.stage)
+            })).resolves.toBeUndefined();
+
+            expect(mockGet).toHaveBeenCalledTimes(2);
+            expect(seenStages).toEqual(['accepted', 'persisting', 'succeeded']);
+        });
+
+        it('fails when task stops making progress', async () => {
+            mockPost.mockResolvedValue({
+                status: 202,
+                data: {
+                    taskId: 'task-2',
+                    state: 'accepted',
+                    stage: 'accepted',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.000Z',
+                    updatedAt: '2026-01-01T00:00:00.000Z'
+                }
+            });
+            mockGet.mockResolvedValue({
+                data: {
+                    taskId: 'task-2',
+                    state: 'running',
+                    stage: 'persisting',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.000Z',
+                    updatedAt: '2026-01-01T00:00:00.000Z'
+                }
+            });
+
+            await expect(api.registerVendorToken('openai', { oauth: true }, {
+                pollIntervalMs: 1,
+                idleTimeoutMs: 10,
+                absoluteTimeoutMs: 100
+            })).rejects.toThrow('Failed to register vendor token: Vendor token registration stalled after 10ms without progress');
+        });
+
+        it('surfaces task failure errors', async () => {
+            mockPost.mockResolvedValue({
+                status: 202,
+                data: {
+                    taskId: 'task-3',
+                    state: 'accepted',
+                    stage: 'accepted',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.000Z',
+                    updatedAt: '2026-01-01T00:00:00.000Z'
+                }
+            });
+            mockGet.mockResolvedValue({
+                data: {
+                    taskId: 'task-3',
+                    state: 'failed',
+                    stage: 'failed',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.100Z',
+                    updatedAt: '2026-01-01T00:00:00.100Z',
+                    error: 'database unavailable'
+                }
+            });
+
+            await expect(api.registerVendorToken('openai', { oauth: true }, {
+                pollIntervalMs: 1,
+                idleTimeoutMs: 50,
+                absoluteTimeoutMs: 500
+            })).rejects.toThrow('Failed to register vendor token: Vendor token registration failed: database unavailable');
         });
     });
 });

--- a/packages/happy-cli/src/api/api.test.ts
+++ b/packages/happy-cli/src/api/api.test.ts
@@ -430,7 +430,8 @@ describe('Api server error handling', () => {
                     pollAfterMs: 1,
                     heartbeatAt: '2026-01-01T00:00:00.100Z',
                     updatedAt: '2026-01-01T00:00:00.100Z',
-                    error: 'database unavailable'
+                    error: 'Vendor token registration failed. Please retry.',
+                    errorCode: 'CONNECT_REGISTER_FAILED'
                 }
             });
 
@@ -438,7 +439,34 @@ describe('Api server error handling', () => {
                 pollIntervalMs: 1,
                 idleTimeoutMs: 50,
                 absoluteTimeoutMs: 500
-            })).rejects.toThrow('Failed to register vendor token: Vendor token registration failed: database unavailable');
+            })).rejects.toThrow('Failed to register vendor token: Vendor token registration failed. Please retry.');
+        });
+
+        it('explains when the long-task record disappears mid-poll', async () => {
+            mockPost.mockResolvedValue({
+                status: 202,
+                data: {
+                    taskId: 'task-4',
+                    state: 'accepted',
+                    stage: 'accepted',
+                    pollAfterMs: 1,
+                    heartbeatAt: '2026-01-01T00:00:00.000Z',
+                    updatedAt: '2026-01-01T00:00:00.000Z'
+                }
+            });
+            mockGet.mockRejectedValue({
+                response: {
+                    status: 404
+                }
+            });
+
+            await expect(api.registerVendorToken('openai', { oauth: true }, {
+                pollIntervalMs: 1,
+                idleTimeoutMs: 50,
+                absoluteTimeoutMs: 500
+            })).rejects.toThrow(
+                'Failed to register vendor token: Vendor token registration task was lost before completion (the server may have restarted or evicted the task). Please retry registration.'
+            );
         });
     });
 });

--- a/packages/happy-cli/src/api/api.ts
+++ b/packages/happy-cli/src/api/api.ts
@@ -10,6 +10,29 @@ import chalk from 'chalk';
 import { Credentials } from '@/persistence';
 import { connectionState, isNetworkError } from '@/utils/serverConnectionErrors';
 
+type LongTaskState = 'accepted' | 'running' | 'succeeded' | 'failed';
+
+type LongTaskStatus = {
+  taskId: string;
+  state: LongTaskState;
+  stage: string;
+  pollAfterMs: number;
+  heartbeatAt: string;
+  updatedAt: string;
+  error?: string;
+};
+
+type RegisterVendorTokenOptions = {
+  onProgress?: (status: LongTaskStatus) => void;
+  pollIntervalMs?: number;
+  idleTimeoutMs?: number;
+  absoluteTimeoutMs?: number;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export class ApiClient {
 
   static async create(credential: Credentials) {
@@ -289,7 +312,7 @@ export class ApiClient {
    * Register a vendor API token with the server
    * The token is sent as a JSON string - server handles encryption
    */
-  async registerVendorToken(vendor: 'openai' | 'anthropic' | 'gemini', apiKey: any): Promise<void> {
+  async registerVendorToken(vendor: 'openai' | 'anthropic' | 'gemini', apiKey: any, options: RegisterVendorTokenOptions = {}): Promise<void> {
     try {
       const response = await axios.post(
         `${configuration.serverUrl}/v1/connect/${vendor}/register`,
@@ -301,11 +324,14 @@ export class ApiClient {
             'Authorization': `Bearer ${this.credential.token}`,
             'Content-Type': 'application/json'
           },
-          timeout: 5000
+          timeout: 10000,
+          validateStatus: (status) => (status >= 200 && status < 300) || status === 202
         }
       );
 
-      if (response.status !== 200 && response.status !== 201) {
+      if (response.status === 202) {
+        await this.waitForLongTask(response.data as LongTaskStatus, options);
+      } else if (response.status !== 200 && response.status !== 201) {
         throw new Error(`Server returned status ${response.status}`);
       }
 
@@ -313,6 +339,71 @@ export class ApiClient {
     } catch (error) {
       logger.debug(`[API] [ERROR] Failed to register vendor token:`, error);
       throw new Error(`Failed to register vendor token: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  private async waitForLongTask(initialStatus: LongTaskStatus, options: RegisterVendorTokenOptions): Promise<void> {
+    const pollIntervalMs = options.pollIntervalMs ?? 500;
+    const idleTimeoutMs = options.idleTimeoutMs ?? 15_000;
+    const absoluteTimeoutMs = options.absoluteTimeoutMs ?? 60_000;
+    const startedAt = Date.now();
+    let lastProgressAt = startedAt;
+    let lastStage = initialStatus.stage;
+    let lastHeartbeatMs = Date.parse(initialStatus.heartbeatAt);
+    let lastUpdatedMs = Date.parse(initialStatus.updatedAt);
+
+    options.onProgress?.(initialStatus);
+
+    while (true) {
+      const response = await axios.get<LongTaskStatus>(
+        `${configuration.serverUrl}/v1/tasks/${initialStatus.taskId}`,
+        {
+          headers: {
+            'Authorization': `Bearer ${this.credential.token}`,
+            'Content-Type': 'application/json'
+          },
+          timeout: 10000
+        }
+      );
+
+      const status = response.data;
+      const heartbeatMs = Date.parse(status.heartbeatAt);
+      const updatedMs = Date.parse(status.updatedAt);
+      const progressed = (
+        status.stage !== lastStage ||
+        heartbeatMs > lastHeartbeatMs ||
+        updatedMs > lastUpdatedMs
+      );
+
+      if (progressed) {
+        lastProgressAt = Date.now();
+      }
+
+      if (status.stage !== lastStage) {
+        options.onProgress?.(status);
+      }
+
+      lastStage = status.stage;
+      lastHeartbeatMs = heartbeatMs;
+      lastUpdatedMs = updatedMs;
+
+      if (status.state === 'succeeded') {
+        return;
+      }
+
+      if (status.state === 'failed') {
+        throw new Error(`Vendor token registration failed: ${status.error ?? 'Unknown task failure'}`);
+      }
+
+      const now = Date.now();
+      if (now - lastProgressAt > idleTimeoutMs) {
+        throw new Error(`Vendor token registration stalled after ${idleTimeoutMs}ms without progress`);
+      }
+      if (now - startedAt > absoluteTimeoutMs) {
+        throw new Error(`Vendor token registration exceeded ${absoluteTimeoutMs}ms overall timeout`);
+      }
+
+      await sleep(status.pollAfterMs || pollIntervalMs);
     }
   }
 

--- a/packages/happy-cli/src/api/api.ts
+++ b/packages/happy-cli/src/api/api.ts
@@ -20,6 +20,7 @@ type LongTaskStatus = {
   heartbeatAt: string;
   updatedAt: string;
   error?: string;
+  errorCode?: string;
 };
 
 type RegisterVendorTokenOptions = {
@@ -355,16 +356,26 @@ export class ApiClient {
     options.onProgress?.(initialStatus);
 
     while (true) {
-      const response = await axios.get<LongTaskStatus>(
-        `${configuration.serverUrl}/v1/tasks/${initialStatus.taskId}`,
-        {
-          headers: {
-            'Authorization': `Bearer ${this.credential.token}`,
-            'Content-Type': 'application/json'
-          },
-          timeout: 10000
+      let response: { data: LongTaskStatus };
+      try {
+        response = await axios.get<LongTaskStatus>(
+          `${configuration.serverUrl}/v1/tasks/${initialStatus.taskId}`,
+          {
+            headers: {
+              'Authorization': `Bearer ${this.credential.token}`,
+              'Content-Type': 'application/json'
+            },
+            timeout: 10000
+          }
+        );
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          throw new Error(
+            'Vendor token registration task was lost before completion (the server may have restarted or evicted the task). Please retry registration.'
+          );
         }
-      );
+        throw error;
+      }
 
       const status = response.data;
       const heartbeatMs = Date.parse(status.heartbeatAt);
@@ -392,7 +403,7 @@ export class ApiClient {
       }
 
       if (status.state === 'failed') {
-        throw new Error(`Vendor token registration failed: ${status.error ?? 'Unknown task failure'}`);
+        throw new Error(status.error ?? 'Vendor token registration failed');
       }
 
       const now = Date.now();

--- a/packages/happy-cli/src/commands/connect.test.ts
+++ b/packages/happy-cli/src/commands/connect.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    mockReadCredentials: vi.fn(),
+    mockApiCreate: vi.fn(),
+    mockAuthenticateCodex: vi.fn(),
+    mockAuthenticateClaude: vi.fn(),
+    mockAuthenticateGemini: vi.fn(),
+    mockDecodeJwtPayload: vi.fn(),
+}));
+
+vi.mock('@/persistence', () => ({
+    readCredentials: mocks.mockReadCredentials,
+}));
+
+vi.mock('@/api/api', () => ({
+    ApiClient: {
+        create: mocks.mockApiCreate,
+    },
+}));
+
+vi.mock('./connect/authenticateCodex', () => ({
+    authenticateCodex: mocks.mockAuthenticateCodex,
+}));
+
+vi.mock('./connect/authenticateClaude', () => ({
+    authenticateClaude: mocks.mockAuthenticateClaude,
+}));
+
+vi.mock('./connect/authenticateGemini', () => ({
+    authenticateGemini: mocks.mockAuthenticateGemini,
+}));
+
+vi.mock('./connect/utils', () => ({
+    decodeJwtPayload: mocks.mockDecodeJwtPayload,
+}));
+
+vi.mock('chalk', () => ({
+    default: new Proxy({}, {
+        get: () => (value: string) => value
+    })
+}));
+
+import { handleConnectCommand } from './connect';
+
+describe('handleConnectCommand', () => {
+    const registerVendorToken = vi.fn();
+    const getVendorToken = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mocks.mockReadCredentials.mockResolvedValue({
+            token: 'happy-token',
+            encryption: { type: 'legacy', secret: new Uint8Array(32) },
+        });
+        mocks.mockApiCreate.mockResolvedValue({
+            registerVendorToken,
+            getVendorToken,
+        });
+        mocks.mockAuthenticateCodex.mockResolvedValue({ access_token: 'openai-token' });
+        mocks.mockAuthenticateClaude.mockResolvedValue({ access_token: 'anthropic-token' });
+        mocks.mockAuthenticateGemini.mockResolvedValue({ access_token: 'gemini-token' });
+        mocks.mockDecodeJwtPayload.mockReturnValue(null);
+
+        vi.spyOn(process, 'exit').mockImplementation((() => {
+            throw new Error('process.exit');
+        }) as never);
+    });
+
+    it('passes an onProgress callback to registerVendorToken for codex connect', async () => {
+        registerVendorToken.mockResolvedValue(undefined);
+
+        await expect(handleConnectCommand(['codex'])).rejects.toThrow('process.exit');
+
+        expect(registerVendorToken).toHaveBeenCalledTimes(1);
+        const [vendor, payload, options] = registerVendorToken.mock.calls[0];
+        expect(vendor).toBe('openai');
+        expect(payload).toEqual({ oauth: { access_token: 'openai-token' } });
+        expect(options).toEqual(expect.objectContaining({
+            onProgress: expect.any(Function),
+        }));
+    });
+
+    it('prints unique progress stages while waiting for registration', async () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        registerVendorToken.mockImplementation(async (_vendor: string, _payload: unknown, options?: { onProgress?: (status: { stage: string }) => void }) => {
+            options?.onProgress?.({ stage: 'accepted' });
+            options?.onProgress?.({ stage: 'persisting' });
+            options?.onProgress?.({ stage: 'persisting' });
+            options?.onProgress?.({ stage: 'succeeded' });
+        });
+
+        await expect(handleConnectCommand(['codex'])).rejects.toThrow('process.exit');
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Request accepted by Happy cloud'));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Persisting encrypted token'));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Registration complete'));
+        expect(logSpy.mock.calls.filter(([message]) => String(message).includes('Persisting encrypted token'))).toHaveLength(1);
+    });
+});

--- a/packages/happy-cli/src/commands/connect.ts
+++ b/packages/happy-cli/src/commands/connect.ts
@@ -71,6 +71,7 @@ ${chalk.bold('Examples:')}
 ${chalk.bold('Notes:')} 
   • You must be authenticated with Happy first (run 'happy auth login')
   • API keys are encrypted and stored securely in Happy cloud
+  • Registration may take a moment while Happy finishes persisting your token
   • You can manage your stored keys at app.happy.engineering
 `);
 }
@@ -90,22 +91,38 @@ async function handleConnectVendor(vendor: 'codex' | 'claude' | 'gemini', displa
     const api = await ApiClient.create(credentials);
 
     // Handle vendor authentication
+    const stageLabels: Record<string, string> = {
+        accepted: 'Request accepted by Happy cloud',
+        encrypting: 'Encrypting token',
+        persisting: 'Persisting encrypted token',
+        succeeded: 'Registration complete'
+    };
+    const seenStages = new Set<string>();
+    const logRegisterProgress = (status: { stage: string }) => {
+        if (seenStages.has(status.stage)) {
+            return;
+        }
+        seenStages.add(status.stage);
+        const message = stageLabels[status.stage] ?? `Still processing (${status.stage})`;
+        console.log(chalk.gray(`  … ${message}`));
+    };
+
     if (vendor === 'codex') {
         console.log('🚀 Registering Codex token with server');
         const codexAuthTokens = await authenticateCodex();
-        await api.registerVendorToken('openai', { oauth: codexAuthTokens });
+        await api.registerVendorToken('openai', { oauth: codexAuthTokens }, { onProgress: logRegisterProgress });
         console.log('✅ Codex token registered with server');
         process.exit(0);
     } else if (vendor === 'claude') {
         console.log('🚀 Registering Anthropic token with server');
         const anthropicAuthTokens = await authenticateClaude();
-        await api.registerVendorToken('anthropic', { oauth: anthropicAuthTokens });
+        await api.registerVendorToken('anthropic', { oauth: anthropicAuthTokens }, { onProgress: logRegisterProgress });
         console.log('✅ Anthropic token registered with server');
         process.exit(0);
     } else if (vendor === 'gemini') {
         console.log('🚀 Registering Gemini token with server');
         const geminiAuthTokens = await authenticateGemini();
-        await api.registerVendorToken('gemini', { oauth: geminiAuthTokens });
+        await api.registerVendorToken('gemini', { oauth: geminiAuthTokens }, { onProgress: logRegisterProgress });
         console.log('✅ Gemini token registered with server');
         
         // Also update local Gemini config to keep tokens in sync

--- a/packages/happy-server/sources/app/api/longTaskStore.ts
+++ b/packages/happy-server/sources/app/api/longTaskStore.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from "crypto";
+
+export type LongTaskState = "accepted" | "running" | "succeeded" | "failed";
+
+export interface LongTaskRecord<Result = undefined> {
+    id: string;
+    ownerId: string;
+    kind: string;
+    state: LongTaskState;
+    stage: string;
+    createdAt: string;
+    updatedAt: string;
+    heartbeatAt: string;
+    pollAfterMs: number;
+    error?: string;
+    result?: Result;
+}
+
+type CreateLongTaskInput = {
+    ownerId: string;
+    kind: string;
+    stage?: string;
+    pollAfterMs?: number;
+};
+
+type UpdateLongTaskInput<Result = undefined> = {
+    state?: LongTaskState;
+    stage?: string;
+    pollAfterMs?: number;
+    error?: string;
+    result?: Result;
+    heartbeat?: boolean;
+};
+
+const DEFAULT_POLL_AFTER_MS = 500;
+const TERMINAL_TTL_MS = 10 * 60 * 1000;
+const tasks = new Map<string, LongTaskRecord>();
+
+function nowIso(): string {
+    return new Date().toISOString();
+}
+
+function pruneExpiredTasks(now = Date.now()) {
+    for (const [taskId, task] of tasks.entries()) {
+        if ((task.state === "succeeded" || task.state === "failed") && now - Date.parse(task.updatedAt) > TERMINAL_TTL_MS) {
+            tasks.delete(taskId);
+        }
+    }
+}
+
+export function createLongTask(input: CreateLongTaskInput): LongTaskRecord {
+    pruneExpiredTasks();
+    const now = nowIso();
+    const task: LongTaskRecord = {
+        id: randomUUID(),
+        ownerId: input.ownerId,
+        kind: input.kind,
+        state: "accepted",
+        stage: input.stage ?? "accepted",
+        createdAt: now,
+        updatedAt: now,
+        heartbeatAt: now,
+        pollAfterMs: input.pollAfterMs ?? DEFAULT_POLL_AFTER_MS
+    };
+    tasks.set(task.id, task);
+    return { ...task };
+}
+
+export function getLongTask(taskId: string, ownerId: string): LongTaskRecord | null {
+    pruneExpiredTasks();
+    const task = tasks.get(taskId);
+    if (!task || task.ownerId !== ownerId) {
+        return null;
+    }
+    return { ...task };
+}
+
+export function updateLongTask<Result = undefined>(taskId: string, ownerId: string, update: UpdateLongTaskInput<Result>): LongTaskRecord | null {
+    const task = tasks.get(taskId);
+    if (!task || task.ownerId !== ownerId) {
+        return null;
+    }
+
+    const now = nowIso();
+    if (update.state) {
+        task.state = update.state;
+    }
+    if (update.stage) {
+        task.stage = update.stage;
+    }
+    if (typeof update.pollAfterMs === "number") {
+        task.pollAfterMs = update.pollAfterMs;
+    }
+    if (Object.prototype.hasOwnProperty.call(update, "error")) {
+        task.error = update.error;
+    }
+    if (Object.prototype.hasOwnProperty.call(update, "result")) {
+        task.result = update.result;
+    }
+    task.updatedAt = now;
+    if (update.heartbeat || update.stage || update.state) {
+        task.heartbeatAt = now;
+    }
+
+    return { ...task };
+}
+
+export async function withLongTaskHeartbeat<T>(
+    taskId: string,
+    ownerId: string,
+    callback: () => Promise<T>,
+    intervalMs = 1000
+): Promise<T> {
+    const interval = setInterval(() => {
+        updateLongTask(taskId, ownerId, { heartbeat: true });
+    }, intervalMs);
+
+    try {
+        return await callback();
+    } finally {
+        clearInterval(interval);
+        updateLongTask(taskId, ownerId, { heartbeat: true });
+    }
+}
+
+export function __resetLongTaskStoreForTests() {
+    tasks.clear();
+}

--- a/packages/happy-server/sources/app/api/longTaskStore.ts
+++ b/packages/happy-server/sources/app/api/longTaskStore.ts
@@ -13,6 +13,7 @@ export interface LongTaskRecord<Result = undefined> {
     heartbeatAt: string;
     pollAfterMs: number;
     error?: string;
+    errorCode?: string;
     result?: Result;
 }
 
@@ -28,13 +29,14 @@ type UpdateLongTaskInput<Result = undefined> = {
     stage?: string;
     pollAfterMs?: number;
     error?: string;
+    errorCode?: string;
     result?: Result;
     heartbeat?: boolean;
 };
 
 const DEFAULT_POLL_AFTER_MS = 500;
 const TERMINAL_TTL_MS = 10 * 60 * 1000;
-const tasks = new Map<string, LongTaskRecord>();
+const tasks = new Map<string, LongTaskRecord<any>>();
 
 function nowIso(): string {
     return new Date().toISOString();
@@ -93,6 +95,9 @@ export function updateLongTask<Result = undefined>(taskId: string, ownerId: stri
     }
     if (Object.prototype.hasOwnProperty.call(update, "error")) {
         task.error = update.error;
+    }
+    if (Object.prototype.hasOwnProperty.call(update, "errorCode")) {
+        task.errorCode = update.errorCode;
     }
     if (Object.prototype.hasOwnProperty.call(update, "result")) {
         task.result = update.result;

--- a/packages/happy-server/sources/app/api/routes/connectRoutes.test.ts
+++ b/packages/happy-server/sources/app/api/routes/connectRoutes.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+    dbMock,
+    encryptStringMock,
+    decryptStringMock,
+    resetMocks
+} = vi.hoisted(() => {
+    const dbMock = {
+        serviceAccountToken: {
+            upsert: vi.fn(),
+            findUnique: vi.fn(),
+            delete: vi.fn(),
+            findMany: vi.fn()
+        }
+    };
+
+    const encryptStringMock = vi.fn((path: string[], value: string) => `encrypted:${path.join("/")}:${value}`);
+    const decryptStringMock = vi.fn((_: string[], value: string) => `decrypted:${value}`);
+
+    const resetMocks = () => {
+        dbMock.serviceAccountToken.upsert.mockReset();
+        dbMock.serviceAccountToken.findUnique.mockReset();
+        dbMock.serviceAccountToken.delete.mockReset();
+        dbMock.serviceAccountToken.findMany.mockReset();
+        encryptStringMock.mockClear();
+        decryptStringMock.mockClear();
+    };
+
+    return {
+        dbMock,
+        encryptStringMock,
+        decryptStringMock,
+        resetMocks
+    };
+});
+
+vi.mock("@/storage/db", () => ({
+    db: dbMock
+}));
+
+vi.mock("@/modules/encrypt", () => ({
+    encryptString: encryptStringMock,
+    decryptString: decryptStringMock
+}));
+
+vi.mock("@/app/auth/auth", () => ({
+    auth: {
+        createGithubToken: vi.fn(),
+        verifyGithubToken: vi.fn()
+    }
+}));
+
+vi.mock("@/app/events/eventRouter", () => ({
+    eventRouter: {}
+}));
+
+vi.mock("@/app/github/githubConnect", () => ({
+    githubConnect: vi.fn()
+}));
+
+vi.mock("@/app/github/githubDisconnect", () => ({
+    githubDisconnect: vi.fn()
+}));
+
+vi.mock("@/context", () => ({
+    Context: {
+        create: vi.fn((userId: string) => ({ userId }))
+    }
+}));
+
+vi.mock("@/utils/log", () => ({
+    log: vi.fn()
+}));
+
+vi.mock("zod", () => {
+    const createSchema = () => {
+        const schema: any = {};
+        schema.optional = () => schema;
+        schema.nullable = () => schema;
+        schema.passthrough = () => schema;
+        schema.array = () => schema;
+        schema.uuid = () => schema;
+        schema.int = () => schema;
+        schema.positive = () => schema;
+        return schema;
+    };
+
+    const z = {
+        object: () => createSchema(),
+        string: () => createSchema(),
+        enum: () => createSchema(),
+        literal: () => createSchema(),
+        boolean: () => createSchema(),
+        any: () => createSchema(),
+        array: () => createSchema(),
+        number: () => createSchema(),
+    };
+
+    return { z };
+});
+
+import { connectRoutes } from "./connectRoutes";
+import { __resetLongTaskStoreForTests } from "../longTaskStore";
+
+type RouteHandler = (request: any, reply: any) => Promise<any>;
+
+class FakeReply {
+    statusCode = 200;
+    payload: any;
+
+    code(statusCode: number) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    send(payload: any) {
+        this.payload = payload;
+        return payload;
+    }
+
+    redirect(url: string) {
+        this.statusCode = 302;
+        this.payload = { redirect: url };
+        return this.payload;
+    }
+}
+
+function createFakeApp() {
+    const routes = new Map<string, RouteHandler>();
+
+    const app = {
+        authenticate: vi.fn(),
+        addContentTypeParser: vi.fn(),
+        get: vi.fn((path: string, _opts: any, handler: RouteHandler) => {
+            routes.set(`GET ${path}`, handler);
+        }),
+        post: vi.fn((path: string, _opts: any, handler: RouteHandler) => {
+            routes.set(`POST ${path}`, handler);
+        }),
+        delete: vi.fn((path: string, _opts: any, handler: RouteHandler) => {
+            routes.set(`DELETE ${path}`, handler);
+        }),
+    };
+
+    connectRoutes(app as any);
+
+    const invoke = async (method: "GET" | "POST" | "DELETE", path: string, request: any) => {
+        const handler = routes.get(`${method} ${path}`);
+        if (!handler) {
+            throw new Error(`Missing route for ${method} ${path}`);
+        }
+        const reply = new FakeReply();
+        const result = await handler(request, reply);
+        return {
+            statusCode: reply.statusCode,
+            payload: reply.payload ?? result
+        };
+    };
+
+    return { invoke };
+}
+
+async function waitForTaskState(invoke: ReturnType<typeof createFakeApp>["invoke"], taskId: string, expectedState: string, userId = "user-1") {
+    const deadline = Date.now() + 2000;
+
+    while (Date.now() < deadline) {
+        const response = await invoke("GET", "/v1/tasks/:taskId", {
+            params: { taskId },
+            userId
+        });
+
+        if (response.statusCode === 200 && response.payload.state === expectedState) {
+            return response.payload;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    throw new Error(`Timed out waiting for task ${taskId} to reach ${expectedState}`);
+}
+
+describe("connectRoutes", () => {
+    beforeEach(() => {
+        resetMocks();
+        __resetLongTaskStoreForTests();
+    });
+
+    it("returns 202 and eventually succeeds for vendor token registration", async () => {
+        dbMock.serviceAccountToken.upsert.mockResolvedValue({ ok: true });
+        const { invoke } = createFakeApp();
+
+        const accepted = await invoke("POST", "/v1/connect/:vendor/register", {
+            userId: "user-1",
+            params: { vendor: "openai" },
+            body: { token: "{\"oauth\":true}" }
+        });
+
+        expect(accepted.statusCode).toBe(202);
+        expect(accepted.payload.state).toBe("accepted");
+
+        const succeeded = await waitForTaskState(invoke, accepted.payload.taskId, "succeeded");
+        expect(succeeded.stage).toBe("succeeded");
+        expect(dbMock.serviceAccountToken.upsert).toHaveBeenCalledTimes(1);
+        expect(encryptStringMock).toHaveBeenCalledWith(
+            ["user", "user-1", "vendors", "openai", "token"],
+            "{\"oauth\":true}"
+        );
+    });
+
+    it("refreshes heartbeat while persisting a long-running registration", async () => {
+        dbMock.serviceAccountToken.upsert.mockImplementation(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1200));
+            return { ok: true };
+        });
+        const { invoke } = createFakeApp();
+
+        const accepted = await invoke("POST", "/v1/connect/:vendor/register", {
+            userId: "user-1",
+            params: { vendor: "gemini" },
+            body: { token: "{\"slow\":true}" }
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        const first = await invoke("GET", "/v1/tasks/:taskId", {
+            params: { taskId: accepted.payload.taskId },
+            userId: "user-1"
+        });
+        expect(first.payload.state).toBe("running");
+        expect(first.payload.stage).toBe("persisting");
+
+        await new Promise((resolve) => setTimeout(resolve, 900));
+        const second = await invoke("GET", "/v1/tasks/:taskId", {
+            params: { taskId: accepted.payload.taskId },
+            userId: "user-1"
+        });
+        expect(second.payload.stage).toBe("persisting");
+        expect(Date.parse(second.payload.heartbeatAt)).toBeGreaterThan(Date.parse(first.payload.heartbeatAt));
+
+        const succeeded = await waitForTaskState(invoke, accepted.payload.taskId, "succeeded");
+        expect(succeeded.state).toBe("succeeded");
+    });
+
+    it("surfaces task failure details", async () => {
+        dbMock.serviceAccountToken.upsert.mockRejectedValue(new Error("database unavailable"));
+        const { invoke } = createFakeApp();
+
+        const accepted = await invoke("POST", "/v1/connect/:vendor/register", {
+            userId: "user-1",
+            params: { vendor: "anthropic" },
+            body: { token: "{\"oauth\":true}" }
+        });
+
+        const failed = await waitForTaskState(invoke, accepted.payload.taskId, "failed");
+        expect(failed.stage).toBe("failed");
+        expect(failed.error).toBe("database unavailable");
+    });
+
+    it("keeps token lookup behavior intact", async () => {
+        dbMock.serviceAccountToken.findUnique.mockResolvedValue({ token: "ciphertext" });
+        const { invoke } = createFakeApp();
+
+        const response = await invoke("GET", "/v1/connect/:vendor/token", {
+            userId: "user-1",
+            params: { vendor: "openai" }
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.payload).toEqual({ token: "decrypted:ciphertext" });
+    });
+});

--- a/packages/happy-server/sources/app/api/routes/connectRoutes.test.ts
+++ b/packages/happy-server/sources/app/api/routes/connectRoutes.test.ts
@@ -253,7 +253,35 @@ describe("connectRoutes", () => {
 
         const failed = await waitForTaskState(invoke, accepted.payload.taskId, "failed");
         expect(failed.stage).toBe("failed");
-        expect(failed.error).toBe("database unavailable");
+        expect(failed.error).toBe("Vendor token registration failed. Please retry.");
+        expect(failed.errorCode).toBe("CONNECT_REGISTER_FAILED");
+    });
+
+    it("returns 202 before synchronous registration work starts", async () => {
+        let releaseUpsert: (() => void) | undefined;
+        dbMock.serviceAccountToken.upsert.mockImplementation(() => new Promise((resolve) => {
+            releaseUpsert = () => resolve({ ok: true });
+        }));
+        const { invoke } = createFakeApp();
+
+        const accepted = await invoke("POST", "/v1/connect/:vendor/register", {
+            userId: "user-1",
+            params: { vendor: "openai" },
+            body: { token: "{\"oauth\":true}" }
+        });
+
+        expect(accepted.statusCode).toBe(202);
+        expect(encryptStringMock).not.toHaveBeenCalled();
+        expect(dbMock.serviceAccountToken.upsert).not.toHaveBeenCalled();
+
+        const deadline = Date.now() + 2000;
+        while (!releaseUpsert && Date.now() < deadline) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        expect(releaseUpsert).toBeTypeOf("function");
+        releaseUpsert?.();
+        const succeeded = await waitForTaskState(invoke, accepted.payload.taskId, "succeeded");
+        expect(succeeded.state).toBe("succeeded");
     });
 
     it("keeps token lookup behavior intact", async () => {

--- a/packages/happy-server/sources/app/api/routes/connectRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/connectRoutes.ts
@@ -8,6 +8,53 @@ import { githubConnect } from "@/app/github/githubConnect";
 import { githubDisconnect } from "@/app/github/githubDisconnect";
 import { Context } from "@/context";
 import { db } from "@/storage/db";
+import { createLongTask, getLongTask, updateLongTask, withLongTaskHeartbeat } from "../longTaskStore";
+
+const connectRegisterTaskResponseSchema = z.object({
+    taskId: z.string().uuid(),
+    state: z.enum(["accepted", "running", "succeeded", "failed"]),
+    stage: z.string(),
+    pollAfterMs: z.number().int().positive(),
+    heartbeatAt: z.string(),
+    updatedAt: z.string(),
+    error: z.string().optional()
+});
+
+async function processVendorRegisterTask(taskId: string, userId: string, vendor: "openai" | "anthropic" | "gemini", token: string) {
+    try {
+        updateLongTask(taskId, userId, {
+            state: "running",
+            stage: "encrypting"
+        });
+
+        const encrypted = encryptString(["user", userId, "vendors", vendor, "token"], token);
+
+        updateLongTask(taskId, userId, {
+            state: "running",
+            stage: "persisting"
+        });
+
+        await withLongTaskHeartbeat(taskId, userId, async () => {
+            await db.serviceAccountToken.upsert({
+                where: { accountId_vendor: { accountId: userId, vendor } },
+                update: { updatedAt: new Date(), token: encrypted },
+                create: { accountId: userId, vendor, token: encrypted }
+            });
+        }, 1000);
+
+        updateLongTask(taskId, userId, {
+            state: "succeeded",
+            stage: "succeeded",
+            error: undefined
+        });
+    } catch (error) {
+        updateLongTask(taskId, userId, {
+            state: "failed",
+            stage: "failed",
+            error: error instanceof Error ? error.message : "Unknown error"
+        });
+    }
+}
 
 export function connectRoutes(app: Fastify) {
 
@@ -253,17 +300,60 @@ export function connectRoutes(app: Fastify) {
             }),
             params: z.object({
                 vendor: z.enum(['openai', 'anthropic', 'gemini'])
-            })
+            }),
+            response: {
+                202: connectRegisterTaskResponseSchema
+            }
         }
     }, async (request, reply) => {
         const userId = request.userId;
-        const encrypted = encryptString(['user', userId, 'vendors', request.params.vendor, 'token'], request.body.token);
-        await db.serviceAccountToken.upsert({
-            where: { accountId_vendor: { accountId: userId, vendor: request.params.vendor } },
-            update: { updatedAt: new Date(), token: encrypted },
-            create: { accountId: userId, vendor: request.params.vendor, token: encrypted }
+        const task = createLongTask({
+            ownerId: userId,
+            kind: "connect-register",
+            stage: "accepted",
+            pollAfterMs: 500
         });
-        reply.send({ success: true });
+
+        void processVendorRegisterTask(task.id, userId, request.params.vendor, request.body.token);
+
+        return reply.code(202).send({
+            taskId: task.id,
+            state: task.state,
+            stage: task.stage,
+            pollAfterMs: task.pollAfterMs,
+            heartbeatAt: task.heartbeatAt,
+            updatedAt: task.updatedAt
+        });
+    });
+
+    app.get('/v1/tasks/:taskId', {
+        preHandler: app.authenticate,
+        schema: {
+            params: z.object({
+                taskId: z.string().uuid()
+            }),
+            response: {
+                200: connectRegisterTaskResponseSchema,
+                404: z.object({
+                    error: z.string()
+                })
+            }
+        }
+    }, async (request, reply) => {
+        const task = getLongTask(request.params.taskId, request.userId);
+        if (!task) {
+            return reply.code(404).send({ error: 'Task not found' });
+        }
+
+        return reply.send({
+            taskId: task.id,
+            state: task.state,
+            stage: task.stage,
+            pollAfterMs: task.pollAfterMs,
+            heartbeatAt: task.heartbeatAt,
+            updatedAt: task.updatedAt,
+            error: task.error
+        });
     });
 
     app.get('/v1/connect/:vendor/token', {

--- a/packages/happy-server/sources/app/api/routes/connectRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/connectRoutes.ts
@@ -17,8 +17,14 @@ const connectRegisterTaskResponseSchema = z.object({
     pollAfterMs: z.number().int().positive(),
     heartbeatAt: z.string(),
     updatedAt: z.string(),
-    error: z.string().optional()
+    error: z.string().optional(),
+    errorCode: z.string().optional()
 });
+
+const CONNECT_REGISTER_FAILURE = {
+    error: "Vendor token registration failed. Please retry.",
+    errorCode: "CONNECT_REGISTER_FAILED"
+} as const;
 
 async function processVendorRegisterTask(taskId: string, userId: string, vendor: "openai" | "anthropic" | "gemini", token: string) {
     try {
@@ -45,13 +51,19 @@ async function processVendorRegisterTask(taskId: string, userId: string, vendor:
         updateLongTask(taskId, userId, {
             state: "succeeded",
             stage: "succeeded",
-            error: undefined
+            error: undefined,
+            errorCode: undefined
         });
     } catch (error) {
+        log(
+            { module: "connect-register", level: "error" },
+            `Failed to register ${vendor} token for user ${userId}: ${error instanceof Error ? error.stack ?? error.message : String(error)}`
+        );
         updateLongTask(taskId, userId, {
             state: "failed",
             stage: "failed",
-            error: error instanceof Error ? error.message : "Unknown error"
+            error: CONNECT_REGISTER_FAILURE.error,
+            errorCode: CONNECT_REGISTER_FAILURE.errorCode
         });
     }
 }
@@ -314,7 +326,9 @@ export function connectRoutes(app: Fastify) {
             pollAfterMs: 500
         });
 
-        void processVendorRegisterTask(task.id, userId, request.params.vendor, request.body.token);
+        setImmediate(() => {
+            void processVendorRegisterTask(task.id, userId, request.params.vendor, request.body.token);
+        });
 
         return reply.code(202).send({
             taskId: task.id,
@@ -322,7 +336,8 @@ export function connectRoutes(app: Fastify) {
             stage: task.stage,
             pollAfterMs: task.pollAfterMs,
             heartbeatAt: task.heartbeatAt,
-            updatedAt: task.updatedAt
+            updatedAt: task.updatedAt,
+            errorCode: task.errorCode
         });
     });
 
@@ -352,7 +367,8 @@ export function connectRoutes(app: Fastify) {
             pollAfterMs: task.pollAfterMs,
             heartbeatAt: task.heartbeatAt,
             updatedAt: task.updatedAt,
-            error: task.error
+            error: task.error,
+            errorCode: task.errorCode
         });
     });
 


### PR DESCRIPTION
Fixes #983.

## Summary
`happy connect codex` could fail with `timeout of 5000ms exceeded` even when vendor token registration was still progressing normally. The old flow treated registration as a single synchronous HTTP call with a hardcoded 5s client timeout, so it could not distinguish a slow-but-active request from a genuinely stalled one.

This change converts vendor token registration into a small long-task handshake for the `connect register` path. The server now accepts the work, tracks task stage and heartbeat in memory, and exposes task status for polling. The CLI waits on observable progress instead of a fixed request timeout, and reports task stages while waiting.

## What Changed
- switched `registerVendorToken()` to an activity-aware long-task wait loop in the CLI
- changed `POST /v1/connect/:vendor/register` to return `202 Accepted` with task metadata
- added `GET /v1/tasks/:taskId` for task status polling
- added an in-memory long-task store for registration state, stage, and heartbeat tracking
- added CLI progress output for accepted/encrypting/persisting/succeeded stages
- updated API documentation for the new contract
- added regression tests for progress, stall, failure, and heartbeat behavior

## Validation
- dynamic tests passed:
  - CLI: 14 passing
  - Server: 4 passing
- type diagnostics passed for `happy-cli` and `happy-server`

## Known Limitation
The long-task store is intentionally in-memory for this first rollout. That keeps the registration path lightweight for a single-process foreground wait flow, but tasks do not survive server restarts and are not shared across multiple server instances yet.
