### PR TITLE
feat(happy-app): scroll-to-bottom button in chat session

### DIFF
--- a/packages/happy-app/sources/components/ChatList.tsx
+++ b/packages/happy-app/sources/components/ChatList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useSession, useSessionMessages } from "@/sync/storage";
-import { ActivityIndicator, FlatList, Platform, View } from 'react-native';
+import { FlatList, NativeScrollEvent, NativeSyntheticEvent, Platform, Pressable, View } from 'react-native';
 import { useCallback } from 'react';
 import { useHeaderHeight } from '@/utils/responsive';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -8,6 +8,10 @@ import { MessageView } from './MessageView';
 import { Metadata, Session } from '@/sync/storageTypes';
 import { ChatFooter } from './ChatFooter';
 import { Message } from '@/sync/typesMessage';
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+
+const SCROLL_THRESHOLD = 300;
 
 export const ChatList = React.memo((props: { session: Session }) => {
     const { messages } = useSessionMessages(props.session.id);
@@ -38,24 +42,86 @@ const ChatListInternal = React.memo((props: {
     sessionId: string,
     messages: Message[],
 }) => {
+    const { theme } = useUnistyles();
+    const flatListRef = React.useRef<FlatList>(null);
+    const [showScrollButton, setShowScrollButton] = React.useState(false);
+
     const keyExtractor = useCallback((item: any) => item.id, []);
     const renderItem = useCallback(({ item }: { item: any }) => (
         <MessageView message={item} metadata={props.metadata} sessionId={props.sessionId} />
     ), [props.metadata, props.sessionId]);
+
+    // In inverted FlatList, offset 0 = latest messages (visual bottom).
+    // Offset increases as user scrolls up to see older messages.
+    const handleScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+        const offsetY = e.nativeEvent.contentOffset.y;
+        setShowScrollButton(offsetY > SCROLL_THRESHOLD);
+    }, []);
+
+    const scrollToBottom = useCallback(() => {
+        flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+    }, []);
+
     return (
-        <FlatList
-            data={props.messages}
-            inverted={true}
-            keyExtractor={keyExtractor}
-            maintainVisibleContentPosition={{
-                minIndexForVisible: 0,
-                autoscrollToTopThreshold: 10,
-            }}
-            keyboardShouldPersistTaps="handled"
-            keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'none'}
-            renderItem={renderItem}
-            ListHeaderComponent={<ListFooter sessionId={props.sessionId} />}
-            ListFooterComponent={<ListHeader />}
-        />
+        <View style={{ flex: 1 }}>
+            <FlatList
+                ref={flatListRef}
+                data={props.messages}
+                inverted={true}
+                keyExtractor={keyExtractor}
+                maintainVisibleContentPosition={{
+                    minIndexForVisible: 0,
+                    autoscrollToTopThreshold: 10,
+                }}
+                keyboardShouldPersistTaps="handled"
+                keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'none'}
+                renderItem={renderItem}
+                onScroll={handleScroll}
+                scrollEventThrottle={16}
+                ListHeaderComponent={<ListFooter sessionId={props.sessionId} />}
+                ListFooterComponent={<ListHeader />}
+            />
+            {showScrollButton && (
+                <View style={styles.scrollButtonContainer}>
+                    <Pressable
+                        style={({ pressed }) => [
+                            styles.scrollButton,
+                            pressed ? styles.scrollButtonPressed : styles.scrollButtonDefault
+                        ]}
+                        onPress={scrollToBottom}
+                    >
+                        <Ionicons name="chevron-down" size={20} color={theme.colors.fab.icon} />
+                    </Pressable>
+                </View>
+            )}
+        </View>
     )
 });
+
+const styles = StyleSheet.create((theme) => ({
+    scrollButtonContainer: {
+        position: 'absolute',
+        right: 16,
+        bottom: 8,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    scrollButton: {
+        borderRadius: 18,
+        width: 36,
+        height: 36,
+        alignItems: 'center',
+        justifyContent: 'center',
+        shadowColor: theme.colors.shadow.color,
+        shadowOffset: { width: 0, height: 2 },
+        shadowRadius: 3.84,
+        shadowOpacity: theme.colors.shadow.opacity,
+        elevation: 5,
+    },
+    scrollButtonDefault: {
+        backgroundColor: theme.colors.fab.background,
+    },
+    scrollButtonPressed: {
+        backgroundColor: theme.colors.fab.backgroundPressed,
+    },
+}));


### PR DESCRIPTION
## Summary

- Add a floating scroll-to-bottom button (chevron-down) that appears when user scrolls up in a chat session
- Button smoothly scrolls back to latest messages on tap
- Follows existing FAB.tsx pattern for consistent styling

## Implementation

- `onScroll` handler on inverted FlatList tracks `contentOffset.y`
- Button appears when offset exceeds 300px threshold
- `scrollToOffset({ offset: 0, animated: true })` jumps to newest messages (inverted list)
- 36x36 compact button using `theme.colors.fab.*` colors
- Cross-platform: iOS, Android, Web, macOS/Tauri

## Test plan

- [ ] Scroll up in a long chat session — button should appear
- [ ] Tap button — should smooth-scroll to latest message
- [ ] Stay near bottom — button should not appear
- [ ] Test on iOS, Android, and web

Fixes #1038

🤖 Generated with [Claude Code](https://claude.ai/code)