### PR TITLE
fix(happy-cli): fall back to web auth in non-TTY environments

### DIFF
--- a/packages/happy-cli/src/ui/auth.test.ts
+++ b/packages/happy-cli/src/ui/auth.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getAuthMethodFallbackForEnvironment } from './auth';
+
+const originalStdoutIsTTY = process.stdout.isTTY;
+const originalStdinIsTTY = process.stdin.isTTY;
+const originalCI = process.env.CI;
+const originalHeadless = process.env.HEADLESS;
+
+describe('getAuthMethodFallbackForEnvironment', () => {
+    afterEach(() => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
+
+        if (originalCI === undefined) {
+            delete process.env.CI;
+        } else {
+            process.env.CI = originalCI;
+        }
+
+        if (originalHeadless === undefined) {
+            delete process.env.HEADLESS;
+        } else {
+            process.env.HEADLESS = originalHeadless;
+        }
+    });
+
+    it('falls back to web auth when stdout is not a TTY', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+
+        expect(getAuthMethodFallbackForEnvironment()).toBe('web');
+    });
+
+    it('falls back to web auth when stdin is not a TTY', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+        Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+        expect(getAuthMethodFallbackForEnvironment()).toBe('web');
+    });
+
+    it('falls back to web auth in CI or headless environments', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        process.env.CI = '1';
+
+        expect(getAuthMethodFallbackForEnvironment()).toBe('web');
+
+        delete process.env.CI;
+        process.env.HEADLESS = '1';
+
+        expect(getAuthMethodFallbackForEnvironment()).toBe('web');
+    });
+
+    it('keeps the interactive selector when the terminal is fully interactive', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        delete process.env.CI;
+        delete process.env.HEADLESS;
+
+        expect(getAuthMethodFallbackForEnvironment()).toBeNull();
+    });
+});

--- a/packages/happy-cli/src/ui/auth.ts
+++ b/packages/happy-cli/src/ui/auth.ts
@@ -57,12 +57,28 @@ export async function doAuth(): Promise<Credentials | null> {
     }
 }
 
+export function getAuthMethodFallbackForEnvironment(): AuthMethod | null {
+    if (!process.stdout.isTTY || !process.stdin.isTTY || process.env.CI || process.env.HEADLESS) {
+        return 'web';
+    }
+
+    return null;
+}
+
 /**
  * Display authentication method selector and return user choice
  */
 function selectAuthenticationMethod(): Promise<AuthMethod | null> {
+    const fallbackMethod = getAuthMethodFallbackForEnvironment();
+    if (fallbackMethod) {
+        logger.debug('[AUTH] Non-interactive environment detected, skipping Ink auth selector');
+        console.log('\nNon-interactive terminal detected. Falling back to Web Browser authentication.\n');
+        return Promise.resolve(fallbackMethod);
+    }
+
     return new Promise((resolve) => {
         let hasResolved = false;
+        let app: ReturnType<typeof render>;
 
         const onSelect = (method: AuthMethod) => {
             if (!hasResolved) {
@@ -80,7 +96,7 @@ function selectAuthenticationMethod(): Promise<AuthMethod | null> {
             }
         };
 
-        const app = render(React.createElement(AuthSelector, { onSelect, onCancel }), {
+        app = render(React.createElement(AuthSelector, { onSelect, onCancel }), {
             exitOnCtrlC: false,
             patchConsole: false
         });


### PR DESCRIPTION
This fixes a happy-cli auth regression where `happy auth login` always rendered the Ink-based auth selector even when stdin/stdout were not TTYs, which caused non-interactive runs to fail with Ink's raw-mode error before authentication could continue. The fix adds a small environment fallback in `packages/happy-cli/src/ui/auth.ts` so non-interactive, CI, and headless environments automatically skip the selector and continue with `web` auth, while fully interactive terminals keep the existing selector unchanged. Closes #1010.

## What changed
- add `getAuthMethodFallbackForEnvironment()` to centralize the non-interactive fallback decision
- skip `render(<AuthSelector />)` when stdin/stdout are not TTYs or when `CI` / `HEADLESS` is set
- add `src/ui/auth.test.ts` covering stdout non-TTY, stdin non-TTY, CI/headless, and interactive terminal behavior

## Proof it works
- `npm run build` passed in `packages/happy-cli`
- `npm test -- src/ui/auth.test.ts` passed with `4 tests`
- runtime proof from a patched local build in a non-TTY environment:

```text
Non-interactive terminal detected. Falling back to Web Browser authentication.
Failed to create authentication request, please try again later.
Authentication failed: Authentication failed or was cancelled
```

The important behavior change is that the command now falls back cleanly instead of crashing with `Raw mode is not supported on the current process.stdin`.

## Notes
- I validated the build and test flow in a matching local worktree created from `main@33481c9`.
- I also reproduced the new runtime behavior with `HAPPY_HOME_DIR=/tmp/happy-auth-proof ./bin/happy.mjs auth login` in a non-interactive shell.