### PR TITLE
happy-cli: fall back to web auth in non-TTY terminals

### DIFF
--- a/packages/happy-cli/src/ui/auth.test.ts
+++ b/packages/happy-cli/src/ui/auth.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    process.env.HAPPY_HOME_DIR = '/tmp/happy-cli-auth-test';
+
+    return {
+        render: vi.fn(),
+    };
+});
+
+vi.mock('ink', () => ({
+    render: mocks.render,
+    Text: () => null,
+    Box: () => null,
+    useInput: vi.fn(),
+}));
+
+import { selectAuthenticationMethod } from './auth.js';
+
+const originalStdinTTY = process.stdin.isTTY;
+const originalStdoutTTY = process.stdout.isTTY;
+
+function setTTY(stdinTTY: boolean, stdoutTTY: boolean) {
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: stdinTTY });
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: stdoutTTY });
+}
+
+describe('selectAuthenticationMethod', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.clearAllMocks();
+        setTTY(true, true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    afterAll(() => {
+        Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: originalStdinTTY });
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: originalStdoutTTY });
+    });
+
+    it.each([
+        [false, true],
+        [true, false],
+    ])('falls back to web authentication when stdin=%s and stdout=%s are not both TTY', async (stdinTTY, stdoutTTY) => {
+        setTTY(stdinTTY, stdoutTTY);
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+        await expect(selectAuthenticationMethod()).resolves.toBe('web');
+
+        expect(logSpy).toHaveBeenCalledWith(
+            'Non-interactive terminal detected. Falling back to Web Browser authentication.',
+        );
+        expect(mocks.render).not.toHaveBeenCalled();
+    });
+
+    it('renders the selector in interactive terminals', async () => {
+        const unmount = vi.fn();
+        mocks.render.mockImplementation((element: { props: { onSelect: (method: string) => void } }) => {
+            queueMicrotask(() => element.props.onSelect('mobile'));
+            return { unmount };
+        });
+
+        await expect(selectAuthenticationMethod()).resolves.toBe('mobile');
+
+        expect(mocks.render).toHaveBeenCalledTimes(1);
+        expect(unmount).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/happy-cli/src/ui/auth.ts
+++ b/packages/happy-cli/src/ui/auth.ts
@@ -60,7 +60,16 @@ export async function doAuth(): Promise<Credentials | null> {
 /**
  * Display authentication method selector and return user choice
  */
-function selectAuthenticationMethod(): Promise<AuthMethod | null> {
+function hasInteractiveTerminal(): boolean {
+    return Boolean(process.stdout.isTTY && process.stdin.isTTY);
+}
+
+export function selectAuthenticationMethod(): Promise<AuthMethod | null> {
+    if (!hasInteractiveTerminal()) {
+        console.log('Non-interactive terminal detected. Falling back to Web Browser authentication.');
+        return Promise.resolve('web');
+    }
+
     return new Promise((resolve) => {
         let hasResolved = false;
 


### PR DESCRIPTION
## Summary
- skip the Ink auth selector when either stdin or stdout is not a TTY
- fall back to the existing web-auth path with an explicit notice instead of crashing in raw mode
- add focused auth tests covering both stdin-non-TTY and stdout-non-TTY fallback, while preserving interactive selector behavior

## Proof
- `auth-test-proof.log`: focused auth test passes (`3 tests`)
- `auth-runtime-proof.log`: non-TTY run prints `Non-interactive terminal detected. Falling back to Web Browser authentication.` and does not hit Ink's raw-mode failure

## Notes
- `packages/happy-cli` currently has an unrelated clean-branch build baseline failure in `upstream/main`; evidence is recorded in `happy-build-baseline.log`
- runtime smoke proof used `HAPPY_SERVER_URL=http://127.0.0.1:9` to force a fast auth-request failure after the fallback path was selected

Closes #1010
