### PR TITLE
feat(server): multi-process via streams adapter + room-based RPC routing

### DIFF
--- a/docs/multi-process.md
+++ b/docs/multi-process.md
@@ -1,0 +1,328 @@
+# Multi-process happy-server
+
+How handy-server runs across multiple Kubernetes replicas: socket distribution,
+room-based RPC routing, broadcast fan-out, daemon lifecycle, and what happens
+during the messy cases (pod kill, brief reconnect, network partition).
+
+> **Status:** the code in this doc is on `main` but `handy.yaml` ships
+> `replicas: 1`. Flipping prod to multi-replica is a separate decision.
+
+## TL;DR
+
+handy-server uses the **Socket.IO Redis streams adapter** to forward
+`io.to(...).emit(...)` between replicas through a single Redis stream. RPC
+routing (web → daemon) goes through **Socket.IO rooms** named
+`rpc:<userId>:<method>`. The server resolves the daemon socket via
+`io.in(room).fetchSockets()` (the cluster-adapter primitive that works
+cross-replica), and sends the request to a single RemoteSocket. There is **no
+Redis key, no TTL, no Lua-CAS cleanup, no keep-alive refresh path** —
+membership is standard Socket.IO room state, cleaned up automatically on
+disconnect.
+
+If the daemon is briefly offline at call time (k8s pod cycling, transient
+network drop), the server **waits up to 10 seconds** for it to reappear before
+failing. If the daemon is in flight when its socket dies, a **presence poll**
+aborts the call within ~1 second instead of waiting the full 30s
+emit-with-ack timeout.
+
+`connectionStateRecovery` is **commented out** in `socket.ts`. The streams
+adapter supports it (verified working) but we ship parity with the
+pre-multi-process behavior first; clients still do a full REST re-fetch on
+every reconnect via `apiSocket.onReconnected`.
+
+## What an rpc-call does (control flow)
+
+```
+rpc-call from web client
+.
+├── input validation
+│   └── method name → invalid → callback({ok:false, error:'Invalid parameters'})
+│
+├── 1. resolve target via cluster adapter
+│   └── fetchRoomSockets(io, 'rpc:<userId>:<method>')
+│       ├── io.in(room).timeout(500ms).fetchSockets()
+│       ├── on success → returns [...]
+│       └── on failure (peer replica unresponsive, fast adapter timeout)
+│           └── log + return [] (treat as "nobody here")
+│       │
+│       ├── returns [target] → go to step 2
+│       └── returns []      → go to wait-for-reconnect
+│
+├── wait-for-reconnect grace (only when no target found)
+│   └── waitForRoomMember(io, room, 10_000ms)
+│       └── poll every 200ms via fetchRoomSockets:
+│           ├── room gained a member → return [target]
+│           └── deadline reached     → return []
+│       │
+│       ├── grace produced [target] → go to step 2
+│       └── grace produced []
+│           └── callback({ok:false, error:'RPC method not available'})
+│
+├── 2. sanity checks on resolved target
+│   ├── multiple sockets in room → log warn, use first
+│   └── target.id === socket.id  → callback({ok:false, error:'same socket'})
+│
+├── 3. fire emit + race a presence poll
+│   ├── ackPromise = target.timeout(30_000).emitWithAck('rpc-request', ...)
+│   │   (cluster adapter routes cross-replica via Redis stream)
+│   │
+│   └── presencePoll = while (alive)
+│       └── sleep 1s, fetchRoomSockets again
+│           ├── target still in room → keep watching
+│           └── target absent       → throw 'RPC target disconnected'
+│
+├── Promise.race(ackPromise, presencePoll)
+│   ├── ackPromise resolves → callback({ok:true, result})
+│   ├── ackPromise throws (timeout / err) → callback({ok:false, error: msg})
+│   └── presencePoll throws → callback({ok:false, error:'RPC target disconnected'})
+│
+└── finally
+    └── presenceAlive = false  (stops the poll cleanly on success or failure)
+```
+
+## What a daemon does (lifecycle)
+
+```
+daemon (machine-scoped or session-scoped)
+.
+├── connect to handy-server
+│   └── server: socket.handshake.auth.token → auth.verifyToken
+│       └── attaches rpcHandler / *UpdateHandler / etc
+│
+├── emit('rpc-register', { method })
+│   └── server: socket.join('rpc:<userId>:<method>')
+│       └── ack: emit('rpc-registered', { method })
+│       (Socket.IO room state, NO Redis key, NO TTL)
+│
+├── on('rpc-request', (data, cb) => …)
+│   └── handler runs, cb(result) returns the value via the cluster adapter
+│
+├── disconnect (any reason)
+│   └── Socket.IO automatically removes the socket from all rooms
+│       (cluster adapter syncs via heartbeat; no manual cleanup needed)
+│
+└── auto-reconnect
+    └── on 'connect': re-emit rpc-register
+        (the only client-side responsibility)
+```
+
+## What a broadcast does (event emission)
+
+```
+eventRouter.emitUpdate / emitEphemeral
+.
+└── io.to(rooms).emit('update' | 'ephemeral', payload)
+    ├── streams adapter: XADD on the 'socket.io' Redis stream
+    │   (MAXLEN ~ 50000, auto-trimmed by Redis)
+    └── every replica's XREAD loop picks up the entry
+        └── delivers to its local sockets that match the room set
+            (sockets that disconnected before the emit miss it; client
+             falls through to apiSocket onReconnected → REST refetch)
+```
+
+Rooms used by `eventRouter`:
+
+```
+.
+├── user:<userId>                              all of a user's sockets
+├── user:<userId>:user-scoped                  only the web/desktop clients
+├── user:<userId>:session:<sessionId>          session-scoped subscribers
+└── user:<userId>:machine:<machineId>          one specific machine
+```
+
+## Where the code lives
+
+```
+.
+├── packages/happy-server/sources/app/
+│   ├── api/socket.ts                      io.Server setup, attaches the
+│   │                                       streams adapter when REDIS_URL
+│   │                                       is set, commented-out
+│   │                                       connectionStateRecovery
+│   ├── api/socket/rpcHandler.ts           the entire RPC routing layer
+│   │                                       (~180 lines, single code path)
+│   ├── api/socket/machineUpdateHandler.ts no longer touches RPC state
+│   ├── api/socket/sessionUpdateHandler.ts no longer touches RPC state
+│   └── events/eventRouter.ts              broadcast emission via rooms
+│
+└── packages/happy-server/deploy/handy.yaml  k8s Deployment + Service
+                                             (replicas: 1 in this PR)
+```
+
+## What was wrong before (the four bugs)
+
+The previous attempt stored RPC routing state as `rpc:user:<u>:method:<m>` →
+socketId Redis keys with a 60-second TTL refreshed by `machine-alive` /
+`session-alive` heartbeats. This had three killer bugs (smoking gun was #3):
+
+```
+.
+├── #1  In-flight RPC eats the full 30s timeout when the target pod dies
+│       io.to(deadSocketId).emitWithAck() has no fast-fail.
+│       FIX: presence poll aborts within ~1s
+│
+├── #2  Reconnect race
+│       Between the daemon's disconnect cleanup and re-register, ~5–7% of
+│       cross-pod RPCs fail with either "method not available" (key
+│       deleted) or "target not reachable" (key still pointed at dead
+│       socketId).
+│       FIX: atomic socket.join / auto-leave on disconnect, no race window
+│
+├── #3  Silent TTL expiry
+│       Daemon stays connected, registration vanishes after 60s if the
+│       keep-alive event was missed for any reason. Daemon never knows;
+│       stays broken until reconnect.
+│       FIX: no TTL exists anymore
+│
+└── #4  Streams adapter "unbounded growth"
+        FALSE ALARM. The adapter trims with MAXLEN ~ on every XADD. Capped
+        at ~50k entries. Crossing this off the list.
+```
+
+The full postmortem with reproduction commands is at
+`deploy/integration-tests/POSTMORTEM.md`.
+
+## How we tested it
+
+Local minikube with a 2-replica handy-server, Redis, Postgres, exposed as a
+real `LoadBalancer` service via `minikube tunnel`. All harnesses live in
+`deploy/integration-tests/`.
+
+```
+.
+├── test-rpc-cross-replica.mjs   steady-state cross-pod RPC
+│                                 (50 parallel + 20 sequential)
+├── test-multiprocess.mjs        broadcast fan-out + pod-kill recovery
+├── hammer.mjs <scenario>        pod-kill-mid-rpc, reconnect-storm,
+│                                 ttl-expiry, brief-disconnect,
+│                                 long-disconnect
+├── network-loss.mjs             long-running RPC loop with summary,
+│                                 usable with iptables blackouts
+├── missed-events.mjs            brief disconnect → triggered broadcast →
+│                                 reconnect; verifies missed-events
+│                                 behavior matches main (lost from socket,
+│                                 recovered via REST refetch)
+├── probe-rpc.mjs                direct rpc-register sanity probe +
+│                                 Redis key inspector
+├── probe-fetchsockets.mjs       fetchSockets latency probe
+├── POSTMORTEM.md                full bug-by-bug
+└── ../local.sh                  bring up the whole minikube stack
+```
+
+To bring up the test environment from scratch:
+
+```bash
+deploy/local.sh                                        # provisions stack
+kubectl get pods -l app=handy-server                   # confirm 2 replicas
+kubectl patch svc handy-server -p '{"spec":{"type":"LoadBalancer"}}'
+minikube tunnel &                                      # exposes :3000
+node deploy/integration-tests/test-rpc-cross-replica.mjs
+```
+
+Final gauntlet result against the fix:
+
+```
+.
+├── steady-state cross-pod RPC          50/50 + 20/20 ✅ (after ~5s warmup)
+├── pod-kill-mid-rpc                    1612ms fast-fail ✅ (was 30000ms)
+├── brief-disconnect                    SUCCESS in 2011ms ✅
+├── long-disconnect                     bounded 10542ms ✅ (10s grace + ~0.5s)
+├── ttl-expiry (smoking gun)            ALL 5 calls pass through +75s ✅
+├── reconnect-storm (5 cycles)          96–97% success ✅ (only inherent
+│                                         in-flight failures, ~3%)
+├── broadcast multi-process             20/20 fan-out, 5/5 unaffected ✅
+├── network-loss 60s loop               85/85 zero failures ✅
+└── missed-events parity                event lost via socket, in DB,
+                                        recovered=undefined ✅ (matches main)
+```
+
+## Tunable constants
+
+```
+RPC_RECONNECT_GRACE_MS        10_000   wait-for-reconnect window (2× heartbeat)
+RPC_RECONNECT_POLL_MS            200   poll cadence inside the grace
+RPC_PRESENCE_POLL_MS           1_000   presence-poll cadence during in-flight
+RPC_PRESENCE_FETCH_TIMEOUT_MS    500   per-call cross-replica fetchSockets cap
+RPC_CALL_TIMEOUT_MS           30_000   upper bound on emitWithAck — same as main
+                                       (no support for >30s RPCs in either)
+```
+
+## Adapter details and limits worth knowing
+
+```
+.
+├── streams adapter discovery
+│   ~5s after a pod starts, the adapter's heartbeat exchange means
+│   cross-replica fetchSockets() may not see all rooms. First few RPCs
+│   immediately after a fresh rollout can hit the wait-for-reconnect
+│   grace; we sized RPC_RECONNECT_GRACE_MS at 10s to cover 2 heartbeat
+│   cycles.
+│
+├── MAXLEN ~ 50000
+│   configured in socket.ts. Auto-trims on every XADD, no cleanup needed.
+│
+├── fetchSockets() cross-replica
+│   defaults to a 5-second timeout per request. We pass timeout(500) for
+│   our presence polls so a single unresponsive replica doesn't stall
+│   every poll for 5s.
+│
+├── emitWithAck from a RemoteSocket
+│   works cross-replica through the cluster adapter (the streams adapter
+│   inherits ClusterAdapterWithHeartbeat which implements BROADCAST_ACK
+│   and FETCH_SOCKETS_RESPONSE).
+│
+└── multiple sockets in the same RPC room
+    shouldn't happen in practice (one daemon per machine, one method
+    registration). If it does, we log a warn and pick targets[0]. Same
+    blast radius as the previous Redis last-write-wins behavior.
+```
+
+## What we still don't do (intentional, deferred)
+
+```
+.
+├── connectionStateRecovery
+│   Commented out in socket.ts. Enabling it would let brief disconnects
+│   skip the heavy REST refetch (events replay through the streams
+│   adapter via restoreSession). Verified working — not shipped to
+│   preserve parity with main on this dimension.
+│
+├── In-flight RPC continuity across daemon reconnect
+│   Coupled to the above. With connectionStateRecovery enabled AND a
+│   recovery-aware presence poll (i.e. "wait N seconds for the same
+│   socketId to come back before failing"), an in-flight RPC could
+│   survive a brief network blip on the daemon: the daemon's handler
+│   keeps running, the ack packet sits in the client's sendBuffer,
+│   reconnect flushes it, the caller gets its result. Today the presence
+│   poll fast-fails the call as soon as the room is empty, which kills
+│   this case. Out of scope for this PR.
+│
+├── User-affinity routing at the LB
+│   Cross-pod RPC overhead is ~3–6ms via the streams adapter. JWT-aware
+│   routing (Envoy / Istio / nginx-lua) would be a bigger infra change
+│   than the fix itself. Tracked as future-work.
+│
+├── UI "reconnecting…" indicator
+│   Server now waits 10s for daemons. Client doesn't yet show that wait
+│   in the UI. apiSocket-side change, separate from this PR.
+│
+├── Tuning the adapter discovery window
+│   5s is the streams adapter's default heartbeatInterval. Lowering it
+│   would reduce the fresh-pod-startup race but increase Redis chatter.
+│
+└── Long-running RPCs (> 30s)
+    Not supported on either main or this PR. Bash command in the CLI has
+    its own 30s cap that races dead-even with the server's 30s emit
+    timeout. Bumping requires both server and (possibly added) client
+    timeouts.
+```
+
+## Reference
+
+- Socket.IO rooms: <https://socket.io/docs/v4/rooms/>
+- `fetchSockets()`: <https://socket.io/docs/v4/server-api/#serverfetchsockets>
+- Broadcasting events: <https://socket.io/docs/v4/broadcasting-events/>
+- Memory usage: <https://socket.io/docs/v4/memory-usage/>
+- Streams adapter source: <https://github.com/socketio/socket.io-redis-streams-adapter>
+- Connection state recovery: <https://socket.io/docs/v4/connection-state-recovery>
+- Discussion #5062 (broadcast emitWithAck waits for all): <https://github.com/socketio/socket.io/discussions/5062>

--- a/packages/happy-server/package.json
+++ b/packages/happy-server/package.json
@@ -42,7 +42,6 @@
     "@fastify/cors": "^10.0.1",
     "@prisma/client": "^6.11.1",
     "@slopus/happy-wire": "workspace:*",
-    "@socket.io/redis-adapter": "^8.3.0",
     "@socket.io/redis-streams-adapter": "^0.2.2",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/semver": "^7.7.0",

--- a/packages/happy-server/package.json
+++ b/packages/happy-server/package.json
@@ -42,6 +42,8 @@
     "@fastify/cors": "^10.0.1",
     "@prisma/client": "^6.11.1",
     "@slopus/happy-wire": "workspace:*",
+    "@socket.io/redis-adapter": "^8.3.0",
+    "@socket.io/redis-streams-adapter": "^0.2.2",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/semver": "^7.7.0",
     "axios": "^1.6.8",

--- a/packages/happy-server/sources/app/api/socket.ts
+++ b/packages/happy-server/sources/app/api/socket.ts
@@ -1,7 +1,9 @@
 import { onShutdown } from "@/utils/shutdown";
 import { Fastify } from "./types";
 import { buildMachineActivityEphemeral, ClientConnection, eventRouter } from "@/app/events/eventRouter";
-import { Server, Socket } from "socket.io";
+import { Server } from "socket.io";
+import { createAdapter } from "@socket.io/redis-streams-adapter";
+import { Redis } from "ioredis";
 import { log } from "@/utils/log";
 import { auth } from "@/app/auth/auth";
 import { decrementWebSocketConnection, incrementWebSocketConnection, websocketEventsCounter } from "../monitoring/metrics2";
@@ -28,10 +30,32 @@ export function startSocket(app: Fastify) {
         allowUpgrades: true,
         upgradeTimeout: 10000,
         connectTimeout: 20000,
-        serveClient: false // Don't serve the client files
+        serveClient: false, // Don't serve the client files
+        // Brief-disconnect event replay. Currently OFF to preserve parity with
+        // pre-multi-process prod behavior — clients fall through to the full
+        // REST re-fetch path on every reconnect (apiSocket.ts onReconnected
+        // listener). Enabling this lets socket.io replay missed events from
+        // the streams adapter (which implements restoreSession via the Redis
+        // stream) so the client can skip the heavy refetch when
+        // socket.recovered === true. Verified working cross-replica via
+        // deploy/integration-tests/missed-events.mjs (event #2 fired during a
+        // forced engine.close() arrived after auto-reconnect, recovered=true).
+        // Ship parity first; turn this on as a follow-up.
+        // connectionStateRecovery: {
+        //     maxDisconnectionDuration: 2 * 60 * 1000,
+        // },
     });
 
