### PR TITLE
feat: add yolo mode, config panel fix, and archived sessions toggle

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -55,6 +55,7 @@ import {
     type ModelMode,
     type EffortLevel,
 } from '@/components/modelModeOptions';
+import { isRunningOnMac } from '@/utils/platform';
 
 // Agent icon assets
 const agentIcons = {
@@ -675,9 +676,18 @@ function NewSessionScreen() {
 
     const hasText = prompt.trim().length > 0;
 
-    // Auto collapse config once when user starts typing, never auto-expand again
+    // Auto collapse config once when user starts typing (mobile only)
+    // On desktop (web / Mac Catalyst) the panel stays expanded
+    // Also skip collapsing on the initial render when draft text is restored
     const hasCollapsedOnceRef = React.useRef(false);
+    const isInitialRef = React.useRef(true);
+    const isDesktop = Platform.OS === 'web' || isRunningOnMac();
     React.useEffect(() => {
+        if (isInitialRef.current) {
+            isInitialRef.current = false;
+            return;
+        }
+        if (isDesktop) return;
         if (hasText && !hasCollapsedOnceRef.current) {
             hasCollapsedOnceRef.current = true;
             LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -21,6 +21,8 @@ import { UpdateBanner } from './UpdateBanner';
 import { layout } from './layout';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
+import { useSettingMutable } from '@/sync/storage';
+import { t } from '@/text';
 
 const stylesheet = StyleSheet.create((theme) => ({
     container: {
@@ -170,6 +172,24 @@ const stylesheet = StyleSheet.create((theme) => ({
         paddingBottom: 12,
         backgroundColor: theme.colors.groupped.background,
     },
+    archiveToggle: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 24,
+        paddingVertical: 16,
+    },
+    archiveToggleLine: {
+        flex: 1,
+        height: StyleSheet.hairlineWidth,
+        backgroundColor: theme.colors.groupped.sectionTitle,
+        opacity: 0.3,
+    },
+    archiveToggleText: {
+        fontSize: 12,
+        color: theme.colors.textSecondary,
+        paddingHorizontal: 12,
+        ...Typography.default('semiBold'),
+    },
 }));
 
 export function SessionsList() {
@@ -179,6 +199,10 @@ export function SessionsList() {
     const pathname = usePathname();
     const isTablet = useIsTablet();
     const compactSessionView = useSetting('compactSessionView');
+    const [hideInactiveSessions, setHideInactiveSessions] = useSettingMutable('hideInactiveSessions');
+    const toggleArchived = React.useCallback(() => {
+        setHideInactiveSessions(!hideInactiveSessions);
+    }, [hideInactiveSessions, setHideInactiveSessions]);
     const selectable = isTablet;
     const dataWithSelected = selectable ? React.useMemo(() => {
         return data?.map(item => ({
@@ -205,6 +229,7 @@ export function SessionsList() {
         switch (item.type) {
             case 'header': return `header-${item.title}-${index}`;
             case 'active-sessions': return 'active-sessions';
+            case 'archive-toggle': return 'archive-toggle';
             case 'project-group': return `project-group-${item.machine.id}-${item.displayPath}-${index}`;
             case 'session': return `session-${item.session.id}`;
         }
@@ -219,6 +244,17 @@ export function SessionsList() {
                             {item.title}
                         </Text>
                     </View>
+                );
+
+            case 'archive-toggle':
+                return (
+                    <Pressable style={styles.archiveToggle} onPress={toggleArchived}>
+                        <View style={styles.archiveToggleLine} />
+                        <Text style={styles.archiveToggleText}>
+                            {item.hidden ? t('sidebar.showArchived') : t('sidebar.hideArchived')}
+                        </Text>
+                        <View style={styles.archiveToggleLine} />
+                    </Pressable>
                 );
 
             case 'active-sessions':
@@ -268,7 +304,7 @@ export function SessionsList() {
                     />
                 );
         }
-    }, [pathname, dataWithSelected, compactSessionView]);
+    }, [pathname, dataWithSelected, compactSessionView, toggleArchived]);
 
 
     // Remove this section as we'll use FlatList for all items now

--- a/packages/happy-app/sources/components/tools/PermissionFooter.tsx
+++ b/packages/happy-app/sources/components/tools/PermissionFooter.tsx
@@ -25,13 +25,14 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
     const { theme } = useUnistyles();
     const [loadingButton, setLoadingButton] = useState<'allow' | 'deny' | 'abort' | null>(null);
     const [loadingAllEdits, setLoadingAllEdits] = useState(false);
+    const [loadingBypass, setLoadingBypass] = useState(false);
     const [loadingForSession, setLoadingForSession] = useState(false);
     
     // Check if this is a Codex session - check both metadata.flavor and tool name prefix
     const isCodex = metadata?.flavor === 'codex' || toolName.startsWith('Codex');
 
     const handleApprove = async () => {
-        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingForSession) return;
+        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession) return;
 
         setLoadingButton('allow');
         try {
@@ -44,7 +45,7 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
     };
 
     const handleApproveAllEdits = async () => {
-        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingForSession) return;
+        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession) return;
 
         setLoadingAllEdits(true);
         try {
@@ -58,8 +59,22 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
         }
     };
 
+    const handleBypassPermissions = async () => {
+        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession) return;
+
+        setLoadingBypass(true);
+        try {
+            await sessionAllow(sessionId, permission.id, 'bypassPermissions');
+            storage.getState().updateSessionPermissionMode(sessionId, 'bypassPermissions');
+        } catch (error) {
+            console.error('Failed to bypass permissions:', error);
+        } finally {
+            setLoadingBypass(false);
+        }
+    };
+
     const handleApproveForSession = async () => {
-        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingForSession || !toolName) return;
+        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession || !toolName) return;
 
         setLoadingForSession(true);
         try {
@@ -79,7 +94,7 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
     };
 
     const handleDeny = async () => {
-        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingForSession) return;
+        if (permission.status !== 'pending' || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession) return;
 
         setLoadingButton('deny');
         try {
@@ -152,8 +167,9 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
     };
 
     // Detect which button was used based on mode (for Claude) or decision (for Codex)
-    const isApprovedViaAllow = isApproved && permission.mode !== 'acceptEdits' && !isToolAllowed(toolName, toolInput, permission.allowedTools);
+    const isApprovedViaAllow = isApproved && permission.mode !== 'acceptEdits' && permission.mode !== 'bypassPermissions' && !isToolAllowed(toolName, toolInput, permission.allowedTools);
     const isApprovedViaAllEdits = isApproved && permission.mode === 'acceptEdits';
+    const isApprovedViaBypass = isApproved && permission.mode === 'bypassPermissions';
     const isApprovedForSession = isApproved && isToolAllowed(toolName, toolInput, permission.allowedTools);
     
     // Codex-specific status detection with fallback
@@ -362,10 +378,10 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
                         styles.button,
                         isPending && styles.buttonAllow,
                         isApprovedViaAllow && styles.buttonSelected,
-                        (isDenied || isApprovedViaAllEdits || isApprovedForSession) && styles.buttonInactive
+                        (isDenied || isApprovedViaAllEdits || isApprovedViaBypass || isApprovedForSession) && styles.buttonInactive
                     ]}
                     onPress={handleApprove}
-                    disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingForSession}
+                    disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession}
                     activeOpacity={isPending ? 0.7 : 1}
                 >
                     {loadingButton === 'allow' && isPending ? (
@@ -392,10 +408,10 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
                             styles.button,
                             isPending && styles.buttonAllowAll,
                             isApprovedViaAllEdits && styles.buttonSelected,
-                            (isDenied || isApprovedViaAllow || isApprovedForSession) && styles.buttonInactive
+                            (isDenied || isApprovedViaAllow || isApprovedViaBypass || isApprovedForSession) && styles.buttonInactive
                         ]}
                         onPress={handleApproveAllEdits}
-                        disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingForSession}
+                        disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession}
                         activeOpacity={isPending ? 0.7 : 1}
                     >
                         {loadingAllEdits && isPending ? (
@@ -416,6 +432,37 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
                     </TouchableOpacity>
                 )}
 
