### PR TITLE
fix(happy-app): Enter key not working on Windows web app

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -525,7 +525,9 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
         if (Platform.OS === 'web') {
             // On mobile web (touch devices), Enter should insert a newline since
             // there's no Shift key available. Users send via the send button instead.
-            const isTouchDevice = typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+            // Use pointer:coarse media query instead of ontouchstart/maxTouchPoints
+            // to avoid false positives on Windows touch-screen laptops with keyboards.
+            const isTouchDevice = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
             if (agentInputEnterToSend && event.key === 'Enter' && !event.shiftKey && !isTouchDevice) {
                 if (props.value.trim()) {
                     if (isSendBlocked) {


### PR DESCRIPTION
## Summary

- Fix Enter-to-send not working on Windows web app (desktop browsers with touch screens)
- Replace `ontouchstart` / `maxTouchPoints` touch detection with `pointer: coarse` media query
- Windows touch-screen laptops now correctly enable Enter-to-send since their primary pointer is `fine` (mouse/trackpad)

## Root Cause

`AgentInput.tsx` line 528 used `'ontouchstart' in window || navigator.maxTouchPoints > 0` to detect touch devices. On Windows laptops with touch screens, `maxTouchPoints > 0` returns `true`, causing Enter-to-send to be disabled even though a physical keyboard is available.

The `(pointer: coarse)` media query checks the **primary** input device rather than touch capability, correctly identifying desktop browsers as non-touch even with a touch screen present.

## Test plan

- [ ] Windows desktop browser (with touch screen) — Enter should send
- [ ] Windows desktop browser (without touch screen) — Enter should send
- [ ] Mobile browser (iOS Safari, Android Chrome) — Enter should insert newline
- [ ] iPad with external keyboard — separate issue (#1006), not affected by this change

Fixes #1040
Related: #1006

🤖 Generated with [Claude Code](https://claude.ai/code)