### PR TITLE
test(server): integration tests + minikube provisioning for multi-process

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../packages/happy-server/deploy/handy.yaml
+  - ../../packages/happy-server/deploy/happy-redis.yaml

--- a/deploy/integration-tests/POSTMORTEM.md
+++ b/deploy/integration-tests/POSTMORTEM.md
@@ -1,0 +1,240 @@
+# Multi-pod Redis adapter — postmortem
+
+Local reproduction in minikube against the full broken stack
+(`888b87a3` + `b42b9c45` + `9e9e5f4f`, restored in working tree, NOT
+on origin/main).
+
+## Setup
+- 2 happy-server replicas behind a `LoadBalancer` service via `minikube tunnel`
+- Single Redis (`@socket.io/redis-streams-adapter`)
+- All tests use `transports: ['websocket']` (matches prod client)
+- Test harnesses: `deploy/hammer.mjs`, `deploy/network-loss.mjs`,
+  `deploy/test-rpc-cross-replica.mjs`, `deploy/test-multiprocess.mjs`
+
+## What works (steady state)
+
+| Test                    | Result      | Notes |
+|-------------------------|-------------|-------|
+| Cross-replica broadcast | ✅ 20/20    | Pod kill, fan-out, all 8 surviving clients undisrupted |
+| Cross-pod RPC (steady)  | ✅ 50/50 ×5 | Repeated; once warm, parallel + sequential RPCs all pass |
+| LB cross-pod routing    | ✅          | k8s service distributes new sockets across both pods |
+
+The original `9e9e5f4f` claim "Tested locally: 10/10 cross-replica RPC
+calls pass" is true — **in steady state**, with no churn, no kills, no
+network jitter, and no waiting longer than the TTL.
+
+## What's broken (4 reproduced bugs)
+
+### Bug #1: in-flight RPC eats the full 30s timeout when target pod dies
+
+**Repro:** `node deploy/hammer.mjs pod-kill-mid-rpc`
+
+```
+[+ 1.85s] firing rpc-call (will block 5s in handler)
+[+ 1.89s]   daemon got rpc-request, sleeping 5s
+[+ 2.85s] killing daemon pod handy-server-67b86c7b7c-2bc6f
+[+ 2.94s]   socket disconnect: transport close
+[+ 3.27s]   socket reconnected
+[+31.85s] rpc-call result: ok=false latency=30002ms err=operation has timed out
+```
+
+- Daemon's pod is killed mid-call. Daemon socket transport-closes within 90ms.
+- Daemon **reconnects in 0.4s** on a different pod.
+- Caller's `rpc-call` **hangs for the full 30 seconds** then times out.
+
+**Root cause:**
+`rpcHandler.ts:159` does
+`io.to(targetSocketId).timeout(30000).emitWithAck('rpc-request', ...)`.
+The streams adapter broadcasts the request through Redis. No replica
+has the dead `targetSocketId`. No socket replies. `emitWithAck` waits
+the full timeout. There is no fast-fail path for "the target socketId
+no longer exists anywhere in the cluster."
+
+The dead Redis key is not cleaned up either — the daemon's pod was
+SIGKILL'd so its disconnect handler never ran. Even on graceful
+shutdown the cleanup is best-effort.
+
+**Production manifestation:** every pod recycle, every daemon
+reconnect → every concurrent web RPC eats 30s. Multiple retries from
+the client compound this into multi-minute hangs. This explains the
+user's "say lol after running ls 3 times took 3 minutes" report.
+
+### Bug #2: reconnect-storm race ⇒ ~6% RPC failures
+
+**Repro:** `node deploy/hammer.mjs reconnect-storm`
+
+```
+results: success=178 fail=12
+  err: RPC method not available ×7   ← Redis key was deleted, not yet recreated
+  err: RPC target not reachable ×5   ← Redis key still pointed at dead socketId
+```
+
+- Daemon reconnects 5×, callers fire RPCs at 200ms intervals throughout.
+- ~150ms reconnect window per cycle = ~1 RPC-window per reconnect per caller.
+- 5 cycles × 5 callers ≈ 25 vulnerable calls, 12 fail.
+
+**Root cause:** the daemon's disconnect handler runs a Lua CAS that
+deletes the Redis key. The reconnect's `rpc-register` runs a fresh
+SET. Between those two events any cross-pod caller sees one of:
+
+- key absent → `RPC method not available`
+- key present pointing at the **old** socketId (not yet cleaned up
+  because the daemon's disconnect handler ran on a different pod and
+  raced with the new register) → `RPC target not reachable`
+
+There is no atomic "swap" semantic. The design fundamentally cannot
+maintain RPC availability across a daemon socket transition.
+
+**Production manifestation:** the prod web client logs showed 🔌
+"Socket reconnected" followed by repeated `fetchMessages → 0 messages`
+churn. Every reconnect = a small but real burst of RPC failures, which
+cascade into the sync layer's invalidate loop.
+
+### Bug #3 (smoking gun): silent TTL expiry while daemon is connected
+
+**Repro:** `node deploy/hammer.mjs ttl-expiry`, OR
+`node deploy/network-loss.mjs` — both reproduce this at the +60s mark
+without any network manipulation.
+
+```
+[+   5.19s] t=+5s  rpc: ok=true
+[+  30.25s] t=+30s rpc: ok=true
+[+  55.35s] t=+55s rpc: ok=true
+[+  65.35s] t=+65s rpc: ok=false err=RPC method not available
+[+  75.36s] t=+75s rpc: ok=false err=RPC method not available
+```
+
+- Daemon **stays connected** the whole time.
+- After exactly 60 seconds the Redis key expires (`RPC_TTL_SECONDS = 60`,
+  `rpcHandler.ts:6`).
+- The daemon never knows. No code path on the daemon side detects the
+  expiration and re-registers. **The state stays broken until the
+  daemon reconnects** (which it might not do for hours).
+
+**Root cause:** TTL refresh only happens inside `machine-alive` and
+`session-alive` handlers (`machineUpdateHandler.ts:53`,
+`sessionUpdateHandler.ts:185`). If for **any reason** the daemon
+doesn't fire a keep-alive event in the 60-second window — slow
+network, blocked event loop on either side, dropped UDP, paused
+process, GC pause, anything — the registration vaporizes silently.
+
+There is no:
+- monitoring on the server to detect expired-but-still-connected
+  sockets
+- monitoring on the daemon to detect "my registration is gone"
+- background re-registration timer on the daemon
+
+**Production manifestation:** explains the cases where RPCs fail with
+"method not available" even though the daemon is "online" in the UI.
+Once it happens, it stays broken.
+
+### Bug #4: streams adapter unbounded-ish growth
+
+**Observation:** `kubectl exec happy-redis-0 -- redis-cli XINFO STREAM socket.io`
+
+```
+length            4946
+groups            0
+recorded-first-entry-id  1775994568700-0  (~70 minutes ago)
+last-generated-id        1775998585928-0  (now)
+entries-added            4946
+```
+
+- The `socket.io` stream has been growing for ~70 minutes.
+- `maxLen: 50000` was configured (`socket.ts:40`) — we are not at it
+  yet, but with enough activity we will be.
+- `groups: 0` — the adapter does not use Redis consumer groups, just
+  in-memory cursors per replica. After a pod restart, the new pod
+  resumes from `$` (latest), losing whatever was written during the
+  restart window.
+
+This is not an immediate-fire bug but it (a) means events written
+during a pod restart are lost cross-replica, and (b) at higher load
+will trigger XADD trimming and increase Redis pressure.
+
+## What I could not reproduce locally
+
+- **`transport close` storms with no apparent pod activity** (the
+  user's prod symptom). My local minikube only produces `transport
+  close` from explicit `kubectl delete pod`. Possible prod sources I
+  didn't get to:
+  - Cluster ingress / LB idle-timeout closing long-lived websockets
+  - K8s liveness probe killing pods on slow `/health` (not seen here
+    — `/health` is fast)
+  - OOMKill from Redis adapter buffering or pino logging
+  - Server-side ping timeout because event loop is blocked by the
+    `refreshRpcRegistrations` SCAN+pipeline path on heavy users
+- **Network-blackout effects:** `iptables -I OUTPUT -d <redis>`
+  applied via `kubectl debug --profile=netadmin --target=handy` did
+  not visibly affect ongoing RPCs in my run. Either kube-proxy
+  rewrites the destination before my rule, or conntrack ESTABLISHED
+  state is bypassing the drop, or the streams adapter buffers
+  gracefully through brief outages. Needs deeper packet capture work.
+
+## Why the original commits believed it worked
+
+`9e9e5f4f`'s test plan was steady-state cross-pod RPC with both
+sockets connected and no churn. That's exactly the slice that **does**
+work. The bugs all live in transitions: pod kill, reconnect, TTL roll.
+None of them appear in a 10-second smoke test of "send RPC, get reply."
+
+`888b87a3`'s "tested on real LB, 216 events/sec, 49ms disconnect
+detection" tests broadcast fan-out only — **never RPC routing**. That
+is also the slice that works.
+
+The fixes were shipped in sequence each catching the previous bug's
+shape, but none of them stress-tested the actual problem class:
+**RPC routing identity is tied to a transient socketId, and there is
+no atomic update path across daemon socket transitions.**
+
+## Minimum-viable fix candidates
+
+I am NOT writing code yet — these are sketches for the next
+conversation.
+
+1. **Re-register on every reconnect** (client side, daemon)
+    - Already done by happy-cli for fresh connects but the
+      *reconnect* path may not hit register again. Verify
+      `rpcRegistry` re-fires on `socket.connect` after disconnect.
+    - Cheap, doesn't fix in-flight calls but stops bug #3 from
+      sticking.
+
+2. **Index registrations by `socketId → [methods]` on each pod**
+    - Rebuild authoritative cleanup on disconnect without depending
+      on TTL.
+    - Drop the 60s TTL entirely, or raise it to e.g. 1 hour and
+      treat as a janitor-only safety net.
+
+3. **Fast-fail RPC when target socket is gone**
+    - Before `io.to(socketId).emitWithAck`, do a cheap presence
+      check via the adapter. If no pod claims the socketId, return
+      `'RPC target not reachable'` immediately instead of waiting
+      30s.
+    - The adapter exposes `fetchSockets({rooms: [socketId]})` for
+      this. Costs one Redis round trip per call.
+
+4. **Stop routing by socketId; route by stable method-name channel**
+    - Daemon subscribes to `rpc:method:<userId>:<method>` Redis
+      pub/sub channel.
+    - Caller publishes a request envelope `{requestId, params, replyTo}`.
+    - Daemon publishes response to `replyTo`.
+    - Decouples from socketId entirely. Reconnects don't lose RPC
+      identity. This is the "clean" fix; it's a bigger refactor.
+
+5. **Sticky daemon-aware routing**
+    - Route any user's RPC calls to the pod that hosts that user's
+      daemon. k8s `Service` with `sessionAffinity: ClientIP` per-user
+      hash. Means cross-pod RPC ≈ never happens. Smaller blast
+      radius without the protocol redesign.
+
+## Repro inventory (in `deploy/`)
+
+| File                          | Purpose |
+|-------------------------------|---------|
+| `local.sh`                    | Bring up minikube + 2-replica stack |
+| `test-multiprocess.mjs`       | Broadcast fan-out + pod-kill recovery |
+| `test-rpc-cross-replica.mjs`  | Steady-state cross-pod RPC |
+| `hammer.mjs`                  | Bug repros: pod-kill / reconnect-storm / ttl-expiry |
+| `network-loss.mjs`            | Long-running RPC loop with summary, used with iptables |
+| `probe-rpc.mjs`               | Direct rpc-register + Redis-key inspector |
+| `POSTMORTEM.md`               | This file |

--- a/deploy/integration-tests/hammer.mjs
+++ b/deploy/integration-tests/hammer.mjs
@@ -1,0 +1,347 @@
+// Hammer harness for the multi-pod handy-server stack.
+//
+// Scenarios:
+//   pod-kill-mid-rpc       Kill daemon's pod while caller has an in-flight RPC.
+//   ttl-expiry             Stop refreshing TTL, wait > 60s, see if RPC keeps working.
+//   reconnect-storm        Force-disconnect daemon repeatedly under load.
+//   redis-blackout         Drop pod→Redis traffic mid-test (TODO).
+//   cross-pod-broadcast    Subscribe on pod A, emit on pod B, measure fan-out.
+//
+// Run as:  node deploy/hammer.mjs <scenario>
+
+import tweetnacl from "tweetnacl";
+import { io } from "socket.io-client";
+import { Buffer } from "buffer";
+import { execSync, spawnSync } from "child_process";
+
+const SERVER = "http://127.0.0.1:3000";
+const base64 = (b) => Buffer.from(b).toString("base64");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getToken() {
+    const kp = tweetnacl.sign.keyPair();
+    const ch = tweetnacl.randomBytes(32);
+    const sig = tweetnacl.sign.detached(ch, kp.secretKey);
+    const r = await fetch(`${SERVER}/v1/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            publicKey: base64(kp.publicKey),
+            challenge: base64(ch),
+            signature: base64(sig),
+        }),
+    });
+    if (!r.ok) throw new Error(`auth ${r.status}`);
+    const j = await r.json();
+    return j.token;
+}
+
+function kc(args) {
+    return execSync(`kubectl ${args}`).toString().trim();
+}
+
+function getPods() {
+    return kc("get pods -l app=handy-server -o jsonpath='{.items[*].metadata.name}'")
+        .replace(/'/g, "")
+        .split(/\s+/)
+        .filter(Boolean);
+}
+
+function findPodFor(socketId) {
+    for (const p of getPods()) {
+        try {
+            const out = execSync(`kubectl logs ${p} --tail=2000 2>/dev/null`).toString();
+            if (out.includes(socketId)) return p;
+        } catch {}
+    }
+    return "?";
+}
+
+async function connect(token, opts = {}) {
+    const s = io(SERVER, {
+        path: "/v1/updates",
+        auth: { token, ...opts },
+        transports: ["websocket"],
+        reconnection: opts.reconnection ?? true,
+        reconnectionDelay: 200,
+        reconnectionDelayMax: 2000,
+        reconnectionAttempts: opts.reconnectionAttempts ?? 100,
+    });
+    s.on("connect", () => log(`  socket ${s.id} connected`));
+    s.on("disconnect", (reason) => log(`  socket ${s.id ?? "?"} disconnect: ${reason}`));
+    s.on("connect_error", (e) => log(`  socket connect_error: ${e.message}`));
+    return new Promise((res, rej) => {
+        const t = setTimeout(() => rej(new Error("connect timeout")), 10_000);
+        s.once("connect", () => { clearTimeout(t); res(s); });
+        s.once("connect_error", (e) => { clearTimeout(t); rej(e); });
+    });
+}
+
+const startTime = Date.now();
+function log(msg) {
+    const t = ((Date.now() - startTime) / 1000).toFixed(2);
+    console.log(`[+${t.padStart(6)}s] ${msg}`);
+}
+
+// Retry rpc-register because the server's connection handler does an
+// async auth.verifyToken before attaching the rpcHandler — messages
+// emitted in that window can be dropped. Up to 5 attempts at 200ms.
+async function awaitRegister(daemon, method) {
+    for (let i = 0; i < 5; i++) {
+        const acked = await new Promise((res) => {
+            const t = setTimeout(() => res(false), 200);
+            daemon.once("rpc-registered", () => { clearTimeout(t); res(true); });
+            daemon.emit("rpc-register", { method });
+        });
+        if (acked) return;
+    }
+    throw new Error(`rpc-register failed after 5 attempts for ${method}`);
+}
+
+async function registerEcho(daemon, method) {
+    daemon.on("rpc-request", (data, cb) => cb(data.params));
+    await awaitRegister(daemon, method);
+}
+
+async function rpcCall(caller, method, payload, timeout = 10_000) {
+    const start = Date.now();
+    try {
+        const result = await caller.timeout(timeout).emitWithAck("rpc-call", { method, params: payload });
+        return { ok: result.ok, error: result.error, latency: Date.now() - start, payload: result.result };
+    } catch (e) {
+        return { ok: false, error: e.message, latency: Date.now() - start };
+    }
+}
+
+// === SCENARIO: pod-kill-mid-rpc ===
+async function podKillMidRpc() {
+    log("=== pod-kill-mid-rpc ===");
+    const token = await getToken();
+    const sessionId = `kill-${Date.now()}`;
+    const METHOD = `${sessionId}:slow`;
+
+    log("connecting daemon");
+    const daemon = await connect(token, { clientType: "session-scoped", sessionId });
+
+    daemon.on("rpc-request", async (data, cb) => {
+        log(`  daemon got rpc-request, sleeping 5s`);
+        await sleep(5_000);
+        cb(data.params);
+    });
+    await awaitRegister(daemon, METHOD);
+    log(`registered method ${METHOD}`);
+
+    const daemonPod = findPodFor(daemon.id);
+    log(`daemon pod = ${daemonPod}`);
+
+    // Make sure caller lands on a different pod by trying many
+    let caller, callerPod;
+    for (let i = 0; i < 20; i++) {
+        const c = await connect(token, { clientType: "user-scoped" });
+        await sleep(200);
+        const p = findPodFor(c.id);
+        if (p !== daemonPod) {
+            caller = c;
+            callerPod = p;
+            break;
+        }
+        c.disconnect();
+    }
+    if (!caller) {
+        log("could not get cross-pod caller, using same-pod");
+        caller = await connect(token, { clientType: "user-scoped" });
+        callerPod = daemonPod;
+    }
+    log(`caller pod = ${callerPod} (cross-pod=${callerPod !== daemonPod})`);
+
+    log("firing rpc-call (will block 5s in handler)");
+    const callPromise = rpcCall(caller, METHOD, "alive?", 30_000);
+
+    // Kill daemon's pod 1s into the call
+    await sleep(1_000);
+    log(`killing daemon pod ${daemonPod}`);
+    try {
+        kc(`delete pod ${daemonPod} --grace-period=0 --force --wait=false`);
+    } catch (e) {
+        log(`kill error: ${e.message}`);
+    }
+
+    const result = await callPromise;
+    log(`rpc-call result: ok=${result.ok} latency=${result.latency}ms err=${result.error ?? "-"}`);
+
+    daemon.disconnect();
+    caller.disconnect();
+    process.exit(0);
+}
+
+// === SCENARIO: reconnect-storm ===
+async function reconnectStorm() {
+    log("=== reconnect-storm ===");
+    const token = await getToken();
+    const sessionId = `storm-${Date.now()}`;
+    const METHOD = `${sessionId}:echo`;
+
+    const daemon = await connect(token, { clientType: "session-scoped", sessionId });
+    await registerEcho(daemon, METHOD);
+    log(`daemon registered`);
+
+    const callers = [];
+    for (let i = 0; i < 5; i++) {
+        callers.push(await connect(token, { clientType: "user-scoped" }));
+    }
+    log(`${callers.length} callers connected`);
+    await sleep(500);
+
+    // Background: every 200ms each caller fires an RPC
+    let success = 0, fail = 0;
+    const errors = new Map();
+    let stop = false;
+    const callerLoops = callers.map(async (c, i) => {
+        while (!stop) {
+            const r = await rpcCall(c, METHOD, `c${i}-${Date.now()}`, 5_000);
+            if (r.ok) success++;
+            else { fail++; errors.set(r.error, (errors.get(r.error) || 0) + 1); }
+            await sleep(200);
+        }
+    });
+
+    // Force daemon to reconnect 5 times with 1s pauses
+    for (let i = 0; i < 5; i++) {
+        await sleep(2_000);
+        log(`disconnecting daemon (round ${i + 1}/5)`);
+        daemon.disconnect();
+        await sleep(100);
+        daemon.connect();
+        await new Promise((r) => daemon.once("connect", r));
+        await registerEcho(daemon, METHOD);
+        log(`daemon re-registered after reconnect`);
+    }
+
+    await sleep(2_000);
+    stop = true;
+    await Promise.all(callerLoops);
+
+    log(`results: success=${success} fail=${fail}`);
+    for (const [err, n] of errors) log(`  err: ${err} ×${n}`);
+
+    daemon.disconnect();
+    callers.forEach(c => c.disconnect());
+    process.exit(0);
+}
+
+// === SCENARIO: ttl-expiry ===
+async function ttlExpiry() {
+    log("=== ttl-expiry ===");
+    log("daemon registers, then we wait 70s WITHOUT sending machine-alive");
+    log("this should let the 60s Redis TTL expire");
+    const token = await getToken();
+    const sessionId = `ttl-${Date.now()}`;
+    const METHOD = `${sessionId}:echo`;
+
+    const daemon = await connect(token, { clientType: "session-scoped", sessionId });
+    await registerEcho(daemon, METHOD);
+    log("daemon registered, daemon stays connected, but we never send keep-alive");
+
+    const caller = await connect(token, { clientType: "user-scoped" });
+
+    for (const t of [5, 30, 55, 65, 75]) {
+        await sleep((t - (t === 5 ? 0 : (t === 30 ? 5 : t === 55 ? 30 : t === 65 ? 55 : 65))) * 1_000);
+        const r = await rpcCall(caller, METHOD, `t=${t}`, 5_000);
+        log(`t=+${t}s rpc: ok=${r.ok} err=${r.error ?? "-"} latency=${r.latency}ms`);
+    }
+
+    daemon.disconnect();
+    caller.disconnect();
+    process.exit(0);
+}
+
+// === SCENARIO: brief-disconnect ===
+// Daemon disconnects RIGHT BEFORE the caller fires its rpc-call. Daemon
+// reconnects 1.5s later. With wait-for-reconnect grace, the call should
+// succeed (single RPC, ~1.5s latency). Without grace, it would fail fast.
+async function briefDisconnect() {
+    log("=== brief-disconnect ===");
+    const token = await getToken();
+    const sessionId = `brief-${Date.now()}`;
+    const METHOD = `${sessionId}:echo`;
+
+    const daemon = await connect(token, { clientType: "session-scoped", sessionId });
+    daemon.on("rpc-request", (data, cb) => cb({ echo: data.params }));
+    await awaitRegister(daemon, METHOD);
+    log("daemon registered");
+
+    const caller = await connect(token, { clientType: "user-scoped" });
+    log("caller connected");
+
+    // Disconnect daemon immediately
+    log("disconnecting daemon");
+    daemon.disconnect();
+
+    // Schedule reconnect in 1.5s — also re-register
+    setTimeout(async () => {
+        log("daemon RECONNECTING");
+        daemon.connect();
+        await new Promise((r) => daemon.once("connect", r));
+        log("daemon reconnected, re-registering");
+        await awaitRegister(daemon, METHOD);
+    }, 1500);
+
+    // Fire rpc-call immediately. Should wait, then succeed.
+    log("firing rpc-call (daemon offline, will reconnect in 1.5s)");
+    const t0 = Date.now();
+    const r = await rpcCall(caller, METHOD, "hello", 10_000);
+    log(`rpc-call: ok=${r.ok} latency=${Date.now() - t0}ms result=${JSON.stringify(r.payload ?? r.error)}`);
+
+    // Also test that subsequent calls work after reconnect
+    await sleep(500);
+    const r2 = await rpcCall(caller, METHOD, "hello2", 5_000);
+    log(`follow-up rpc-call: ok=${r2.ok} latency=${r2.latency}ms`);
+
+    daemon.disconnect();
+    caller.disconnect();
+    process.exit(0);
+}
+
+// === SCENARIO: long-disconnect ===
+// Daemon disconnects and never comes back. The wait-for-reconnect grace must
+// expire and the call must fail with "RPC method not available" promptly
+// (within ~grace + small fudge), not hang for 30s.
+async function longDisconnect() {
+    log("=== long-disconnect ===");
+    const token = await getToken();
+    const sessionId = `long-${Date.now()}`;
+    const METHOD = `${sessionId}:echo`;
+
+    const daemon = await connect(token, { clientType: "session-scoped", sessionId });
+    daemon.on("rpc-request", (data, cb) => cb({ echo: data.params }));
+    await awaitRegister(daemon, METHOD);
+    log("daemon registered");
+
+    const caller = await connect(token, { clientType: "user-scoped" });
+
+    log("disconnecting daemon FOREVER");
+    daemon.disconnect();
+
+    log("firing rpc-call (daemon will not reconnect)");
+    const t0 = Date.now();
+    const r = await rpcCall(caller, METHOD, "ghost", 30_000);
+    log(`rpc-call: ok=${r.ok} latency=${Date.now() - t0}ms err=${r.error ?? "-"}`);
+
+    caller.disconnect();
+    process.exit(0);
+}
+
+// === main ===
+const scenario = process.argv[2];
+const scenarios = {
+    "pod-kill-mid-rpc": podKillMidRpc,
+    "reconnect-storm": reconnectStorm,
+    "ttl-expiry": ttlExpiry,
+    "brief-disconnect": briefDisconnect,
+    "long-disconnect": longDisconnect,
+};
+if (!scenario || !scenarios[scenario]) {
+    console.error(`usage: node deploy/hammer.mjs <${Object.keys(scenarios).join("|")}>`);
+    process.exit(2);
+}
+scenarios[scenario]().catch((e) => { console.error(e); process.exit(1); });

--- a/deploy/integration-tests/missed-events.mjs
+++ b/deploy/integration-tests/missed-events.mjs
@@ -1,0 +1,162 @@
+// Definitive test of message-propagation across reconnect.
+//
+// Scenario:
+//   1. Connect a user-scoped socket (the "watcher") and capture every `update`
+//      event it receives.
+//   2. Trigger a server-side broadcast by POSTing /v1/sessions — server emits
+//      'new-session' update to the user-scoped room.
+//   3. Verify the watcher received it.
+//   4. Disconnect the watcher.
+//   5. Trigger another /v1/sessions POST while the watcher is offline.
+//   6. Reconnect the watcher.
+//   7. Wait briefly. Did the missed event arrive?
+//   8. Also: hit GET /v1/sessions to confirm the second session exists in DB
+//      (the client's fall-back re-fetch path).
+//
+// EXPECTED with current config (no connectionStateRecovery):
+//   - Step 3 watcher receives event #1 ✅
+//   - Step 7 watcher receives ZERO new events (the missed broadcast is lost)
+//   - Step 8 GET returns BOTH sessions (DB has them) ✅
+//
+// This proves: broadcasts are LOST during disconnect, and the client must
+// re-fetch on reconnect to catch up. Same as origin/main, same as the broken
+// multi-replica code, same as the fix.
+
+import tweetnacl from "tweetnacl";
+import { io } from "socket.io-client";
+import { Buffer } from "buffer";
+
+const SERVER = process.env.SERVER ?? "http://127.0.0.1:3000";
+const base64 = (b) => Buffer.from(b).toString("base64");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const t0 = Date.now();
+const log = (m) => console.log(`[+${((Date.now() - t0) / 1000).toFixed(2).padStart(7)}s] ${m}`);
+
+async function getToken() {
+    const kp = tweetnacl.sign.keyPair();
+    const ch = tweetnacl.randomBytes(32);
+    const sig = tweetnacl.sign.detached(ch, kp.secretKey);
+    const r = await fetch(`${SERVER}/v1/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ publicKey: base64(kp.publicKey), challenge: base64(ch), signature: base64(sig) }),
+    });
+    if (!r.ok) throw new Error(`auth ${r.status}`);
+    return (await r.json()).token;
+}
+
+async function createSession(token, tag) {
+    const r = await fetch(`${SERVER}/v1/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+        body: JSON.stringify({ tag, metadata: JSON.stringify({ tag }) }),
+    });
+    if (!r.ok) throw new Error(`createSession ${r.status} ${await r.text()}`);
+    return (await r.json()).session;
+}
+
+async function listSessions(token) {
+    const r = await fetch(`${SERVER}/v1/sessions`, {
+        headers: { "Authorization": `Bearer ${token}` },
+    });
+    if (!r.ok) throw new Error(`listSessions ${r.status}`);
+    return (await r.json()).sessions;
+}
+
+function connectWatcher(token) {
+    const events = [];
+    const socket = io(SERVER, {
+        path: "/v1/updates",
+        auth: { token, clientType: "user-scoped" },
+        transports: ["websocket"],
+        // Auto-reconnect MUST be enabled for connectionStateRecovery to work.
+        // Recovery only fires when the socket reconnects through the engine's
+        // own auto-reconnect path (not from a manual disconnect+connect).
+        // Delay set to 1500ms so we have a clean window to fire the missed
+        // event AFTER the disconnect but BEFORE auto-reconnect completes.
+        reconnection: true,
+        reconnectionDelay: 1500,
+        reconnectionDelayMax: 1500,
+    });
+    socket.on("update", (data) => {
+        const t = data?.body?.t ?? "?";
+        events.push({ t, body: data?.body });
+    });
+    socket.on("connect", () => {
+        log(`  watcher connected as ${socket.id}, recovered=${socket.recovered}`);
+    });
+    socket.on("disconnect", (reason) => {
+        log(`  watcher disconnect: ${reason}`);
+    });
+    return { socket, events };
+}
+
+async function main() {
+    const token = await getToken();
+    log("auth ok");
+
+    const { socket: watcher, events } = connectWatcher(token);
+    await new Promise((r) => watcher.once("connect", r));
+
+    // === STEP 1+2: trigger event #1 while watcher is connected ===
+    const tag1 = `test-${Date.now()}-A`;
+    log(`creating session #1 (tag=${tag1})`);
+    const s1 = await createSession(token, tag1);
+    log(`  session #1 id=${s1.id}`);
+    await sleep(500);  // give the broadcast a moment
+
+    // === STEP 3: did the watcher receive it? ===
+    const newSessionEvents1 = events.filter(e => e.t === "new-session");
+    log(`  watcher received ${newSessionEvents1.length} new-session events`);
+    log(`  ✅ event #1 received: ${newSessionEvents1.some(e => e.body.id === s1.id) ? "YES" : "NO"}`);
+
+    // === STEP 4: force a TRANSPORT-LEVEL disconnect (not graceful), so the
+    // engine's auto-reconnect path runs — that path sends the recovery
+    // handshake. A manual socket.disconnect() would NOT trigger recovery. ===
+    log("force-closing watcher transport (engine.close)");
+    const eventsBefore = events.length;
+    const oldSid = watcher.id;
+    watcher.io.engine.close();
+    await sleep(200);
+
+    // === STEP 5: trigger event #2 while watcher offline ===
+    const tag2 = `test-${Date.now()}-B`;
+    log(`creating session #2 (tag=${tag2}) — watcher OFFLINE`);
+    const s2 = await createSession(token, tag2);
+    log(`  session #2 id=${s2.id}`);
+
+    // === STEP 6: wait for auto-reconnect ===
+    log("waiting for auto-reconnect");
+    if (!watcher.connected) {
+        await new Promise((r) => watcher.once("connect", r));
+    }
+    log(`  reconnected, new sid=${watcher.id} (was ${oldSid}), recovered=${watcher.recovered}`);
+    await sleep(1500);  // give server time to push any replayed events
+
+    // === STEP 7: did missed event arrive? ===
+    const newEvents = events.slice(eventsBefore);
+    const missedReceived = newEvents.some(e => e.t === "new-session" && e.body.id === s2.id);
+    log(`  events received after reconnect: ${newEvents.length}`);
+    log(`  missed-event #2 replayed via socket: ${missedReceived ? "YES (state recovery worked)" : "NO (lost; client must re-fetch)"}`);
+
+    // === STEP 8: REST fall-back ===
+    const allSessions = await listSessions(token);
+    const inDb1 = allSessions.find(s => s.id === s1.id);
+    const inDb2 = allSessions.find(s => s.id === s2.id);
+    log(`  REST GET /v1/sessions returns ${allSessions.length} sessions`);
+    log(`  session #1 in DB: ${inDb1 ? "YES" : "NO"}`);
+    log(`  session #2 in DB: ${inDb2 ? "YES" : "NO"}`);
+
+    log("");
+    log("=== SUMMARY ===");
+    log(`event #1 (online):  watcher received: ${newSessionEvents1.some(e => e.body.id === s1.id) ? "YES ✅" : "NO ❌"}`);
+    log(`event #2 (offline): watcher received via socket on reconnect: ${missedReceived ? "YES (recovery)" : "NO (lost from stream)"}`);
+    log(`event #2 in DB:     ${inDb2 ? "YES (REST re-fetch path works)" : "NO ❌"}`);
+    log(`socket.recovered on reconnect: ${watcher.recovered}`);
+
+    watcher.disconnect();
+    process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/deploy/integration-tests/network-loss.mjs
+++ b/deploy/integration-tests/network-loss.mjs
@@ -1,0 +1,130 @@
+// Network-loss test: connect daemon + caller, fire RPCs every 250ms in a loop,
+// log every result. External script blocks/unblocks pod-Redis or pod-pod traffic
+// while this is running. After SIGTERM/Ctrl-C we print a summary.
+
+import tweetnacl from "tweetnacl";
+import { io } from "socket.io-client";
+import { Buffer } from "buffer";
+import { execSync } from "child_process";
+
+const SERVER = "http://127.0.0.1:3000";
+const base64 = (b) => Buffer.from(b).toString("base64");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getToken() {
+    const kp = tweetnacl.sign.keyPair();
+    const ch = tweetnacl.randomBytes(32);
+    const sig = tweetnacl.sign.detached(ch, kp.secretKey);
+    const r = await fetch(`${SERVER}/v1/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ publicKey: base64(kp.publicKey), challenge: base64(ch), signature: base64(sig) }),
+    });
+    if (!r.ok) throw new Error(`auth ${r.status}`);
+    return (await r.json()).token;
+}
+
+function findPod(socketId) {
+    const pods = execSync(`kubectl get pods -l app=handy-server -o jsonpath='{.items[*].metadata.name}'`).toString().replace(/'/g, "").split(/\s+/).filter(Boolean);
+    for (const p of pods) {
+        try {
+            const out = execSync(`kubectl logs ${p} --tail=2000 2>/dev/null`).toString();
+            if (out.includes(socketId)) return p;
+        } catch {}
+    }
+    return "?";
+}
+
+const t0 = Date.now();
+const log = (m) => console.log(`[+${((Date.now() - t0) / 1000).toFixed(2).padStart(7)}s] ${m}`);
+
+async function main() {
+    const token = await getToken();
+    const sessionId = `net-${Date.now()}`;
+    const METHOD = `${sessionId}:echo`;
+
+    log("connecting daemon");
+    const daemon = io(SERVER, { path: "/v1/updates", auth: { token, clientType: "session-scoped", sessionId }, transports: ["websocket"], reconnection: true, reconnectionDelay: 200, reconnectionDelayMax: 1000 });
+    await new Promise((r) => daemon.once("connect", r));
+    daemon.on("rpc-request", (data, cb) => cb(data.params));
+    daemon.emit("rpc-register", { method: METHOD });
+    await new Promise((r) => daemon.once("rpc-registered", r));
+    log(`daemon ${daemon.id} registered, pod=${findPod(daemon.id)}`);
+
+    log("connecting cross-pod caller");
+    let caller, callerPod;
+    const daemonPod = findPod(daemon.id);
+    for (let i = 0; i < 20; i++) {
+        const c = io(SERVER, { path: "/v1/updates", auth: { token, clientType: "user-scoped" }, transports: ["websocket"], reconnection: true });
+        await new Promise((r) => c.once("connect", r));
+        await sleep(150);
+        const p = findPod(c.id);
+        if (p !== daemonPod) {
+            caller = c;
+            callerPod = p;
+            break;
+        }
+        c.disconnect();
+    }
+    if (!caller) {
+        caller = io(SERVER, { path: "/v1/updates", auth: { token, clientType: "user-scoped" }, transports: ["websocket"], reconnection: true });
+        await new Promise((r) => caller.once("connect", r));
+        callerPod = daemonPod;
+    }
+    log(`caller ${caller.id}, pod=${callerPod} (cross-pod=${callerPod !== daemonPod})`);
+
+    daemon.on("disconnect", (reason) => log(`!! daemon disconnect: ${reason}`));
+    daemon.on("connect", () => {
+        log(`!! daemon reconnected as ${daemon.id}, re-registering`);
+        daemon.emit("rpc-register", { method: METHOD });
+    });
+    caller.on("disconnect", (reason) => log(`!! caller disconnect: ${reason}`));
+    caller.on("connect", () => log(`!! caller reconnected as ${caller.id}`));
+
+    const stats = { ok: 0, fail: 0, byErr: new Map() };
+    let i = 0;
+    const startLoop = async () => {
+        while (true) {
+            const start = Date.now();
+            i++;
+            try {
+                const res = await caller.timeout(5_000).emitWithAck("rpc-call", { method: METHOD, params: `n${i}` });
+                const lat = Date.now() - start;
+                if (res.ok && res.result === `n${i}`) {
+                    stats.ok++;
+                    if (i % 10 === 0) log(`  rpc#${i} ok lat=${lat}ms`);
+                } else {
+                    stats.fail++;
+                    const e = res.error || "wrong-result";
+                    stats.byErr.set(e, (stats.byErr.get(e) || 0) + 1);
+                    log(`  rpc#${i} FAIL lat=${lat}ms err=${e}`);
+                }
+            } catch (e) {
+                stats.fail++;
+                const err = e.message || String(e);
+                stats.byErr.set(err, (stats.byErr.get(err) || 0) + 1);
+                log(`  rpc#${i} FAIL lat=${Date.now() - start}ms err=${err}`);
+            }
+            await sleep(250);
+        }
+    };
+    startLoop().catch((e) => log(`loop error: ${e.message}`));
+
+    const print = () => {
+        log(`\n=== SUMMARY ===`);
+        log(`total=${i} ok=${stats.ok} fail=${stats.fail}`);
+        for (const [err, n] of stats.byErr) log(`  ${err} ×${n}`);
+        log(`daemonPod=${daemonPod} callerPod=${callerPod}`);
+    };
+    process.on("SIGTERM", () => { print(); process.exit(0); });
+    process.on("SIGINT", () => { print(); process.exit(0); });
+
+    // Auto-stop after 60s
+    await sleep(60_000);
+    print();
+    daemon.disconnect();
+    caller.disconnect();
+    process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/deploy/integration-tests/probe-fetchsockets.mjs
+++ b/deploy/integration-tests/probe-fetchsockets.mjs
@@ -1,0 +1,107 @@
+// Probe: verify that io.in(roomName).fetchSockets() finds remote sockets
+// across replicas via the Redis streams adapter, and that calling
+// .timeout().emitWithAck() on a RemoteSocket works cross-pod.
+//
+// We can't run this from outside the cluster — fetchSockets is server-side.
+// So we test it indirectly: connect a client that joins a custom room via
+// a server probe endpoint, then call from another connection to trigger
+// a server-side handler that does fetchSockets.
+//
+// SIMPLER ALTERNATIVE: just test the new rpc handler directly. It's the
+// thing we care about. fetchSockets is internal to the server.
+//
+// This script is intentionally tiny — connect, register, call, measure.
+
+import tweetnacl from "tweetnacl";
+import { io } from "socket.io-client";
+import { Buffer } from "buffer";
+import { execSync } from "child_process";
+
+const SERVER = "http://127.0.0.1:3000";
+const base64 = (b) => Buffer.from(b).toString("base64");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function getToken() {
+    const kp = tweetnacl.sign.keyPair();
+    const ch = tweetnacl.randomBytes(32);
+    const sig = tweetnacl.sign.detached(ch, kp.secretKey);
+    const r = await fetch(`${SERVER}/v1/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ publicKey: base64(kp.publicKey), challenge: base64(ch), signature: base64(sig) }),
+    });
+    if (!r.ok) throw new Error(`auth ${r.status}`);
+    return (await r.json()).token;
+}
+
+function findPod(socketId) {
+    const pods = execSync(`kubectl get pods -l app=handy-server -o jsonpath='{.items[*].metadata.name}'`).toString().replace(/'/g, "").split(/\s+/).filter(Boolean);
+    for (const p of pods) {
+        try {
+            const out = execSync(`kubectl logs ${p} --tail=2000 2>/dev/null`).toString();
+            if (out.includes(socketId)) return p;
+        } catch {}
+    }
+    return "?";
+}
+
+async function main() {
+    const token = await getToken();
+    const sessionId = `probe-fs-${Date.now()}`;
+    const METHOD = `${sessionId}:echo`;
+
+    // Connect daemon
+    const daemon = io(SERVER, { path: "/v1/updates", auth: { token, clientType: "session-scoped", sessionId }, transports: ["websocket"], reconnection: false });
+    await new Promise((r) => daemon.once("connect", r));
+    daemon.on("rpc-request", (data, cb) => cb({ echo: data.params, fromDaemon: daemon.id }));
+    daemon.emit("rpc-register", { method: METHOD });
+    await new Promise((r) => daemon.once("rpc-registered", r));
+    const daemonPod = findPod(daemon.id);
+    console.log(`daemon ${daemon.id} on ${daemonPod}`);
+
+    // Connect a caller, retry until cross-pod
+    let caller, callerPod;
+    for (let i = 0; i < 30; i++) {
+        const c = io(SERVER, { path: "/v1/updates", auth: { token, clientType: "user-scoped" }, transports: ["websocket"], reconnection: false });
+        await new Promise((r) => c.once("connect", r));
+        await sleep(150);
+        const p = findPod(c.id);
+        if (p !== daemonPod) { caller = c; callerPod = p; break; }
+        c.disconnect();
+    }
+    if (!caller) {
+        console.log("could not get cross-pod caller; running same-pod");
+        caller = io(SERVER, { path: "/v1/updates", auth: { token, clientType: "user-scoped" }, transports: ["websocket"], reconnection: false });
+        await new Promise((r) => caller.once("connect", r));
+        callerPod = daemonPod;
+    }
+    console.log(`caller ${caller.id} on ${callerPod} (cross-pod=${callerPod !== daemonPod})`);
+
+    // Make a single rpc-call. Time it.
+    const start = Date.now();
+    try {
+        const result = await caller.timeout(5000).emitWithAck("rpc-call", { method: METHOD, params: "hello" });
+        const lat = Date.now() - start;
+        console.log(`call lat=${lat}ms result=${JSON.stringify(result).slice(0, 200)}`);
+    } catch (e) {
+        console.log(`call FAILED in ${Date.now() - start}ms: ${e.message}`);
+    }
+
+    // Now disconnect daemon and try the call again — measure fast-fail latency
+    console.log("\n-- daemon gone, testing fast-fail --");
+    daemon.disconnect();
+    await sleep(500);  // give server a moment to clean up
+
+    const t2 = Date.now();
+    try {
+        const r2 = await caller.timeout(5000).emitWithAck("rpc-call", { method: METHOD, params: "ghost" });
+        console.log(`ghost call lat=${Date.now() - t2}ms result=${JSON.stringify(r2)}`);
+    } catch (e) {
+        console.log(`ghost call FAILED in ${Date.now() - t2}ms: ${e.message}`);
+    }
+
+    caller.disconnect();
+    process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/deploy/integration-tests/probe-rpc.mjs
+++ b/deploy/integration-tests/probe-rpc.mjs
@@ -1,0 +1,69 @@
+import tweetnacl from "tweetnacl";
+import { io } from "socket.io-client";
+import { Buffer } from "buffer";
+import { execSync } from "child_process";
+
+const SERVER = "http://127.0.0.1:3000";
+const base64 = (buf) => Buffer.from(buf).toString("base64");
+
+async function getToken() {
+    const keyPair = tweetnacl.sign.keyPair();
+    const challenge = tweetnacl.randomBytes(32);
+    const signature = tweetnacl.sign.detached(challenge, keyPair.secretKey);
+    const res = await fetch(`${SERVER}/v1/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            publicKey: base64(keyPair.publicKey),
+            challenge: base64(challenge),
+            signature: base64(signature),
+        }),
+    });
+    if (!res.ok) throw new Error(`Auth failed: ${res.status}`);
+    const json = await res.json();
+    return json;
+}
+
+function redisCli(cmd) {
+    return execSync(`kubectl exec happy-redis-0 -- redis-cli ${cmd}`).toString().trim();
+}
+
+async function main() {
+    const { token, user } = await getToken();
+    console.log(`Auth: userId=${user?.id ?? '?'}`);
+
+    const sessionId = `probe-${Date.now()}`;
+    const METHOD = `${sessionId}:echo`;
+
+    const daemon = io(SERVER, {
+        path: "/v1/updates",
+        auth: { token, clientType: "session-scoped", sessionId },
+        transports: ["websocket"],
+        reconnection: false,
+    });
+
+    daemon.on("connect", () => console.log(`daemon connected: ${daemon.id}`));
+    daemon.on("rpc-registered", (d) => console.log(`✅ rpc-registered ack: ${JSON.stringify(d)}`));
+    daemon.on("rpc-error", (d) => console.log(`❌ rpc-error: ${JSON.stringify(d)}`));
+    daemon.on("connect_error", (e) => console.log(`connect_error: ${e.message}`));
+
+    await new Promise(r => daemon.on("connect", r));
+
+    // Check redis BEFORE register
+    console.log(`\nbefore register: KEYS rpc:* → "${redisCli("KEYS 'rpc:*'")}"`);
+
+    daemon.emit("rpc-register", { method: METHOD });
+    console.log(`emitted rpc-register method=${METHOD}`);
+
+    // Wait for ack OR 1s
+    await new Promise(r => setTimeout(r, 1000));
+
+    console.log(`\nafter register: KEYS rpc:* → "${redisCli("KEYS 'rpc:*'")}"`);
+    const allKeys = redisCli("KEYS '*'");
+    console.log(`all redis keys: "${allKeys}"`);
+
+    daemon.disconnect();
+    process.exit(0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/deploy/integration-tests/test-multiprocess.mjs
+++ b/deploy/integration-tests/test-multiprocess.mjs
@@ -1,0 +1,236 @@
+import tweetnacl from "tweetnacl";
+import { io } from "socket.io-client";
+import { Buffer } from "buffer";
+import { execSync } from "child_process";
+
+const SERVER = "http://127.0.0.1:3000"; // minikube tunnel LB
+const NUM_CLIENTS = 20;
+
+const base64 = (buf) => Buffer.from(buf).toString("base64");
+
+async function getToken() {
+  const keyPair = tweetnacl.sign.keyPair();
+  const challenge = tweetnacl.randomBytes(32);
+  const signature = tweetnacl.sign.detached(challenge, keyPair.secretKey);
+  const res = await fetch(`${SERVER}/v1/auth`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      publicKey: base64(keyPair.publicKey),
+      challenge: base64(challenge),
+      signature: base64(signature),
+    }),
+  });
+  if (!res.ok) throw new Error(`Auth failed: ${res.status}`);
+  return (await res.json()).token;
+}
+
+function getPods() {
+  return execSync("kubectl get pods -l app=handy-server -o jsonpath='{.items[*].metadata.name}'")
+    .toString().replace(/'/g, "").trim().split(/\s+/);
+}
+
+function findSocketInPodLogs(socketId, pods) {
+  for (const pod of pods) {
+    const logs = execSync(`kubectl logs ${pod} --tail=200 2>/dev/null`).toString();
+    if (logs.includes(socketId)) return pod;
+  }
+  return "unknown";
+}
+
+async function test() {
+  console.log("=== RECONNECTION TEST via LoadBalancer ===");
+  console.log(`Server: ${SERVER} (minikube tunnel)\n`);
+
+  const health = await fetch(`${SERVER}/health`).then(r => r.json());
+  console.log(`Health: ${health.status}`);
+
+  const pods = getPods();
+  console.log(`Pods: ${pods.join(", ")}\n`);
+
+  const token = await getToken();
+
+  // ============================================================
+  // Connect ALL clients through the LB — no pod targeting
+  // k8s distributes them naturally
+  // ============================================================
+  console.log(`--- Connecting ${NUM_CLIENTS} clients through LoadBalancer ---`);
+  console.log(`Reconnection: enabled (500ms delay, 20 attempts)\n`);
+
+  const clients = [];
+  for (let i = 0; i < NUM_CLIENTS; i++) {
+    const socket = io(SERVER, {
+      path: "/v1/updates",
+      auth: { token, clientType: "user-scoped" },
+      transports: ["websocket"],
+      reconnection: true,
+      reconnectionDelay: 500,
+      reconnectionDelayMax: 3000,
+      reconnectionAttempts: 20,
+    });
+
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error(`Client ${i}: timeout`)), 10000);
+      socket.on("connect", () => { clearTimeout(timeout); resolve(); });
+      socket.on("connect_error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+
+    clients.push({
+      socket,
+      originalId: socket.id,
+      disconnectTime: null,
+      reconnectTime: null,
+      disconnected: false,
+      reconnected: false,
+      reconnectAttempt: 0,
+      pod: null,
+    });
+  }
+  console.log(`  ${NUM_CLIENTS} clients connected.\n`);
+
+  // Check pod distribution from logs
+  await new Promise(r => setTimeout(r, 2000));
+
+  const podDist = {};
+  for (const pod of pods) podDist[pod] = 0;
+
+  for (const client of clients) {
+    const pod = findSocketInPodLogs(client.originalId, pods);
+    client.pod = pod;
+    if (podDist[pod] !== undefined) podDist[pod]++;
+    else podDist[pod] = 1;
+  }
+
+  console.log("  Pod distribution:");
+  for (const [pod, count] of Object.entries(podDist)) {
+    console.log(`    ${pod}: ${count} clients`);
+  }
+
+  // Kill the pod with more clients
+  const podToKill = Object.entries(podDist).sort((a, b) => b[1] - a[1])[0][0];
+  const affectedCount = podDist[podToKill];
+  console.log(`\n  Will kill: ${podToKill} (${affectedCount} clients affected)\n`);
+
+  // ============================================================
+  // Track disconnect + reconnect
+  // ============================================================
+  for (const client of clients) {
+    client.socket.on("disconnect", (reason) => {
+      if (!client.disconnectTime) {
+        client.disconnectTime = Date.now();
+        client.disconnected = true;
+        client.disconnectReason = reason;
+      }
+    });
+    client.socket.on("reconnect", (attempt) => {
+      client.reconnectTime = Date.now();
+      client.reconnected = true;
+      client.reconnectAttempt = attempt;
+    });
+    client.socket.on("reconnect_failed", () => {
+      client.reconnectFailed = true;
+    });
+  }
+
+  // ============================================================
+  // KILL
+  // ============================================================
+  console.log("--- KILLING POD ---");
+  const killTime = Date.now();
+  execSync(`kubectl delete pod ${podToKill} --grace-period=0 --force 2>/dev/null || true`);
+  console.log(`  ${podToKill} killed.\n`);
+
+  for (let sec = 1; sec <= 30; sec++) {
+    await new Promise(r => setTimeout(r, 1000));
+
+    const disconnected = clients.filter(c => c.disconnected).length;
+    const reconnected = clients.filter(c => c.reconnected).length;
+    const failed = clients.filter(c => c.reconnectFailed).length;
+    const connected = clients.filter(c => c.socket.connected).length;
+
+    console.log(
+      `  t+${sec.toString().padStart(2)}s:  connected=${connected}/${NUM_CLIENTS}  disconnected=${disconnected}  reconnected=${reconnected}  failed=${failed}`
+    );
+
+    if (connected >= NUM_CLIENTS || (reconnected + failed >= affectedCount && sec > 3)) {
+      console.log(`  Settled.`);
+      break;
+    }
+  }
+
+  // ============================================================
+  // RESULTS
+  // ============================================================
+  console.log("\n--- RESULTS ---\n");
+
+  const affected = clients.filter(c => c.pod === podToKill);
+  const unaffected = clients.filter(c => c.pod !== podToKill);
+
+  // Affected
+  const affDisc = affected.filter(c => c.disconnected);
+  const affRecon = affected.filter(c => c.reconnected);
+
+  console.log(`Affected clients (on killed pod): ${affected.length}`);
+  if (affDisc.length > 0) {
+    const dt = affDisc.map(c => c.disconnectTime - killTime);
+    console.log(`  Disconnect:    ${affDisc.length}/${affected.length} detected in avg ${Math.round(dt.reduce((a, b) => a + b, 0) / dt.length)}ms`);
+  }
+  if (affRecon.length > 0) {
+    const rt = affRecon.map(c => c.reconnectTime - killTime);
+    const down = affRecon.map(c => c.reconnectTime - c.disconnectTime);
+    console.log(`  Reconnected:   ${affRecon.length}/${affected.length} via LB auto-failover`);
+    console.log(`  Reconnect at:  avg ${Math.round(rt.reduce((a, b) => a + b, 0) / rt.length)}ms from kill`);
+    console.log(`  User downtime: avg ${Math.round(down.reduce((a, b) => a + b, 0) / down.length)}ms`);
+    console.log(`  Attempts:      ${affRecon.map(c => c.reconnectAttempt).join(", ")}`);
+  }
+
+  // Unaffected
+  const unaffDisc = unaffected.filter(c => c.disconnected);
+  console.log(`\nUnaffected clients (surviving pod): ${unaffected.length}`);
+  console.log(`  Disrupted: ${unaffDisc.length} (should be 0)`);
+  console.log(`  Connected: ${unaffected.filter(c => c.socket.connected).length}`);
+
+  // Verify events work after recovery
+  console.log("\nVerifying events post-recovery...");
+  let eventCount = 0;
+  const connected = clients.filter(c => c.socket.connected);
+  for (const c of connected) {
+    c.socket.removeAllListeners("update");
+    c.socket.on("update", () => eventCount++);
+  }
+
+  await fetch(`${SERVER}/v1/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ tag: `post-kill-${Date.now()}`, metadata: "{}" }),
+  });
+  await new Promise(r => setTimeout(r, 2000));
+
+  console.log(`  Connected: ${connected.length}/${NUM_CLIENTS}`);
+  console.log(`  Events:    ${eventCount}/${connected.length}`);
+
+  // ============================================================
+  console.log("\n========================================");
+  console.log("           VERDICT");
+  console.log("========================================");
+  console.log(`Pod distribution:    ${Object.entries(podDist).map(([p, c]) => `${c}`).join(" / ")}`);
+  if (affDisc.length > 0) {
+    const dt = affDisc.map(c => c.disconnectTime - killTime);
+    console.log(`Disconnect speed:    ${Math.round(dt.reduce((a, b) => a + b, 0) / dt.length)}ms`);
+  }
+  if (affRecon.length > 0) {
+    const down = affRecon.map(c => c.reconnectTime - c.disconnectTime);
+    console.log(`Auto-reconnect:      ${affRecon.length}/${affected.length} clients`);
+    console.log(`User downtime:       ${Math.round(down.reduce((a, b) => a + b, 0) / down.length)}ms avg`);
+  }
+  console.log(`Surviving clients:   ${unaffected.filter(c => c.socket.connected).length}/${unaffected.length} unaffected`);
+  console.log(`Post-kill events:    ${eventCount}/${connected.length}`);
+
+  for (const c of clients) c.socket.disconnect();
+  process.exit(0);
+}
+
+test().catch((err) => {
+  console.error("Test failed:", err.message);
+  process.exit(1);
+});

--- a/deploy/integration-tests/test-multiprocess.ts
+++ b/deploy/integration-tests/test-multiprocess.ts
@@ -1,0 +1,227 @@
+import { io, Socket } from "socket.io-client";
+import * as privacyKit from "privacy-kit";
+
+const MASTER_SECRET = "local-dev-secret-not-for-production";
+const POD_A = "http://localhost:3005";
+const POD_B = "http://localhost:3006";
+const SOCKET_PATH = "/v1/updates";
+
+async function createToken(userId: string): Promise<string> {
+    const generator = await privacyKit.createPersistentTokenGenerator({
+        service: "handy",
+        seed: MASTER_SECRET,
+    });
+    return await generator.new({ user: userId });
+}
+
+function connect(
+    url: string,
+    token: string,
+    label: string,
+    opts: { clientType?: string; sessionId?: string; machineId?: string } = {}
+): Promise<Socket> {
+    return new Promise((resolve, reject) => {
+        const socket = io(url, {
+            path: SOCKET_PATH,
+            transports: ["websocket"],
+            auth: {
+                token,
+                clientType: opts.clientType || "user-scoped",
+                sessionId: opts.sessionId,
+                machineId: opts.machineId,
+            },
+        });
+
+        const timeout = setTimeout(() => {
+            socket.disconnect();
+            reject(new Error(`${label}: connection timeout`));
+        }, 10000);
+
+        socket.on("connect", () => {
+            clearTimeout(timeout);
+            console.log(`  [${label}] connected (${socket.id})`);
+            resolve(socket);
+        });
+
+        socket.on("connect_error", (err) => {
+            clearTimeout(timeout);
+            reject(new Error(`${label}: ${err.message}`));
+        });
+    });
+}
+
+// Test 1: A machine-scoped client connecting triggers a "machine-activity" ephemeral
+// with recipientFilter "user-scoped-only". Both user-scoped clients (on different pods)
+// should receive it via Redis adapter broadcast.
+async function testCrossProcessBroadcast(): Promise<boolean> {
+    console.log("\n--- Test 1: Cross-process ephemeral broadcast ---");
+
+    const token = await createToken("test-user-broadcast");
+
+    const clientA = await connect(POD_A, token, "Pod A / user-scoped");
+    const clientB = await connect(POD_B, token, "Pod B / user-scoped");
+
+    const received = { a: false, b: false };
+
+    const done = new Promise<void>((resolve) => {
+        const check = () => { if (received.a && received.b) resolve(); };
+
+        clientA.on("ephemeral", (data: any) => {
+            console.log(`  [Pod A] ephemeral: ${JSON.stringify(data)}`);
+            received.a = true;
+            check();
+        });
+
+        clientB.on("ephemeral", (data: any) => {
+            console.log(`  [Pod B] ephemeral: ${JSON.stringify(data)}`);
+            received.b = true;
+            check();
+        });
+    });
+
+    // Give clients a moment to fully register rooms
+    await sleep(500);
+
+    // Connecting a machine-scoped client triggers machine-activity ephemeral to user-scoped clients
+    console.log("  Connecting machine client to Pod A to trigger broadcast...");
+    const machine = await connect(POD_A, token, "Pod A / machine", {
+        clientType: "machine-scoped",
+        machineId: "test-machine-1",
+    });
+
+    const result = await race(done, 5000);
+
+    machine.disconnect();
+    clientA.disconnect();
+    clientB.disconnect();
+
+    if (result === "ok") {
+        console.log("  PASS: Both pods received the ephemeral event");
+        return true;
+    } else {
+        console.log(`  FAIL: a=${received.a}, b=${received.b} (expected both true)`);
+        return false;
+    }
+}
+
+// Test 2: Session-scoped client should NOT receive "user-scoped-only" events
+async function testRoomIsolation(): Promise<boolean> {
+    console.log("\n--- Test 2: Room isolation (session-scoped excluded from user-scoped-only) ---");
+
+    const token = await createToken("test-user-isolation");
+
+    const userClient = await connect(POD_A, token, "Pod A / user-scoped");
+    const sessionClient = await connect(POD_B, token, "Pod B / session-scoped", {
+        clientType: "session-scoped",
+        sessionId: "test-session-1",
+    });
+
+    let userGot = false;
+    let sessionGot = false;
+
+    userClient.on("ephemeral", () => { userGot = true; });
+    sessionClient.on("ephemeral", () => { sessionGot = true; });
+
+    await sleep(500);
+
+    const machine = await connect(POD_A, token, "Pod A / machine-iso", {
+        clientType: "machine-scoped",
+        machineId: "test-machine-iso",
+    });
+
+    await sleep(3000);
+
+    machine.disconnect();
+    userClient.disconnect();
+    sessionClient.disconnect();
+
+    if (userGot && !sessionGot) {
+        console.log("  PASS: user-scoped got event, session-scoped did not");
+        return true;
+    } else {
+        console.log(`  FAIL: user=${userGot}, session=${sessionGot} (expected true, false)`);
+        return false;
+    }
+}
+
+// Test 3: Machine disconnect triggers offline ephemeral across pods
+async function testDisconnectBroadcast(): Promise<boolean> {
+    console.log("\n--- Test 3: Machine disconnect broadcasts across pods ---");
+
+    const token = await createToken("test-user-disconnect");
+
+    const userClient = await connect(POD_B, token, "Pod B / user-scoped");
+
+    let offlineReceived = false;
+
+    userClient.on("ephemeral", (data: any) => {
+        if (data.type === "machine-activity" && data.active === false) {
+            console.log(`  [Pod B] received offline event: ${JSON.stringify(data)}`);
+            offlineReceived = true;
+        }
+    });
+
+    await sleep(500);
+
+    const machine = await connect(POD_A, token, "Pod A / machine-dc", {
+        clientType: "machine-scoped",
+        machineId: "test-machine-dc",
+    });
+
+    await sleep(500);
+
+    // Disconnect the machine — should broadcast offline to user-scoped on Pod B
+    console.log("  Disconnecting machine client...");
+    machine.disconnect();
+
+    await sleep(2000);
+
+    userClient.disconnect();
+
+    if (offlineReceived) {
+        console.log("  PASS: Offline event received across pods");
+        return true;
+    } else {
+        console.log("  FAIL: No offline event received");
+        return false;
+    }
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+function race(promise: Promise<void>, ms: number): Promise<"ok" | "timeout"> {
+    return Promise.race([
+        promise.then(() => "ok" as const),
+        sleep(ms).then(() => "timeout" as const),
+    ]);
+}
+
+async function main() {
+    console.log("=== Multi-Process Socket.IO Test ===");
+    console.log(`Pod A: ${POD_A} | Pod B: ${POD_B}\n`);
+
+    // Verify both pods are reachable
+    for (const [label, url] of [["Pod A", POD_A], ["Pod B", POD_B]]) {
+        const res = await fetch(`${url}/health`);
+        const data = await res.json();
+        console.log(`${label} health: ${JSON.stringify(data)}`);
+    }
+
+    let passed = 0;
+    const tests = [testCrossProcessBroadcast, testRoomIsolation, testDisconnectBroadcast];
+
+    for (const test of tests) {
+        try {
+            if (await test()) passed++;
+        } catch (e: any) {
+            console.log(`  ERROR: ${e.message}`);
+        }
+    }
+
+    console.log(`\n=== Results: ${passed}/${tests.length} passed ===`);
+    process.exit(passed === tests.length ? 0 : 1);
+}
+
+main();

--- a/deploy/integration-tests/test-rpc-cross-replica.mjs
+++ b/deploy/integration-tests/test-rpc-cross-replica.mjs
@@ -1,0 +1,185 @@
+import tweetnacl from "tweetnacl";
+import { io } from "socket.io-client";
+import { Buffer } from "buffer";
+import { execSync } from "child_process";
+
+const SERVER = "http://127.0.0.1:3000";
+const base64 = (buf) => Buffer.from(buf).toString("base64");
+
+async function getToken() {
+    const keyPair = tweetnacl.sign.keyPair();
+    const challenge = tweetnacl.randomBytes(32);
+    const signature = tweetnacl.sign.detached(challenge, keyPair.secretKey);
+    const res = await fetch(`${SERVER}/v1/auth`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            publicKey: base64(keyPair.publicKey),
+            challenge: base64(challenge),
+            signature: base64(signature),
+        }),
+    });
+    if (!res.ok) throw new Error(`Auth failed: ${res.status}`);
+    return (await res.json()).token;
+}
+
+function getPods() {
+    return execSync("kubectl get pods -l app=handy-server -o jsonpath='{.items[*].metadata.name}'")
+        .toString().replace(/'/g, "").trim().split(/\s+/);
+}
+
+function findSocketPod(socketId, pods) {
+    for (const pod of pods) {
+        const logs = execSync(`kubectl logs ${pod} --tail=500 2>/dev/null`).toString();
+        if (logs.includes(socketId)) return pod;
+    }
+    return "unknown";
+}
+
+function connectSocket(token, opts = {}) {
+    const socket = io(SERVER, {
+        path: "/v1/updates",
+        auth: { token, ...opts },
+        transports: ["websocket"],
+        reconnection: true,
+        reconnectionDelay: 500,
+        reconnectionAttempts: 20,
+    });
+    return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error("connect timeout")), 10000);
+        socket.on("connect", () => { clearTimeout(timeout); resolve(socket); });
+        socket.on("connect_error", (err) => { clearTimeout(timeout); reject(err); });
+    });
+}
+
+async function test() {
+    console.log("=== RPC CROSS-REPLICA TEST ===\n");
+
+    const health = await fetch(`${SERVER}/health`).then(r => r.json());
+    console.log(`Health: ${health.status}`);
+    const pods = getPods();
+    console.log(`Pods: ${pods.join(", ")} (${pods.length} replicas)\n`);
+
+    const token = await getToken();
+
+    // 1. Connect a "daemon" socket (session-scoped) that will handle RPCs
+    const METHOD = `test-session-${Date.now()}:echo`;
+    const daemon = await connectSocket(token, { clientType: "session-scoped", sessionId: `test-session-${Date.now()}` });
+
+    // Register an RPC handler
+    daemon.emit("rpc-register", { method: METHOD });
+    daemon.on("rpc-request", (data, callback) => {
+        // Echo back the params
+        callback(data.params);
+    });
+    await new Promise(r => setTimeout(r, 500));
+
+    // 2. Connect multiple "web app" sockets (user-scoped) that will call RPCs
+    const NUM_CALLERS = 10;
+    const callers = [];
+    for (let i = 0; i < NUM_CALLERS; i++) {
+        callers.push(await connectSocket(token, { clientType: "user-scoped" }));
+    }
+
+    await new Promise(r => setTimeout(r, 2000));
+
+    // Check pod distribution
+    const daemonPod = findSocketPod(daemon.id, pods);
+    console.log(`Daemon socket: ${daemon.id} → ${daemonPod}`);
+    const callerPods = {};
+    for (const c of callers) {
+        const pod = findSocketPod(c.id, pods);
+        callerPods[pod] = (callerPods[pod] || 0) + 1;
+    }
+    console.log(`Caller distribution: ${JSON.stringify(callerPods)}`);
+
+    const crossReplica = Object.keys(callerPods).some(p => p !== daemonPod);
+    console.log(`Cross-replica callers: ${crossReplica ? "YES" : "NO (all on same pod)"}\n`);
+
+    // 3. Hammer RPC calls from all callers
+    const CALLS_PER_CALLER = 5;
+    const TOTAL = NUM_CALLERS * CALLS_PER_CALLER;
+    let success = 0;
+    let fail = 0;
+    const errors = [];
+
+    console.log(`--- Sending ${TOTAL} RPC calls (${CALLS_PER_CALLER} per caller) ---`);
+
+    const promises = [];
+    for (const caller of callers) {
+        for (let i = 0; i < CALLS_PER_CALLER; i++) {
+            const payload = `ping-${i}`;
+            promises.push(
+                new Promise((resolve) => {
+                    caller.timeout(10000).emitWithAck("rpc-call", {
+                        method: METHOD,
+                        params: payload,
+                    }).then((result) => {
+                        if (result.ok && result.result === payload) {
+                            success++;
+                        } else {
+                            fail++;
+                            errors.push(result.error || "unexpected result");
+                        }
+                        resolve();
+                    }).catch((err) => {
+                        fail++;
+                        errors.push(err.message);
+                        resolve();
+                    });
+                })
+            );
+        }
+    }
+
+    await Promise.all(promises);
+
+    console.log(`  Success: ${success}/${TOTAL}`);
+    console.log(`  Failed:  ${fail}/${TOTAL}`);
+    if (errors.length > 0) {
+        const uniq = [...new Set(errors)];
+        console.log(`  Errors:  ${uniq.join(", ")}`);
+    }
+
+    // 4. Sequential calls to test consistency
+    console.log(`\n--- Sequential RPC calls (20x) ---`);
+    let seqSuccess = 0;
+    let seqFail = 0;
+    const seqErrors = [];
+    for (let i = 0; i < 20; i++) {
+        const caller = callers[i % callers.length];
+        try {
+            const result = await caller.timeout(10000).emitWithAck("rpc-call", {
+                method: METHOD,
+                params: `seq-${i}`,
+            });
+            if (result.ok) seqSuccess++;
+            else { seqFail++; seqErrors.push(result.error); }
+        } catch (err) {
+            seqFail++;
+            seqErrors.push(err.message);
+        }
+    }
+    console.log(`  Success: ${seqSuccess}/20`);
+    console.log(`  Failed:  ${seqFail}/20`);
+    if (seqErrors.length > 0) console.log(`  Errors:  ${[...new Set(seqErrors)].join(", ")}`);
+
+    // Verdict
+    console.log("\n========================================");
+    console.log("           VERDICT");
+    console.log("========================================");
+    console.log(`Replicas:       ${pods.length}`);
+    console.log(`Cross-replica:  ${crossReplica ? "YES" : "NO"}`);
+    console.log(`Parallel RPCs:  ${success}/${TOTAL} passed`);
+    console.log(`Sequential:     ${seqSuccess}/20 passed`);
+    console.log(success === TOTAL && seqSuccess === 20 ? "✅ ALL PASSED" : "❌ FAILURES DETECTED");
+
+    daemon.disconnect();
+    for (const c of callers) c.disconnect();
+    process.exit(success === TOTAL && seqSuccess === 20 ? 0 : 1);
+}
+
+test().catch((err) => {
+    console.error("Test failed:", err.message);
+    process.exit(1);
+});

--- a/deploy/local.sh
+++ b/deploy/local.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OVERLAY="$REPO_ROOT/deploy/overlays/local"
+
+echo "=== Happy Local Deployment (minikube) ==="
+
+# 1. Ensure minikube is running
+if ! minikube status --format='{{.Host}}' 2>/dev/null | grep -q Running; then
+    echo "Starting minikube..."
+    minikube start
+else
+    echo "minikube is running."
+fi
+
+# 2. Point docker to minikube's daemon
+echo "Configuring docker to use minikube..."
+eval $(minikube docker-env)
+
+# 3. Build the server image
+echo "Building happy-server:local image..."
+docker build -t happy-server:local -f "$REPO_ROOT/Dockerfile.server" "$REPO_ROOT"
+
+# 4. Run prisma migrations inside a temporary pod
+echo "Running database migrations..."
+kubectl kustomize "$OVERLAY" --load-restrictor=LoadRestrictionsNone | kubectl apply -f -
+
+echo "Waiting for postgres to be ready..."
+kubectl wait --for=condition=ready pod -l app=happy-postgres --timeout=60s
+
+# Run migrations via a one-shot job
+kubectl run happy-migrate --rm -i --restart=Never \
+    --image=happy-server:local \
+    --image-pull-policy=Never \
+    --env="DATABASE_URL=postgresql://happy:happy@happy-postgres:5432/happy" \
+    -- sh -c "cd /repo && npx prisma migrate deploy --schema=packages/happy-server/prisma/schema.prisma" \
+    2>/dev/null || true
+
+# 5. Restart server pods to pick up fresh image
+echo "Restarting server pods..."
+kubectl rollout restart deployment/handy-server
+kubectl rollout status deployment/handy-server --timeout=120s
+
+# 6. Print status
+echo ""
+echo "=== Deployed ==="
+kubectl get pods
+echo ""
+echo "Server replicas: $(kubectl get deployment handy-server -o jsonpath='{.spec.replicas}')"
+echo ""
+echo "To access the server:"
+echo "  kubectl port-forward svc/handy-server 3005:3000"
+echo ""
+echo "To view logs from both pods:"
+echo "  kubectl logs -l app=handy-server --all-containers -f"
+echo ""
+echo "To test cross-process events, connect WebSocket clients"
+echo "and verify events route between pods."

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -1,0 +1,43 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - postgres.yaml
+  - secrets.yaml
+
+# Use locally-built image instead of private registry
+images:
+  - name: docker.korshakov.com/handy-server
+    newName: happy-server
+    newTag: local
+
+# Patch: 2 replicas + remove ExternalSecret (not available locally)
+patches:
+  # Scale to 2 replicas for multi-process testing
+  - target:
+      kind: Deployment
+      name: handy-server
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2
+
+  # Remove S3_PUBLIC_URL (using local file storage)
+  - target:
+      kind: Deployment
+      name: handy-server
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/env/3
+
+  # Remove ExternalSecret — we use plain Secret instead
+  - target:
+      kind: ExternalSecret
+      name: handy-secrets
+    patch: |-
+      $patch: delete
+      apiVersion: external-secrets.io/v1beta1
+      kind: ExternalSecret
+      metadata:
+        name: handy-secrets

--- a/deploy/overlays/local/postgres.yaml
+++ b/deploy/overlays/local/postgres.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: happy-postgres
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: happy-postgres
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: happy-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: happy-postgres
+  template:
+    metadata:
+      labels:
+        app: happy-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: happy
+            - name: POSTGRES_PASSWORD
+              value: happy
+            - name: POSTGRES_DB
+              value: happy

--- a/deploy/overlays/local/secrets.yaml
+++ b/deploy/overlays/local/secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: handy-secrets
+type: Opaque
+stringData:
+  DATABASE_URL: postgresql://happy:happy@happy-postgres:5432/happy
+  HANDY_MASTER_SECRET: local-dev-secret-not-for-production


### PR DESCRIPTION
Local minikube harness for the multi-process server fix in #1042. Stacks on top so the core impl can be reviewed independently from the test infrastructure.

## Layout

```
deploy/
├── local.sh                           one-shot minikube provisioning script
├── base/kustomization.yaml            kustomize entry point
├── overlays/local/                    postgres + secrets + 2-replica patch
└── integration-tests/
    ├── hammer.mjs                     5 named bug-repro scenarios:
    │                                    - pod-kill-mid-rpc
    │                                    - reconnect-storm
    │                                    - ttl-expiry (smoking gun #3)
    │                                    - brief-disconnect (NEW capability)
    │                                    - long-disconnect
    ├── network-loss.mjs               60s long-running RPC loop with summary
    ├── missed-events.mjs              brief disconnect → broadcast → reconnect;
    │                                    proves parity with main on event loss
    ├── test-rpc-cross-replica.mjs     50 parallel + 20 sequential cross-pod RPCs
    ├── test-multiprocess.mjs          broadcast fan-out + pod-kill recovery
    ├── probe-rpc.mjs                  direct rpc-register sanity probe
    ├── probe-fetchsockets.mjs         fetchSockets latency probe
    └── POSTMORTEM.md                  full bug-by-bug breakdown with repros
```

## Bring up the stack from scratch

```bash
deploy/local.sh
kubectl patch svc handy-server -p '{"spec":{"type":"LoadBalancer"}}'
minikube tunnel &
node deploy/integration-tests/test-rpc-cross-replica.mjs
```

## Final gauntlet result against #1042

```
.
├── steady-state cross-pod RPC      50/50 + 20/20 ✅ (after ~5s warmup)
├── pod-kill-mid-rpc                1.6s fast-fail ✅ (was 30s)
├── brief-disconnect (NEW)          SUCCESS in ~2s ✅
├── long-disconnect                 bounded ~10.5s ✅
├── ttl-expiry (smoking gun)        ALL pass through +75s ✅
├── reconnect-storm                 96–97% ✅ (only inherent in-flight)
├── broadcast multi-process         20/20 fan-out, 5/5 unaffected ✅
├── network-loss 60s loop           85/85 zero failures ✅
└── missed-events parity            event lost via socket, in DB,
                                    recovered=undefined ✅ (matches main)
```

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>