### PR TITLE
deploy(server): scale to 3 replicas (maxUnavailable 0, maxSurge 2)

### DIFF
--- a/packages/happy-server/deploy/handy.yaml
+++ b/packages/happy-server/deploy/handy.yaml
@@ -6,9 +6,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 0
-  replicas: 1
+      maxUnavailable: 0
+      maxSurge: 2
+  replicas: 3
   selector:
     matchLabels:
       app: handy-server


### PR DESCRIPTION
Flips `handy.yaml` to the multi-replica configuration. Sits on top of #1042 (core RPC fix) and #1043 (integration tests) in the same stack.

## The actual change

```yaml
# packages/happy-server/deploy/handy.yaml
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0   # was 1
      maxSurge: 2         # was 0
  replicas: 3             # was 1
```

## Why this is safe now

The previously-reverted scale-up (`ea8c588b`) had the *same* config shape, but it rode on top of the buggy Redis-keyed RPC routing. All four bugs from the postmortem (30s in-flight timeouts, reconnect races, silent TTL expiry, no grace window) were hit in production exactly because the scale-up removed the single-pod safety net.

This PR re-enables the scale-up **after** the room-based routing fix in #1042. Specifically:

```
.
├── #1 30s in-flight timeout
│   └── FIXED by presence poll in rpcHandler.ts — aborts within ~1s
│       of the target socket leaving the room
│
├── #2 reconnect race (~6% RPC failures)
│   └── FIXED by atomic socket.join/leave on disconnect — no gap
│       between old registration cleanup and new registration
│
├── #3 silent TTL expiry (smoking gun)
│   └── FIXED — no TTL exists anymore, room membership is the source
│       of truth, cleaned up by Socket.IO on disconnect
│
└── adapter discovery race after rollouts
    └── COVERED by RPC_RECONNECT_GRACE_MS=10s (2× heartbeat). First few
        cross-replica RPCs right after a pod starts may still fast-fail
        if they miss the grace window; client retries, user feels
        nothing past the first call.
```

## Rolling update semantics with the new settings

```
replicas: 3, maxSurge: 2, maxUnavailable: 0
.
├── steady state: 3 pods serving
├── rollout kicks off: up to 5 pods briefly (3 old + 2 new)
├── new pods pass readiness → old pods drain
│   └── 10s graceful drain + 5s adapter heartbeat re-discovery
├── at no point are fewer than 3 pods serving (maxUnavailable: 0)
└── settle back to 3 pods on the new image
```

## Merge order

**This PR must merge last** in the stack. Order:

1. #1042 (core RPC fix) → `gh stack sync` on top branches
2. #1043 (integration tests) → `gh stack sync` on top branches
3. #1046 (this PR — deploy config flip)

Or use `gh stack merge 1046` to land all three in one command (merges #1046 + everything below it).

## What's NOT in this PR

- Client changes (web/CLI are unchanged and don't need changes for multi-replica — covered in the #1042 description)
- `connectionStateRecovery` on the server (commented out in `socket.ts`, intentional, covered in #1042)
- User-affinity / JWT-aware routing at the LB (tracked as follow-up in `docs/multi-process.md`)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>