### PR TITLE
fix: make GitHub OAuth redirect URL configurable via PUBLIC_APP_URL

### DIFF
--- a/packages/happy-server/sources/app/api/routes/connectRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/connectRoutes.ts
@@ -99,7 +99,8 @@ export function connectRoutes(app: Fastify) {
         const tokenData = await auth.verifyGithubToken(state);
         if (!tokenData) {
             log({ module: 'github-oauth' }, `Invalid state token: ${state}`);
-            return reply.redirect('https://app.happy.engineering?error=invalid_state');
+            const appUrl = process.env.PUBLIC_APP_URL || 'https://app.happy.engineering';
+            return reply.redirect(`${appUrl}?error=invalid_state`);
         }
 
         const userId = tokenData.userId;
@@ -107,7 +108,8 @@ export function connectRoutes(app: Fastify) {
         const clientSecret = process.env.GITHUB_CLIENT_SECRET;
 
         if (!clientId || !clientSecret) {
-            return reply.redirect('https://app.happy.engineering?error=server_config');
+            const appUrl = process.env.PUBLIC_APP_URL || 'https://app.happy.engineering';
+            return reply.redirect(`${appUrl}?error=server_config`);
         }
 
         try {
@@ -132,7 +134,8 @@ export function connectRoutes(app: Fastify) {
             };
 
             if (tokenResponseData.error) {
-                return reply.redirect(`https://app.happy.engineering?error=${encodeURIComponent(tokenResponseData.error)}`);
+                const appUrl = process.env.PUBLIC_APP_URL || 'https://app.happy.engineering';
+                return reply.redirect(`${appUrl}?error=${encodeURIComponent(tokenResponseData.error)}`);
             }
 
             const accessToken = tokenResponseData.access_token;
@@ -148,7 +151,8 @@ export function connectRoutes(app: Fastify) {
             const userData = await userResponse.json() as GitHubProfile;
 
             if (!userResponse.ok) {
-                return reply.redirect('https://app.happy.engineering?error=github_user_fetch_failed');
+                const appUrl = process.env.PUBLIC_APP_URL || 'https://app.happy.engineering';
+                return reply.redirect(`${appUrl}?error=github_user_fetch_failed`);
             }
 
             // Use the new githubConnect operation
@@ -156,11 +160,13 @@ export function connectRoutes(app: Fastify) {
             await githubConnect(ctx, userData, accessToken!);
 
             // Redirect to app with success
-            return reply.redirect(`https://app.happy.engineering?github=connected&user=${encodeURIComponent(userData.login)}`);
+            const appUrl = process.env.PUBLIC_APP_URL || 'https://app.happy.engineering';
+            return reply.redirect(`${appUrl}?github=connected&user=${encodeURIComponent(userData.login)}`);
 
         } catch (error) {
             log({ module: 'github-oauth' }, `Error in GitHub GET callback: ${error}`);
-            return reply.redirect('https://app.happy.engineering?error=server_error');
+            const appUrl = process.env.PUBLIC_APP_URL || 'https://app.happy.engineering';
+            return reply.redirect(`${appUrl}?error=server_error`);
         }
     });
 


### PR DESCRIPTION
Description:                                                    
  Previously the redirect URL after GitHub OAuth completion was hardcoded to `https://app.happy.engineering`, which doesn't work for self-deployed instances. This change makes it configurable via the `PUBLIC_APP_URL` environment variable.
                                                                                                                                                                                                                                              
  ### Changes:                                                                                                                                                                                                                                                          
  - All error and success redirects after GitHub OAuth now use `PUBLIC_APP_URL` from environment
  - Falls back to default `https://app.happy.engineering` if `PUBLIC_APP_URL` is not set (fully backward compatible)                                                                                                                                                    
                                                                                                                                                                                                                                                                        
  ### Testing:                                                                                                                                                                                                                                                          
  - [x] Existing official deployments continue to work as before                                                                                                                                                                                                        
  - [x] Self-deployed users can now set `PUBLIC_APP_URL` to their own domain                                                                                                                                                                                            
  - [x] Fixes the issue where after OAuth completion it always redirects to the official site instead of the user's own domain
                                                                                                                                                                                                                                                                        
  This fixes the issue reported when connecting GitHub account on self-deployed instances.