### PR TITLE
feat(app): add turn-level navigation for chat sessions

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -13,11 +13,14 @@ import {
 } from '@/components/modelModeOptions';
 import { getSuggestions } from '@/components/autocomplete/suggestions';
 import { ChatHeaderView } from '@/components/ChatHeaderView';
-import { ChatList } from '@/components/ChatList';
+import { ChatList, ChatListHandle } from '@/components/ChatList';
+import { TurnInfo } from '@/hooks/useTurnIndices';
 import { Deferred } from '@/components/Deferred';
 import { EmptyMessages } from '@/components/EmptyMessages';
 import { SessionActionsAnchor, SessionActionsPopover } from '@/components/SessionActionsPopover';
 import { VoiceAssistantStatusBar } from '@/components/VoiceAssistantStatusBar';
+import { TurnNavigator } from '@/components/TurnNavigator';
+import { useTurnNavigationKeyboard } from '@/hooks/useTurnNavigationKeyboard';
 import { useDraft } from '@/hooks/useDraft';
 import { Modal } from '@/modal';
 import { voiceHooks } from '@/realtime/hooks/voiceHooks';
@@ -356,11 +359,40 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
         gitStatusSync.getSync(sessionId);
     }, [sessionId, realtimeStatus]);
 
+    const chatListRef = React.useRef<ChatListHandle>(null);
+    const [turnInfo, setTurnInfo] = React.useState<{ current: number | null; total: number; turns: TurnInfo[] }>({ current: null, total: 0, turns: [] });
+
+    const handleTurnChange = React.useCallback((current: number | null, total: number, turns: TurnInfo[]) => {
+        setTurnInfo({ current, total, turns });
+    }, []);
+
+    // Reset turn info when ChatList unmounts (messages become empty)
+    React.useEffect(() => {
+        if (messages.length === 0) {
+            setTurnInfo({ current: null, total: 0, turns: [] });
+        }
+    }, [messages.length]);
+
+    const handlePrevTurn = React.useCallback(() => chatListRef.current?.prevTurn(), []);
+    const handleNextTurn = React.useCallback(() => chatListRef.current?.nextTurn(), []);
+    const handlePrevPage = React.useCallback(() => chatListRef.current?.prevPage(), []);
+    const handleNextPage = React.useCallback(() => chatListRef.current?.nextPage(), []);
+    const handleEndTurn = React.useCallback(() => chatListRef.current?.goToEnd(), []);
+    const handleGoToTurn = React.useCallback((turnNumber: number) => chatListRef.current?.goToTurn(turnNumber), []);
+
+    useTurnNavigationKeyboard({
+        onPrev: handlePrevTurn,
+        onNext: handleNextTurn,
+        onPrevPage: handlePrevPage,
+        onNextPage: handleNextPage,
+        onEnd: handleEndTurn,
+    });
+
     let content = (
         <>
             <Deferred>
                 {messages.length > 0 && (
-                    <ChatList session={session} />
+                    <ChatList ref={chatListRef} session={session} onTurnChange={handleTurnChange} />
                 )}
             </Deferred>
         </>
@@ -496,6 +528,19 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                     content={content}
                     input={input}
                     placeholder={placeholder}
+                />
+                <TurnNavigator
+                    currentTurnNumber={turnInfo.current}
+                    totalTurns={turnInfo.total}
+                    turns={turnInfo.turns}
+                    onPrev={handlePrevTurn}
+                    onNext={handleNextTurn}
+                    onPrevPage={handlePrevPage}
+                    onNextPage={handleNextPage}
+                    onEnd={handleEndTurn}
+                    onGoToTurn={handleGoToTurn}
+                    hasPrev={turnInfo.current !== null ? turnInfo.current > 1 : turnInfo.total > 0}
+                    hasNext={turnInfo.current !== null && turnInfo.current < turnInfo.total}
                 />
             </View >
 

--- a/packages/happy-app/sources/app/(app)/dev/index.tsx
+++ b/packages/happy-app/sources/app/(app)/dev/index.tsx
@@ -244,6 +244,12 @@ export default function DevScreen() {
                     onPress={() => router.push('/dev/inverted-list')}
                 />
                 <Item
+                    title="Turn Navigation"
+                    subtitle="Turn-level navigation with skip and jump"
+                    icon={<Ionicons name="navigate-outline" size={28} color="#007AFF" />}
+                    onPress={() => router.push('/dev/turn-navigation-demo')}
+                />
+                <Item
                     title="Tool Views"
                     subtitle="Tool call visualization components"
                     icon={<Ionicons name="construct-outline" size={28} color="#007AFF" />}

--- a/packages/happy-app/sources/app/(app)/dev/messages-demo-data.ts
+++ b/packages/happy-app/sources/app/(app)/dev/messages-demo-data.ts
@@ -477,3 +477,56 @@ export const NewComponent: React.FC<NewComponentProps> = ({ title, description }
         ]
     }
 ];
+
+// ============================================================================
+// Turn Navigation Demo Data
+// ============================================================================
+
+/** Helper to build a quick turn: user → agent → tool → agent */
+function buildTurn(turnNum: number, baseTime: number): Message[] {
+    const t = baseTime - turnNum * 30000;
+    return [
+        {
+            id: `turn-nav-user-${turnNum}`,
+            localId: null,
+            createdAt: t,
+            kind: 'user-text' as const,
+            text: `Turn ${turnNum}: Can you check file #${turnNum}?`,
+        },
+        {
+            id: `turn-nav-agent-${turnNum}-1`,
+            localId: null,
+            createdAt: t + 1000,
+            kind: 'agent-text' as const,
+            text: `Sure, let me read file #${turnNum} for you.`,
+        },
+        {
+            id: `turn-nav-tool-${turnNum}`,
+            localId: null,
+            createdAt: t + 2000,
+            kind: 'tool-call' as const,
+            tool: createToolCall('Read', 'completed', {
+                file_path: `/src/file${turnNum}.ts`,
+            }, `// content of file${turnNum}.ts\nexport const value = ${turnNum};`),
+            children: [],
+        },
+        {
+            id: `turn-nav-agent-${turnNum}-2`,
+            localId: null,
+            createdAt: t + 3000,
+            kind: 'agent-text' as const,
+            text: `File #${turnNum} contains a simple export with value \`${turnNum}\`. ${turnNum % 3 === 0 ? 'This file also imports from a shared utility module.' : 'Looks straightforward.'}`,
+        },
+    ];
+}
+
+const NAV_BASE_TIME = Date.now();
+
+/** 15 turns of conversation data for testing turn navigation including page-skip */
+export const turnNavigationMessages: Message[] = Array.from(
+    { length: 15 },
+    (_, i) => buildTurn(i + 1, NAV_BASE_TIME),
+).flat();
+
+/** Single turn — TurnNavigator should be hidden */
+export const singleTurnMessages: Message[] = buildTurn(1, NAV_BASE_TIME);

