### PR TITLE
fix(cli): restart daemon when launching Happy from a different project root

### DIFF
--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
@@ -1,61 +1,101 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-  mockLoggerDebug: vi.fn(),
-  mockIsDaemonRunningCurrentlyInstalledHappyVersion: vi.fn(),
-  mockSpawnHappyCLI: vi.fn(),
-}))
-
-vi.mock('@/ui/logger', () => ({
-  logger: {
-    debug: mocks.mockLoggerDebug,
-  },
-}))
+const mockIsDaemonRunningCurrentlyInstalledHappyVersion = vi.fn();
+const mockStopDaemon = vi.fn();
+const mockReadDaemonState = vi.fn();
+const mockSpawnHappyCLI = vi.fn();
+const mockUnref = vi.fn();
 
 vi.mock('./controlClient', () => ({
-  isDaemonRunningCurrentlyInstalledHappyVersion: mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion,
-}))
+  isDaemonRunningCurrentlyInstalledHappyVersion: mockIsDaemonRunningCurrentlyInstalledHappyVersion,
+  stopDaemon: mockStopDaemon,
+}));
+
+vi.mock('@/persistence', () => ({
+  readDaemonState: mockReadDaemonState,
+}));
 
 vi.mock('@/utils/spawnHappyCLI', () => ({
-  spawnHappyCLI: mocks.mockSpawnHappyCLI,
-}))
-
-import { ensureDaemonRunning } from './ensureDaemonRunning'
+  spawnHappyCLI: mockSpawnHappyCLI,
+}));
 
 describe('ensureDaemonRunning', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    mocks.mockSpawnHappyCLI.mockReturnValue({
-      unref: vi.fn(),
-    })
-  })
+    vi.resetAllMocks();
+    vi.resetModules();
+    vi.useFakeTimers();
+    mockSpawnHappyCLI.mockReturnValue({ unref: mockUnref });
+    mockStopDaemon.mockResolvedValue(undefined);
+    mockReadDaemonState.mockResolvedValue({
+      pid: 123,
+      httpPort: 456,
+      startTime: 'now',
+      startedWithCliVersion: '1.1.6',
+      startedFromCwd: process.cwd(),
+    });
+  });
 
-  it('returns without spawning when the daemon is already running', async () => {
-    mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(true)
+  it('does nothing when the daemon version matches and cwd is unchanged', async () => {
+    mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(true);
 
-    await ensureDaemonRunning()
+    const { ensureDaemonRunning } = await import('./ensureDaemonRunning');
+    await ensureDaemonRunning();
 
-    expect(mocks.mockSpawnHappyCLI).not.toHaveBeenCalled()
-    expect(mocks.mockLoggerDebug).toHaveBeenCalledWith(
-      'Ensuring Happy background service is running & matches our version...',
-    )
-  })
+    expect(mockStopDaemon).not.toHaveBeenCalled();
+    expect(mockSpawnHappyCLI).not.toHaveBeenCalled();
+  });
 
-  it('starts the daemon when the installed version is not running', async () => {
-    const mockUnref = vi.fn()
-    mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(false)
-    mocks.mockSpawnHappyCLI.mockReturnValue({
-      unref: mockUnref,
-    })
+  it('restarts the daemon when the current cwd changed', async () => {
+    mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(true);
+    mockReadDaemonState.mockResolvedValue({
+      pid: 123,
+      httpPort: 456,
+      startTime: 'now',
+      startedWithCliVersion: '1.1.6',
+      startedFromCwd: '/tmp/other-project',
+    });
 
-    await ensureDaemonRunning()
+    const { ensureDaemonRunning } = await import('./ensureDaemonRunning');
+    const promise = ensureDaemonRunning();
+    await vi.runAllTimersAsync();
+    await promise;
 
-    expect(mocks.mockSpawnHappyCLI).toHaveBeenCalledWith(['daemon', 'start-sync'], {
+    expect(mockStopDaemon).toHaveBeenCalledTimes(1);
+    expect(mockSpawnHappyCLI).toHaveBeenCalledWith(['daemon', 'start-sync'], {
       detached: true,
       stdio: 'ignore',
       env: process.env,
-    })
-    expect(mockUnref).toHaveBeenCalled()
-    expect(mocks.mockLoggerDebug).toHaveBeenCalledWith('Starting Happy background service...')
-  })
-})
+    });
+    expect(mockUnref).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts the daemon once for older state files without a remembered cwd', async () => {
+    mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(true);
+    mockReadDaemonState.mockResolvedValue({
+      pid: 123,
+      httpPort: 456,
+      startTime: 'now',
+      startedWithCliVersion: '1.1.6',
+    });
+
+    const { ensureDaemonRunning } = await import('./ensureDaemonRunning');
+    const promise = ensureDaemonRunning();
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockStopDaemon).toHaveBeenCalledTimes(1);
+    expect(mockSpawnHappyCLI).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts the daemon when none is running', async () => {
+    mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(false);
+
+    const { ensureDaemonRunning } = await import('./ensureDaemonRunning');
+    const promise = ensureDaemonRunning();
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(mockStopDaemon).not.toHaveBeenCalled();
+    expect(mockSpawnHappyCLI).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
@@ -1,12 +1,29 @@
 import { logger } from '@/ui/logger'
