### PR TITLE
feat: auto-exit CLI on archive and unlock send for disconnected sessions

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -377,7 +377,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                 dotColor: sessionStatus.statusDotColor,
                 isPulsing: sessionStatus.isPulsing
             }}
-            blockSend={isDisconnected}
+            blockSend={false}
             onSend={() => {
                 if (message.trim()) {
                     setMessage('');

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -197,6 +197,12 @@ export class ApiSessionClient extends EventEmitter {
                     if (data.body.metadata && data.body.metadata.version > this.metadataVersion) {
                         this.metadata = decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.metadata.value));
                         this.metadataVersion = data.body.metadata.version;
+                        // Check if session was archived from web/mobile
+                        const meta = this.metadata as any;
+                        if (meta?.lifecycleState === 'archiveRequested' || meta?.lifecycleState === 'archived') {
+                            logger.debug(`[SOCKET] Session archived (${meta.lifecycleState}), exiting...`);
+                            this.emit('archived');
+                        }
                     }
                     if (data.body.agentState && data.body.agentState.version > this.agentStateVersion) {
                         this.agentState = data.body.agentState.value ? decrypt(this.encryptionKey, this.encryptionVariant, decodeBase64(data.body.agentState.value)) : null;

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -263,6 +263,12 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     let currentAppendSystemPrompt: string | undefined = undefined; // Track current append system prompt
     let currentAllowedTools: string[] | undefined = undefined; // Track current allowed tools
     let currentDisallowedTools: string[] | undefined = undefined; // Track current disallowed tools
+    // Exit when session is archived from web/mobile
+    session.on('archived', () => {
+        logger.debug('[loop] Session archived from web/mobile, cleaning up...');
+        cleanup();
+    });
+
     session.onUserMessage((message) => {
 
         // Resolve permission mode from meta - pass through as-is, mapping happens at SDK boundary


### PR DESCRIPTION
## Summary
- **Auto-exit CLI when session is archived from web/mobile**: Listen for `lifecycleState` changes (`archiveRequested` / `archived`) in metadata updates via the WebSocket session client, and trigger cleanup to gracefully exit the CLI process.
- **Allow sending messages to disconnected sessions**: Change `blockSend` from `isDisconnected` to `false` in `SessionView.tsx` so users can queue messages even when the CLI session is temporarily disconnected.

## Test plan
- [ ] Start a CLI session, then archive it from the web or mobile app — verify the CLI exits gracefully
- [ ] Disconnect a CLI session (e.g., kill the daemon), then try sending a message from the app — verify the send input is not blocked
- [ ] Reconnect the session and verify queued messages are delivered

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)