### PR TITLE
fix: filter out isMeta messages to prevent Skill content from polluting chat

### DIFF
--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
@@ -538,6 +538,15 @@ function mapClaudeLogMessageToSessionEnvelopesInternal(
     }
 
     if (message.type === 'user') {
+        // Skip meta messages (e.g. Skill tool content injections) — they are internal
+        // context for the model, not user-visible content
+        if (message.isMeta) {
+            return {
+                currentTurnId: state.currentTurnId,
+                envelopes,
+            };
+        }
+
         if (typeof message.message.content === 'string') {
             if (message.isSidechain) {
                 const turnId = ensureTurn(state, envelopes);


### PR DESCRIPTION
## Summary

- When Claude Code invokes the Skill tool, the SDK emits a separate user message with `isMeta: true` containing the full skill description as a text block. The session protocol mapper was not checking this flag, so the entire skill content was forwarded to the frontend as visible agent text.
- This is especially noticeable with long skills like Superpowers (thousands of characters rendered inline in the chat).
- The fix adds an early return in `sessionProtocolMapper.ts` for `isMeta` user messages, preventing them from generating any session envelopes.

## Root Cause

The Claude SDK sends three messages when a Skill tool is invoked:

1. **Assistant**: `tool_use` (name: "Skill")
2. **User**: `tool_result` (content: "Launching skill: ...")
3. **User**: `text` block with `isMeta: true` + `sourceToolUseID` — contains the full skill content

The `isMeta` field already existed in the `RawJSONLines` schema (`types.ts:25`) but was never consumed anywhere. Message (3) was treated as a regular user message, and its text block was emitted as a visible `{ t: 'text' }` envelope to the frontend.

## Changes

- `packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts`: Skip user messages where `isMeta === true`

## Test plan

- [x] Existing `sessionProtocolMapper.test.ts` tests pass (11/11)
- [ ] Verify in a live session that Skill tool calls no longer render their full content in the chat UI
- [ ] Verify that normal tool results (Bash, Read, Edit, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)