-    let rpcListeners = new Map<string, Map<string, Socket>>();
+    // Multi-process support: attach Redis streams adapter when REDIS_URL is set
+    if (process.env.REDIS_URL) {
+        const streamClient = new Redis(process.env.REDIS_URL);
+        io.adapter(createAdapter(streamClient, { maxLen: 50000 }));
+        log({ module: 'websocket' }, 'Redis streams adapter enabled for multi-process support');
+    }
+
+    // Initialize event router with Socket.IO server instance
+    eventRouter.init(io);
+
     io.on("connection", async (socket) => {
         log({ module: 'websocket' }, `New connection attempt from socket: ${socket.id}`);
         const token = socket.handshake.auth.token as string;
@@ -132,12 +156,7 @@ export function startSocket(app: Fastify) {
         });
 
         // Handlers
-        let userRpcListeners = rpcListeners.get(userId);
-        if (!userRpcListeners) {
-            userRpcListeners = new Map<string, Socket>();
-            rpcListeners.set(userId, userRpcListeners);
-        }
-        rpcHandler(userId, socket, userRpcListeners);
+        rpcHandler(userId, socket, io);
         usageHandler(userId, socket);
         sessionUpdateHandler(userId, socket, connection);
         pingHandler(socket);

--- a/packages/happy-server/sources/app/api/socket/rpcHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/rpcHandler.ts
@@ -1,61 +1,98 @@
-import { eventRouter } from "@/app/events/eventRouter";
 import { log } from "@/utils/log";
-import { Socket } from "socket.io";
+import { Server, Socket } from "socket.io";
+import type { RemoteSocket } from "socket.io";
+import type { DefaultEventsMap } from "socket.io/dist/typed-events";
 
-export function rpcHandler(userId: string, socket: Socket, rpcListeners: Map<string, Socket>) {
-    
-    // RPC register - Register this socket as a listener for an RPC method
-    socket.on('rpc-register', async (data: any) => {
+// RPC routing uses Socket.IO rooms. A daemon registering method M for user U
+// joins room `rpc:U:M`. Callers look the daemon up cross-replica via
+// io.in(room).fetchSockets() — supplied by the cluster adapter (the streams
+// adapter inherits from ClusterAdapterWithHeartbeat, which implements both
+// fetchSockets-cross-replica and broadcast-ack-cross-replica).
+//
+// No Redis keys, no TTLs, no Lua, no keep-alive refresh path. On disconnect
+// Socket.IO removes the socket from all rooms automatically.
+
+const RPC_ROOM_PREFIX = 'rpc:';
+const RPC_CALL_TIMEOUT_MS = 30_000;
+const RPC_PRESENCE_POLL_MS = 1_000;
+// Timeout for presence-poll fetchSockets. Must be << RPC_CALL_TIMEOUT_MS so a
+// dead replica that never replies to FETCH_SOCKETS doesn't itself stall the
+// poll for the cluster-adapter default of 5s.
+const RPC_PRESENCE_FETCH_TIMEOUT_MS = 500;
+// How long an rpc-call waits for the daemon socket to appear in the room when
+// the room is empty at call time (e.g. brief daemon reconnect window). Set to
+// 10s — 2× the streams adapter's 5s heartbeat interval — so cross-replica
+// room discovery has time to converge after a pod restart. Lower values cause
+// transient "method not available" failures for ~5s after every rolling
+// deploy when the daemon's reconnect lands on a freshly-started replica.
+const RPC_RECONNECT_GRACE_MS = 10_000;
+const RPC_RECONNECT_POLL_MS = 200;
+
+function rpcRoom(userId: string, method: string): string {
+    return `${RPC_ROOM_PREFIX}${userId}:${method}`;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+type RoomSockets = RemoteSocket<DefaultEventsMap, any>[];
+
+/**
+ * fetchSockets(room) wrapped with our short cross-replica timeout. Returns
+ * `[]` and logs on failure (cluster-adapter request timeout, peer replica
+ * unresponsive). Cluster-adapter default timeout is 5s; we cap at 500ms so a
+ * single dead peer doesn't stall the caller for the entire grace window.
+ */
+async function fetchRoomSockets(io: Server, room: string): Promise<RoomSockets> {
+    try {
+        return await io.in(room)
+            .timeout(RPC_PRESENCE_FETCH_TIMEOUT_MS)
+            .fetchSockets();
+    } catch (error) {
+        log({ module: 'websocket' }, `fetchSockets failed for ${room}: ${error}`);
+        return [];
+    }
+}
+
+/**
+ * Poll fetchRoomSockets until it returns at least one socket OR `maxMs`
+ * elapses. Used to give a daemon a brief window to reconnect when an
+ * rpc-call arrives during a transient disconnect.
+ */
+async function waitForRoomMember(io: Server, room: string, maxMs: number): Promise<RoomSockets> {
+    const deadline = Date.now() + maxMs;
+    while (true) {
+        const sockets = await fetchRoomSockets(io, room);
+        if (sockets.length > 0) return sockets;
+        if (Date.now() >= deadline) return sockets;
+        await sleep(RPC_RECONNECT_POLL_MS);
+    }
+}
+
+export function rpcHandler(userId: string, socket: Socket, io: Server) {
+
+    socket.on('rpc-register', (data: any) => {
         try {
-            const { method } = data;
-
+            const { method } = data ?? {};
             if (!method || typeof method !== 'string') {
                 socket.emit('rpc-error', { type: 'register', error: 'Invalid method name' });
                 return;
             }
-
-            // Check if method was already registered
-            const previousSocket = rpcListeners.get(method);
-            if (previousSocket && previousSocket !== socket) {
-                // log({ module: 'websocket-rpc' }, `RPC method ${method} re-registered: ${previousSocket.id} -> ${socket.id}`);
-            }
-
-            // Register this socket as the listener for this method
-            rpcListeners.set(method, socket);
-
+            socket.join(rpcRoom(userId, method));
             socket.emit('rpc-registered', { method });
-            // log({ module: 'websocket-rpc' }, `RPC method registered: ${method} on socket ${socket.id} (user: ${userId})`);
-            // log({ module: 'websocket-rpc' }, `Active RPC methods for user ${userId}: ${Array.from(rpcListeners.keys()).join(', ')}`);
         } catch (error) {
             log({ module: 'websocket', level: 'error' }, `Error in rpc-register: ${error}`);
             socket.emit('rpc-error', { type: 'register', error: 'Internal error' });
         }
     });
 
-    // RPC unregister - Remove this socket as a listener for an RPC method
-    socket.on('rpc-unregister', async (data: any) => {
+    socket.on('rpc-unregister', (data: any) => {
         try {
-            const { method } = data;
-
+            const { method } = data ?? {};
             if (!method || typeof method !== 'string') {
                 socket.emit('rpc-error', { type: 'unregister', error: 'Invalid method name' });
                 return;
             }
-
-            if (rpcListeners.get(method) === socket) {
-                rpcListeners.delete(method);
-                // log({ module: 'websocket-rpc' }, `RPC method unregistered: ${method} from socket ${socket.id} (user: ${userId})`);
-
-                if (rpcListeners.size === 0) {
-                    rpcListeners.delete(userId);
-                    // log({ module: 'websocket-rpc' }, `All RPC methods unregistered for user ${userId}`);
-                } else {
-                    // log({ module: 'websocket-rpc' }, `Remaining RPC methods for user ${userId}: ${Array.from(rpcListeners.keys()).join(', ')}`);
-                }
-            } else {
-                // log({ module: 'websocket-rpc' }, `RPC unregister ignored: ${method} not registered on socket ${socket.id}`);
-            }
-
+            socket.leave(rpcRoom(userId, method));
             socket.emit('rpc-unregistered', { method });
         } catch (error) {
             log({ module: 'websocket', level: 'error' }, `Error in rpc-unregister: ${error}`);
@@ -63,108 +100,80 @@ export function rpcHandler(userId: string, socket: Socket, rpcListeners: Map<str
         }
     });
 
-    // RPC call - Call an RPC method on another socket of the same user
     socket.on('rpc-call', async (data: any, callback: (response: any) => void) => {
         try {
-            const { method, params } = data;
-
+            const { method, params } = data ?? {};
             if (!method || typeof method !== 'string') {
-                if (callback) {
-                    callback({
-                        ok: false,
-                        error: 'Invalid parameters: method is required'
-                    });
-                }
+                callback?.({ ok: false, error: 'Invalid parameters: method is required' });
                 return;
             }
 
-            const targetSocket = rpcListeners.get(method);
-            if (!targetSocket || !targetSocket.connected) {
-                // log({ module: 'websocket-rpc' }, `RPC call failed: Method ${method} not available (disconnected or not registered)`);
-                if (callback) {
-                    callback({
-                        ok: false,
-                        error: 'RPC method not available'
-                    });
-                }
+            // 1. Find the daemon socket(s) cross-replica via the adapter.
+            // If the room is empty OR fetchSockets fails (peer replica
+            // unresponsive — fetchRoomSockets logs and returns []) fall
+            // through to the wait-for-reconnect grace window.
+            const room = rpcRoom(userId, method);
+            let targets = await fetchRoomSockets(io, room);
+            if (targets.length === 0) {
+                targets = await waitForRoomMember(io, room, RPC_RECONNECT_GRACE_MS);
+            }
+
+            if (targets.length === 0) {
+                callback?.({ ok: false, error: 'RPC method not available' });
+                return;
+            }
+            if (targets.length > 1) {
+                log({ module: 'websocket', level: 'warn' },
+                    `Multiple sockets in ${room} (${targets.length}); using first`);
+            }
+
+            const target = targets[0];
+            if (target.id === socket.id) {
+                callback?.({ ok: false, error: 'Cannot call RPC on the same socket' });
                 return;
             }
 
-            // Don't allow calling your own socket
-            if (targetSocket === socket) {
-                // log({ module: 'websocket-rpc' }, `RPC call failed: Attempted self-call on method ${method}`);
-                if (callback) {
-                    callback({
-                        ok: false,
-                        error: 'Cannot call RPC on the same socket'
-                    });
+            // 2. Single-target emit with timeout — works cross-replica via adapter.
+            //
+            // Race against a presence poll that aborts fast if the target leaves
+            // the room. WHY: emitWithAck has no idea the target socket is dead;
+            // when the daemon's pod gets killed mid-call, the cluster adapter's
+            // outgoing BROADCAST request is queued waiting for a BROADCAST_ACK
+            // that will never come, and the request only times out at the user-
+            // set RPC_CALL_TIMEOUT_MS (30s). Heartbeat-based pod liveness
+            // detection in the adapter takes ~10s and doesn't proactively
+            // cancel pending broadcasts. Polling fetchSockets is the only way
+            // to detect "the target socket is gone" and abort fast (~1s).
+            const ackPromise = target.timeout(RPC_CALL_TIMEOUT_MS)
+                .emitWithAck('rpc-request', { method, params });
+
+            let presenceAlive = true;
+            const presencePoll = (async () => {
+                while (presenceAlive) {
+                    await sleep(RPC_PRESENCE_POLL_MS);
+                    if (!presenceAlive) return;
+                    const stillThere = await fetchRoomSockets(io, room);
+                    if (!stillThere.some(s => s.id === target.id)) {
+                        throw new Error('RPC target disconnected');
+                    }
                 }
-                return;
-            }
+            })();
 
-            // Log RPC call initiation
-            const startTime = Date.now();
-            // log({ module: 'websocket-rpc' }, `RPC call initiated: ${socket.id} -> ${method} (target: ${targetSocket.id})`);
-
-            // Forward the RPC request to the target socket using emitWithAck
             try {
-                const response = await targetSocket.timeout(30000).emitWithAck('rpc-request', {
-                    method,
-                    params
-                });
-
-                const duration = Date.now() - startTime;
-                // log({ module: 'websocket-rpc' }, `RPC call succeeded: ${method} (${duration}ms)`);
-
-                // Forward the response back to the caller via callback
-                if (callback) {
-                    callback({
-                        ok: true,
-                        result: response
-                    });
-                }
-
+                const response = await Promise.race([ackPromise, presencePoll]);
+                callback?.({ ok: true, result: response });
             } catch (error) {
-                const duration = Date.now() - startTime;
                 const errorMsg = error instanceof Error ? error.message : 'RPC call failed';
-                // log({ module: 'websocket-rpc' }, `RPC call failed: ${method} - ${errorMsg} (${duration}ms)`);
-
-                // Timeout or error occurred
-                if (callback) {
-                    callback({
-                        ok: false,
-                        error: errorMsg
-                    });
-                }
+                callback?.({ ok: false, error: errorMsg });
+            } finally {
+                presenceAlive = false;
             }
         } catch (error) {
-            // log({ module: 'websocket', level: 'error' }, `Error in rpc-call: ${error}`);
-            if (callback) {
-                callback({
-                    ok: false,
-                    error: 'Internal error'
-                });
-            }
+            log({ module: 'websocket', level: 'error' }, `Error in rpc-call: ${error}`);
+            callback?.({ ok: false, error: 'Internal error' });
         }
     });
 
-    socket.on('disconnect', () => {
-
-        const methodsToRemove: string[] = [];
-        for (const [method, registeredSocket] of rpcListeners.entries()) {
-            if (registeredSocket === socket) {
-                methodsToRemove.push(method);
-            }
-        }
-
-        if (methodsToRemove.length > 0) {
-            // log({ module: 'websocket-rpc' }, `Cleaning up RPC methods on disconnect for socket ${socket.id}: ${methodsToRemove.join(', ')}`);
-            methodsToRemove.forEach(method => rpcListeners.delete(method));
-        }
-
-        if (rpcListeners.size === 0) {
-            rpcListeners.delete(userId);
-            // log({ module: 'websocket-rpc' }, `All RPC listeners removed for user ${userId}`);
-        }
-    });
+    // No disconnect handler — Socket.IO removes the socket from all rooms
+    // automatically, and the cluster adapter syncs the removal to other replicas.
 }

--- a/packages/happy-server/sources/app/events/eventRouter.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.ts
@@ -1,4 +1,4 @@
-import { Socket } from "socket.io";
+import { Server, Socket } from "socket.io";
 import { log } from "@/utils/log";
 import { GitHubProfile } from "@/app/api/types";
 import { AccountProfile } from "@/types";
@@ -202,29 +202,35 @@ export interface EphemeralPayload {
 // === EVENT ROUTER CLASS ===
 
 class EventRouter {
-    private userConnections = new Map<string, Set<ClientConnection>>();
+    private io!: Server;
 
-    // === CONNECTION MANAGEMENT ===
+    // === INITIALIZATION ===
+
+    init(io: Server): void {
+        this.io = io;
+    }
+
+    // === CONNECTION MANAGEMENT (via Socket.IO rooms) ===
 
     addConnection(userId: string, connection: ClientConnection): void {
-        if (!this.userConnections.has(userId)) {
-            this.userConnections.set(userId, new Set());
+        const socket = connection.socket;
+        socket.join(`user:${userId}`);
+
+        switch (connection.connectionType) {
+            case 'user-scoped':
+                socket.join(`user:${userId}:user-scoped`);
+                break;
+            case 'session-scoped':
+                socket.join(`user:${userId}:session:${connection.sessionId}`);
+                break;
+            case 'machine-scoped':
+                socket.join(`user:${userId}:machine:${connection.machineId}`);
+                break;
         }
-        this.userConnections.get(userId)!.add(connection);
     }
 
     removeConnection(userId: string, connection: ClientConnection): void {
-        const connections = this.userConnections.get(userId);
-        if (connections) {
-            connections.delete(connection);
-            if (connections.size === 0) {
-                this.userConnections.delete(userId);
-            }
-        }
-    }
-
-    getConnections(userId: string): Set<ClientConnection> | undefined {
-        return this.userConnections.get(userId);
+        // Socket.IO automatically removes sockets from all rooms on disconnect
     }
 
     // === EVENT EMISSION METHODS ===
@@ -261,42 +267,18 @@ class EventRouter {
 
     // === PRIVATE ROUTING LOGIC ===
 
-    private shouldSendToConnection(
-        connection: ClientConnection,
-        filter: RecipientFilter
-    ): boolean {
+    private getRoomsForFilter(userId: string, filter: RecipientFilter): string[] {
         switch (filter.type) {
-            case 'all-interested-in-session':
-                // Send to session-scoped with matching session + all user-scoped
-                if (connection.connectionType === 'session-scoped') {
-                    if (connection.sessionId !== filter.sessionId) {
-                        return false;  // Wrong session
-                    }
-                } else if (connection.connectionType === 'machine-scoped') {
-                    return false;  // Machines don't need session updates
-                }
-                // user-scoped always gets it
-                return true;
-
-            case 'user-scoped-only':
-                return connection.connectionType === 'user-scoped';
-
-            case 'machine-scoped-only':
-                // Send to user-scoped (mobile/web needs all machine updates) + only the specific machine
-                if (connection.connectionType === 'user-scoped') {
-                    return true;
-                }
-                if (connection.connectionType === 'machine-scoped') {
-                    return connection.machineId === filter.machineId;
-                }
-                return false;  // session-scoped doesn't need machine updates
-
             case 'all-user-authenticated-connections':
-                // Send to all connection types (default behavior)
-                return true;
-
-            default:
-                return false;
+                return [`user:${userId}`];
+            case 'user-scoped-only':
+                return [`user:${userId}:user-scoped`];
+            case 'all-interested-in-session':
+                // Union: session watchers + user-scoped (Socket.IO deduplicates)
+                return [`user:${userId}:session:${filter.sessionId}`, `user:${userId}:user-scoped`];
+            case 'machine-scoped-only':
+                // Union: specific machine + user-scoped
+                return [`user:${userId}:machine:${filter.machineId}`, `user:${userId}:user-scoped`];
         }
     }
 
@@ -307,24 +289,12 @@ class EventRouter {
         recipientFilter: RecipientFilter;
         skipSenderConnection?: ClientConnection;
     }): void {
-        const connections = this.userConnections.get(params.userId);
-        if (!connections) {
-            log({ module: 'websocket', level: 'warn' }, `No connections found for user ${params.userId}`);
-            return;
-        }
+        const rooms = this.getRoomsForFilter(params.userId, params.recipientFilter);
 
-        for (const connection of connections) {
-            // Skip message echo
-            if (params.skipSenderConnection && connection === params.skipSenderConnection) {
-                continue;
-            }
-
-            // Apply recipient filter
-            if (!this.shouldSendToConnection(connection, params.recipientFilter)) {
-                continue;
-            }
-
-            connection.socket.emit(params.eventName, params.payload);
+        if (params.skipSenderConnection) {
+            params.skipSenderConnection.socket.broadcast.to(rooms).emit(params.eventName, params.payload);
+        } else {
+            this.io.to(rooms).emit(params.eventName, params.payload);
         }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,9 +675,6 @@ importers:
       '@slopus/happy-wire':
         specifier: workspace:*
         version: link:../happy-wire
-      '@socket.io/redis-adapter':
-        specifier: ^8.3.0
-        version: 8.3.0(socket.io-adapter@2.5.6)
       '@socket.io/redis-streams-adapter':
         specifier: ^0.2.2
         version: 0.2.3(socket.io-adapter@2.5.6)
@@ -3633,12 +3630,6 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
-
-  '@socket.io/redis-adapter@8.3.0':
-    resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      socket.io-adapter: ^2.5.4
 
   '@socket.io/redis-streams-adapter@0.2.3':
     resolution: {integrity: sha512-c8b+ZO6L10TQx7HbVwbupJQ3yj4aZOzxN1u8paIM8tFxJBJUiujdm0SryWC0xv7gIG8LbPsXIHiBHGi7TEVVqQ==}
@@ -7462,9 +7453,6 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
-  notepack.io@3.0.1:
-    resolution: {integrity: sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==}
-
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -9221,10 +9209,6 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
-
-  uid2@1.0.0:
-    resolution: {integrity: sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==}
-    engines: {node: '>= 4.0.0'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -12824,15 +12808,6 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@socket.io/component-emitter@3.1.2': {}
-
-  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.6)':
-    dependencies:
-      debug: 4.3.7
-      notepack.io: 3.0.1
-      socket.io-adapter: 2.5.6
-      uid2: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@socket.io/redis-streams-adapter@0.2.3(socket.io-adapter@2.5.6)':
     dependencies:
@@ -17249,8 +17224,6 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
-  notepack.io@3.0.1: {}
-
   npm-package-arg@11.0.3:
     dependencies:
       hosted-git-info: 7.0.2
@@ -19236,8 +19209,6 @@ snapshots:
   ua-parser-js@1.0.41: {}
 
   ufo@1.6.3: {}
-
-  uid2@1.0.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,12 @@ importers:
       '@slopus/happy-wire':
         specifier: workspace:*
         version: link:../happy-wire
+      '@socket.io/redis-adapter':
+        specifier: ^8.3.0
+        version: 8.3.0(socket.io-adapter@2.5.6)
+      '@socket.io/redis-streams-adapter':
+        specifier: ^0.2.2
+        version: 0.2.3(socket.io-adapter@2.5.6)
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
@@ -2701,6 +2707,10 @@ packages:
       react: '*'
       react-native: '*'
 
+  '@msgpack/msgpack@2.8.0':
+    resolution: {integrity: sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==}
+    engines: {node: '>= 10'}
+
   '@noble/curves@1.5.0':
     resolution: {integrity: sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==}
 
@@ -3623,6 +3633,18 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@socket.io/redis-adapter@8.3.0':
+    resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      socket.io-adapter: ^2.5.4
+
+  '@socket.io/redis-streams-adapter@0.2.3':
+    resolution: {integrity: sha512-c8b+ZO6L10TQx7HbVwbupJQ3yj4aZOzxN1u8paIM8tFxJBJUiujdm0SryWC0xv7gIG8LbPsXIHiBHGi7TEVVqQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      socket.io-adapter: ^2.5.4
 
   '@stablelib/base64@2.0.1':
     resolution: {integrity: sha512-P2z89A7N1ETt6RxgpVdDT2xlg8cnm3n6td0lY9gyK7EiWK3wdq388yFX/hLknkCC0we05OZAD1rfxlQJUbl5VQ==}
@@ -5040,6 +5062,15 @@ packages:
 
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -7431,6 +7462,9 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  notepack.io@3.0.1:
+    resolution: {integrity: sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==}
+
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -9187,6 +9221,10 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  uid2@1.0.0:
+    resolution: {integrity: sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==}
+    engines: {node: '>= 4.0.0'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -11774,6 +11812,8 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0)
 
+  '@msgpack/msgpack@2.8.0': {}
+
   '@noble/curves@1.5.0':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -12784,6 +12824,23 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.6)':
+    dependencies:
+      debug: 4.3.7
+      notepack.io: 3.0.1
+      socket.io-adapter: 2.5.6
+      uid2: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@socket.io/redis-streams-adapter@0.2.3(socket.io-adapter@2.5.6)':
+    dependencies:
+      '@msgpack/msgpack': 2.8.0
+      debug: 4.3.7
+      socket.io-adapter: 2.5.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@stablelib/base64@2.0.1': {}
 
@@ -14339,6 +14396,10 @@ snapshots:
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
+
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3:
     dependencies:
@@ -17188,6 +17249,8 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  notepack.io@3.0.1: {}
+
   npm-package-arg@11.0.3:
     dependencies:
       hosted-git-info: 7.0.2
@@ -19173,6 +19236,8 @@ snapshots:
   ua-parser-js@1.0.41: {}
 
   ufo@1.6.3: {}
+
+  uid2@1.0.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
Re-introduces multi-replica server support, this time without the four bugs from the prior attempt. `handy.yaml` stays at `replicas: 1` — this PR only ships the code; flipping prod to multi-replica is a separate decision.

The integration tests, kustomize overlay, and minikube provisioning script that validate this fix are in the next PR in the stack: #1043.

## What an rpc-call does (control flow)

```
rpc-call from web client
.
├── input validation
│   └── method name → invalid → callback({ok:false, error:'Invalid parameters'})
│
├── 1. resolve target via cluster adapter
│   └── fetchRoomSockets(io, 'rpc:<userId>:<method>')
│       ├── io.in(room).timeout(500ms).fetchSockets()
│       ├── on success → returns [...]
│       └── on failure (peer replica unresponsive, fast adapter timeout)
│           └── log + return [] (treat as "nobody here")
│       │
│       ├── returns [target] → go to step 2
│       └── returns []      → go to wait-for-reconnect
│
├── wait-for-reconnect grace (only when no target found)
│   └── waitForRoomMember(io, room, 10_000ms)
│       └── poll every 200ms via fetchRoomSockets:
│           ├── room gained a member → return [target]
│           └── deadline reached     → return []
│       │
│       ├── grace produced [target] → go to step 2
│       └── grace produced []
│           └── callback({ok:false, error:'RPC method not available'})
│
├── 2. sanity checks on resolved target
│   ├── multiple sockets in room → log warn, use first
│   └── target.id === socket.id  → callback({ok:false, error:'same socket'})
│
├── 3. fire emit + race a presence poll
│   ├── ackPromise = target.timeout(30_000).emitWithAck('rpc-request', ...)
│   │   (cluster adapter routes cross-replica via Redis stream)
│   │
│   └── presencePoll = while (alive)
│       └── sleep 1s, fetchRoomSockets again
│           ├── target still in room → keep watching
│           └── target absent       → throw 'RPC target disconnected'
│
├── Promise.race(ackPromise, presencePoll)
│   ├── ackPromise resolves → callback({ok:true, result})
│   ├── ackPromise throws (timeout / err) → callback({ok:false, error: msg})
│   └── presencePoll throws → callback({ok:false, error:'RPC target disconnected'})
│
└── finally
    └── presenceAlive = false  (stops the poll cleanly on success or failure)
```

## What a daemon does

```
daemon (machine-scoped or session-scoped) lifecycle
.
├── connect to handy-server
│   └── server: socket.handshake.auth.token → auth.verifyToken
│       └── attaches rpcHandler / *UpdateHandler / etc
│
├── emit('rpc-register', { method })
│   └── server: socket.join('rpc:<userId>:<method>')
│       └── ack: emit('rpc-registered', { method })
│       (Socket.IO room state, NO Redis key, NO TTL)
│
├── on('rpc-request', (data, cb) => …)
│   └── handler runs, cb(result) returns the value via the cluster adapter
│
├── disconnect (any reason)
│   └── Socket.IO automatically removes the socket from all rooms
│       (cluster adapter syncs via heartbeat; no manual cleanup needed)
│
└── auto-reconnect
    └── on 'connect': re-emit rpc-register
        (the only client-side responsibility)
```

## What a broadcast does (event emission)

```
eventRouter.emitUpdate / emitEphemeral
.
└── io.to(rooms).emit('update' | 'ephemeral', payload)
    ├── streams adapter: XADD on the 'socket.io' Redis stream
    │   (MAXLEN ~ 50000, auto-trimmed by Redis)
    └── every replica's XREAD loop picks up the entry
        └── delivers to its local sockets that match the room set
            (sockets that disconnected before the emit miss it; client
             falls through to apiSocket onReconnected → REST refetch)
```

---

## Why this is safe to ship

`handy.yaml` is **unchanged** from main: `replicas: 1, maxUnavailable: 1, maxSurge: 0`. Production runs single-pod regardless of this PR. Flipping to multi-replica is a follow-up decision.

The previous attempt (`888b87a3` + `b42b9c45` + `9e9e5f4f`, reverted in `325d1075`) had four bugs that all came from one design decision: **storing socketIds in Redis with a 60s TTL refreshed by keep-alive heartbeats**. Killing that design kills all four bugs at once.

| Bug (prior attempt) | This PR |
|---|---|
| #1 In-flight RPC eats full 30s timeout when target pod dies | Presence poll aborts within ~1s |
| #2 Reconnect race → 5-7% RPC failures | Atomic `socket.join` / auto-leave on disconnect; race window is gone |
| #3 Silent 60s TTL expiry while daemon is connected | No TTL exists |
| #4 Streams adapter "unbounded growth" | False alarm — `MAXLEN ~ 50000` already auto-trims |

## Files changed (this PR only)

```
.
├── server (functional)
│   ├── rpcHandler.ts                      full rewrite (~180 lines, single path)
│   ├── socket.ts                          drop second ioredis client, attach
│   │                                       streams adapter, commented-out
│   │                                       connectionStateRecovery
│   ├── eventRouter.ts                     rooms-based emission (was local Map)
│   └── package.json + pnpm-lock.yaml      re-add @socket.io/redis-streams-adapter
│
└── human docs
    └── docs/multi-process.md              high-level entry point with full
                                            ASCII control flow + reference
```

The deploy infrastructure and integration tests live in #1043 (stacked on top).

## Tunable constants

```
RPC_RECONNECT_GRACE_MS        10_000   wait-for-reconnect window (2× heartbeat)
RPC_RECONNECT_POLL_MS            200   poll cadence inside the grace
RPC_PRESENCE_POLL_MS           1_000   presence-poll cadence during in-flight
RPC_PRESENCE_FETCH_TIMEOUT_MS    500   per-call cross-replica fetchSockets cap
RPC_CALL_TIMEOUT_MS           30_000   upper bound on emitWithAck — same as main
                                       (no support for >30s RPCs in either)
```

## What's NOT in this PR (deferred)

- **Flipping prod to multi-replica.** `replicas: 1` stays. Separate deploy decision.
- **`connectionStateRecovery`.** Commented out in `socket.ts` with rationale. Streams adapter supports it (verified working in `missed-events.mjs`). Enabling it would let brief reconnects skip the heavy REST refetch. Ship parity first.
- **In-flight RPC continuity across daemon reconnect.** Coupled to the above. With `connectionStateRecovery` enabled AND a recovery-aware presence poll, an in-flight RPC could survive a brief network blip on the daemon. Today the presence poll fast-fails the call as soon as the room is empty.
- **User-affinity routing at the LB.** Cross-pod RPC overhead is ~3–6ms via the streams adapter. JWT-aware routing would need Envoy/Istio or nginx-lua — bigger infra change than the fix itself.
- **UI "reconnecting…" indicator.** Server now waits 10s for daemons. Client doesn't yet show that wait.
- **Adapter discovery race after rolling deploys.** Inherent ~5–10s window; the 10s grace covers it for normal workloads.

## Reference

- [Socket.IO Rooms](https://socket.io/docs/v4/rooms/)
- [`fetchSockets()`](https://socket.io/docs/v4/server-api/#serverfetchsockets)
- [Memory usage](https://socket.io/docs/v4/memory-usage/)
- [Streams adapter](https://github.com/socketio/socket.io-redis-streams-adapter)
- [Connection state recovery](https://socket.io/docs/v4/connection-state-recovery)

Full bug-by-bug analysis with exact reproduction commands lives in the next PR: `deploy/integration-tests/POSTMORTEM.md` (#1043).
High-level reference: `docs/multi-process.md` (in this PR).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>