### PR TITLE
fix: persist change_title to Claude Code local JSONL

### DIFF
--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -14,6 +14,21 @@ import { z } from "zod";
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
 import { randomUUID } from "node:crypto";
+import { appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Resolve the Claude Code session JSONL file path.
+ *
+ * Claude stores sessions at:
+ *   ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
+ * where <encoded-cwd> is the working directory with '/' replaced by '-'.
+ */
+function resolveClaudeSessionFile(workingDir: string, sessionId: string): string {
+    const projectName = workingDir.replace(/\//g, '-');
+    return join(homedir(), '.claude', 'projects', projectName, `${sessionId}.jsonl`);
+}
 
 function createMcpServer(handler: (title: string) => Promise<{ success: boolean; error?: string }>): McpServer {
     const mcp = new McpServer({
@@ -63,11 +78,35 @@ export async function startHappyServer(client: ApiSessionClient) {
     const handler = async (title: string) => {
         logger.debug('[happyMCP] Changing title to:', title);
         try {
+            // Update Happy cloud metadata
             client.sendClaudeSessionMessage({
                 type: 'summary',
                 summary: title,
                 leafUuid: randomUUID()
             });
+
+            // Persist custom-title to Claude Code's local session JSONL.
+            // Claude Code reads {type: "custom-title"} entries for /resume
+            // and status bar display. Without this, titles only update in
+            // Happy's cloud metadata but not in Claude Code's local UI.
+            try {
+                const metadata = client.getMetadata() as Record<string, unknown> | null;
+                const workingDir = metadata?.path as string | undefined;
+                if (workingDir && client.sessionId) {
+                    const sessionFile = resolveClaudeSessionFile(workingDir, client.sessionId);
+                    const entry = JSON.stringify({
+                        type: 'custom-title',
+                        customTitle: title,
+                        sessionId: client.sessionId,
+                    });
+                    await appendFile(sessionFile, entry + '\n');
+                    logger.debug('[happyMCP] Wrote custom-title to Claude JSONL:', sessionFile);
+                }
+            } catch (e) {
+                // Non-fatal: title is still persisted in Happy cloud metadata
+                logger.debug('[happyMCP] Failed to write custom-title to Claude JSONL:', e);
+            }
+
             return { success: true };
         } catch (error) {
             return { success: false, error: String(error) };


### PR DESCRIPTION
## Problem

The `change_title` MCP tool sets session titles that appear in Happy's mobile/web app but **not** in Claude Code's `/resume` list or status bar.

### Root cause

`startHappyServer.ts` sends `{type: 'summary', summary: title}` via `sendClaudeSessionMessage()`. This updates Happy's cloud metadata correctly, but Claude Code reads titles from `{type: 'custom-title', customTitle: title}` entries in the **local session JSONL file** (`~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`).

Since no `custom-title` entry is ever written, `/resume` falls back to auto-generating a title from the first user message — making `change_title` effectively a no-op for the local Claude Code UI.

### How I found this

1. Called `mcp__happy__change_title` → tool returned `"Successfully changed chat title to: ..."`
2. Ran `/resume` → title unchanged
3. Traced through Happy source: `startHappyServer.ts` handler → `sendClaudeSessionMessage({type: 'summary'})` → `apiSession.ts` updates cloud metadata only
4. Traced through Claude Code source (minified `cli.js`): `/resume` reads `{type: 'custom-title'}` from JSONL, `/rename` writes `{type: 'custom-title'}` to JSONL
5. Confirmed: zero `{type: 'custom-title'}` entries in any session JSONL despite multiple `change_title` calls

## Solution

After updating Happy cloud metadata (existing behavior preserved), also append a `{type: 'custom-title'}` entry to the Claude session JSONL file. The JSONL path is derived from the session's working directory using the same encoding as Claude Code's session scanner test fixtures:

```
~/.claude/projects/<cwd-with-slashes-as-dashes>/<sessionId>.jsonl
```

The JSONL write is wrapped in a try/catch — if it fails (e.g. path mismatch on a future Claude version), the cloud metadata update still succeeds and the tool doesn't error.

## Changes

- `packages/happy-cli/src/claude/utils/startHappyServer.ts`:
  - Added `resolveClaudeSessionFile()` helper to compute the JSONL path
  - Added `appendFile()` call in the `change_title` handler to write `{type: 'custom-title'}` after the existing metadata update
  - Added imports: `appendFile` from `node:fs/promises`, `join` from `node:path`, `homedir` from `node:os`

## Testing

Before this fix:
```
> change_title("My Title")
✓ "Successfully changed chat title to: My Title"
> /resume
❯ sprightly-drifting-ritchie   ← auto-generated, not "My Title"
```

After this fix:
```
> change_title("My Title")
✓ "Successfully changed chat title to: My Title"
> /resume
❯ My Title                     ← persisted correctly
```