### PR TITLE
fix(app): web chat scroll direction inverted

### DIFF
--- a/packages/happy-app/sources/components/ChatList.web.tsx
+++ b/packages/happy-app/sources/components/ChatList.web.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useSession, useSessionMessages } from '@/sync/storage';
+import { View } from 'react-native';
+import { useHeaderHeight } from '@/utils/responsive';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MessageView } from './MessageView';
+import { Metadata, Session } from '@/sync/storageTypes';
+import { ChatFooter } from './ChatFooter';
+import { Message } from '@/sync/typesMessage';
+
+export const ChatList = React.memo((props: { session: Session }) => {
+    const { messages } = useSessionMessages(props.session.id);
+    return (
+        <ChatListInternal
+            metadata={props.session.metadata}
+            sessionId={props.session.id}
+            messages={messages}
+        />
+    );
+});
+
+const ChatListInternal = React.memo((props: {
+    metadata: Metadata | null;
+    sessionId: string;
+    messages: Message[];
+}) => {
+    const headerHeight = useHeaderHeight();
+    const safeArea = useSafeAreaInsets();
+    const session = useSession(props.sessionId)!;
+
+    // flex-direction: column-reverse gives us native browser reversed scroll
+    // without scaleY(-1), so middle-click auto-scroll and wheel work correctly.
+    // Messages are already newest-first from the store, which matches column-reverse order.
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'column-reverse',
+                overflowY: 'auto',
+                overflowX: 'hidden',
+                height: '100%',
+                WebkitOverflowScrolling: 'touch',
+                scrollbarWidth: 'thin',
+            }}
+        >
+            {/* In column-reverse, first DOM element = visual bottom */}
+            <ChatFooter controlledByUser={session.agentState?.controlledByUser || false} />
+            {props.messages.map((message) => (
+                <MessageView
+                    key={message.id}
+                    message={message}
+                    metadata={props.metadata}
+                    sessionId={props.sessionId}
+                />
+            ))}
+            {/* Top spacer for header — last in DOM = visual top */}
+            <View style={{ flexDirection: 'row', alignItems: 'center', height: headerHeight + safeArea.top + 32 }} />
+        </div>
+    );
+});


### PR DESCRIPTION
## Problem

On web, `ChatList` renders an `inverted` React Native FlatList, which RN-Web implements as `transform: scaleY(-1)` on the scroll container. That transform breaks every native scroll interaction the browser provides:

- wheel direction is inverted — scrolling up moves the view the wrong way
- `maintainVisibleContentPosition` is silently dropped
- middle-click auto-scroll runs backwards

## Fix

A web-only `ChatList.web.tsx` that gets the same visual layout — newest message at the bottom — from `flex-direction: column-reverse` instead of a CSS transform. Messages already arrive newest-first from the store, which is exactly the order `column-reverse` wants, so no data reshaping is needed. With no transform on the container, wheel, `maintainVisibleContentPosition` and auto-scroll all behave the way the browser intends — which is what RN-Web's `inverted` was trying to achieve in the first place.

Native is untouched: Expo/Metro auto-resolves `.web.tsx` for web builds only, the same pattern already used by `MultiTextInput.web.tsx` and `Shaker.web.tsx`.

## Proof

Side-by-side of the two CSS approaches, scrolled with `page.mouse.wheel(0, ±120)` — real wheel events that go through the same native scroll handling the bug exhibits:

![scroll fix](https://github.com/chphch/happy/releases/download/pr-proofs/1048-scroll-fix.gif)

Captured `scrollTop` after each wheel gesture confirms the divergence:

| step | gesture | BEFORE `scrollTop` | AFTER `scrollTop` |
|---|---|---|---|
| 0 | (initial) | 0 | 0 |
| 1 | wheel up | **0** (stuck — gesture inverted) | -120 (history revealed) |
| 2 | wheel up | **0** | -240 |
| 3 | wheel up | **0** | -360 |
| 4 | wheel up | **0** | -480 |
| 5 | wheel down | 120 (now scrolls in the wrong direction) | -360 (back toward newest) |
| 6 | wheel down | 240 | -240 |
| 7 | wheel down | 360 | -120 |

<details>
<summary>Capture details</summary>

Synthetic side-by-side, because the relevant bug is purely about CSS-level scroll handling and the diff is one isolated component with no app-wide state involved. Reproduction page: two `<div class="chat">` siblings, one with `transform: scaleY(-1)` (with an inner `scaleY(-1)` on rows to undo the text flip), one with `flex-direction: column-reverse`. Driven by `page.mouse.wheel` in headless Chromium.

</details>

## Scope

One new file, `packages/happy-app/sources/components/ChatList.web.tsx` (+60). No changes to the native path, no new dependencies, no API or schema change.
