### PR TITLE
fix(Dockerfile): add curl for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ FROM node:20-slim AS runner
 
 WORKDIR /repo
 
-RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ffmpeg curl && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production
 ENV DATA_DIR=/data


### PR DESCRIPTION
The docker-compose.yaml configures a healthcheck that uses curl to check the /health endpoint, but curl is not installed in the runtime image (node:20-slim).

This causes the container to be reported as **unhealthy** even though the server is running correctly.

**Error before fix:**


**Fix:** Install curl alongside ffmpeg in the runtime stage.

Fixes #N/A