+                {/* Bypass all permissions (yolo mode) - only show for ExitPlanMode */}
+                {(toolName === 'exit_plan_mode' || toolName === 'ExitPlanMode') && (
+                    <TouchableOpacity
+                        style={[
+                            styles.button,
+                            isPending && styles.buttonForSession,
+                            isApprovedViaBypass && styles.buttonSelected,
+                            (isDenied || isApprovedViaAllow || isApprovedViaAllEdits || isApprovedForSession) && styles.buttonInactive
+                        ]}
+                        onPress={handleBypassPermissions}
+                        disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession}
+                        activeOpacity={isPending ? 0.7 : 1}
+                    >
+                        {loadingBypass && isPending ? (
+                            <View style={[styles.buttonContent, { width: 40, height: 20, justifyContent: 'center' }]}>
+                                <ActivityIndicator size={Platform.OS === 'ios' ? "small" : 14 as any} color={styles.loadingIndicatorForSession.color} />
+                            </View>
+                        ) : (
+                            <View style={styles.buttonContent}>
+                                <Text style={[
+                                    styles.buttonText,
+                                    isPending && styles.buttonTextForSession,
+                                    isApprovedViaBypass && styles.buttonTextSelected
+                                ]} numberOfLines={1} ellipsizeMode="tail">
+                                    {t('claude.permissions.yesAllowEverything')}
+                                </Text>
+                            </View>
+                        )}
+                    </TouchableOpacity>
+                )}
+
                 {/* Allow for session button - only show for non-edit, non-exit-plan tools */}
                 {toolName && toolName !== 'Edit' && toolName !== 'MultiEdit' && toolName !== 'Write' && toolName !== 'NotebookEdit' && toolName !== 'exit_plan_mode' && toolName !== 'ExitPlanMode' && (
                     <TouchableOpacity
@@ -423,10 +470,10 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
                             styles.button,
                             isPending && styles.buttonForSession,
                             isApprovedForSession && styles.buttonSelected,
-                            (isDenied || isApprovedViaAllow || isApprovedViaAllEdits) && styles.buttonInactive
+                            (isDenied || isApprovedViaAllow || isApprovedViaAllEdits || isApprovedViaBypass) && styles.buttonInactive
                         ]}
                         onPress={handleApproveForSession}
