### PR TITLE
fix: UI improvements, markdown overflow fix, and MCP/skills passthrough

### DIFF
--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -87,8 +87,16 @@ const SectionHeader = React.memo(({ session, displayPath }: { session: SessionRo
         router.navigate('/new');
     }, [session.machineId, session.homeDir, repoPath, isWorktree, sessionPath, draft, router]);
 
+    const [isHovered, setIsHovered] = React.useState(false);
+
     return (
-        <View style={hasBranch ? styles.sectionHeader : styles.sectionHeaderSingleLine}>
+        <View
+            style={hasBranch ? styles.sectionHeader : styles.sectionHeaderSingleLine}
+            // @ts-ignore - Web only events
+            onMouseEnter={() => setIsHovered(true)}
+            // @ts-ignore - Web only events
+            onMouseLeave={() => setIsHovered(false)}
+        >
             {/* Avatar — vertically centered */}
             <View style={styles.sectionHeaderAvatar}>
                 <Avatar id={session.avatarId} size={24} flavor={null} />
@@ -122,11 +130,11 @@ const SectionHeader = React.memo(({ session, displayPath }: { session: SessionRo
                 )}
             </View>
 
-            {/* + button — vertically centered, large hit area */}
+            {/* + button — vertically centered, large hit area; desktop: hover-only */}
             <Pressable
                 onPress={handleAdd}
                 hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
-                style={styles.addButton}
+                style={[styles.addButton, { opacity: Platform.OS !== 'web' || isHovered ? 1 : 0 }]}
             >
                 <Ionicons name="add-outline" size={14} color={theme.colors.textSecondary} />
             </Pressable>

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -606,7 +606,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                                 onPress={() => handleSettingsSelect(mode)}
                                                 style={({ pressed }) => ({
                                                     flexDirection: 'row',
-                                                    alignItems: 'center',
+                                                    alignItems: 'flex-start',
                                                     paddingHorizontal: 16,
                                                     paddingVertical: 8,
                                                     backgroundColor: pressed ? theme.colors.surfacePressed : 'transparent'
@@ -620,7 +620,8 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                                     borderColor: isSelected ? theme.colors.radio.active : theme.colors.radio.inactive,
                                                     alignItems: 'center',
                                                     justifyContent: 'center',
-                                                    marginRight: 12
+                                                    marginRight: 12,
+                                                    marginTop: 2,
                                                 }}>
                                                     {isSelected && (
                                                         <View style={{
@@ -661,124 +662,35 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                     marginHorizontal: 16
                                 }} />
 
-                                {/* Model Section */}
-                                <View style={{ paddingVertical: 8 }}>
-                                    <Text style={{
-                                        fontSize: 12,
-                                        fontWeight: '600',
-                                        color: theme.colors.textSecondary,
-                                        paddingHorizontal: 16,
-                                        paddingBottom: 4,
-                                        ...Typography.default('semiBold')
-                                    }}>
-                                        {t('agentInput.model.title')}
-                                    </Text>
-                                    {availableModels.length > 0 ? (
-                                        availableModels.map((model) => {
-                                            const isSelected = props.modelMode?.key === model.key;
-
-                                            return (
-                                                <Pressable
-                                                    key={model.key}
-                                                    onPress={() => {
-                                                        hapticsLight();
-                                                        props.onModelModeChange?.(model);
-                                                        setShowSettings(false);
-                                                    }}
-                                                    style={({ pressed }) => ({
-                                                        flexDirection: 'row',
-                                                        alignItems: 'center',
-                                                        paddingHorizontal: 16,
-                                                        paddingVertical: 8,
-                                                        backgroundColor: pressed ? theme.colors.surfacePressed : 'transparent'
-                                                    })}
-                                                >
-                                                    <View style={{
-                                                        width: 16,
-                                                        height: 16,
-                                                        borderRadius: 8,
-                                                        borderWidth: 2,
-                                                        borderColor: isSelected ? theme.colors.radio.active : theme.colors.radio.inactive,
-                                                        alignItems: 'center',
-                                                        justifyContent: 'center',
-                                                        marginRight: 12
-                                                    }}>
-                                                        {isSelected && (
-                                                            <View style={{
-                                                                width: 6,
-                                                                height: 6,
-                                                                borderRadius: 3,
-                                                                backgroundColor: theme.colors.radio.dot
-                                                            }} />
-                                                        )}
-                                                    </View>
-                                                    <View>
-                                                        <Text style={{
-                                                            fontSize: 14,
-                                                            color: isSelected ? theme.colors.radio.active : theme.colors.text,
-                                                            ...Typography.default()
-                                                        }}>
-                                                            {model.name}
-                                                        </Text>
-                                                        {!!model.description && (
-                                                            <Text style={{
-                                                                fontSize: 11,
-                                                                color: theme.colors.textSecondary,
-                                                                ...Typography.default()
-                                                            }}>
-                                                                {model.description}
-                                                            </Text>
-                                                        )}
-                                                    </View>
-                                                </Pressable>
-                                            );
-                                        })
-                                    ) : (
+                                {/* Model + Effort side by side */}
+                                <View style={{ flexDirection: 'row' }}>
+                                    {/* Model Section */}
+                                    <View style={{ paddingVertical: 8, flex: 1 }}>
                                         <Text style={{
-                                            fontSize: 13,
+                                            fontSize: 12,
+                                            fontWeight: '600',
                                             color: theme.colors.textSecondary,
                                             paddingHorizontal: 16,
-                                            paddingVertical: 8,
-                                            ...Typography.default()
+                                            paddingBottom: 4,
+                                            ...Typography.default('semiBold')
                                         }}>
-                                            {t('agentInput.model.configureInCli')}
+                                            {t('agentInput.model.title')}
                                         </Text>
-                                    )}
-                                </View>
-
-                                {/* Effort Level Section */}
-                                {availableEffortLevels.length > 0 && props.onEffortLevelChange && (
-                                    <>
-                                        <View style={{
-                                            height: 1,
-                                            backgroundColor: theme.colors.divider,
-                                            marginHorizontal: 16
-                                        }} />
-                                        <View style={{ paddingVertical: 8 }}>
-                                            <Text style={{
-                                                fontSize: 12,
-                                                fontWeight: '600',
-                                                color: theme.colors.textSecondary,
-                                                paddingHorizontal: 16,
-                                                paddingBottom: 4,
-                                                ...Typography.default('semiBold')
-                                            }}>
-                                                {t('agentInput.effort.title')}
-                                            </Text>
-                                            {availableEffortLevels.map((level) => {
-                                                const isSelected = props.effortLevel?.key === level.key;
+                                        {availableModels.length > 0 ? (
+                                            availableModels.map((model) => {
+                                                const isSelected = props.modelMode?.key === model.key;
 
                                                 return (
                                                     <Pressable
-                                                        key={level.key}
+                                                        key={model.key}
                                                         onPress={() => {
                                                             hapticsLight();
-                                                            props.onEffortLevelChange?.(level);
+                                                            props.onModelModeChange?.(model);
                                                             setShowSettings(false);
                                                         }}
                                                         style={({ pressed }) => ({
                                                             flexDirection: 'row',
-                                                            alignItems: 'center',
+                                                            alignItems: 'flex-start',
                                                             paddingHorizontal: 16,
                                                             paddingVertical: 8,
                                                             backgroundColor: pressed ? theme.colors.surfacePressed : 'transparent'
@@ -792,7 +704,8 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                                             borderColor: isSelected ? theme.colors.radio.active : theme.colors.radio.inactive,
                                                             alignItems: 'center',
                                                             justifyContent: 'center',
-                                                            marginRight: 12
+                                                            marginRight: 12,
+                                                            marginTop: 2,
                                                         }}>
                                                             {isSelected && (
                                                                 <View style={{
@@ -809,24 +722,117 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                                                 color: isSelected ? theme.colors.radio.active : theme.colors.text,
                                                                 ...Typography.default()
                                                             }}>
-                                                                {level.name}
+                                                                {model.name}
                                                             </Text>
-                                                            {!!level.description && (
+                                                            {!!model.description && (
                                                                 <Text style={{
                                                                     fontSize: 11,
                                                                     color: theme.colors.textSecondary,
                                                                     ...Typography.default()
                                                                 }}>
-                                                                    {level.description}
+                                                                    {model.description}
                                                                 </Text>
                                                             )}
                                                         </View>
                                                     </Pressable>
                                                 );
-                                            })}
-                                        </View>
-                                    </>
-                                )}
+                                            })
+                                        ) : (
+                                            <Text style={{
+                                                fontSize: 13,
+                                                color: theme.colors.textSecondary,
+                                                paddingHorizontal: 16,
+                                                paddingVertical: 8,
+                                                ...Typography.default()
+                                            }}>
+                                                {t('agentInput.model.configureInCli')}
+                                            </Text>
+                                        )}
+                                    </View>
+
+                                    {/* Effort Level Section — second column */}
+                                    {availableEffortLevels.length > 0 && props.onEffortLevelChange && (
+                                        <>
+                                            <View style={{
+                                                width: 1,
+                                                backgroundColor: theme.colors.divider,
+                                                marginVertical: 8,
+                                            }} />
+                                            <View style={{ paddingVertical: 8, flex: 1 }}>
+                                                <Text style={{
+                                                    fontSize: 12,
+                                                    fontWeight: '600',
+                                                    color: theme.colors.textSecondary,
+                                                    paddingHorizontal: 16,
+                                                    paddingBottom: 4,
+                                                    ...Typography.default('semiBold')
+                                                }}>
+                                                    {t('agentInput.effort.title')}
+                                                </Text>
+                                                {availableEffortLevels.map((level) => {
+                                                    const isSelected = props.effortLevel?.key === level.key;
+
+                                                    return (
+                                                        <Pressable
+                                                            key={level.key}
+                                                            onPress={() => {
+                                                                hapticsLight();
+                                                                props.onEffortLevelChange?.(level);
+                                                                setShowSettings(false);
+                                                            }}
+                                                            style={({ pressed }) => ({
+                                                                flexDirection: 'row',
+                                                                alignItems: 'flex-start',
+                                                                paddingHorizontal: 16,
+                                                                paddingVertical: 8,
+                                                                backgroundColor: pressed ? theme.colors.surfacePressed : 'transparent'
+                                                            })}
+                                                        >
+                                                            <View style={{
+                                                                width: 16,
+                                                                height: 16,
+                                                                borderRadius: 8,
+                                                                borderWidth: 2,
+                                                                borderColor: isSelected ? theme.colors.radio.active : theme.colors.radio.inactive,
+                                                                alignItems: 'center',
+                                                                justifyContent: 'center',
+                                                                marginRight: 12,
+                                                                marginTop: 2,
+                                                            }}>
+                                                                {isSelected && (
+                                                                    <View style={{
+                                                                        width: 6,
+                                                                        height: 6,
+                                                                        borderRadius: 3,
+                                                                        backgroundColor: theme.colors.radio.dot
+                                                                    }} />
+                                                                )}
+                                                            </View>
+                                                            <View>
+                                                                <Text style={{
+                                                                    fontSize: 14,
+                                                                    color: isSelected ? theme.colors.radio.active : theme.colors.text,
+                                                                    ...Typography.default()
+                                                                }}>
+                                                                    {level.name}
+                                                                </Text>
+                                                                {!!level.description && (
+                                                                    <Text style={{
+                                                                        fontSize: 11,
+                                                                        color: theme.colors.textSecondary,
+                                                                        ...Typography.default()
+                                                                    }}>
+                                                                        {level.description}
+                                                                    </Text>
+                                                                )}
+                                                            </View>
+                                                        </Pressable>
+                                                    );
+                                                })}
+                                            </View>
+                                        </>
+                                    )}
+                                </View>
                             </FloatingOverlay>
                         </View>
                     </>

--- a/packages/happy-app/sources/components/ChatList.tsx
+++ b/packages/happy-app/sources/components/ChatList.tsx
@@ -45,7 +45,7 @@ const ChatListInternal = React.memo((props: {
     const { theme } = useUnistyles();
     const flatListRef = React.useRef<FlatList>(null);
     const [showScrollButton, setShowScrollButton] = React.useState(false);
-
+    const isNearBottom = React.useRef(true);
     const keyExtractor = useCallback((item: any) => item.id, []);
     const renderItem = useCallback(({ item }: { item: any }) => (
         <MessageView message={item} metadata={props.metadata} sessionId={props.sessionId} />
@@ -56,10 +56,33 @@ const ChatListInternal = React.memo((props: {
     const handleScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
         const offsetY = e.nativeEvent.contentOffset.y;
         setShowScrollButton(offsetY > SCROLL_THRESHOLD);
+        // Track near-bottom state for auto-scroll on new content
+        isNearBottom.current = offsetY < 100;
+    }, []);
+
+    const onContentSizeChange = useCallback(() => {
+        if (isNearBottom.current) {
+            flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+        }
     }, []);
 
     const scrollToBottom = useCallback(() => {
         flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+    }, []);
+
+    // On macOS/web, Shift+wheel swaps deltaX/deltaY — restore vertical scrolling
+    React.useEffect(() => {
+        if (Platform.OS !== 'web') return;
+        const node = (flatListRef.current as any)?.getScrollableNode?.() as HTMLElement | undefined;
+        if (!node) return;
+        const handler = (e: WheelEvent) => {
+            if (e.shiftKey && Math.abs(e.deltaX) > 0 && Math.abs(e.deltaY) < 1) {
+                node.scrollTop += e.deltaX;
+                e.preventDefault();
+            }
+        };
+        node.addEventListener('wheel', handler, { passive: false });
+        return () => node.removeEventListener('wheel', handler);
     }, []);
 
     return (
@@ -77,6 +100,7 @@ const ChatListInternal = React.memo((props: {
                 keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'none'}
                 renderItem={renderItem}
                 onScroll={handleScroll}
+                onContentSizeChange={onContentSizeChange}
                 scrollEventThrottle={16}
                 ListHeaderComponent={<ListFooter sessionId={props.sessionId} />}
                 ListFooterComponent={<ListHeader />}

--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -202,6 +202,7 @@ const styles = StyleSheet.create((theme) => ({
     marginHorizontal: 16,
     marginBottom: 12,
     borderRadius: 16,
+    maxWidth: '100%',
   },
   agentEventContainer: {
     marginHorizontal: 8,
@@ -214,6 +215,8 @@ const styles = StyleSheet.create((theme) => ({
   },
   toolContainer: {
     marginHorizontal: 8,
+    maxWidth: '100%',
+    overflow: 'hidden',
   },
   debugText: {
     color: theme.colors.agentEventText,

--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -1,6 +1,27 @@
 import { MarkdownSpan, parseMarkdown } from './parseMarkdown';
 import * as React from 'react';
-import { Image, Pressable, ScrollView, View, Platform } from 'react-native';
+import { Image, Pressable, ScrollView, View, Platform, ScrollView as ScrollViewType } from 'react-native';
+
+// Converts vertical wheel events to horizontal scroll on web, blocks page scroll
+function useHorizontalWheelScroll() {
+    const ref = React.useRef<ScrollViewType>(null);
+    React.useEffect(() => {
+        if (Platform.OS !== 'web' || !ref.current) return;
+        const node = (ref.current as any)?.getScrollableNode?.() ?? (ref.current as any);
+        if (!node || !node.addEventListener) return;
+        const handler = (e: WheelEvent) => {
+            const el = node as HTMLElement;
+            const maxScroll = el.scrollWidth - el.clientWidth;
+            if (maxScroll <= 0) return;
+            e.preventDefault();
+            e.stopPropagation();
+            el.scrollLeft += e.deltaY || e.deltaX;
+        };
+        node.addEventListener('wheel', handler, { passive: false });
+        return () => node.removeEventListener('wheel', handler);
+    });
+    return ref;
+}
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { StyleSheet } from 'react-native-unistyles';
 import { Text } from '../StyledText';
@@ -160,6 +181,7 @@ function RenderNumberedListBlock(props: { items: { number: number, spans: Markdo
 
 function RenderCodeBlock(props: { content: string, language: string | null, first: boolean, last: boolean, selectable: boolean }) {
     const [isHovered, setIsHovered] = React.useState(false);
+    const wheelRef = useHorizontalWheelScroll();
 
     const copyCode = React.useCallback(async () => {
         try {
@@ -181,10 +203,10 @@ function RenderCodeBlock(props: { content: string, language: string | null, firs
         >
             {props.language && <Text selectable={props.selectable} style={style.codeLanguage}>{props.language}</Text>}
             <ScrollView
-                style={{ flexGrow: 0, flexShrink: 0 }}
+                ref={wheelRef}
                 horizontal={true}
                 contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 16 }}
-                showsHorizontalScrollIndicator={false}
+                showsHorizontalScrollIndicator={true}
             >
                 <SimpleSyntaxHighlighter
                     code={props.content}
@@ -301,16 +323,18 @@ function RenderTableBlock(props: {
     const rowCount = props.rows.length;
     const isLastRow = (rowIndex: number) => rowIndex === rowCount - 1;
 
+    const wheelRef = useHorizontalWheelScroll();
+
     return (
         <View style={[style.tableContainer, props.first && style.first, props.last && style.last]}>
             <ScrollView
+                ref={wheelRef}
                 horizontal
-                showsHorizontalScrollIndicator={Platform.OS !== 'web'}
+                showsHorizontalScrollIndicator={true}
                 nestedScrollEnabled={true}
                 style={style.tableScrollView}
             >
                 <View style={style.tableContent}>
-                    {/* Render each column as a vertical container */}
                     {props.headers.map((header, colIndex) => (
                         <View
                             key={`column-${colIndex}`}
@@ -319,11 +343,9 @@ function RenderTableBlock(props: {
                                 colIndex === columnCount - 1 && style.tableColumnLast
                             ]}
                         >
-                            {/* Header cell for this column */}
                             <View style={[style.tableCell, style.tableHeaderCell, style.tableCellFirst]}>
                                 <Text style={style.tableHeaderText}><RenderSpans spans={header} baseStyle={style.tableHeaderText} onLinkPress={props.onLinkPress} selectable={props.selectable} /></Text>
                             </View>
-                            {/* Data cells for this column */}
                             {props.rows.map((row, rowIndex) => (
                                 <View
                                     key={`cell-${rowIndex}-${colIndex}`}
@@ -458,6 +480,7 @@ const style = StyleSheet.create((theme) => ({
         marginVertical: 8,
         position: 'relative',
         zIndex: 1,
+        width: '100%',
     },
     copyButtonWrapper: {
         position: 'absolute',
@@ -585,9 +608,7 @@ const style = StyleSheet.create((theme) => ({
         borderColor: theme.colors.divider,
         borderRadius: 8,
         overflow: 'hidden',
-        maxWidth: '100%',
-        flexGrow: 0,
-        flexShrink: 1,
+        width: '100%',
     },
     tableScrollView: {
         flexGrow: 0,

--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -608,7 +608,8 @@ const style = StyleSheet.create((theme) => ({
         borderColor: theme.colors.divider,
         borderRadius: 8,
         overflow: 'hidden',
-        width: '100%',
+        maxWidth: '100%',
+        alignSelf: 'flex-start',
     },
     tableScrollView: {
         flexGrow: 0,

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -210,6 +210,7 @@ export function getClaudeEffortLevels(): EffortLevel[] {
         { key: 'low', name: 'low' },
         { key: 'medium', name: 'medium' },
         { key: 'high', name: 'high' },
+        { key: 'max', name: 'max' },
     ];
 }
 

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -37,6 +37,8 @@ export const MetadataSchema = z.object({
     codexThreadId: z.string().optional(), // Codex app-server thread ID
     tools: z.array(z.string()).optional(),
     slashCommands: z.array(z.string()).optional(),
+    mcpServers: z.array(z.object({ name: z.string(), status: z.string() })).optional(),
+    skills: z.array(z.string()).optional(),
     homeDir: z.string().optional(), // User's home directory on the machine
     happyHomeDir: z.string().optional(), // Happy configuration directory 
     startedFromDaemon: z.boolean().optional(),

--- a/packages/happy-app/sources/sync/suggestionCommands.ts
+++ b/packages/happy-app/sources/sync/suggestionCommands.ts
@@ -31,7 +31,6 @@ export const IGNORED_COMMANDS = [
     "ide",
     "init",
     "install-github-app",
-    "mcp",
     "memory",
     "migrate-installer",
     "model",
@@ -55,7 +54,9 @@ export const IGNORED_COMMANDS = [
 // Default commands always available
 const DEFAULT_COMMANDS: CommandItem[] = [
     { command: 'compact', description: 'Compact the conversation history' },
-    { command: 'clear', description: 'Clear the conversation' }
+    { command: 'clear', description: 'Clear the conversation' },
+    { command: 'mcp', description: 'Show connected MCP servers' },
+    { command: 'skills', description: 'Show available skills' },
 ];
 
 // Command descriptions for known tools/commands

--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -267,7 +267,7 @@ const rawAgentRecordSchema = z.discriminatedUnion('type', [z.object({
     type: z.literal('output'),
     data: z.intersection(z.discriminatedUnion('type', [
         z.object({ type: z.literal('system') }),
-        z.object({ type: z.literal('result') }),
+        z.object({ type: z.literal('result'), result: z.string().nullish(), subtype: z.string().nullish(), is_error: z.boolean().nullish() }),
         z.object({ type: z.literal('summary'), summary: z.string() }),
         z.object({ type: z.literal('assistant'), message: z.object({ role: z.literal('assistant'), model: z.string(), content: z.array(rawAgentContentSchema), usage: usageDataSchema.optional() }), parent_tool_use_id: z.string().nullable().optional() }),
         z.object({ type: z.literal('user'), message: z.object({ role: z.literal('user'), content: z.union([z.string(), z.array(rawAgentContentSchema)]) }), parent_tool_use_id: z.string().nullable().optional(), toolUseResult: z.any().nullable().optional() }),
@@ -738,6 +738,28 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
 
             // Skip compact summary messages
             if (raw.content.data.isCompactSummary) {
+                return null;
+            }
+
+            // Handle Result messages (e.g. slash command errors like "Unknown skill: mcp")
+            if (raw.content.data.type === 'result') {
+                const resultText = raw.content.data.result;
+                if (resultText) {
+                    return {
+                        id,
+                        localId,
+                        createdAt,
+                        role: 'agent',
+                        content: [{
+                            type: 'text' as const,
+                            text: resultText,
+                            uuid: raw.content.data.uuid ?? id,
+                            parentUUID: raw.content.data.parentUuid ?? null,
+                        }],
+                        isSidechain: false,
+                        meta: raw.meta,
+                    } satisfies NormalizedMessage;
+                }
                 return null;
             }
 

--- a/packages/happy-app/sources/theme.css
+++ b/packages/happy-app/sources/theme.css
@@ -13,7 +13,7 @@ html, body {
 }
 
 ::-webkit-scrollbar-track {
-    background: var(--colors-surface-high);
+    background: transparent;
     border-radius: 6px;
 }
 
@@ -30,13 +30,13 @@ html, body {
 }
 
 ::-webkit-scrollbar-corner {
-    background: var(--colors-surface-high);
+    background: transparent;
 }
 
 /* Firefox */
 * {
     scrollbar-width: thin;
-    scrollbar-color: var(--colors-divider) var(--colors-surface-high);
+    scrollbar-color: var(--colors-divider) transparent;
 }
 
 /* Ensure scrollbars are visible on hover for macOS */

--- a/packages/happy-app/sources/unistyles.ts
+++ b/packages/happy-app/sources/unistyles.ts
@@ -1,7 +1,7 @@
 import { StyleSheet, UnistylesRuntime } from 'react-native-unistyles';
 import { darkTheme, lightTheme } from './theme';
 import { loadThemePreference } from './sync/persistence';
-import { Appearance } from 'react-native';
+import { Appearance, Platform } from 'react-native';
 import * as SystemUI from 'expo-system-ui';
 
 //
@@ -80,3 +80,18 @@ const setRootBackgroundColor = () => {
 
 // Set initial background color
 setRootBackgroundColor();
+
+// Re-sync theme when tab becomes visible (web only — Appearance API may miss changes while hidden)
+if (Platform.OS === 'web' && themePreference === 'adaptive') {
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+            const themeName = Appearance.getColorScheme() === 'dark' ? 'dark' : 'light';
+            // Toggle adaptive off, set correct theme, toggle back on
+            UnistylesRuntime.setAdaptiveThemes(false);
+            UnistylesRuntime.setTheme(themeName);
+            UnistylesRuntime.setAdaptiveThemes(true);
+            const color = appThemes[themeName].colors.groupped.background;
+            UnistylesRuntime.setRootViewBackgroundColor(color);
+        }
+    });
+}

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -270,6 +270,8 @@ export type Metadata = {
   codexThreadId?: string, // Codex app-server thread ID
   tools?: string[],
   slashCommands?: string[],
+  mcpServers?: Array<{ name: string; status: string }>,
+  skills?: string[],
   homeDir: string,
   happyHomeDir: string,
   happyLibDir: string,

--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -41,7 +41,7 @@ export async function claudeRemote(opts: {
     onMessage: (message: SDKMessage) => void,
     onCompletionEvent?: (message: string) => void,
     onSessionReset?: () => void,
-    onSDKMetadata?: (metadata: { tools?: string[]; slashCommands?: string[] }) => void
+    onSDKMetadata?: (metadata: { tools?: string[]; slashCommands?: string[]; mcpServers?: { name: string; status: string }[]; skills?: string[] }) => void
 }) {
 
     // Check if session is valid
@@ -191,6 +191,8 @@ export async function claudeRemote(opts: {
                     opts.onSDKMetadata({
                         tools: systemInit.tools,
                         slashCommands: systemInit.slash_commands,
+                        mcpServers: systemInit.mcp_servers?.map(s => ({ name: s.name, status: s.status })),
+                        skills: systemInit.skills,
                     });
                 }
 

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -347,6 +347,8 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                             ...currentMetadata,
                             tools: metadata.tools,
                             slashCommands: metadata.slashCommands,
+                            mcpServers: metadata.mcpServers,
+                            skills: metadata.skills,
                         }));
                     },
                     onQueryReady: (q) => {

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -241,6 +241,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     let currentAppendSystemPrompt: string | undefined = undefined; // Track current append system prompt
     let currentAllowedTools: string[] | undefined = undefined; // Track current allowed tools
     let currentDisallowedTools: string[] | undefined = undefined; // Track current disallowed tools
+    let currentRunMode: 'local' | 'remote' = options.startingMode ?? 'local';
     // Exit when session is archived from web/mobile
     session.on('archived', () => {
         logger.debug('[loop] Session archived from web/mobile, cleaning up...');
@@ -354,6 +355,48 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             return;
         }
 
+        if (specialCommand.type === 'mcp' || specialCommand.type === 'skills') {
+            // In local mode, let Claude Code handle these commands natively
+            if (currentRunMode === 'local') {
+                logger.debug(`[start] /${specialCommand.type} in local mode — passing through to Claude Code`);
+            } else {
+                logger.debug(`[start] Detected /${specialCommand.type} command in remote mode`);
+                const metadata = session.getMetadata();
+                let responseText: string;
+
+                if (specialCommand.type === 'mcp') {
+                    const servers = metadata?.mcpServers;
+                    if (servers && servers.length > 0) {
+                        responseText = '**MCP Servers**\n\n' + servers.map(s => `- **${s.name}** — ${s.status}`).join('\n');
+                    } else {
+                        responseText = 'No MCP servers configured. Session may still be initializing — try again after sending a message.';
+                    }
+                } else {
+                    const skills = metadata?.skills ?? metadata?.slashCommands;
+                    if (skills && skills.length > 0) {
+                        responseText = '**Available Skills**\n\n' + skills.map(s => `- /${s}`).join('\n');
+                    } else {
+                        responseText = 'No skills available. Session may still be initializing — try again after sending a message.';
+                    }
+                }
+
+                session.sendClaudeSessionMessage({
+                    type: 'assistant',
+                    uuid: randomUUID(),
+                    parentUuid: null,
+                    isSidechain: false,
+                    sessionId: session.sessionId || 'unknown',
+                    timestamp: new Date().toISOString(),
+                    message: {
+                        role: 'assistant',
+                        model: 'system',
+                        content: [{ type: 'text', text: responseText }],
+                    },
+                } as any);
+                return;
+            }
+        }
+
         // Push with resolved permission mode, model, system prompts, and tools
         const enhancedMode: EnhancedMode = {
             permissionMode: messagePermissionMode || 'default',
@@ -434,6 +477,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         api,
         allowedTools: happyServer.toolNames.map(toolName => `mcp__happy__${toolName}`),
         onModeChange: (newMode) => {
+            currentRunMode = newMode;
             session.sendSessionEvent({ type: 'switch', mode: newMode });
             session.updateAgentState((currentState) => ({
                 ...currentState,

--- a/packages/happy-cli/src/parsers/specialCommands.ts
+++ b/packages/happy-cli/src/parsers/specialCommands.ts
@@ -12,7 +12,7 @@ export interface ClearCommandResult {
 }
 
 export interface SpecialCommandResult {
-    type: 'compact' | 'clear' | null;
+    type: 'compact' | 'clear' | 'mcp' | 'skills' | null;
     originalMessage?: string;
 }
 
@@ -75,6 +75,14 @@ export function parseSpecialCommand(message: string): SpecialCommandResult {
         };
     }
     
+    const trimmed = message.trim().toLowerCase();
+    if (trimmed === '/mcp') {
+        return { type: 'mcp' };
+    }
+    if (trimmed === '/skills') {
+        return { type: 'skills' };
+    }
+
     return {
         type: null
     };


### PR DESCRIPTION
## Summary

- UI improvements and theme updates across multiple app components
- Fix markdown code blocks and tables overflowing beyond screen width — now properly constrained with horizontal scroll
- Add horizontal wheel-to-scroll for code blocks and tables on web
- Small tables retain their natural width instead of stretching to full width
- MCP and skills commands now pass through to Claude Code natively in local mode instead of being intercepted
- Skills metadata forwarded as-is from Claude Code init

## Changes

**happy-app:**
- Constrain agent message and tool containers with `maxWidth: 100%`
- Code blocks use `width: 100%` with native horizontal ScrollView scrollbar
- Tables use `maxWidth: 100%` + `alignSelf: flex-start` so small tables stay compact
- Add `useHorizontalWheelScroll` hook for web — converts vertical wheel to horizontal scroll on code blocks and tables
- UI updates to AgentInput, ChatList, ActiveSessionsGroupCompact, theme, and unistyles

**happy-cli:**
- `/mcp` and `/skills` commands pass through to Claude Code in local mode
- Only intercept these commands in remote mode
- Track current run mode (`local`/`remote`) for command routing
- Forward skills metadata as-is from system init