-import { isDaemonRunningCurrentlyInstalledHappyVersion } from './controlClient'
+import { isDaemonRunningCurrentlyInstalledHappyVersion, stopDaemon } from './controlClient'
+import { readDaemonState } from '@/persistence'
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI'
+import { resolve } from 'node:path'
 
 export async function ensureDaemonRunning(): Promise<void> {
   logger.debug('Ensuring Happy background service is running & matches our version...')
 
-  if (await isDaemonRunningCurrentlyInstalledHappyVersion()) {
-    return
+  const daemonMatchesInstalledVersion = await isDaemonRunningCurrentlyInstalledHappyVersion()
+  if (daemonMatchesInstalledVersion) {
+    const daemonState = await readDaemonState()
+    const currentCwd = resolve(process.cwd())
+    const daemonCwd = daemonState?.startedFromCwd ? resolve(daemonState.startedFromCwd) : null
+
+    if (daemonCwd === currentCwd) {
+      return
+    }
+
+    logger.debug(
+      `Restarting Happy background service to adopt current working directory (daemon=${daemonCwd ?? 'unknown'}, current=${currentCwd})...`
+    )
+
+    await stopDaemon().catch((error) => {
+      logger.debug('Failed to stop existing daemon before restart', error)
+    })
   }
 
   logger.debug('Starting Happy background service...')

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -640,6 +640,7 @@ export async function startDaemon(): Promise<void> {
       httpPort: controlPort,
       startTime: new Date().toLocaleString(),
       startedWithCliVersion: packageJson.version,
+      startedFromCwd: process.cwd(),
       daemonLogPath: logger.logFilePath
     };
     writeDaemonState(fileState);

--- a/packages/happy-cli/src/persistence.ts
+++ b/packages/happy-cli/src/persistence.ts
@@ -72,6 +72,7 @@ export interface DaemonLocallyPersistedState {
   httpPort: number;
   startTime: string;
   startedWithCliVersion: string;
+  startedFromCwd?: string;
   lastHeartbeat?: string;
   daemonLogPath?: string;
 }
@@ -392,4 +393,3 @@ export async function releaseDaemonLock(lockHandle: FileHandle): Promise<void> {
     }
   } catch { }
 }
-


### PR DESCRIPTION
Happy could reuse an already-running daemon that had been started from a different working directory than the current `happy` launch. When a remote/mobile client then opened a child folder relative to the current project root, the daemon could resolve that path against stale cwd context, which matches the symptom where the session UI looked normal but the spawned chat never produced replies. This change persists the daemon startup cwd and restarts the daemon when Happy is launched from a different project root so relative remote paths stay anchored to the folder the user actually launched from.

## What changed
- persist `startedFromCwd` in local daemon state
- compare daemon startup cwd vs current `process.cwd()` in `ensureDaemonRunning()`
- restart the daemon when the cwd changed even if the CLI version matches
- add focused tests for unchanged cwd, changed cwd, legacy state without cwd, and no-daemon startup

## Proof
```text
pnpm --filter happy typecheck
> happy@1.1.6 typecheck /Users/leo/project/happy/packages/happy-cli
> tsc --noEmit
```

```text
pnpm --filter happy exec vitest run src/daemon/ensureDaemonRunning.test.ts
✓ |unit| src/daemon/ensureDaemonRunning.test.ts (4 tests)
Test Files  1 passed (1)
Tests       4 passed (4)
```

## Manual verification to run
1. Start `happy` from one project root so the daemon is already running.
2. Launch `happy` from a different project root.
3. From web/mobile, open a child folder under that second root and send a message.
4. Confirm the session now responds normally instead of hanging with no reply.

## Notes
- This PR is focused on the daemon cwd reuse regression only.
- I have not yet captured end-to-end mobile/web proof from a live authenticated machine, so I am opening this as a draft first.