### PR TITLE
fix(mcp): add NO_PROXY for local MCP servers behind HTTP proxy

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -4,6 +4,7 @@ import { createInterface } from "node:readline";
 import { mkdirSync, existsSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { logger } from "@/ui/logger";
+import { ensureLocalProxyBypass } from "./utils/proxyBypass";
 import { claudeCheckSession } from "./utils/claudeCheckSession";
 import { claudeFindLastSession } from "./utils/claudeFindLastSession";
 import { getProjectPath } from "./utils/path";
@@ -240,6 +241,10 @@ export async function claudeLocal(opts: {
             const env = {
                 ...process.env,
                 ...opts.claudeEnvVars
+            }
+
+            if (opts.mcpServers && Object.keys(opts.mcpServers).length > 0) {
+                ensureLocalProxyBypass(env);
             }
 
             logger.debug(`[ClaudeLocal] Spawning launcher: ${claudeCliPath}`);

--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -23,6 +23,7 @@ import {
     AbortError
 } from './types'
 import { getDefaultClaudeCodePath, getCleanEnv, logDebug, streamToStdin } from './utils'
+import { ensureLocalProxyBypass } from '../utils/proxyBypass'
 import type { Writable } from 'node:stream'
 import { logger } from '@/ui/logger'
 
@@ -340,7 +341,13 @@ export function query(config: {
 
     // Spawn Claude Code process
     // Use clean env for global claude to avoid local node_modules/.bin taking precedence
-    const spawnEnv = isCommandOnly ? getCleanEnv() : process.env
+    let spawnEnv = isCommandOnly ? getCleanEnv() : process.env
+
+    if (mcpServers && Object.keys(mcpServers).length > 0) {
+        spawnEnv = { ...spawnEnv }
+        ensureLocalProxyBypass(spawnEnv)
+    }
+
     logDebug(`Spawning Claude Code process: ${spawnCommand} ${spawnArgs.join(' ')} (using ${isCommandOnly ? 'clean' : 'normal'} env)`)
 
     const child = spawn(spawnCommand, spawnArgs, {

--- a/packages/happy-cli/src/claude/utils/proxyBypass.test.ts
+++ b/packages/happy-cli/src/claude/utils/proxyBypass.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { ensureLocalProxyBypass } from './proxyBypass'
+
+describe('ensureLocalProxyBypass', () => {
+    it('sets NO_PROXY and no_proxy when env is empty', () => {
+        const env: Record<string, string | undefined> = {}
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('127.0.0.1,localhost,::1')
+        expect(env.no_proxy).toBe('127.0.0.1,localhost,::1')
+    })
+
+    it('appends to existing NO_PROXY that has no local entries', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: 'internal.corp' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('internal.corp,127.0.0.1,localhost,::1')
+        expect(env.no_proxy).toBe('internal.corp,127.0.0.1,localhost,::1')
+    })
+
+    it('is idempotent when all loopback entries already present', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: '127.0.0.1,localhost,::1' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('127.0.0.1,localhost,::1')
+    })
+
+    it('reads no_proxy (lowercase) when NO_PROXY is absent', () => {
+        const env: Record<string, string | undefined> = { no_proxy: 'foo.bar' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('foo.bar,127.0.0.1,localhost,::1')
+        expect(env.no_proxy).toBe('foo.bar,127.0.0.1,localhost,::1')
+    })
+
+    it('prefers NO_PROXY over no_proxy when both exist', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: 'a.com', no_proxy: 'b.com' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('a.com,127.0.0.1,localhost,::1')
+        expect(env.no_proxy).toBe('a.com,127.0.0.1,localhost,::1')
+    })
+
+    it('only appends missing entries when some loopback addresses already present', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: '127.0.0.1' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('127.0.0.1,localhost,::1')
+    })
+
+    it('only appends missing entries when localhost is present but others are not', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: 'localhost' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('localhost,127.0.0.1,::1')
+    })
+
+    it('handles whitespace in existing entries', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: ' 127.0.0.1 , localhost , ::1 ' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe(' 127.0.0.1 , localhost , ::1 ')
+    })
+
+    it('appends only ::1 when IPv4 loopback entries already present', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: '127.0.0.1,localhost' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('127.0.0.1,localhost,::1')
+    })
+
+    it('appends IPv4 entries when only ::1 is present', () => {
+        const env: Record<string, string | undefined> = { NO_PROXY: '::1' }
+        ensureLocalProxyBypass(env)
+        expect(env.NO_PROXY).toBe('::1,127.0.0.1,localhost')
+    })
+})

--- a/packages/happy-cli/src/claude/utils/proxyBypass.ts
+++ b/packages/happy-cli/src/claude/utils/proxyBypass.ts
@@ -1,0 +1,18 @@
+/**
+ * Prevents local MCP HTTP servers from being routed through a configured HTTP proxy
+ * by appending 127.0.0.1, localhost, and ::1 (IPv6 loopback) to NO_PROXY if missing.
+ *
+ * Writes both NO_PROXY and no_proxy (undici reads no_proxy first).
+ * When both exist, NO_PROXY takes precedence and the merged result is written to both.
+ */
+export function ensureLocalProxyBypass(env: Record<string, string | undefined>): void {
+    const existing = env.NO_PROXY || env.no_proxy || ''
+    const entries = existing.split(',').map(s => s.trim()).filter(Boolean)
+
+    const toAdd = ['127.0.0.1', 'localhost', '::1'].filter(h => !entries.includes(h))
+    if (toAdd.length === 0) return
+
+    const updated = existing ? `${existing},${toAdd.join(',')}` : toAdd.join(',')
+    env.NO_PROXY = updated
+    env.no_proxy = updated
+}


### PR DESCRIPTION
## Summary

- Fixes silent MCP server failure when `HTTP_PROXY` is set without `NO_PROXY`
- Adds `ensureLocalProxyBypass()` utility to inject `127.0.0.1`, `localhost`, and `::1` into `NO_PROXY`/`no_proxy`
- Applied in both `claudeLocal` and SDK `query` spawn paths
- Includes 10 unit tests covering all edge cases

## Problem

In enterprise environments with HTTP proxies, local MCP HTTP servers (bound to `127.0.0.1`) are routed through the proxy and fail silently. The MCP server is marked as "failed" and its tools become invisible — no error is surfaced to the user.

This is a different dimension of the proxy problem from #578 (which handles outbound API/WebSocket connections). This PR fixes the **inbound local** connection path: when Claude Code spawns a child process that needs to reach a local MCP server.

Related issues: #451, #572, #94

## Root Cause

When `HTTP_PROXY`/`HTTPS_PROXY` is set but `NO_PROXY` doesn't include localhost addresses, Node.js routes requests to `127.0.0.1` through the proxy. The proxy can't reach localhost, so the connection fails silently.

## Solution

Before spawning Claude, check if MCP servers are configured and ensure `127.0.0.1`, `localhost`, and `::1` (IPv6 loopback) are in the `NO_PROXY` environment variable.

Key implementation details:
- Writes both `NO_PROXY` (Node.js `http` module) and `no_proxy` (`undici`) variants
- Only appends missing entries (idempotent)
- Only applied when `mcpServers` are configured (minimal intervention)
- In `query.ts`, spreads `process.env` before mutation to avoid polluting the global env
- Covers IPv6 loopback (`::1`) for Node.js 17+ which may resolve `localhost` to `::1`

## Files Changed

| File | Change |
|------|--------|
| `src/claude/utils/proxyBypass.ts` | New — 18 lines, `ensureLocalProxyBypass()` |
| `src/claude/utils/proxyBypass.test.ts` | New — 10 unit tests |
| `src/claude/claudeLocal.ts` | +5 lines — import + call |
| `src/claude/sdk/query.ts` | +9/-1 lines — import + env spread + call |

## Test Plan

- [x] 10 unit tests for `ensureLocalProxyBypass()` (all passing)
  - Empty env, existing NO_PROXY, no_proxy lowercase, both variants, partial presence, IPv6 only, whitespace, idempotency
- [ ] Manual test: set `HTTP_PROXY`, verify MCP tools work
- [ ] Manual test: verify no-op when `NO_PROXY` already includes `127.0.0.1`
- [ ] Manual test: verify no env pollution when no MCP servers configured