-                        disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingForSession}
+                        disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession}
                         activeOpacity={isPending ? 0.7 : 1}
                     >
                         {loadingForSession && isPending ? (
@@ -455,7 +502,7 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
                         (isApproved) && styles.buttonInactive
                     ]}
                     onPress={handleDeny}
-                    disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingForSession}
+                    disabled={!isPending || loadingButton !== null || loadingAllEdits || loadingBypass || loadingForSession}
                     activeOpacity={isPending ? 0.7 : 1}
                 >
                     {loadingButton === 'deny' && isPending ? (

--- a/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
+++ b/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
@@ -9,37 +9,57 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
         if (!data) {
             return data;
         }
-        if (!hideInactiveSessions) {
-            return data;
-        }
 
-        const filtered: SessionListViewItem[] = [];
-        let pendingProjectGroup: SessionListViewItem | null = null;
+        const result: SessionListViewItem[] = [];
+        let hasInactive = false;
 
+        // First pass: add active sessions group and check if inactive sessions exist
         for (const item of data) {
-            if (item.type === 'project-group') {
-                pendingProjectGroup = item;
-                continue;
-            }
-
-            if (item.type === 'session') {
-                if (item.session.active) {
-                    if (pendingProjectGroup) {
-                        filtered.push(pendingProjectGroup);
-                        pendingProjectGroup = null;
-                    }
-                    filtered.push(item);
-                }
-                continue;
-            }
-
-            pendingProjectGroup = null;
-
             if (item.type === 'active-sessions') {
-                filtered.push(item);
+                result.push(item);
+            } else if (item.type === 'session' && !item.session.active) {
+                hasInactive = true;
             }
         }
 
-        return filtered;
+        // Insert archive toggle if there are inactive sessions
+        if (hasInactive) {
+            result.push({ type: 'archive-toggle', hidden: hideInactiveSessions });
+        }
+
+        // If not hiding, add all remaining items (headers, project groups, inactive sessions)
+        if (!hideInactiveSessions) {
+            let pendingProjectGroup: SessionListViewItem | null = null;
+
+            for (const item of data) {
+                if (item.type === 'active-sessions') {
+                    continue; // already added
+                }
+
+                if (item.type === 'project-group') {
+                    pendingProjectGroup = item;
+                    continue;
+                }
+
+                if (item.type === 'session') {
+                    if (!item.session.active) {
+                        if (pendingProjectGroup) {
+                            result.push(pendingProjectGroup);
+                            pendingProjectGroup = null;
+                        }
+                        result.push(item);
+                    }
+                    continue;
+                }
+
+                pendingProjectGroup = null;
+
+                if (item.type === 'header') {
+                    result.push(item);
+                }
+            }
+        }
+
+        return result;
     }, [data, hideInactiveSessions]);
 }

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -64,6 +64,7 @@ interface SessionMessages {
 export type SessionListViewItem =
     | { type: 'header'; title: string }
     | { type: 'active-sessions'; sessions: Session[] }
+    | { type: 'archive-toggle'; hidden: boolean }
     | { type: 'project-group'; displayPath: string; machine: Machine }
     | { type: 'session'; session: Session; variant?: 'default' | 'no-path' };
 

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -450,6 +450,8 @@ export const en = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Show archived',
+        hideArchived: 'Hide archived',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -778,6 +778,7 @@ export const en = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Yes, allow all edits during this session',
+            yesAllowEverything: 'Yes, allow everything during this session',
             yesForTool: "Yes, don't ask again for this tool",
             noTellClaude: 'No, and provide feedback',
         }

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -452,6 +452,8 @@ export const ca: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Mostra arxivades',
+        hideArchived: 'Amaga arxivades',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -779,6 +779,7 @@ export const ca: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Sí, permet totes les edicions durant aquesta sessió',
+            yesAllowEverything: 'Sí, permet-ho tot durant aquesta sessió',
             yesForTool: 'Sí, no tornis a preguntar per aquesta eina',
             noTellClaude: 'No, proporciona comentaris',
         }

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -793,6 +793,7 @@ export const en: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Yes, allow all edits during this session',
+            yesAllowEverything: 'Yes, allow everything during this session',
             yesForTool: "Yes, don't ask again for this tool",
             noTellClaude: 'No, and provide feedback',
         }

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -466,6 +466,8 @@ export const en: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Show archived',
+        hideArchived: 'Hide archived',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -452,6 +452,8 @@ export const es: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Mostrar archivadas',
+        hideArchived: 'Ocultar archivadas',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -779,6 +779,7 @@ export const es: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Sí, permitir todas las ediciones durante esta sesión',
+            yesAllowEverything: 'Sí, permitir todo durante esta sesión',
             yesForTool: 'Sí, no volver a preguntar para esta herramienta',
             noTellClaude: 'No, proporcionar comentarios',
         }

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -777,6 +777,7 @@ export const it: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Sì, consenti tutte le modifiche durante questa sessione',
+            yesAllowEverything: 'Sì, consenti tutto durante questa sessione',
             yesForTool: 'Sì, non chiedere più per questo strumento',
             noTellClaude: 'No, fornisci feedback',
         }

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -450,6 +450,8 @@ export const it: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Mostra archiviate',
+        hideArchived: 'Nascondi archiviate',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -453,6 +453,8 @@ export const ja: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'アーカイブを表示',
+        hideArchived: 'アーカイブを非表示',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -780,6 +780,7 @@ export const ja: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'はい、このセッション中のすべての編集を許可',
+            yesAllowEverything: 'はい、このセッション中のすべてを許可',
             yesForTool: "はい、このツールについては確認しない",
             noTellClaude: 'いいえ、フィードバックを提供',
         }

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -462,6 +462,8 @@ export const pl: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Pokaż zarchiwizowane',
+        hideArchived: 'Ukryj zarchiwizowane',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -789,6 +789,7 @@ export const pl: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Tak, zezwól na wszystkie edycje podczas tej sesji',
+            yesAllowEverything: 'Tak, zezwól na wszystko podczas tej sesji',
             yesForTool: 'Tak, nie pytaj ponownie dla tego narzędzia',
             noTellClaude: 'Nie, przekaż opinię',
         }

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -778,6 +778,7 @@ export const pt: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Sim, permitir todas as edições durante esta sessão',
+            yesAllowEverything: 'Sim, permitir tudo durante esta sessão',
             yesForTool: 'Sim, não perguntar novamente para esta ferramenta',
             noTellClaude: 'Não, fornecer feedback',
         }

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -451,6 +451,8 @@ export const pt: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Mostrar arquivadas',
+        hideArchived: 'Ocultar arquivadas',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -461,6 +461,8 @@ export const ru: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: 'Показать архив',
+        hideArchived: 'Скрыть архив',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -776,6 +776,7 @@ export const ru: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: 'Да, разрешить все правки в этой сессии',
+            yesAllowEverything: 'Да, разрешить всё в этой сессии',
             yesForTool: 'Да, больше не спрашивать для этого инструмента',
             noTellClaude: 'Нет, дать обратную связь',
         }

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -780,6 +780,7 @@ export const zhHans: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: '是，允许本次会话的所有编辑',
+            yesAllowEverything: '是，允许本次会话的所有操作',
             yesForTool: '是，不再询问此工具',
             noTellClaude: '否，提供反馈',
         }

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -453,6 +453,8 @@ export const zhHans: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: '显示已归档',
+        hideArchived: '隐藏已归档',
     },
 
     toolView: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -779,6 +779,7 @@ export const zhHant: TranslationStructure = {
         // Claude permission dialog buttons
         permissions: {
             yesAllowAllEdits: '是，允許本次工作階段的所有編輯',
+            yesAllowEverything: '是，允許本次工作階段的所有操作',
             yesForTool: '是，不再詢問此工具',
             noTellClaude: '否，並告訴 Claude 該如何不同地操作',
         }

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -452,6 +452,8 @@ export const zhHant: TranslationStructure = {
 
     sidebar: {
         sessionsTitle: 'Happy',
+        showArchived: '顯示已封存',
+        hideArchived: '隱藏已封存',
     },
 
     toolView: {


### PR DESCRIPTION
## Summary

- **Yolo mode for plan approval**: Add "Yes, allow everything during this session" option to the permission footer, letting users bypass all permission prompts after approving a plan — not just edits. Useful for trusted workflows where confirming every tool call is friction.

- **Keep config panel expanded on desktop**: Skip auto-collapse on web and Mac Catalyst so the config panel stays visible while typing. Also skip collapsing on initial render when draft text is restored.

- **Show/hide archived sessions toggle**: Add a toggle in the sidebar to show or hide archived sessions. Archived sessions are hidden by default to reduce clutter, with a persisted preference in storage.