--- a/packages/happy-app/sources/app/(app)/dev/turn-navigation-demo.tsx
+++ b/packages/happy-app/sources/app/(app)/dev/turn-navigation-demo.tsx
@@ -1,0 +1,224 @@
+import * as React from 'react';
+import { FlatList, Pressable, Text, View } from 'react-native';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { MessageView } from '@/components/MessageView';
+import { TurnNavigator } from '@/components/TurnNavigator';
+import { useTurnIndices, navigateTurn, NavigateAction } from '@/hooks/useTurnIndices';
+import { useTurnNavigationKeyboard } from '@/hooks/useTurnNavigationKeyboard';
+import { turnNavigationMessages, singleTurnMessages } from './messages-demo-data';
+import { Message } from '@/sync/typesMessage';
+import { useDemoMessages } from '@/hooks/useDemoMessages';
+
+/**
+ * Demo page for testing turn-level navigation.
+ *
+ * Uses a standalone inverted FlatList (not ChatList) because
+ * ChatList requires a full Session object from the Zustand store.
+ * This lets us test the hook + navigator with pure mock data.
+ */
+export default React.memo(function TurnNavigationDemoScreen() {
+    const { theme } = useUnistyles();
+    const [dataset, setDataset] = React.useState<'multi' | 'single'>('multi');
+    const rawMessages = dataset === 'multi' ? turnNavigationMessages : singleTurnMessages;
+    // Sort newest-first to match inverted FlatList convention (same as useSessionMessages)
+    const messages = React.useMemo(
+        () => [...rawMessages].sort((a, b) => b.createdAt - a.createdAt),
+        [rawMessages],
+    );
+
+    // Load into demo session for MessageView permission rendering
+    const sessionId = useDemoMessages(messages);
+
+    // Turn navigation state — use ref to avoid stale closures in doNavigate
+    const turns = useTurnIndices(messages);
+    const selectedIdxRef = React.useRef<number | null>(null);
+    const [selectedIdx, setSelectedIdx] = React.useState<number | null>(null);
+    const flatListRef = React.useRef<FlatList>(null);
+
+    // Reset selection when switching datasets
+    React.useEffect(() => { selectedIdxRef.current = null; setSelectedIdx(null); }, [dataset]);
+
+    const doNavigate = React.useCallback((action: NavigateAction) => {
+        if (turns.length === 0) return;
+        const next = navigateTurn(turns, selectedIdxRef.current, action);
+        selectedIdxRef.current = next;
+        setSelectedIdx(next);
+
+        if (next === null) {
+            flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+        } else {
+            const turn = turns[next];
+            if (turn) {
+                flatListRef.current?.scrollToIndex({
+                    index: turn.index,
+                    animated: true,
+                    viewPosition: 0.3,
+                });
+            }
+        }
+    }, [turns]);
+
+    const handlePrev = React.useCallback(() => doNavigate('prev'), [doNavigate]);
+    const handleNext = React.useCallback(() => doNavigate('next'), [doNavigate]);
+    const handlePrevPage = React.useCallback(() => doNavigate('prevPage'), [doNavigate]);
+    const handleNextPage = React.useCallback(() => doNavigate('nextPage'), [doNavigate]);
+    const handleEnd = React.useCallback(() => doNavigate('end'), [doNavigate]);
+
+    useTurnNavigationKeyboard({
+        onPrev: handlePrev,
+        onNext: handleNext,
+        onPrevPage: handlePrevPage,
+        onNextPage: handleNextPage,
+        onEnd: handleEnd,
+    });
+
+    const currentTurnNumber = selectedIdx !== null
+        ? turns[selectedIdx]?.turnNumber ?? null
+        : null;
+    const hasPrev = selectedIdx !== null ? selectedIdx < turns.length - 1 : turns.length > 0;
+    const hasNext = selectedIdx !== null && selectedIdx > 0;
+
+    const scrollRetryState = React.useRef<{ targetIndex: number; attempts: number } | null>(null);
+    const MAX_SCROLL_RETRIES = 5;
+    const handleScrollToIndexFailed = React.useCallback((info: {
+        index: number;
+        highestMeasuredFrameIndex: number;
+        averageItemLength: number;
+    }) => {
+        const state = scrollRetryState.current;
+        if (!state || state.targetIndex !== info.index) {
+            scrollRetryState.current = { targetIndex: info.index, attempts: 1 };
+        } else {
+            state.attempts++;
+            if (state.attempts > MAX_SCROLL_RETRIES) {
+                flatListRef.current?.scrollToOffset({
+                    offset: info.averageItemLength * info.index,
+                    animated: false,
+                });
+                scrollRetryState.current = null;
+                return;
+            }
+        }
+        const intermediateIndex = Math.min(info.index, info.highestMeasuredFrameIndex);
+        flatListRef.current?.scrollToIndex({
+            index: intermediateIndex,
+            animated: false,
+            viewPosition: 0.5,
+        });
+        setTimeout(() => {
+            flatListRef.current?.scrollToIndex({
+                index: info.index,
+                animated: true,
+                viewPosition: 0.3,
+            });
+        }, 200);
+    }, []);
+
+    return (
+        <View style={styles.container}>
+            {/* Dataset toggle */}
+            <View style={styles.toggleRow}>
+                <ToggleButton
+                    label={`Multi-turn (${turnNavigationMessages.filter(m => m.kind === 'user-text').length})`}
+                    active={dataset === 'multi'}
+                    onPress={() => setDataset('multi')}
+                />
+                <ToggleButton
+                    label="Single turn"
+                    active={dataset === 'single'}
+                    onPress={() => setDataset('single')}
+                />
+            </View>
+
+            {/* Chat list */}
+            <View style={{ flex: 1 }}>
+                <FlatList
+                    ref={flatListRef}
+                    data={messages}
+                    inverted={true}
+                    keyExtractor={(item) => item.id}
+                    renderItem={({ item }) => (
+                        <MessageView
+                            message={item}
+                            metadata={null}
+                            sessionId={sessionId}
+                        />
+                    )}
+                    onScrollToIndexFailed={handleScrollToIndexFailed}
+                    contentContainerStyle={{ paddingVertical: 20 }}
+                />
+
+                {/* Turn navigator overlay */}
+                <TurnNavigator
+                    currentTurnNumber={currentTurnNumber}
+                    totalTurns={turns.length}
+                    turns={turns}
+                    onPrev={handlePrev}
+                    onNext={handleNext}
+                    onEnd={handleEnd}
+                    onPrevPage={handlePrevPage}
+                    onNextPage={handleNextPage}
+                    onGoToTurn={(turnNumber) => {
+                        const idx = turns.findIndex(t => t.turnNumber === turnNumber);
+                        if (idx !== -1) {
+                            selectedIdxRef.current = idx;
+                            setSelectedIdx(idx);
+                            const turn = turns[idx];
+                            flatListRef.current?.scrollToIndex({
+                                index: turn.index,
+                                animated: true,
+                                viewPosition: 0.3,
+                            });
+                        }
+                    }}
+                    hasPrev={hasPrev}
+                    hasNext={hasNext}
+                />
+            </View>
+        </View>
+    );
+});
+
+const ToggleButton = React.memo((props: { label: string; active: boolean; onPress: () => void }) => {
+    const { theme } = useUnistyles();
+    return (
+        <Pressable
+            onPress={props.onPress}
+            style={[
+                styles.toggleButton,
+                { backgroundColor: props.active ? theme.colors.fab.background : 'transparent' },
+            ]}
+        >
+            <Text style={[
+                styles.toggleText,
+                { color: props.active ? theme.colors.fab.icon : theme.colors.textSecondary },
+            ]}>
+                {props.label}
+            </Text>
+        </Pressable>
+    );
+});
+
+const styles = StyleSheet.create((theme) => ({
+    container: {
+        flex: 1,
+        backgroundColor: theme.colors.surface,
+    },
+    toggleRow: {
+        flexDirection: 'row',
+        gap: 8,
+        padding: 12,
+        paddingTop: 60,
+        borderBottomWidth: 1,
+        borderBottomColor: theme.colors.divider,
+    },
+    toggleButton: {
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+        borderRadius: 16,
+    },
+    toggleText: {
+        fontSize: 13,
+        fontWeight: '600',
+    },
+}));

--- a/packages/happy-app/sources/components/ChatList.tsx
+++ b/packages/happy-app/sources/components/ChatList.tsx
@@ -10,19 +10,32 @@ import { ChatFooter } from './ChatFooter';
 import { Message } from '@/sync/typesMessage';
 import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { useTurnIndices, navigateTurn, NavigateAction, TurnInfo } from '@/hooks/useTurnIndices';
 
 const SCROLL_THRESHOLD = 300;
 
