### PR TITLE
feat: add Playwright E2E smoke tests (standalone server, no Docker)

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -28,8 +28,6 @@ jobs:
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,65 @@
+name: E2E Smoke Tests
+
+on:
+    pull_request:
+        paths:
+            - 'packages/happy-app/**'
+            - 'packages/happy-server/**'
+            - 'packages/happy-e2e/**'
+            - '.github/workflows/e2e-smoke.yml'
+    push:
+        branches:
+            - main
+        paths:
+            - 'packages/happy-app/**'
+            - 'packages/happy-server/**'
+            - 'packages/happy-e2e/**'
+            - '.github/workflows/e2e-smoke.yml'
+    workflow_dispatch:
+
+jobs:
+    e2e:
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Install Playwright browsers
+              run: pnpm --filter happy-e2e exec playwright install --with-deps chromium
+
+            - name: Run E2E smoke tests
+              run: pnpm e2e
+              env:
+                  CI: true
+
+            - name: Upload Playwright report
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report
+                  path: packages/happy-e2e/playwright-report/
+                  retention-days: 7
+
+            - name: Upload test traces on failure
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-traces
+                  path: packages/happy-e2e/test-results/
+                  retention-days: 3

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
     "scripts": {
         "e2e": "pnpm --filter happy-e2e test",
         "e2e:headed": "pnpm --filter happy-e2e test:headed",
+        "e2e:trace": "pnpm --filter happy-e2e exec playwright test --trace=on",
+        "e2e:report": "pnpm --filter happy-e2e exec playwright show-report",
         "cli": "pnpm --filter happy cli",
         "release": "node ./scripts/release.cjs",
         "web": "pnpm --filter happy-app web",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
     "name": "monorepo",
     "private": true,
     "scripts": {
+        "e2e": "pnpm --filter happy-e2e test",
+        "e2e:headed": "pnpm --filter happy-e2e test:headed",
         "cli": "pnpm --filter happy cli",
         "release": "node ./scripts/release.cjs",
         "web": "pnpm --filter happy-app web",
@@ -32,7 +34,8 @@
             "packages/happy-server",
             "packages/happy-wire",
             "packages/happy-app-logs",
-            "packages/codium"
+            "packages/codium",
+            "packages/happy-e2e"
         ]
     },
     "pnpm": {

--- a/packages/happy-app/sources/app/(app)/index.tsx
+++ b/packages/happy-app/sources/app/(app)/index.tsx
@@ -79,6 +79,7 @@ function NotAuthenticated() {
                             title={t('welcome.createAccount')}
                             action={createAccount}
                             display="inverted"
+                            testID="create-account-button"
                         />
                     </View>
                 </>
@@ -140,6 +141,7 @@ function NotAuthenticated() {
                                     title={t('welcome.createAccount')}
                                     action={createAccount}
                                     display="inverted"
+                                    testID="create-account-button"
                                 />
                             </View>
                         </>)

--- a/packages/happy-app/sources/components/EmptyMainScreen.tsx
+++ b/packages/happy-app/sources/components/EmptyMainScreen.tsx
@@ -91,7 +91,7 @@ export function EmptyMainScreen() {
     const styles = stylesheet;
 
     return (
-        <View style={styles.container}>
+        <View style={styles.container} testID="empty-main-screen">
             {/* Terminal-style code block */}
             <Text style={styles.title}>{t('components.emptyMainScreen.readyToCode')}</Text>
             <View style={styles.terminalBlock}>

--- a/packages/happy-app/sources/components/EmptySessionsTablet.tsx
+++ b/packages/happy-app/sources/components/EmptySessionsTablet.tsx
@@ -69,14 +69,14 @@ export function EmptySessionsTablet() {
     };
     
     return (
-        <View style={styles.container}>
-            <Ionicons 
-                name="terminal-outline" 
-                size={64} 
+        <View style={styles.container} testID="empty-main-screen">
+            <Ionicons
+                name="terminal-outline"
+                size={64}
                 color={theme.colors.textSecondary}
                 style={styles.iconContainer}
             />
-            
+
             <Text style={styles.titleText}>
                 No active sessions
             </Text>

--- a/packages/happy-app/sources/components/RoundButton.tsx
+++ b/packages/happy-app/sources/components/RoundButton.tsx
@@ -37,7 +37,7 @@ const stylesheet = StyleSheet.create((theme) => ({
     },
 }));
 
-export const RoundButton = React.memo((props: { size?: RoundButtonSize, display?: RoundButtonDisplay, title?: any, style?: StyleProp<ViewStyle>, textStyle?: StyleProp<TextStyle>, disabled?: boolean, loading?: boolean, onPress?: () => void, action?: () => Promise<any> }) => {
+export const RoundButton = React.memo((props: { size?: RoundButtonSize, display?: RoundButtonDisplay, title?: any, style?: StyleProp<ViewStyle>, textStyle?: StyleProp<TextStyle>, disabled?: boolean, loading?: boolean, onPress?: () => void, action?: () => Promise<any>, testID?: string }) => {
     const { theme } = useUnistyles();
     const styles = stylesheet;
     const [loading, setLoading] = React.useState(false);
@@ -80,6 +80,7 @@ export const RoundButton = React.memo((props: { size?: RoundButtonSize, display?
 
     return (
         <Pressable
+            testID={props.testID}
             disabled={doLoading || props.disabled}
             hitSlop={size.hitSlop}
             style={(p) => ([

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -315,7 +315,7 @@ export function SessionsList() {
     // Footer removed - all sessions now shown inline
 
     return (
-        <View style={styles.container}>
+        <View style={styles.container} testID="session-list">
             <View style={styles.contentContainer}>
                 <FlatList
                     data={dataWithSelected}

--- a/packages/happy-e2e/.env.test
+++ b/packages/happy-e2e/.env.test
@@ -1,0 +1,5 @@
+HANDY_MASTER_SECRET=happy-e2e-test-secret-do-not-use-in-prod
+PORT=3005
+DB_PROVIDER=pglite
+NODE_ENV=test
+METRICS_ENABLED=false

--- a/packages/happy-e2e/.gitignore
+++ b/packages/happy-e2e/.gitignore
@@ -1,0 +1,5 @@
+.pglite-dir
+playwright-report/
+test-results/
+node_modules/
+dist/

--- a/packages/happy-e2e/globalSetup.ts
+++ b/packages/happy-e2e/globalSetup.ts
@@ -1,0 +1,11 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+export default async function globalSetup() {
+    // Generate a unique PGlite directory for this test run so DB is isolated.
+    // Written to a side-channel file so playwright.config.ts can read it.
+    const pgliteDir = path.join(os.tmpdir(), `happy-e2e-${Date.now()}`);
+    process.env.PGLITE_DIR = pgliteDir;
+    fs.writeFileSync(path.join(__dirname, '.pglite-dir'), pgliteDir);
+}

--- a/packages/happy-e2e/package.json
+++ b/packages/happy-e2e/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "happy-e2e",
+    "version": "0.0.0",
+    "private": true,
+    "scripts": {
+        "test": "playwright test",
+        "test:headed": "playwright test --headed",
+        "test:debug": "playwright test --debug"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "tweetnacl": "^1.0.3",
+        "tsx": "^4.19.2",
+        "typescript": "^5.4.0"
+    }
+}

--- a/packages/happy-e2e/playwright.config.ts
+++ b/packages/happy-e2e/playwright.config.ts
@@ -1,0 +1,92 @@
+import { defineConfig, devices } from '@playwright/test';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+// Read PGLITE_DIR written by globalSetup. Falls back to a stable temp path
+// when running locally without globalSetup having run yet.
+function getPgliteDir(): string {
+    const sideChannel = path.join(__dirname, '.pglite-dir');
+    if (fs.existsSync(sideChannel)) {
+        return fs.readFileSync(sideChannel, 'utf-8').trim();
+    }
+    return process.env.PGLITE_DIR ?? path.join(os.tmpdir(), 'happy-e2e-dev');
+}
+
+const pgliteDir = getPgliteDir();
+const serverDir = path.resolve(__dirname, '../../packages/happy-server');
+const appDir = path.resolve(__dirname, '../../packages/happy-app');
+
+const TEST_SECRET = 'happy-e2e-test-secret-do-not-use-in-prod';
+const SERVER_PORT = 3005;
+const APP_PORT = 8081;
+
+export const SERVER_URL = `http://localhost:${SERVER_PORT}`;
+export const APP_URL = `http://localhost:${APP_PORT}`;
+
+export default defineConfig({
+    testDir: './tests',
+    timeout: 60_000,
+    retries: process.env.CI ? 1 : 0,
+    workers: 1, // both servers are shared singletons
+
+    globalSetup: './globalSetup.ts',
+
+    reporter: [
+        ['list'],
+        ['html', { open: 'never', outputFolder: 'playwright-report' }],
+    ],
+
+    use: {
+        baseURL: APP_URL,
+        trace: 'retain-on-failure',
+        screenshot: 'only-on-failure',
+        headless: true,
+    },
+
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+
+    webServer: [
+        {
+            // Standalone server: migrate DB then start HTTP server.
+            // PGlite (embedded postgres) — no Docker required.
+            command: [
+                `PGLITE_DIR="${pgliteDir}"`,
+                `HANDY_MASTER_SECRET="${TEST_SECRET}"`,
+                `PORT=${SERVER_PORT}`,
+                `DB_PROVIDER=pglite`,
+                `METRICS_ENABLED=false`,
+                `node_modules/.bin/tsx ./sources/standalone.ts migrate`,
+                `&&`,
+                `PGLITE_DIR="${pgliteDir}"`,
+                `HANDY_MASTER_SECRET="${TEST_SECRET}"`,
+                `PORT=${SERVER_PORT}`,
+                `DB_PROVIDER=pglite`,
+                `METRICS_ENABLED=false`,
+                `node_modules/.bin/tsx ./sources/standalone.ts serve`,
+            ].join(' '),
+            cwd: serverDir,
+            url: SERVER_URL,
+            reuseExistingServer: !process.env.CI,
+            timeout: 30_000,
+        },
+        {
+            // Expo web dev server. EXPO_PUBLIC_HAPPY_SERVER_URL is baked in
+            // at bundle time by Metro — must be set before the process starts.
+            command: [
+                `EXPO_PUBLIC_HAPPY_SERVER_URL=${SERVER_URL}`,
+                `APP_ENV=development`,
+                `node_modules/.bin/expo start --web --non-interactive --port ${APP_PORT} --max-workers 2`,
+            ].join(' '),
+            cwd: appDir,
+            url: APP_URL,
+            reuseExistingServer: !process.env.CI,
+            timeout: 180_000, // Metro cold bundle can take 2-4 min on CI
+        },
+    ],
+});

--- a/packages/happy-e2e/playwright.config.ts
+++ b/packages/happy-e2e/playwright.config.ts
@@ -18,8 +18,8 @@ const serverDir = path.resolve(__dirname, '../../packages/happy-server');
 const appDir = path.resolve(__dirname, '../../packages/happy-app');
 
 const TEST_SECRET = 'happy-e2e-test-secret-do-not-use-in-prod';
-const SERVER_PORT = 3005;
-const APP_PORT = 8081;
+const SERVER_PORT = parseInt(process.env.E2E_SERVER_PORT ?? '3005', 10);
+const APP_PORT = parseInt(process.env.E2E_APP_PORT ?? '8081', 10);
 
 export const SERVER_URL = `http://localhost:${SERVER_PORT}`;
 export const APP_URL = `http://localhost:${APP_PORT}`;
@@ -61,14 +61,14 @@ export default defineConfig({
                 `PORT=${SERVER_PORT}`,
                 `DB_PROVIDER=pglite`,
                 `METRICS_ENABLED=false`,
-                `node_modules/.bin/tsx ./sources/standalone.ts migrate`,
+                `pnpm exec tsx ./sources/standalone.ts migrate`,
                 `&&`,
                 `PGLITE_DIR="${pgliteDir}"`,
                 `HANDY_MASTER_SECRET="${TEST_SECRET}"`,
                 `PORT=${SERVER_PORT}`,
                 `DB_PROVIDER=pglite`,
                 `METRICS_ENABLED=false`,
-                `node_modules/.bin/tsx ./sources/standalone.ts serve`,
+                `pnpm exec tsx ./sources/standalone.ts serve`,
             ].join(' '),
             cwd: serverDir,
             url: SERVER_URL,
@@ -81,7 +81,7 @@ export default defineConfig({
             command: [
                 `EXPO_PUBLIC_HAPPY_SERVER_URL=${SERVER_URL}`,
                 `APP_ENV=development`,
-                `node_modules/.bin/expo start --web --non-interactive --port ${APP_PORT} --max-workers 2`,
+                `CI=1 pnpm exec expo start --web --port ${APP_PORT} --max-workers 2`,
             ].join(' '),
             cwd: appDir,
             url: APP_URL,

--- a/packages/happy-e2e/tests/smoke.test.ts
+++ b/packages/happy-e2e/tests/smoke.test.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import * as tweetnacl from 'tweetnacl';
+
+const SERVER_URL = 'http://localhost:3005';
+const APP_URL = 'http://localhost:8081';
+
+// ─── Auth helpers ──────────────────────────────────────────────────────────
+
+// Server uses privacy-kit's decodeBase64 which expects standard base64 (not base64url)
+function toBase64(buf: Uint8Array): string {
+    return Buffer.from(buf).toString('base64');
+}
+
+async function createTestAccount(): Promise<{ token: string; secret: string }> {
+    const seed = tweetnacl.randomBytes(32);
+    const keypair = tweetnacl.sign.keyPair.fromSeed(seed);
+    const challenge = tweetnacl.randomBytes(32);
+    const signature = tweetnacl.sign.detached(challenge, keypair.secretKey);
+
+    const response = await fetch(`${SERVER_URL}/v1/auth`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            publicKey: toBase64(keypair.publicKey),
+            challenge: toBase64(challenge),
+            signature: toBase64(signature),
+        }),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Auth failed: ${response.status} ${await response.text()}`);
+    }
+
+    const data = await response.json() as { token: string };
+    // App's authGetToken uses base64url for the secret
+    return { token: data.token, secret: Buffer.from(seed).toString('base64url') };
+}
+
+// Navigate to the app pre-authenticated using dev credential query params.
+// _layout.tsx reads these via getDevWebQueryCredentials() and auto-logins.
+// Note: _layout.tsx strips the params from URL after reading them, so each
+// test must pass them fresh.
+function authenticatedUrl(token: string, secret: string): string {
+    return `${APP_URL}/?dev_token=${encodeURIComponent(token)}&dev_secret=${encodeURIComponent(secret)}`;
+}
+
+// ─── Shared credentials (provisioned once per suite) ──────────────────────
+
+let testToken: string;
+let testSecret: string;
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+test.describe('Smoke Tests', () => {
+
+    test.beforeAll(async () => {
+        const creds = await createTestAccount();
+        testToken = creds.token;
+        testSecret = creds.secret;
+    });
+
+    // ── Server ──────────────────────────────────────────────────────────────
+
+    test('standalone server responds', async ({ request }) => {
+        const response = await request.get(SERVER_URL);
+        expect(response.ok()).toBeTruthy();
+    });
+
+    test('auth API creates a valid token', async ({ request }) => {
+        const seed = tweetnacl.randomBytes(32);
+        const keypair = tweetnacl.sign.keyPair.fromSeed(seed);
+        const challenge = tweetnacl.randomBytes(32);
+        const signature = tweetnacl.sign.detached(challenge, keypair.secretKey);
+
+        const response = await request.post(`${SERVER_URL}/v1/auth`, {
+            data: {
+                publicKey: toBase64(keypair.publicKey),
+                challenge: toBase64(challenge),
+                signature: toBase64(signature),
+            },
+        });
+
+        expect(response.ok()).toBeTruthy();
+        const body = await response.json();
+        expect(typeof body.token).toBe('string');
+        expect(body.token.length).toBeGreaterThan(0);
+    });
+
+    // ── App: unauthenticated ────────────────────────────────────────────────
+
+    test('app loads without crash', async ({ page }) => {
+        await page.goto(APP_URL);
+        // Page must not be blank — some content rendered
+        await expect(page.locator('body')).not.toBeEmpty();
+    });
+
+    test('unauthenticated: create account button visible', async ({ page }) => {
+        await page.goto(APP_URL);
+        // libsodium WASM must load before splash hides — allow generous timeout
+        const btn = page.getByTestId('create-account-button');
+        await expect(btn).toBeVisible({ timeout: 20_000 });
+    });
+
+    // ── App: authenticated ──────────────────────────────────────────────────
+
+    test('authenticated: empty state visible', async ({ page }) => {
+        await page.goto(authenticatedUrl(testToken, testSecret));
+        // Fresh account has no sessions → EmptyMainScreen renders
+        const emptyScreen = page.getByTestId('empty-main-screen');
+        await expect(emptyScreen).toBeVisible({ timeout: 20_000 });
+    });
+
+});

--- a/packages/happy-e2e/tests/smoke.test.ts
+++ b/packages/happy-e2e/tests/smoke.test.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 import * as tweetnacl from 'tweetnacl';
 
-const SERVER_URL = 'http://localhost:3005';
-const APP_URL = 'http://localhost:8081';
+const SERVER_URL = `http://localhost:${process.env.E2E_SERVER_PORT ?? '3005'}`;
+const APP_URL = `http://localhost:${process.env.E2E_APP_PORT ?? '8081'}`;
 
 // ─── Auth helpers ──────────────────────────────────────────────────────────
 

--- a/packages/happy-e2e/tsconfig.json
+++ b/packages/happy-e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "CommonJS",
+        "lib": ["ES2022"],
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "outDir": "dist"
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,6 +968,21 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/happy-e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.48.0
+        version: 1.59.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   packages/happy-server:
     dependencies:
       '@date-fns/tz':
@@ -3597,6 +3612,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pondwader/socks5-server@1.0.10':
     resolution: {integrity: sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==}
@@ -7601,6 +7621,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -9675,6 +9700,16 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -14795,6 +14830,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@pondwader/socks5-server@1.0.10': {}
 
   '@posthog/core@1.24.1':
@@ -19388,6 +19427,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -21976,6 +22018,14 @@ snapshots:
       yaml: 2.8.2
     optionalDependencies:
       typescript: 5.9.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - "packages/happy-wire"
   - "packages/happy-app-logs"
   - "packages/codium"
+  - "packages/happy-e2e"


### PR DESCRIPTION
**What this adds:** A minimal Playwright E2E smoke suite (`packages/happy-e2e`) that contributors and agents can run with `pnpm e2e` — no Docker, no phone, no cloud account, no maintainer secrets. Motivated by the observation that agent-driven development on this repo currently gets only typecheck feedback at PR time; one runtime smoke pass catches whole classes of regressions (auth round-trip, app boots, list renders) that typecheck cannot. Designed to add zero recurring maintenance: standalone server uses PGlite (embedded Postgres) so there is no infra to keep alive, the GitHub Actions job is path-gated to `happy-app` / `happy-server` / `happy-e2e` so unrelated PRs do not pay for it, and the auth path reuses the existing `getDevWebQueryCredentials()` instead of inventing a new one.

## Proof

Test run output (5/5 pass) + workflow file: _video pending — will attach a screencast of `pnpm e2e` locally and link the green CI run on this PR (`e2e` check is already passing here)._

## What's included

**New package** `packages/happy-e2e/`:
- `playwright.config.ts` — `webServer` array starts standalone server + Expo web
- `globalSetup.ts` — unique `PGLITE_DIR` per run for DB isolation
- `tests/smoke.test.ts` — 5 smoke tests
- `.env.test` — deterministic test secret (not a production secret)

**5 smoke tests:**
1. Standalone server responds (health check)
2. Auth API round-trip creates a valid token
3. App loads without crash
4. Unauthenticated: "Create account" button visible
5. Authenticated: empty state visible (fresh account has no sessions)

**testID additions** (4 files, needed for Playwright selectors):
- `RoundButton` — `testID` prop threaded to `<Pressable>`
- `index.tsx` — `testID="create-account-button"` on web "Create account" buttons
- `EmptyMainScreen` — `testID="empty-main-screen"` on root view
- `SessionsList` — `testID="session-list"` on container view

## Why this design

- **No Docker** — standalone `pnpm --filter happy-server standalone:dev` (already in CONTRIBUTING.md) + PGlite avoids `pg_*` infra entirely
- **No device** — Expo web in headless Chromium covers the common breakage paths
- **Auth bypass** — generates a real Ed25519 keypair, hits `POST /v1/auth`, injects `?dev_token=...&dev_secret=...` (existing dev-mode hook in `_layout.tsx`)
- **Gated CI** — workflow `paths:` filter, opt-in only when relevant package changes

## Test plan

```bash
pnpm install
pnpm --filter happy-e2e exec playwright install chromium
pnpm e2e               # 5/5 expected
pnpm e2e:headed        # watch mode
```

🤖 Generated with [Claude Code](https://claude.ai/code)
