### PR TITLE
fix(sync): prevent concurrent settings loss during sync roundtrip

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -1301,6 +1301,8 @@ class Sync {
         if (Object.keys(this.pendingSettings).length > 0) {
 
             while (retryCount < maxRetries) {
+                // Snapshot what we're about to send so we can detect concurrent changes
+                const sentPending = { ...this.pendingSettings };
                 let version = storage.getState().settingsVersion;
                 let settings = applySettings(storage.getState().settings, this.pendingSettings);
                 const response = await fetch(`${API_ENDPOINT}/v1/account/settings`, {
@@ -1323,8 +1325,16 @@ class Sync {
                     success: true
                 };
                 if (data.success) {
-                    this.pendingSettings = {};
-                    savePendingSettings({});
+                    // Only clear keys we actually sent — preserve any settings
+                    // added by applySettings() calls during the POST roundtrip
+                    const newPending: Partial<Settings> = {};
+                    for (const key of Object.keys(this.pendingSettings) as (keyof Settings)[]) {
+                        if (!(key in sentPending) || this.pendingSettings[key] !== sentPending[key]) {
+                            (newPending as any)[key] = this.pendingSettings[key];
+                        }
+                    }
+                    this.pendingSettings = newPending;
+                    savePendingSettings(this.pendingSettings);
                     break;
                 }
                 if (data.error === 'version-mismatch') {
@@ -1394,6 +1404,13 @@ class Sync {
 
         // Apply settings to storage
         storage.getState().applySettings(parsedSettings, data.settingsVersion);
+
+        // Re-apply any pending settings that accumulated during this sync cycle
+        // so that the local store reflects the user's latest changes even before
+        // the next POST sends them to the server.
+        if (Object.keys(this.pendingSettings).length > 0) {
+            storage.getState().applySettingsLocal(this.pendingSettings);
+        }
 
         // Sync PostHog opt-out state with settings
         if (tracking) {


### PR DESCRIPTION
## Summary

Fixes two race conditions in settings synchronization that can cause user settings to be silently lost:

1. **Settings added during POST are dropped**: `updateSettingsSync` clears `pendingSettings` wholesale after a successful POST. If `applySettings()` is called while the POST is in-flight (e.g. user toggles a setting), those new changes are wiped out. This PR snapshots the pending bag before the POST and only removes the keys that were actually sent, preserving anything added concurrently.

2. **Pending settings invisible after fetch**: `fetchSettingsSync` overwrites the local store with server state but does not re-apply locally-pending changes. Until the next `updateSettingsSync` POST completes, the UI reverts to the server value even though the pending change is still queued. This PR re-applies pending settings to the local store immediately after a fetch so the UI stays consistent.

## Changes

- **`updateSettingsSync`**: Snapshot `pendingSettings` before POST; on success, diff against snapshot to preserve concurrently-added keys instead of clearing everything.
- **`fetchSettingsSync`**: After applying server settings, call `applySettingsLocal(this.pendingSettings)` to keep the local store in sync with queued changes.

## Test plan

- [ ] Toggle a setting, then immediately toggle a second setting before the first POST completes — verify both settings are persisted
- [ ] Open the app on two devices, change a setting on device A, then on device B before sync completes — verify no settings are lost
- [ ] Force a settings fetch (e.g. reconnect) while a local change is pending — verify the local UI still reflects the pending change