-export const ChatList = React.memo((props: { session: Session }) => {
+export interface ChatListHandle {
+    prevTurn: () => void;
+    nextTurn: () => void;
+    prevPage: () => void;
+    nextPage: () => void;
+    goToEnd: () => void;
+    goToTurn: (turnNumber: number) => void;
+    getTurnInfo: () => { current: number | null; total: number; turns: TurnInfo[] };
+}
+
+export const ChatList = React.memo(React.forwardRef<ChatListHandle, { session: Session; onTurnChange?: (current: number | null, total: number, turns: TurnInfo[]) => void }>((props, ref) => {
     const { messages } = useSessionMessages(props.session.id);
     return (
         <ChatListInternal
+            ref={ref}
             metadata={props.session.metadata}
             sessionId={props.session.id}
             messages={messages}
+            onTurnChange={props.onTurnChange}
         />
     )
-});
+}));
 
 const ListHeader = React.memo(() => {
     const headerHeight = useHeaderHeight();
@@ -37,17 +50,91 @@ const ListFooter = React.memo((props: { sessionId: string }) => {
     )
 });
 
-const ChatListInternal = React.memo((props: {
-    metadata: Metadata | null,
-    sessionId: string,
-    messages: Message[],
-}) => {
+interface ChatListInternalProps {
+    metadata: Metadata | null;
+    sessionId: string;
+    messages: Message[];
+    onTurnChange?: (current: number | null, total: number, turns: TurnInfo[]) => void;
+}
+
+const ChatListInternal = React.memo(React.forwardRef<ChatListHandle, ChatListInternalProps>((props, ref) => {
     const { theme } = useUnistyles();
     const flatListRef = React.useRef<FlatList>(null);
     const [showScrollButton, setShowScrollButton] = React.useState(false);
+    const turns = useTurnIndices(props.messages);
+    // Track selection by turnNumber (stable across array rebuilds)
+    // instead of array index (shifts when new turns are added).
+    const selectedTurnNumberRef = React.useRef<number | null>(null);
 
-    const keyExtractor = useCallback((item: any) => item.id, []);
-    const renderItem = useCallback(({ item }: { item: any }) => (
+    // Resolve the current turnNumber to a turns-array index
+    const resolveIdx = useCallback((): number | null => {
+        const num = selectedTurnNumberRef.current;
+        if (num === null) return null;
+        const idx = turns.findIndex(t => t.turnNumber === num);
+        return idx !== -1 ? idx : null;
+    }, [turns]);
+
+    // Push turn info to parent whenever messages change
+    React.useEffect(() => {
+        // If selected turn no longer exists (e.g. messages cleared), reset
+        if (selectedTurnNumberRef.current !== null) {
+            const exists = turns.some(t => t.turnNumber === selectedTurnNumberRef.current);
+            if (!exists) {
+                selectedTurnNumberRef.current = null;
+            }
+        }
+        props.onTurnChange?.(selectedTurnNumberRef.current, turns.length, turns);
+    }, [turns.length]);
+
+    const scrollToTurnIdx = useCallback((idx: number | null) => {
+        if (idx === null) {
+            selectedTurnNumberRef.current = null;
+            flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+        } else {
+            const turn = turns[idx];
+            if (turn) {
+                selectedTurnNumberRef.current = turn.turnNumber;
+                flatListRef.current?.scrollToIndex({
+                    index: turn.index,
+                    animated: true,
+                    viewPosition: 0.3,
+                });
+            }
+        }
+        const currentNum = idx !== null ? turns[idx]?.turnNumber ?? null : null;
+        props.onTurnChange?.(currentNum, turns.length, turns);
+    }, [turns, props.onTurnChange]);
+
+    const doNavigate = useCallback((action: NavigateAction) => {
+        if (turns.length === 0) return;
+        const currentIdx = resolveIdx();
+        const nextIdx = navigateTurn(turns, currentIdx, action);
+        scrollToTurnIdx(nextIdx);
+    }, [turns, resolveIdx, scrollToTurnIdx]);
+
+    const goToTurn = useCallback((turnNumber: number) => {
+        const idx = turns.findIndex(t => t.turnNumber === turnNumber);
+        if (idx !== -1) {
+            scrollToTurnIdx(idx);
+        }
+    }, [turns, scrollToTurnIdx]);
+
+    React.useImperativeHandle(ref, () => ({
+        prevTurn: () => doNavigate('prev'),
+        nextTurn: () => doNavigate('next'),
+        prevPage: () => doNavigate('prevPage'),
+        nextPage: () => doNavigate('nextPage'),
+        goToEnd: () => doNavigate('end'),
+        goToTurn,
+        getTurnInfo: () => ({
+            current: selectedTurnNumberRef.current,
+            total: turns.length,
+            turns,
+        }),
+    }), [doNavigate, goToTurn, turns]);
+
+    const keyExtractor = useCallback((item: Message) => item.id, []);
+    const renderItem = useCallback(({ item }: { item: Message }) => (
         <MessageView message={item} metadata={props.metadata} sessionId={props.sessionId} />
     ), [props.metadata, props.sessionId]);
 
@@ -60,6 +147,55 @@ const ChatListInternal = React.memo((props: {
 
     const scrollToBottom = useCallback(() => {
         flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+    }, []);
+
+    // scrollToIndex fails for unmeasured variable-height items — this is the
+    // normal path for long conversations. Use progressive scrolling: jump to
+    // the farthest measured item toward the target, wait for new items to
+    // render, then retry. Up to MAX_SCROLL_RETRIES attempts.
+    const scrollRetryState = React.useRef<{ targetIndex: number; attempts: number } | null>(null);
+    const MAX_SCROLL_RETRIES = 5;
+
+    const handleScrollToIndexFailed = useCallback((info: {
+        index: number;
+        highestMeasuredFrameIndex: number;
+        averageItemLength: number;
+    }) => {
+        const state = scrollRetryState.current;
+
+        // First failure for this target — start progressive scroll
+        if (!state || state.targetIndex !== info.index) {
+            scrollRetryState.current = { targetIndex: info.index, attempts: 1 };
+        } else {
+            state.attempts++;
+            if (state.attempts > MAX_SCROLL_RETRIES) {
+                // Give up — best-effort offset jump
+                flatListRef.current?.scrollToOffset({
+                    offset: info.averageItemLength * info.index,
+                    animated: false,
+                });
+                scrollRetryState.current = null;
+                return;
+            }
+        }
+
+        // Jump to the farthest measured item toward the target.
+        // This renders new items closer to the target each time.
+        const intermediateIndex = Math.min(info.index, info.highestMeasuredFrameIndex);
+        flatListRef.current?.scrollToIndex({
+            index: intermediateIndex,
+            animated: false,
+            viewPosition: 0.5,
+        });
+
+        // Wait for newly-visible items to render and get measured, then retry
+        setTimeout(() => {
+            flatListRef.current?.scrollToIndex({
+                index: info.index,
+                animated: true,
+                viewPosition: 0.3,
+            });
+        }, 200);
     }, []);
 
     return (
@@ -78,6 +214,7 @@ const ChatListInternal = React.memo((props: {
                 renderItem={renderItem}
                 onScroll={handleScroll}
                 scrollEventThrottle={16}
+                onScrollToIndexFailed={handleScrollToIndexFailed}
                 ListHeaderComponent={<ListFooter sessionId={props.sessionId} />}
                 ListFooterComponent={<ListHeader />}
             />
@@ -96,7 +233,7 @@ const ChatListInternal = React.memo((props: {
             )}
         </View>
     )
-});
+}));
 
 const styles = StyleSheet.create((theme) => ({
     scrollButtonContainer: {

--- a/packages/happy-app/sources/components/ChatList.tsx
+++ b/packages/happy-app/sources/components/ChatList.tsx
@@ -62,38 +62,44 @@ const ChatListInternal = React.memo(React.forwardRef<ChatListHandle, ChatListInt
     const flatListRef = React.useRef<FlatList>(null);
     const [showScrollButton, setShowScrollButton] = React.useState(false);
     const turns = useTurnIndices(props.messages);
-    // Track selection by turnNumber (stable across array rebuilds)
-    // instead of array index (shifts when new turns are added).
-    const selectedTurnNumberRef = React.useRef<number | null>(null);
+    // Track selection by message ID (stable across rewinds/reorders)
+    // instead of turnNumber (shifts when earlier turns are removed).
+    const selectedMessageIdRef = React.useRef<string | null>(null);
+    // Keep a stable ref to onTurnChange to avoid stale closures in effects
+    const onTurnChangeRef = React.useRef(props.onTurnChange);
+    onTurnChangeRef.current = props.onTurnChange;
 
-    // Resolve the current turnNumber to a turns-array index
+    // Resolve the selected message ID to a turns-array index
     const resolveIdx = useCallback((): number | null => {
-        const num = selectedTurnNumberRef.current;
-        if (num === null) return null;
-        const idx = turns.findIndex(t => t.turnNumber === num);
+        const id = selectedMessageIdRef.current;
+        if (id === null) return null;
+        const idx = turns.findIndex(t => t.messageId === id);
         return idx !== -1 ? idx : null;
     }, [turns]);
 
-    // Push turn info to parent whenever messages change
+    // Push turn info to parent whenever turns change
     React.useEffect(() => {
-        // If selected turn no longer exists (e.g. messages cleared), reset
-        if (selectedTurnNumberRef.current !== null) {
-            const exists = turns.some(t => t.turnNumber === selectedTurnNumberRef.current);
+        // If selected turn no longer exists (e.g. messages cleared/rewound), reset
+        if (selectedMessageIdRef.current !== null) {
+            const exists = turns.some(t => t.messageId === selectedMessageIdRef.current);
             if (!exists) {
-                selectedTurnNumberRef.current = null;
+                selectedMessageIdRef.current = null;
             }
         }
-        props.onTurnChange?.(selectedTurnNumberRef.current, turns.length, turns);
-    }, [turns.length]);
+        const currentNum = selectedMessageIdRef.current !== null
+            ? turns.find(t => t.messageId === selectedMessageIdRef.current)?.turnNumber ?? null
+            : null;
+        onTurnChangeRef.current?.(currentNum, turns.length, turns);
+    }, [turns]);
 
     const scrollToTurnIdx = useCallback((idx: number | null) => {
         if (idx === null) {
-            selectedTurnNumberRef.current = null;
+            selectedMessageIdRef.current = null;
             flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
         } else {
             const turn = turns[idx];
             if (turn) {
-                selectedTurnNumberRef.current = turn.turnNumber;
+                selectedMessageIdRef.current = turn.messageId;
                 flatListRef.current?.scrollToIndex({
                     index: turn.index,
                     animated: true,
@@ -102,8 +108,8 @@ const ChatListInternal = React.memo(React.forwardRef<ChatListHandle, ChatListInt
             }
         }
         const currentNum = idx !== null ? turns[idx]?.turnNumber ?? null : null;
-        props.onTurnChange?.(currentNum, turns.length, turns);
-    }, [turns, props.onTurnChange]);
+        onTurnChangeRef.current?.(currentNum, turns.length, turns);
+    }, [turns]);
 
     const doNavigate = useCallback((action: NavigateAction) => {
         if (turns.length === 0) return;
@@ -126,11 +132,17 @@ const ChatListInternal = React.memo(React.forwardRef<ChatListHandle, ChatListInt
         nextPage: () => doNavigate('nextPage'),
         goToEnd: () => doNavigate('end'),
         goToTurn,
-        getTurnInfo: () => ({
-            current: selectedTurnNumberRef.current,
-            total: turns.length,
-            turns,
-        }),
+        getTurnInfo: () => {
+            const id = selectedMessageIdRef.current;
+            const currentNum = id !== null
+                ? turns.find(t => t.messageId === id)?.turnNumber ?? null
+                : null;
+            return {
+                current: currentNum,
+                total: turns.length,
+                turns,
+            };
+        },
     }), [doNavigate, goToTurn, turns]);
 
     const keyExtractor = useCallback((item: Message) => item.id, []);

--- a/packages/happy-app/sources/components/TurnNavigator.tsx
+++ b/packages/happy-app/sources/components/TurnNavigator.tsx
@@ -1,0 +1,189 @@
+import * as React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { TurnPicker } from './TurnPicker';
+import { TurnInfo } from '@/hooks/useTurnIndices';
+
+interface TurnNavigatorProps {
+    currentTurnNumber: number | null;
+    totalTurns: number;
+    turns: TurnInfo[];
+    onPrev: () => void;
+    onNext: () => void;
+    onPrevPage: () => void;
+    onNextPage: () => void;
+    onEnd: () => void;
+    onGoToTurn: (turnNumber: number) => void;
+    hasPrev: boolean;
+    hasNext: boolean;
+}
+
+export const TurnNavigator = React.memo((props: TurnNavigatorProps) => {
+    const { theme } = useUnistyles();
+    const [pickerOpen, setPickerOpen] = React.useState(false);
+
+    if (props.totalTurns <= 1) return null;
+
+    const label = props.currentTurnNumber !== null
+        ? `${props.currentTurnNumber}/${props.totalTurns}`
+        : `${props.totalTurns}`;
+
+    const iconColor = theme.colors.fab.icon;
+
+    const handleLabelPress = () => setPickerOpen(true);
+
+    const handlePickerSelect = (turnNumber: number) => {
+        setPickerOpen(false);
+        props.onGoToTurn(turnNumber);
+    };
+
+    return (
+        <View style={styles.container}>
+            {/* Skip 5 turns older — rotated skip icon */}
+            <NavButton
+                icon="play-skip-back"
+                onPress={props.onPrevPage}
+                disabled={!props.hasPrev}
+                color={iconColor}
+                rotate="90deg"
+            />
+
+            {/* 1 turn older */}
+            <NavButton
+                icon="chevron-up"
+                onPress={props.onPrev}
+                disabled={!props.hasPrev}
+                color={iconColor}
+            />
+
+            {/* Tappable turn counter — opens picker */}
+            <Pressable onPress={handleLabelPress} hitSlop={8}>
+                <Text style={[styles.label, { color: iconColor }]}>
+                    {label}
+                </Text>
+            </Pressable>
+
+            {/* 1 turn newer */}
+            <NavButton
+                icon="chevron-down"
+                onPress={props.onNext}
+                disabled={!props.hasNext}
+                color={iconColor}
+            />
+
+            {/* Skip 5 turns newer — rotated skip icon */}
+            <NavButton
+                icon="play-skip-forward"
+                onPress={props.onNextPage}
+                disabled={!props.hasNext}
+                color={iconColor}
+                rotate="90deg"
+            />
+
+            {/* Jump to latest — always visible */}
+            <NavButton
+                icon="chevron-down-circle-outline"
+                onPress={props.onEnd}
+                disabled={false}
+                color={iconColor}
+            />
+
+            {/* Turn picker overlay */}
+            {pickerOpen && (
+                <TurnPicker
+                    turns={props.turns}
+                    currentTurnNumber={props.currentTurnNumber}
+                    onSelect={handlePickerSelect}
+                    onClose={() => setPickerOpen(false)}
+                />
+            )}
+        </View>
+    );
+});
+
+const NavButton = React.memo((props: {
+    icon: keyof typeof Ionicons.glyphMap;
+    onPress: () => void;
+    disabled: boolean;
+    color: string;
+    rotate?: string;
+}) => (
+    <Pressable
+        onPress={props.onPress}
+        disabled={props.disabled}
+        style={({ pressed }) => [
+            styles.button,
+            props.disabled && styles.disabled,
+            pressed && !props.disabled && styles.pressed,
+        ]}
+    >
+        <Ionicons
+            name={props.icon}
+            size={18}
+            color={props.color}
+            style={props.rotate ? { transform: [{ rotate: props.rotate }] } : undefined}
+        />
+    </Pressable>
+));
+
+/** Two chevrons stacked tightly — used for skip-5 navigation */
+const DoubleNavButton = React.memo((props: {
+    icon: keyof typeof Ionicons.glyphMap;
+    onPress: () => void;
+    disabled: boolean;
+    color: string;
+}) => (
+    <Pressable
+        onPress={props.onPress}
+        disabled={props.disabled}
+        style={({ pressed }) => [
+            styles.button,
+            props.disabled && styles.disabled,
+            pressed && !props.disabled && styles.pressed,
+        ]}
+    >
+        <View style={styles.doubleChevron}>
+            <Ionicons name={props.icon} size={14} color={props.color} />
+            <Ionicons name={props.icon} size={14} color={props.color} style={styles.doubleChevronSecond} />
+        </View>
+    </Pressable>
+));
+
+const styles = StyleSheet.create((theme) => ({
+    container: {
+        position: 'absolute',
+        right: 12,
+        bottom: 80,
+        alignItems: 'center',
+        backgroundColor: theme.colors.fab.background,
+        borderRadius: 20,
+        paddingVertical: 4,
+        paddingHorizontal: 6,
+        shadowColor: theme.colors.shadow.color,
+        shadowOffset: { width: 0, height: 2 },
+        shadowRadius: 4,
+        shadowOpacity: theme.colors.shadow.opacity,
+        elevation: 4,
+    },
+    button: {
+        padding: 6,
+    },
+    disabled: {
+        opacity: 0.3,
+    },
+    pressed: {
+        opacity: 0.6,
+    },
+    label: {
+        fontSize: 11,
+        fontVariant: ['tabular-nums'],
+        textDecorationLine: 'underline',
+    },
+    doubleChevron: {
+        alignItems: 'center',
+    },
+    doubleChevronSecond: {
+        marginTop: -8,
+    },
+}));

--- a/packages/happy-app/sources/components/TurnNavigator.tsx
+++ b/packages/happy-app/sources/components/TurnNavigator.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { TurnPicker } from './TurnPicker';
 import { TurnInfo } from '@/hooks/useTurnIndices';
+import { TURN_NAVIGATION_SHORTCUTS } from '@/hooks/turnNavigationKeyboard';
 
 interface TurnNavigatorProps {
     currentTurnNumber: number | null;
@@ -22,6 +23,7 @@ interface TurnNavigatorProps {
 export const TurnNavigator = React.memo((props: TurnNavigatorProps) => {
     const { theme } = useUnistyles();
     const [pickerOpen, setPickerOpen] = React.useState(false);
+    const [hoveredTooltip, setHoveredTooltip] = React.useState<string | null>(null);
 
     if (props.totalTurns <= 1) return null;
 
@@ -47,6 +49,8 @@ export const TurnNavigator = React.memo((props: TurnNavigatorProps) => {
                 disabled={!props.hasPrev}
                 color={iconColor}
                 rotate="90deg"
+                tooltip={TURN_NAVIGATION_SHORTCUTS.prevPage}
+                onHoverChange={setHoveredTooltip}
             />
 
             {/* 1 turn older */}
@@ -55,10 +59,18 @@ export const TurnNavigator = React.memo((props: TurnNavigatorProps) => {
                 onPress={props.onPrev}
                 disabled={!props.hasPrev}
                 color={iconColor}
+                tooltip={TURN_NAVIGATION_SHORTCUTS.prev}
+                onHoverChange={setHoveredTooltip}
             />
 
             {/* Tappable turn counter — opens picker */}
-            <Pressable onPress={handleLabelPress} hitSlop={8}>
+            <Pressable
+                onPress={handleLabelPress}
+                hitSlop={8}
+                accessibilityLabel={TURN_NAVIGATION_SHORTCUTS.picker}
+                onHoverIn={() => setHoveredTooltip(TURN_NAVIGATION_SHORTCUTS.picker)}
+                onHoverOut={() => setHoveredTooltip((current) => current === TURN_NAVIGATION_SHORTCUTS.picker ? null : current)}
+            >
                 <Text style={[styles.label, { color: iconColor }]}>
                     {label}
                 </Text>
@@ -70,6 +82,8 @@ export const TurnNavigator = React.memo((props: TurnNavigatorProps) => {
                 onPress={props.onNext}
                 disabled={!props.hasNext}
                 color={iconColor}
+                tooltip={TURN_NAVIGATION_SHORTCUTS.next}
+                onHoverChange={setHoveredTooltip}
             />
 
             {/* Skip 5 turns newer — rotated skip icon */}
@@ -79,6 +93,8 @@ export const TurnNavigator = React.memo((props: TurnNavigatorProps) => {
                 disabled={!props.hasNext}
                 color={iconColor}
                 rotate="90deg"
+                tooltip={TURN_NAVIGATION_SHORTCUTS.nextPage}
+                onHoverChange={setHoveredTooltip}
             />
 
             {/* Jump to latest — always visible */}
@@ -87,7 +103,26 @@ export const TurnNavigator = React.memo((props: TurnNavigatorProps) => {
                 onPress={props.onEnd}
                 disabled={false}
                 color={iconColor}
+                tooltip={TURN_NAVIGATION_SHORTCUTS.end}
+                onHoverChange={setHoveredTooltip}
             />
+
+            {hoveredTooltip && (
+                <View
+                    pointerEvents="none"
+                    style={[
+                        styles.tooltip,
+                        {
+                            backgroundColor: theme.colors.header.background,
+                            borderColor: theme.colors.divider,
+                        },
+                    ]}
+                >
+                    <Text style={[styles.tooltipText, { color: theme.colors.text }]}>
+                        {hoveredTooltip}
+                    </Text>
+                </View>
+            )}
 
             {/* Turn picker overlay */}
             {pickerOpen && (
@@ -108,10 +143,15 @@ const NavButton = React.memo((props: {
     disabled: boolean;
     color: string;
     rotate?: string;
+    tooltip: string;
+    onHoverChange: (tooltip: string | null) => void;
 }) => (
     <Pressable
         onPress={props.onPress}
         disabled={props.disabled}
+        accessibilityLabel={props.tooltip}
+        onHoverIn={() => props.onHoverChange(props.tooltip)}
+        onHoverOut={() => props.onHoverChange(null)}
         style={({ pressed }) => [
             styles.button,
             props.disabled && styles.disabled,
@@ -165,6 +205,26 @@ const styles = StyleSheet.create((theme) => ({
         shadowRadius: 4,
         shadowOpacity: theme.colors.shadow.opacity,
         elevation: 4,
+    },
+    tooltip: {
+        position: 'absolute',
+        right: '100%',
+        top: '50%',
+        transform: [{ translateY: -16 }],
+        marginRight: 10,
+        paddingHorizontal: 10,
+        paddingVertical: 6,
+        borderRadius: 8,
+        borderWidth: StyleSheet.hairlineWidth,
+        shadowColor: theme.colors.shadow.color,
+        shadowOffset: { width: 0, height: 2 },
+        shadowRadius: 6,
+        shadowOpacity: theme.colors.shadow.opacity,
+        elevation: 6,
+    },
+    tooltipText: {
+        fontSize: 12,
+        fontVariant: ['tabular-nums'],
     },
     button: {
         padding: 6,

--- a/packages/happy-app/sources/components/TurnPicker.tsx
+++ b/packages/happy-app/sources/components/TurnPicker.tsx
@@ -1,0 +1,209 @@
+/**
+ * TurnPicker — floating overlay for jumping to a specific turn by
+ * number input or by tapping an item in the scrollable turn list.
+ */
+
+import * as React from 'react';
+import { FlatList, Pressable, Text, TextInput, View } from 'react-native';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { TurnInfo } from '@/hooks/useTurnIndices';
+
+interface TurnPickerProps {
+    turns: TurnInfo[];
+    currentTurnNumber: number | null;
+    onSelect: (turnNumber: number) => void;
+    onClose: () => void;
+}
+
+export const TurnPicker = React.memo((props: TurnPickerProps) => {
+    const { theme } = useUnistyles();
+    const [inputValue, setInputValue] = React.useState(
+        props.currentTurnNumber !== null ? String(props.currentTurnNumber) : '',
+    );
+    const inputRef = React.useRef<TextInput>(null);
+
+    // Auto-focus input on mount
+    React.useEffect(() => {
+        setTimeout(() => inputRef.current?.focus(), 100);
+    }, []);
+
+    // Reverse turns for display: oldest (turn 1) at top, newest at bottom
+    const reversedTurns = React.useMemo(
+        () => [...props.turns].reverse(),
+        [props.turns],
+    );
+
+    const handleSubmit = React.useCallback(() => {
+        const num = parseInt(inputValue, 10);
+        if (num >= 1 && num <= props.turns.length) {
+            props.onSelect(num);
+        }
+    }, [inputValue, props.turns.length, props.onSelect]);
+
+    const handleItemPress = React.useCallback((turnNumber: number) => {
+        props.onSelect(turnNumber);
+    }, [props.onSelect]);
+
+    // Turns sorted newest-first for display (same order as turns array)
+    const renderItem = React.useCallback(({ item }: { item: TurnInfo }) => (
+        <Pressable
+            onPress={() => handleItemPress(item.turnNumber)}
+            style={({ pressed }) => [
+                styles.listItem,
+                item.turnNumber === props.currentTurnNumber && styles.listItemActive,
+                pressed && styles.listItemPressed,
+            ]}
+        >
+            <Text style={[styles.listItemNumber, { color: theme.colors.textSecondary }]}>
+                {item.turnNumber}
+            </Text>
+            <Text
+                style={[styles.listItemText, { color: theme.colors.text }]}
+                numberOfLines={1}
+            >
+                {item.preview || '...'}
+            </Text>
+        </Pressable>
+    ), [handleItemPress, props.currentTurnNumber, theme]);
+
+    return (
+        <>
+            {/* Backdrop */}
+            <Pressable style={styles.backdrop} onPress={props.onClose} />
+
+            {/* Picker panel */}
+            <View style={styles.panel}>
+                {/* Input row */}
+                <View style={styles.inputRow}>
+                    <Text style={[styles.inputLabel, { color: theme.colors.textSecondary }]}>
+                        Go to:
+                    </Text>
+                    <TextInput
+                        ref={inputRef}
+                        style={[styles.input, {
+                            color: theme.colors.text,
+                            borderColor: theme.colors.divider,
+                        }]}
+                        value={inputValue}
+                        onChangeText={setInputValue}
+                        onSubmitEditing={handleSubmit}
+                        keyboardType="number-pad"
+                        returnKeyType="go"
+                        selectTextOnFocus
+                        placeholder={`1-${props.turns.length}`}
+                        placeholderTextColor={theme.colors.textSecondary}
+                    />
+                    <Text style={[styles.inputTotal, { color: theme.colors.textSecondary }]}>
+                        / {props.turns.length}
+                    </Text>
+                </View>
+
+                {/* Divider */}
+                <View style={[styles.divider, { backgroundColor: theme.colors.divider }]} />
+
+                {/* Turn list — display oldest first (natural reading order) */}
+                <FlatList
+                    data={reversedTurns}
+                    keyExtractor={(item) => String(item.turnNumber)}
+                    renderItem={renderItem}
+                    style={styles.list}
+                    keyboardShouldPersistTaps="handled"
+                    initialScrollIndex={
+                        props.currentTurnNumber !== null
+                            ? reversedTurns.findIndex(t => t.turnNumber === props.currentTurnNumber)
+                            : reversedTurns.length - 1
+                    }
+                    getItemLayout={(_, index) => ({
+                        length: ITEM_HEIGHT,
+                        offset: ITEM_HEIGHT * index,
+                        index,
+                    })}
+                />
+            </View>
+        </>
+    );
+});
+
+const ITEM_HEIGHT = 44;
+
+const styles = StyleSheet.create((theme) => ({
+    backdrop: {
+        position: 'absolute',
+        top: -2000,
+        left: -2000,
+        right: -2000,
+        bottom: -2000,
+        zIndex: 999,
+    },
+    panel: {
+        position: 'absolute',
+        right: 50,
+        bottom: 80,
+        width: 280,
+        maxHeight: 360,
+        backgroundColor: theme.colors.surface,
+        borderRadius: 12,
+        shadowColor: theme.colors.shadow.color,
+        shadowOffset: { width: 0, height: 4 },
+        shadowRadius: 8,
+        shadowOpacity: theme.colors.shadow.opacity,
+        elevation: 8,
+        zIndex: 1000,
+        overflow: 'hidden',
+    },
+    inputRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 12,
+        paddingVertical: 10,
+        gap: 8,
+    },
+    inputLabel: {
+        fontSize: 13,
+        fontWeight: '600',
+    },
+    input: {
+        width: 56,
+        height: 32,
+        borderWidth: 1,
+        borderRadius: 8,
+        paddingHorizontal: 8,
+        fontSize: 14,
+        textAlign: 'center',
+        fontVariant: ['tabular-nums'],
+    },
+    inputTotal: {
+        fontSize: 13,
+        fontVariant: ['tabular-nums'],
+    },
+    divider: {
+        height: 1,
+    },
+    list: {
+        maxHeight: 300,
+    },
+    listItem: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        height: ITEM_HEIGHT,
+        paddingHorizontal: 12,
+        gap: 10,
+    },
+    listItemActive: {
+        backgroundColor: theme.colors.surfacePressed,
+    },
+    listItemPressed: {
+        opacity: 0.7,
+    },
+    listItemNumber: {
+        width: 32,
+        fontSize: 13,
+        fontWeight: '600',
+        textAlign: 'right',
+        fontVariant: ['tabular-nums'],
+    },
+    listItemText: {
+        flex: 1,
+        fontSize: 13,
+    },
+}));

--- a/packages/happy-app/sources/hooks/turnNavigationKeyboard.ts
+++ b/packages/happy-app/sources/hooks/turnNavigationKeyboard.ts
@@ -1,0 +1,39 @@
+export type TurnNavigationAction = 'prev' | 'next' | 'prevPage' | 'nextPage' | 'end';
+
+export interface TurnNavigationKeyEvent {
+    key: string;
+    code?: string;
+    altKey: boolean;
+    shiftKey: boolean;
+}
+
+export const TURN_NAVIGATION_SHORTCUTS = {
+    prevPage: 'Alt+Shift+↑',
+    prev: 'Alt+↑',
+    picker: 'Jump to turn',
+    next: 'Alt+↓',
+    nextPage: 'Alt+Shift+↓',
+    end: 'Alt+.',
+} as const;
+
+export function getTurnNavigationAction(event: TurnNavigationKeyEvent): TurnNavigationAction | null {
+    if (!event.altKey) return null;
+
+    if (event.key === 'ArrowUp') {
+        return event.shiftKey ? 'prevPage' : 'prev';
+    }
+
+    if (event.key === 'ArrowDown') {
+        return event.shiftKey ? 'nextPage' : 'next';
+    }
+
+    if ((event.key === 'End' && event.shiftKey) || event.code === 'Period') {
+        return 'end';
+    }
+
+    return null;
+}
+
+export function getTurnNavigationShortcut(action: keyof typeof TURN_NAVIGATION_SHORTCUTS): string {
+    return TURN_NAVIGATION_SHORTCUTS[action];
+}

--- a/packages/happy-app/sources/hooks/useTurnIndices.spec.ts
+++ b/packages/happy-app/sources/hooks/useTurnIndices.spec.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { extractTurnIndices, navigateTurn, TurnInfo, PAGE_SIZE } from './useTurnIndices';
+import { Message } from '@/sync/typesMessage';
+
+// Helper to build a minimal Message array (newest-first order)
+function makeMessages(...kinds: Array<'user' | 'agent' | 'tool'>): Message[] {
+    return kinds.map((k, i) => {
+        if (k === 'user') {
+            return {
+                kind: 'user-text' as const,
+                id: `msg-${i}`,
+                localId: null,
+                createdAt: 1000 - i * 10,
+                text: `User message ${i}`,
+            };
+        }
+        if (k === 'agent') {
+            return {
+                kind: 'agent-text' as const,
+                id: `msg-${i}`,
+                localId: null,
+                createdAt: 1000 - i * 10,
+                text: `Agent reply ${i}`,
+            };
+        }
+        return {
+            kind: 'tool-call' as const,
+            id: `msg-${i}`,
+            localId: null,
+            createdAt: 1000 - i * 10,
+            tool: { name: 'Read', state: 'completed' as const, input: {}, createdAt: 0, startedAt: 0, completedAt: 0, description: null },
+            children: [],
+        };
+    });
+}
+
+// Helper to make a simple TurnInfo array for navigateTurn tests
+function makeTurns(count: number): TurnInfo[] {
+    // turns[0] = newest (turnNumber = count), turns[count-1] = oldest (turnNumber = 1)
+    return Array.from({ length: count }, (_, i) => ({
+        index: i * 3,
+        turnNumber: count - i,
+        preview: `Turn ${count - i}`,
+    }));
+}
+
+// ============================================================================
+// extractTurnIndices
+// ============================================================================
+
+describe('extractTurnIndices', () => {
+    it('returns empty array for no messages', () => {
+        expect(extractTurnIndices([])).toEqual([]);
+    });
+
+    it('returns empty array when there are no user-text messages', () => {
+        const msgs = makeMessages('agent', 'tool', 'agent');
+        expect(extractTurnIndices(msgs)).toEqual([]);
+    });
+
+    it('finds a single turn', () => {
+        const msgs = makeMessages('user', 'agent');
+        const turns = extractTurnIndices(msgs);
+        expect(turns).toHaveLength(1);
+        expect(turns[0].turnNumber).toBe(1);
+        expect(turns[0].index).toBe(0);
+    });
+
+    it('assigns turn numbers oldest=1, newest=N in newest-first data', () => {
+        // Newest-first: [user3, agent3, user2, agent2, user1, agent1]
+        const msgs = makeMessages('user', 'agent', 'user', 'agent', 'user', 'agent');
+        const turns = extractTurnIndices(msgs);
+
+        expect(turns).toHaveLength(3);
+        // turns[0] is the newest user-text (index 0), gets turnNumber 3
+        expect(turns[0]).toMatchObject({ index: 0, turnNumber: 3 });
+        // turns[1] is the second newest (index 2), gets turnNumber 2
+        expect(turns[1]).toMatchObject({ index: 2, turnNumber: 2 });
+        // turns[2] is the oldest (index 4), gets turnNumber 1
+        expect(turns[2]).toMatchObject({ index: 4, turnNumber: 1 });
+    });
+
+    it('skips agent-text and tool-call messages', () => {
+        const msgs = makeMessages('user', 'agent', 'tool', 'agent', 'user', 'tool');
+        const turns = extractTurnIndices(msgs);
+        expect(turns).toHaveLength(2);
+        expect(turns[0].index).toBe(0); // first user-text
+        expect(turns[1].index).toBe(4); // second user-text
+    });
+
+    it('extracts preview text from user message', () => {
+        const msgs: Message[] = [{
+            kind: 'user-text',
+            id: 'u1',
+            localId: null,
+            createdAt: 1000,
+            text: 'Hello world',
+        }];
+        const turns = extractTurnIndices(msgs);
+        expect(turns[0].preview).toBe('Hello world');
+    });
+
+    it('prefers displayText over text for preview', () => {
+        const msgs: Message[] = [{
+            kind: 'user-text',
+            id: 'u1',
+            localId: null,
+            createdAt: 1000,
+            text: 'raw text',
+            displayText: 'Display version',
+        }];
+        const turns = extractTurnIndices(msgs);
+        expect(turns[0].preview).toBe('Display version');
+    });
+
+    it('truncates preview to 60 chars', () => {
+        const longText = 'A'.repeat(80);
+        const msgs: Message[] = [{
+            kind: 'user-text',
+            id: 'u1',
+            localId: null,
+            createdAt: 1000,
+            text: longText,
+        }];
+        const turns = extractTurnIndices(msgs);
+        expect(turns[0].preview).toBe('A'.repeat(57) + '...');
+        expect(turns[0].preview.length).toBe(60);
+    });
+
+    it('shows (empty) for empty text', () => {
+        const msgs: Message[] = [{
+            kind: 'user-text',
+            id: 'u1',
+            localId: null,
+            createdAt: 1000,
+            text: '',
+        }];
+        const turns = extractTurnIndices(msgs);
+        expect(turns[0].preview).toBe('(empty)');
+    });
+});
+
+// ============================================================================
+// navigateTurn
+// ============================================================================
+
+describe('navigateTurn', () => {
+    describe('empty turns', () => {
+        it('returns null for any action on empty turns', () => {
+            expect(navigateTurn([], null, 'prev')).toBeNull();
+            expect(navigateTurn([], null, 'next')).toBeNull();
+            expect(navigateTurn([], null, 'end')).toBeNull();
+            expect(navigateTurn([], 0, 'prev')).toBeNull();
+        });
+    });
+
+    describe('end action', () => {
+        it('always returns null regardless of current position', () => {
+            const turns = makeTurns(10);
+            expect(navigateTurn(turns, null, 'end')).toBeNull();
+            expect(navigateTurn(turns, 0, 'end')).toBeNull();
+            expect(navigateTurn(turns, 5, 'end')).toBeNull();
+            expect(navigateTurn(turns, 9, 'end')).toBeNull();
+        });
+    });
+
+    describe('from bottom (selectedIdx = null)', () => {
+        const turns = makeTurns(10);
+
+        it('prev skips to second newest (index 1), not newest (index 0)', () => {
+            expect(navigateTurn(turns, null, 'prev')).toBe(1);
+        });
+
+        it('prevPage skips PAGE_SIZE turns', () => {
+            expect(navigateTurn(turns, null, 'prevPage')).toBe(PAGE_SIZE);
+        });
+
+        it('next stays at null (already at bottom)', () => {
+            expect(navigateTurn(turns, null, 'next')).toBeNull();
+        });
+
+        it('nextPage stays at null', () => {
+            expect(navigateTurn(turns, null, 'nextPage')).toBeNull();
+        });
+    });
+
+    describe('from bottom with only 1 turn', () => {
+        const turns = makeTurns(1);
+
+        it('prev returns 0 (the only turn)', () => {
+            expect(navigateTurn(turns, null, 'prev')).toBe(0);
+        });
+
+        it('prevPage returns 0 (clamped)', () => {
+            expect(navigateTurn(turns, null, 'prevPage')).toBe(0);
+        });
+    });
+
+    describe('step navigation (prev/next)', () => {
+        const turns = makeTurns(5);
+
+        it('prev increments index (goes to older turn)', () => {
+            expect(navigateTurn(turns, 1, 'prev')).toBe(2);
+        });
+
+        it('prev clamps at oldest turn', () => {
+            expect(navigateTurn(turns, 4, 'prev')).toBe(4);
+        });
+
+        it('next decrements index (goes to newer turn)', () => {
+            expect(navigateTurn(turns, 2, 'next')).toBe(1);
+        });
+
+        it('next returns null when reaching bottom (index 0)', () => {
+            expect(navigateTurn(turns, 0, 'next')).toBeNull();
+        });
+    });
+
+    describe('page navigation (prevPage/nextPage)', () => {
+        const turns = makeTurns(15);
+
+        it('prevPage jumps PAGE_SIZE older', () => {
+            expect(navigateTurn(turns, 2, 'prevPage')).toBe(2 + PAGE_SIZE);
+        });
+
+        it('prevPage clamps at oldest turn', () => {
+            expect(navigateTurn(turns, 12, 'prevPage')).toBe(14);
+        });
+
+        it('nextPage jumps PAGE_SIZE newer', () => {
+            expect(navigateTurn(turns, 8, 'nextPage')).toBe(8 - PAGE_SIZE);
+        });
+
+        it('nextPage returns null when overshooting bottom', () => {
+            expect(navigateTurn(turns, 3, 'nextPage')).toBeNull();
+        });
+    });
+
+    describe('full navigation sequence', () => {
+        it('null → prev → prev → prev → next → next → next → null', () => {
+            const turns = makeTurns(5);
+
+            let pos: number | null = null;
+            pos = navigateTurn(turns, pos, 'prev');   // null → 1
+            expect(pos).toBe(1);
+
+            pos = navigateTurn(turns, pos, 'prev');   // 1 → 2
+            expect(pos).toBe(2);
+
+            pos = navigateTurn(turns, pos, 'prev');   // 2 → 3
+            expect(pos).toBe(3);
+
+            pos = navigateTurn(turns, pos, 'next');   // 3 → 2
+            expect(pos).toBe(2);
+
+            pos = navigateTurn(turns, pos, 'next');   // 2 → 1
+            expect(pos).toBe(1);
+
+            pos = navigateTurn(turns, pos, 'next');   // 1 → 0
+            expect(pos).toBe(0);
+
+            pos = navigateTurn(turns, pos, 'next');   // 0 → null
+            expect(pos).toBeNull();
+        });
+    });
+});

--- a/packages/happy-app/sources/hooks/useTurnIndices.spec.ts
+++ b/packages/happy-app/sources/hooks/useTurnIndices.spec.ts
@@ -40,6 +40,7 @@ function makeTurns(count: number): TurnInfo[] {
     return Array.from({ length: count }, (_, i) => ({
         index: i * 3,
         turnNumber: count - i,
+        messageId: `msg-${i * 3}`,
         preview: `Turn ${count - i}`,
     }));
 }
@@ -73,11 +74,11 @@ describe('extractTurnIndices', () => {
 
         expect(turns).toHaveLength(3);
         // turns[0] is the newest user-text (index 0), gets turnNumber 3
-        expect(turns[0]).toMatchObject({ index: 0, turnNumber: 3 });
+        expect(turns[0]).toMatchObject({ index: 0, turnNumber: 3, messageId: 'msg-0' });
         // turns[1] is the second newest (index 2), gets turnNumber 2
-        expect(turns[1]).toMatchObject({ index: 2, turnNumber: 2 });
+        expect(turns[1]).toMatchObject({ index: 2, turnNumber: 2, messageId: 'msg-2' });
         // turns[2] is the oldest (index 4), gets turnNumber 1
-        expect(turns[2]).toMatchObject({ index: 4, turnNumber: 1 });
+        expect(turns[2]).toMatchObject({ index: 4, turnNumber: 1, messageId: 'msg-4' });
     });
 
     it('skips agent-text and tool-call messages', () => {

--- a/packages/happy-app/sources/hooks/useTurnIndices.ts
+++ b/packages/happy-app/sources/hooks/useTurnIndices.ts
@@ -8,6 +8,8 @@ export interface TurnInfo {
     index: number;
     /** Turn number, 1-based, oldest = 1 */
     turnNumber: number;
+    /** Message ID of the user-text message that starts this turn */
+    messageId: string;
     /** First ~60 chars of the user-text message for preview in turn picker */
     preview: string;
 }
@@ -51,6 +53,7 @@ export function extractTurnIndices(messages: Message[]): TurnInfo[] {
         return {
             index,
             turnNumber: total - i,
+            messageId: msg.id,
             preview,
         };
     });

--- a/packages/happy-app/sources/hooks/useTurnIndices.ts
+++ b/packages/happy-app/sources/hooks/useTurnIndices.ts
@@ -1,0 +1,109 @@
+import { useMemo } from 'react';
+import { Message } from '@/sync/typesMessage';
+
+export const PAGE_SIZE = 5;
+
+export interface TurnInfo {
+    /** Index in the FlatList data array (inverted: 0 = newest) */
+    index: number;
+    /** Turn number, 1-based, oldest = 1 */
+    turnNumber: number;
+    /** First ~60 chars of the user-text message for preview in turn picker */
+    preview: string;
+}
+
+export type NavigateAction = 'prev' | 'next' | 'prevPage' | 'nextPage' | 'end';
+
+/**
+ * Extract turn boundaries from a Message array.
+ *
+ * In an inverted FlatList the data array is ordered newest-first
+ * (index 0 = bottom of screen). A "turn" starts at every
+ * `kind === 'user-text'` message. Turn numbers are assigned
+ * oldest = 1, newest = N so they feel natural to the user.
+ */
+/**
+ * Extract turn boundaries from a Message array.
+ *
+ * In an inverted FlatList the data array is ordered newest-first
+ * (index 0 = bottom of screen). A "turn" starts at every
+ * `kind === 'user-text'` message. Turn numbers are assigned
+ * oldest = 1, newest = N so they feel natural to the user.
+ */
+export function extractTurnIndices(messages: Message[]): TurnInfo[] {
+    const rawIndices: number[] = [];
+    for (let i = 0; i < messages.length; i++) {
+        if (messages[i].kind === 'user-text') {
+            rawIndices.push(i);
+        }
+    }
+
+    const total = rawIndices.length;
+    return rawIndices.map((index, i) => {
+        const msg = messages[index];
+        let text = '';
+        if (msg.kind === 'user-text') {
+            text = (msg.displayText || msg.text || '').trim();
+        }
+        const preview = text.length > 60
+            ? text.slice(0, 57) + '...'
+            : text || '(empty)';
+        return {
+            index,
+            turnNumber: total - i,
+            preview,
+        };
+    });
+}
+
+export function useTurnIndices(messages: Message[]): TurnInfo[] {
+    return useMemo(() => extractTurnIndices(messages), [messages]);
+}
+
+/**
+ * Given the current selected position in the turns array,
+ * compute the next position after applying `action`.
+ *
+ * `selectedIdx` is an index into the `turns` array (NOT the
+ * FlatList data index). `null` means "at the bottom / latest".
+ *
+ * Returns the new turns-array index, or `null` for "go to end".
+ */
+export function navigateTurn(
+    turns: TurnInfo[],
+    selectedIdx: number | null,
+    action: NavigateAction,
+): number | null {
+    if (turns.length === 0) return null;
+
+    // "end" always returns null (= latest / bottom)
+    if (action === 'end') return null;
+
+    // Resolve current position.
+    // null (at bottom) means "already viewing the latest turn" —
+    // prev should skip to the SECOND newest (index 1), not the newest (index 0)
+    // which is already visible. next/nextPage stay at null.
+    if (selectedIdx === null) {
+        if (action === 'next' || action === 'nextPage') return null;
+        if (action === 'prev') return turns.length > 1 ? 1 : 0;
+        // prevPage: skip PAGE_SIZE turns from the latest
+        return Math.min(PAGE_SIZE, turns.length - 1);
+    }
+
+    switch (action) {
+        // In the turns array index 0 = newest, higher = older.
+        // "prev" = go to an older turn = higher index.
+        case 'prev':
+            return Math.min(selectedIdx + 1, turns.length - 1);
+        case 'next': {
+            const next = selectedIdx - 1;
+            return next < 0 ? null : next;
+        }
+        case 'prevPage':
+            return Math.min(selectedIdx + PAGE_SIZE, turns.length - 1);
+        case 'nextPage': {
+            const next = selectedIdx - PAGE_SIZE;
+            return next < 0 ? null : next;
+        }
+    }
+}

--- a/packages/happy-app/sources/hooks/useTurnNavigationKeyboard.spec.ts
+++ b/packages/happy-app/sources/hooks/useTurnNavigationKeyboard.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+    TURN_NAVIGATION_SHORTCUTS,
+    getTurnNavigationAction,
+    getTurnNavigationShortcut,
+} from './turnNavigationKeyboard';
+
+describe('getTurnNavigationAction', () => {
+    it('returns null when Alt is not pressed', () => {
+        expect(getTurnNavigationAction({
+            key: 'ArrowUp',
+            code: 'ArrowUp',
+            altKey: false,
+            shiftKey: false,
+        })).toBeNull();
+    });
+
+    it('maps Alt+ArrowUp to previous turn', () => {
+        expect(getTurnNavigationAction({
+            key: 'ArrowUp',
+            code: 'ArrowUp',
+            altKey: true,
+            shiftKey: false,
+        })).toBe('prev');
+    });
+
+    it('maps Alt+Shift+ArrowUp to previous page', () => {
+        expect(getTurnNavigationAction({
+            key: 'ArrowUp',
+            code: 'ArrowUp',
+            altKey: true,
+            shiftKey: true,
+        })).toBe('prevPage');
+    });
+
+    it('maps Alt+ArrowDown to next turn', () => {
+        expect(getTurnNavigationAction({
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+            altKey: true,
+            shiftKey: false,
+        })).toBe('next');
+    });
+
+    it('maps Alt+Shift+ArrowDown to next page', () => {
+        expect(getTurnNavigationAction({
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+            altKey: true,
+            shiftKey: true,
+        })).toBe('nextPage');
+    });
+
+    it('maps the physical Period key to jump to latest even when the produced key changes', () => {
+        expect(getTurnNavigationAction({
+            key: '>',
+            code: 'Period',
+            altKey: true,
+            shiftKey: false,
+        })).toBe('end');
+    });
+
+    it('still supports Alt+Shift+End for jump to latest', () => {
+        expect(getTurnNavigationAction({
+            key: 'End',
+            code: 'End',
+            altKey: true,
+            shiftKey: true,
+        })).toBe('end');
+    });
+});
+
+describe('turn navigation shortcuts', () => {
+    it('exposes the expected labels for the navigator buttons', () => {
+        expect(TURN_NAVIGATION_SHORTCUTS).toEqual({
+            prevPage: 'Alt+Shift+↑',
+            prev: 'Alt+↑',
+            picker: 'Jump to turn',
+            next: 'Alt+↓',
+            nextPage: 'Alt+Shift+↓',
+            end: 'Alt+.',
+        });
+    });
+
+    it('returns labels for each supported action', () => {
+        expect(getTurnNavigationShortcut('prevPage')).toBe('Alt+Shift+↑');
+        expect(getTurnNavigationShortcut('prev')).toBe('Alt+↑');
+        expect(getTurnNavigationShortcut('next')).toBe('Alt+↓');
+        expect(getTurnNavigationShortcut('nextPage')).toBe('Alt+Shift+↓');
+        expect(getTurnNavigationShortcut('end')).toBe('Alt+.');
+    });
+});

--- a/packages/happy-app/sources/hooks/useTurnNavigationKeyboard.ts
+++ b/packages/happy-app/sources/hooks/useTurnNavigationKeyboard.ts
@@ -12,6 +12,7 @@
 
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
+import { getTurnNavigationAction } from './turnNavigationKeyboard';
 
 interface Handlers {
     onPrev: () => void;
@@ -34,23 +35,21 @@ export function useTurnNavigationKeyboard(handlers: Handlers) {
         if (Platform.OS !== 'web') return;
 
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (!e.altKey) return;
             if (isEditableElement(document.activeElement)) return;
+            const action = getTurnNavigationAction(e);
+            if (!action) return;
 
-            if (e.key === 'ArrowUp' && !e.shiftKey) {
-                e.preventDefault();
+            e.preventDefault();
+
+            if (action === 'prev') {
                 handlers.onPrev();
-            } else if (e.key === 'ArrowDown' && !e.shiftKey) {
-                e.preventDefault();
+            } else if (action === 'next') {
                 handlers.onNext();
-            } else if (e.key === 'ArrowUp' && e.shiftKey) {
-                e.preventDefault();
+            } else if (action === 'prevPage') {
                 handlers.onPrevPage();
-            } else if (e.key === 'ArrowDown' && e.shiftKey) {
-                e.preventDefault();
+            } else if (action === 'nextPage') {
                 handlers.onNextPage();
-            } else if ((e.key === 'End' && e.shiftKey) || e.key === '.') {
-                e.preventDefault();
+            } else if (action === 'end') {
                 handlers.onEnd();
             }
         };

--- a/packages/happy-app/sources/hooks/useTurnNavigationKeyboard.ts
+++ b/packages/happy-app/sources/hooks/useTurnNavigationKeyboard.ts
@@ -1,0 +1,61 @@
+/**
+ * Keyboard shortcuts for turn-level navigation (web only).
+ *
+ * Uses Alt-based modifiers to avoid collisions with browser/OS defaults:
+ *   Alt+↑/↓         — step one turn
+ *   Alt+Shift+↑/↓   — page (skip 5 turns)
+ *   Alt+Shift+End   — jump to latest
+ *   Alt+.           — jump to latest (Mac laptops without End key)
+ *
+ * Shortcuts are suppressed when focus is inside a text input.
+ */
+
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+interface Handlers {
+    onPrev: () => void;
+    onNext: () => void;
+    onPrevPage: () => void;
+    onNextPage: () => void;
+    onEnd: () => void;
+}
+
+function isEditableElement(el: Element | null): boolean {
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === 'TEXTAREA' || tag === 'INPUT') return true;
+    if ((el as HTMLElement).isContentEditable) return true;
+    return false;
+}
+
+export function useTurnNavigationKeyboard(handlers: Handlers) {
+    useEffect(() => {
+        if (Platform.OS !== 'web') return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (!e.altKey) return;
+            if (isEditableElement(document.activeElement)) return;
+
+            if (e.key === 'ArrowUp' && !e.shiftKey) {
+                e.preventDefault();
+                handlers.onPrev();
+            } else if (e.key === 'ArrowDown' && !e.shiftKey) {
+                e.preventDefault();
+                handlers.onNext();
+            } else if (e.key === 'ArrowUp' && e.shiftKey) {
+                e.preventDefault();
+                handlers.onPrevPage();
+            } else if (e.key === 'ArrowDown' && e.shiftKey) {
+                e.preventDefault();
+                handlers.onNextPage();
+            } else if ((e.key === 'End' && e.shiftKey) || e.key === '.') {
+                e.preventDefault();
+                handlers.onEnd();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [handlers.onPrev, handlers.onNext, handlers.onPrevPage, handlers.onNextPage, handlers.onEnd]);
+}


### PR DESCRIPTION
# Summary
Long chat sessions had no way to jump between conversation turns — you had to scroll manually. This PR adds a floating turn navigator with step/page/direct navigation, web keyboard shortcuts, and hover shortcut hints on the navigator buttons.

It also tracks the selected turn by message ID instead of positional turn number, so selection survives remote rewind and clear operations without getting reset. On web, the jump-to-latest shortcut is now matched by the physical `Period` key, which makes `Alt + .` more reliable across keyboard layouts while still keeping `Alt + Shift + End` as a fallback.

# What's included
- `TurnNavigator` — floating FAB with prev/next, skip-5, jump-to-latest, tappable turn counter, and hover shortcut hints
- `TurnPicker` — overlay for direct turn selection by number or tap
- `useTurnIndices` — extracts turn boundaries from messages (`user-text` starts a new turn)
- `useTurnNavigationKeyboard` — web shortcuts for step/page/latest navigation
- `turnNavigationKeyboard` — shared shortcut labels and stable keyboard event matching for web
- `ChatList` integration — `ChatListHandle` ref, progressive scroll retry, and messageId-based selection tracking

# Proof it works
<img width="684" height="1044" alt="image" src="https://github.com/user-attachments/assets/5abd5448-7b2d-4845-9c2f-a6785ef75771" />

# Test plan
- `useTurnIndices` covers turn extraction and navigation state transitions
- Added 9 unit tests for web keyboard shortcut matching and displayed shortcut labels
- `corepack pnpm test sources/hooks/useTurnNavigationKeyboard.spec.ts`
- `corepack pnpm typecheck`
- Manual: navigate turns in a multi-turn session
- Manual: trigger remote rewind and verify selection is preserved
- Manual: verify web shortcuts (`Alt+↑`, `Alt+↓`, `Alt+Shift+↑`, `Alt+Shift+↓`, `Alt+.`, `Alt+Shift+End`)
- Manual: hover each navigator control and verify the shortcut hint appears
- Manual: turn picker number input and tap selection

Files changed (12 files)

| File | What |
|------|------|
| `hooks/useTurnIndices.ts` | Turn extraction and navigation state machine |
| `hooks/useTurnIndices.spec.ts` | Turn extraction/navigation tests |
| `hooks/useTurnNavigationKeyboard.ts` | Web keyboard shortcut hook |
| `hooks/turnNavigationKeyboard.ts` | Shared shortcut labels and stable key matching |
| `hooks/useTurnNavigationKeyboard.spec.ts` | Keyboard shortcut tests |
| `components/ChatList.tsx` | FlatList integration and messageId-based selection |
| `components/TurnNavigator.tsx` | Floating navigation UI and hover shortcut hints |
| `components/TurnPicker.tsx` | Direct turn selection overlay |
| `-session/SessionView.tsx` | Wiring to the chat view |
| `app/(app)/dev/turn-navigation-demo.tsx` | Dev demo page |
| `app/(app)/dev/messages-demo-data.ts` | Mock data for demo |
| `app/(app)/dev/index.tsx` | Dev menu entry |


