### PR TITLE
Fix mobile AskUserQuestion answers in plan mode

### DIFF
--- a/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
+++ b/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
@@ -4,7 +4,6 @@ import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { ToolViewProps } from './_all';
 import { ToolSectionView } from '../ToolSectionView';
 import { sessionAllow } from '@/sync/ops';
-import { sync } from '@/sync/sync';
 import { t } from '@/text';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -224,8 +223,7 @@ export const AskUserQuestionView = React.memo<ToolViewProps>(({ tool, sessionId 
         // captured the values above. TODO: Revisit this logic.
         setIsSubmitted(true);
 
-        // Format answers as readable text
-        const responseLines: string[] = [];
+        const answers: Record<string, string> = {};
         questions.forEach((q, qIndex) => {
             const selected = selections.get(qIndex);
             if (selected && selected.size > 0) {
@@ -233,19 +231,16 @@ export const AskUserQuestionView = React.memo<ToolViewProps>(({ tool, sessionId 
                     .map(optIndex => q.options[optIndex]?.label)
                     .filter(Boolean)
                     .join(', ');
-                responseLines.push(`${q.header}: ${selectedLabels}`);
+                answers[q.question] = selectedLabels;
             }
         });
 
-        const responseText = responseLines.join('\n');
-
         try {
-            // 1. Approve the permission (like PermissionFooter.handleApprove does)
+            // AskUserQuestion expects answers to be returned as part of the tool input,
+            // not as a follow-up plain text message.
             if (tool.permission?.id) {
-                await sessionAllow(sessionId, tool.permission.id);
+                await sessionAllow(sessionId, tool.permission.id, undefined, undefined, 'approved', { answers });
             }
-            // 2. Send the answer as a message
-            await sync.sendMessage(sessionId, responseText);
         } catch (error) {
             console.error('Failed to submit answer:', error);
         } finally {

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -17,6 +17,7 @@ interface SessionPermissionRequest {
     mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
     allowTools?: string[];
     decision?: 'approved' | 'approved_for_session' | 'denied' | 'abort';
+    updatedInput?: Record<string, unknown>;
 }
 
 // Mode change operation types
@@ -322,16 +323,16 @@ export async function sessionAbort(sessionId: string): Promise<void> {
 /**
  * Allow a permission request
  */
-export async function sessionAllow(sessionId: string, id: string, mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan', allowedTools?: string[], decision?: 'approved' | 'approved_for_session'): Promise<void> {
-    const request: SessionPermissionRequest = { id, approved: true, mode, allowTools: allowedTools, decision };
+export async function sessionAllow(sessionId: string, id: string, mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan', allowedTools?: string[], decision?: 'approved' | 'approved_for_session', updatedInput?: Record<string, unknown>): Promise<void> {
+    const request: SessionPermissionRequest = { id, approved: true, mode, allowTools: allowedTools, decision, updatedInput };
     await apiSocket.sessionRPC(sessionId, 'permission', request);
 }
 
 /**
  * Deny a permission request
  */
-export async function sessionDeny(sessionId: string, id: string, mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan', allowedTools?: string[], decision?: 'denied' | 'abort'): Promise<void> {
-    const request: SessionPermissionRequest = { id, approved: false, mode, allowTools: allowedTools, decision };
+export async function sessionDeny(sessionId: string, id: string, mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan', allowedTools?: string[], decision?: 'denied' | 'abort', updatedInput?: Record<string, unknown>): Promise<void> {
+    const request: SessionPermissionRequest = { id, approved: false, mode, allowTools: allowedTools, decision, updatedInput };
     await apiSocket.sessionRPC(sessionId, 'permission', request);
 }
 

--- a/packages/happy-cli/src/claude/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.ts
@@ -22,6 +22,7 @@ interface PermissionResponse {
     reason?: string;
     mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
     allowTools?: string[];
+    updatedInput?: Record<string, unknown>;
     receivedAt?: number;
 }
 
@@ -102,8 +103,12 @@ export class PermissionHandler {
             }
         } else {
             // Handle default case for all other tools
+            const originalInput = (pending.input as Record<string, unknown>) || {};
+            const updatedInput = response.updatedInput
+                ? { ...originalInput, ...response.updatedInput }
+                : originalInput;
             const result: PermissionResult = response.approved
-                ? { behavior: 'allow', updatedInput: (pending.input as Record<string, unknown>) || {} }
+                ? { behavior: 'allow', updatedInput }
                 : { behavior: 'deny', message: response.reason || `The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed.` };
 
             pending.resolve(result);


### PR DESCRIPTION
## Summary

- Fix mobile `AskUserQuestion` submissions in plan mode so Claude receives structured `answers` instead of an empty selection.
- Pass tool answer data through the permission RPC as `updatedInput`.
- Merge `updatedInput` back into the original Claude tool input before allowing the tool call.

## Problem

When Claude asked a native `AskUserQuestion` multiple-choice question, the mobile app handled submission like this:

1. approve the tool
2. send the selected answer as a normal follow-up text message

That ordering is incorrect for `AskUserQuestion`.

Claude expects the user selections to be returned as part of the tool input itself, using the `answers` field on `AskUserQuestionInput`. Because the tool was approved before the structured answers were attached, Claude completed the tool call with empty answers.

This produced behavior like:

```json
{
  "questions": [...],
  "answers": {}
}
```

and logs like:

```text
User has answered your questions: .
```

The later mobile text message was treated as a normal user message rather than the result of the pending question tool call.

## Fix

- Add `updatedInput?: Record<string, unknown>` to the session permission RPC payload.
- Change `AskUserQuestionView` to submit answers as structured data instead of sending a follow-up chat message.
- Build the answer payload in the shape Claude expects, with the full question text as the key and the selected option labels joined as the value.
- Merge `updatedInput` into the pending Claude tool input in `permissionHandler.ts` before returning `behavior: 'allow'`.

## Reproduction

1. Start a Claude session in `plan` mode.
2. Have Claude ask a native `AskUserQuestion` multiple-choice question.
3. On mobile, select one or more options and submit.
4. Before this fix, Claude may respond as if the user did not select any option.

## Validation

### Manual

1. Start `happy claude`.
2. Enter a flow where Claude uses `AskUserQuestion` in `plan` mode.
3. Submit an answer from mobile.
4. Confirm Claude continues with the selected answers instead of saying no option was selected.

### Type checking

Ran successfully:

- `yarn workspace happy typecheck`
- `yarn workspace happy-app typecheck`

## Notes

This PR is intentionally scoped to the `AskUserQuestion` answer transport path between the mobile app and Claude.
