### PR TITLE
fix(happy-cli): Windows fixes — bash RPC cmd flashing, codex spawn ENOENT, MCP bridge launch

### DIFF
--- a/packages/happy-cli/src/codex/codexAppServerClient.test.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.test.ts
@@ -15,8 +15,12 @@ const {
     mockSpawn: vi.fn(),
 }));
 
-vi.mock('child_process', () => ({
+vi.mock('node:child_process', () => ({
     execSync: mockExecSync,
+    spawn: mockSpawn,
+}));
+
+vi.mock('cross-spawn', () => ({
     spawn: mockSpawn,
 }));
 

--- a/packages/happy-cli/src/codex/codexAppServerClient.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.ts
@@ -1203,6 +1203,13 @@ export class CodexAppServerClient {
             return;
         }
 
+        // MCP server lifecycle: log payload so we can diagnose failed launches
+        // (e.g. happy-mcp bridge failing on Windows due to shebang execution).
+        if (method === 'mcpServer/startupStatus/updated') {
+            logger.debug(`[CodexAppServer] mcpServer startup status:`, params);
+            return;
+        }
+
         logger.debug(`[CodexAppServer] Notification: ${method}`);
     }
 }

--- a/packages/happy-cli/src/codex/codexAppServerClient.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.ts
@@ -13,10 +13,10 @@
  * app-server wrapper or approval callbacks. See docs/plans/codex-app-server-migration.md.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process';
+import { execSync, type ChildProcess } from 'node:child_process';
+import { spawn as crossSpawn } from 'cross-spawn';
 import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
 import { logger } from '@/ui/logger';
-import { execSync } from 'child_process';
 import type {
     InitializeParams,
     NewConversationParams,
@@ -427,7 +427,9 @@ export class CodexAppServerClient {
         logger.debug(`[CodexAppServer] Spawning: ${command} ${args.join(' ')}`);
 
         const epoch = ++this.processEpoch;
-        const proc = spawn(command, args, {
+        // Use cross-spawn so npm-installed wrappers (codex.cmd / codex.ps1) resolve on Windows.
+        // Native child_process.spawn fails with ENOENT for .cmd shims (issues #980, #1016).
+        const proc = crossSpawn(command, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
             env,
             windowsHide: true,

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -71,7 +71,7 @@ export async function runCodex(opts: {
 }): Promise<void> {
     // Early check: ensure Codex CLI is installed before proceeding
     try {
-        execSync('codex --version', { encoding: 'utf8', stdio: 'pipe' });
+        execSync('codex --version', { encoding: 'utf8', stdio: 'pipe', windowsHide: true });
     } catch {
         console.error('\n\x1b[1m\x1b[33mCodex CLI is not installed\x1b[0m\n');
         console.error('Please install Codex CLI using one of these methods:\n');

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -550,11 +550,15 @@ export async function runCodex(opts: {
 
     // Start Happy MCP server (HTTP) and prepare STDIO bridge config for Codex
     const happyServer = await startHappyServer(session);
-    const bridgeCommand = join(projectPath(), 'bin', 'happy-mcp.mjs');
+    // Launch the bridge via `node <path>` (rather than relying on the .mjs shebang)
+    // so it works on Windows, where Windows can't execute shebang scripts directly.
+    // codex would otherwise fail to start the MCP server, the change_title tool would
+    // not be visible to the model, and the model would improvise with shell echoes.
+    const bridgeEntrypoint = join(projectPath(), 'bin', 'happy-mcp.mjs');
     const mcpServers = {
         happy: {
-            command: bridgeCommand,
-            args: ['--url', happyServer.url]
+            command: process.execPath,
+            args: ['--no-warnings', '--no-deprecation', bridgeEntrypoint, '--url', happyServer.url]
         }
     } as const;
     let first = true;

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -28,8 +28,12 @@ import { detectResumeSupport } from '@/resume/localHappyAgentAuth';
 import { resolveHappySession } from '@/resume/resolveHappySession';
 
 // Prepare initial metadata
+// Suffix host with `-dev` for the HAPPY_VARIANT=dev variant so the dev daemon
+// is visually distinct from the stable one in the machine list (they otherwise
+// share the same hostname and look identical).
+const hostSuffix = process.env.HAPPY_VARIANT === 'dev' ? '-dev' : '';
 export const initialMachineMetadata: MachineMetadata = {
-  host: os.hostname(),
+  host: os.hostname() + hostSuffix,
   platform: os.platform(),
   happyCliVersion: packageJson.version,
   homeDir: os.homedir(),

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -692,7 +692,7 @@ ${chalk.bold.cyan('Claude Code Options (from `claude --help`):')}
       // Run claude --help and display its output
       // Use execFileSync directly with claude CLI for runtime-agnostic compatibility
       try {
-        const claudeHelp = execFileSync(claudeCliPath, ['--help'], { encoding: 'utf8' })
+        const claudeHelp = execFileSync(claudeCliPath, ['--help'], { encoding: 'utf8', windowsHide: true })
         console.log(claudeHelp)
       } catch (e) {
         console.log(chalk.yellow('Could not retrieve claude help. Make sure claude is installed.'))

--- a/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
+++ b/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
@@ -157,6 +157,7 @@ export function registerCommonHandlers(rpcHandlerManager: RpcHandlerManager, wor
             const options: ExecOptions = {
                 cwd: data.cwd === '/' ? undefined : data.cwd,
                 timeout: data.timeout || 30000, // Default 30 seconds timeout
+                windowsHide: true, // Prevent cmd.exe popup on Windows for every RPC bash call
             };
 
             logger.debug('Shell command executing...', { cwd: options.cwd, timeout: options.timeout });

--- a/packages/happy-cli/src/openclaw/runOpenClaw.ts
+++ b/packages/happy-cli/src/openclaw/runOpenClaw.ts
@@ -52,7 +52,7 @@ export interface RunOpenClawOptions {
  */
 function openclawExec(...args: string[]): string | null {
   try {
-    return execFileSync('openclaw', args, { timeout: 10_000, encoding: 'utf-8' }).trim();
+    return execFileSync('openclaw', args, { timeout: 10_000, encoding: 'utf-8', windowsHide: true }).trim();
   } catch {
     return null;
   }

--- a/packages/happy-cli/src/ui/doctor.ts
+++ b/packages/happy-cli/src/ui/doctor.ts
@@ -23,6 +23,7 @@ export function getEnvironmentInfo(): Record<string, any> {
     return {
         PWD: process.env.PWD,
         HAPPY_HOME_DIR: process.env.HAPPY_HOME_DIR,
+        HAPPY_VARIANT: process.env.HAPPY_VARIANT,
         HAPPY_SERVER_URL: process.env.HAPPY_SERVER_URL,
         HAPPY_PROJECT_ROOT: process.env.HAPPY_PROJECT_ROOT,
         DANGEROUSLY_LOG_TO_SERVER_FOR_AI_AUTO_DEBUGGING: process.env.DANGEROUSLY_LOG_TO_SERVER_FOR_AI_AUTO_DEBUGGING,


### PR DESCRIPTION
## Summary

Closes 5 Windows-only happy-cli bugs reported on the issue tracker. All fixes are no-ops on macOS / Linux. Tested end-to-end on Windows 11 (Node 20.19.5) via a `happy-dev` variant linked against the local build.

### Fixes

- **#985 / #981 — cmd.exe window flashes every 2–3 seconds during `happy daemon start`**

  PR #950 added `windowsHide: true` to many spawn/exec sites but missed the actual hot path: the machine-scoped `bash` RPC handler in [`registerCommonHandlers.ts`](packages/happy-cli/src/modules/common/registerCommonHandlers.ts). The mobile app polls \`git worktree list --porcelain\` through this handler every couple of seconds, which on Windows opened (and immediately closed) a visible cmd window per call, stealing focus and disrupting typing. Added \`windowsHide: true\` there and to a handful of remaining \`execSync\` / \`execFileSync\` sites that the previous PR didn't touch (\`codex --version\` preflight, openclaw query helper, \`claude --help\`).

- **#1016 / #980 — \`happy codex\` fails with \`spawn codex ENOENT\` → 30 s init timeout → non-interactive session**

  npm-installed CLI tools live as \`.cmd\` / \`.ps1\` shim files on Windows. Node's native \`child_process.spawn\` does not resolve those shims, so spawning the codex process fails with ENOENT and the codex session hangs on \"Waiting for messages…\". \`cross-spawn\` is already a dependency and is a drop-in that handles this correctly while delegating to native \`spawn\` on other platforms. Switched the codex app-server spawn site over.

- **#999 — codex sessions: \`happy__change_title\` not visible to model**

  \`bin/happy-mcp.mjs\` is registered as an MCP server via \`{ command: '<path>.mjs' }\`. Unix executes that via the \`#!/usr/bin/env node\` shebang, but Windows can't execute shebang scripts directly, so codex's attempt to spawn the bridge fails silently. Without the bridge the \`happy__change_title\` tool never appears in the model's tool list, and on the user side the model improvises with shell echoes (\`echo \"happy__change_title not available\"\` etc.) — flooding the chat with junk instead of quietly setting the session title. Now spawn the bridge as \`node --no-warnings --no-deprecation <path>\` so codex uses the same Node runtime that's running happy itself; behaviour on Unix is unchanged (the file is just executed by node directly instead of via the shebang). Also added a debug log of the \`mcpServer/startupStatus/updated\` payload so future MCP-launch failures are diagnosable from the session log.

### Bonus

- **\`chore: tag dev variant host with \`-dev\` and log HAPPY_VARIANT\`** — when running under \`HAPPY_VARIANT=dev\`, the machine ends up in the mobile machine list with the same hostname as the stable variant and the two are visually indistinguishable. Append \`-dev\` to the hostname for the dev variant. Also include \`HAPPY_VARIANT\` in the daemon environment dump so it's obvious whether the dev variant is actually being honoured by the spawned daemon process.