### PR TITLE
feat: delete machines + hide offline from settings

### DIFF
--- a/packages/happy-app/CHANGELOG.md
+++ b/packages/happy-app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Version 9 - 2026-04-15
+
+Clean up stale machines cluttering your settings and session picker. Offline machines are now hidden by default with a one-tap reveal, and you can permanently remove machines you no longer use.
+
+- Offline machines are now hidden from the Settings machine list by default, with a button to reveal them
+- Added a delete option in machine details to remove stale machines from your account
+- Session history is preserved when a machine is deleted
+
 ## Version 8 - 2026-04-12
 
 This update migrates the monorepo from Yarn to pnpm, delivering dramatically faster dependency installs for developers and CI.

--- a/packages/happy-app/sources/app/(app)/machine/[id].tsx
+++ b/packages/happy-app/sources/app/(app)/machine/[id].tsx
@@ -8,7 +8,7 @@ import { Typography } from '@/constants/Typography';
 import { useSessions, useAllMachines, useMachine } from '@/sync/storage';
 import { Ionicons, Octicons } from '@expo/vector-icons';
 import type { Session } from '@/sync/storageTypes';
-import { machineStopDaemon, machineUpdateMetadata } from '@/sync/ops';
+import { machineStopDaemon, machineUpdateMetadata, machineDelete } from '@/sync/ops';
 import { Modal } from '@/modal';
 import { formatPathRelativeToHome, getSessionName, getSessionSubtitle } from '@/utils/sessionUtils';
 import { isMachineOnline } from '@/utils/machineUtils';
@@ -72,6 +72,7 @@ export default function MachineDetailScreen() {
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [isStoppingDaemon, setIsStoppingDaemon] = useState(false);
     const [isRenamingMachine, setIsRenamingMachine] = useState(false);
+    const [isDeletingMachine, setIsDeletingMachine] = useState(false);
     const [customPath, setCustomPath] = useState('');
     const [isSpawning, setIsSpawning] = useState(false);
     const inputRef = useRef<MultiTextInputHandle>(null);
@@ -160,6 +161,33 @@ export default function MachineDetailScreen() {
         setIsRefreshing(true);
         await sync.refreshMachines();
         setIsRefreshing(false);
+    };
+
+    const handleDeleteMachine = async () => {
+        if (!machineId) return;
+        const confirmed = await Modal.confirm(
+            t('machine.deleteConfirmTitle'),
+            t('machine.deleteConfirmMessage'),
+            { cancelText: t('common.cancel'), confirmText: t('common.delete'), destructive: true }
+        );
+        if (!confirmed) return;
+
+        setIsDeletingMachine(true);
+        try {
+            const result = await machineDelete(machineId);
+            if (result.success) {
+                router.back();
+            } else {
+                Modal.alert(t('common.error'), result.message || t('machine.deleteFailed'));
+            }
+        } catch (error) {
+            Modal.alert(
+                t('common.error'),
+                error instanceof Error ? error.message : t('machine.deleteFailed')
+            );
+        } finally {
+            setIsDeletingMachine(false);
+        }
     };
 
     const handleRenameMachine = async () => {
@@ -593,6 +621,24 @@ export default function MachineDetailScreen() {
                             title={t('machine.metadataVersion')}
                             subtitle={String(machine.metadataVersion)}
                         />
+                </ItemGroup>
+
+                {/* Danger zone */}
+                <ItemGroup title={t('machine.dangerZone')} footer={t('machine.deleteFooter')}>
+                    <Item
+                        title={t('machine.delete')}
+                        titleStyle={{ color: '#FF3B30' }}
+                        onPress={handleDeleteMachine}
+                        disabled={isDeletingMachine}
+                        showChevron={false}
+                        rightElement={
+                            isDeletingMachine ? (
+                                <ActivityIndicator size="small" color={theme.colors.textSecondary} />
+                            ) : (
+                                <Ionicons name="trash-outline" size={20} color="#FF3B30" />
+                            )
+                        }
+                    />
                 </ItemGroup>
             </ItemList>
         </>

--- a/packages/happy-app/sources/changelog/changelog.json
+++ b/packages/happy-app/sources/changelog/changelog.json
@@ -1,6 +1,17 @@
 {
   "entries": [
     {
+      "version": 9,
+      "date": "2026-04-15",
+      "summary": "Clean up stale machines cluttering your settings and session picker. Offline machines are now hidden by default with a one-tap reveal, and you can permanently remove machines you no longer use.",
+      "changes": [
+        "Offline machines are now hidden from the Settings machine list by default, with a button to reveal them",
+        "Added a delete option in machine details to remove stale machines from your account",
+        "Session history is preserved when a machine is deleted"
+      ],
+      "rawMarkdown": "## Version 9 - 2026-04-15\n\n\nClean up stale machines cluttering your settings and session picker. Offline machines are now hidden by default with a one-tap reveal, and you can permanently remove machines you no longer use.\n\n- Offline machines are now hidden from the Settings machine list by default, with a button to reveal them\n- Added a delete option in machine details to remove stale machines from your account\n- Session history is preserved when a machine is deleted"
+    },
+    {
       "version": 8,
       "date": "2026-04-12",
       "summary": "This update migrates the monorepo from Yarn to pnpm, delivering dramatically faster dependency installs for developers and CI.",
@@ -108,5 +119,5 @@
       "rawMarkdown": "## Version 1 - 2025-05-12\n\n\nWelcome to Happy - your secure, encrypted mobile companion for Claude Code. This inaugural release establishes the foundation for private, powerful AI interactions on the go.\n\n- Implemented end-to-end encrypted session management ensuring complete privacy\n- Integrated intelligent voice assistant with natural conversation capabilities\n- Added experimental file manager with syntax highlighting and tree navigation\n- Built seamless real-time synchronization across all your devices\n- Established native support for iOS, Android, and responsive web interfaces"
     }
   ],
-  "latestVersion": 8
+  "latestVersion": 9
 }

--- a/packages/happy-app/sources/components/SettingsView.tsx
+++ b/packages/happy-app/sources/components/SettingsView.tsx
@@ -38,7 +38,18 @@ export const SettingsView = React.memo(function SettingsView() {
     const isPro = __DEV__ || useEntitlement('pro');
     const experiments = useSetting('experiments');
     const isCustomServer = isUsingCustomServer();
-    const allMachines = useAllMachines();
+    const [showOfflineMachines, setShowOfflineMachines] = React.useState(false);
+    const allMachinesWithOffline = useAllMachines({ includeOffline: true });
+    const offlineMachineCount = React.useMemo(
+        () => allMachinesWithOffline.filter(m => !isMachineOnline(m)).length,
+        [allMachinesWithOffline]
+    );
+    const visibleMachines = React.useMemo(
+        () => showOfflineMachines
+            ? allMachinesWithOffline
+            : allMachinesWithOffline.filter(isMachineOnline),
+        [allMachinesWithOffline, showOfflineMachines]
+    );
     const profile = useProfile();
     const displayName = getDisplayName(profile);
     const avatarUrl = getAvatarUrl(profile);
@@ -256,9 +267,9 @@ export const SettingsView = React.memo(function SettingsView() {
             </ItemGroup> */}
 
             {/* Machines (sorted: online first, then last seen desc) */}
-            {allMachines.length > 0 && (
+            {allMachinesWithOffline.length > 0 && (
                 <ItemGroup title={t('settings.machines')}>
-                    {[...allMachines].map((machine) => {
+                    {visibleMachines.map((machine) => {
                         const isOnline = isMachineOnline(machine);
                         const host = machine.metadata?.host || 'Unknown';
                         const displayName = machine.metadata?.displayName;
@@ -293,6 +304,19 @@ export const SettingsView = React.memo(function SettingsView() {
                             />
                         );
                     })}
+                    {offlineMachineCount > 0 && (
+                        <Item
+                            title={showOfflineMachines
+                                ? t('settings.hideOfflineMachines')
+                                : t('settings.showOfflineMachines', { count: offlineMachineCount })}
+                            onPress={() => setShowOfflineMachines(v => !v)}
+                            showChevron={false}
+                            titleStyle={{
+                                textAlign: 'center',
+                                color: theme.colors.textLink,
+                            }}
+                        />
+                    )}
                 </ItemGroup>
             )}
 

--- a/packages/happy-app/sources/sync/apiTypes.ts
+++ b/packages/happy-app/sources/sync/apiTypes.ts
@@ -34,6 +34,11 @@ export const ApiDeleteSessionSchema = z.object({
     sid: z.string(), // Session ID
 });
 
+export const ApiDeleteMachineSchema = z.object({
+    t: z.literal('delete-machine'),
+    machineId: z.string(),
+});
+
 export const ApiUpdateAccountSchema = z.object({
     t: z.literal('update-account'),
     id: z.string(),
@@ -120,6 +125,7 @@ export const ApiUpdateSchema = z.union([
     ApiUpdateSessionStateSchema,
     ApiUpdateAccountSchema,
     ApiUpdateMachineStateSchema,
+    ApiDeleteMachineSchema,
     ApiNewArtifactSchema,
     ApiUpdateArtifactSchema,
     ApiDeleteArtifactSchema,

--- a/packages/happy-app/sources/sync/encryption/encryption.ts
+++ b/packages/happy-app/sources/sync/encryption/encryption.ts
@@ -136,6 +136,13 @@ export class Encryption {
         return this.machineEncryptions.get(machineId) || null;
     }
 
+    /**
+     * Remove machine encryption from memory when the machine is deleted
+     */
+    removeMachineEncryption(machineId: string): void {
+        this.machineEncryptions.delete(machineId);
+    }
+
     //
     // Legacy methods for machine metadata (temporary until machines are migrated)
     //

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -197,6 +197,28 @@ export async function machineResumeSession(options: ResumeSessionOptions): Promi
 }
 
 /**
+ * Permanently remove a machine from the server. Sessions spawned by the
+ * machine are preserved; only the Machine row and its AccessKeys are deleted.
+ */
+export async function machineDelete(machineId: string): Promise<{ success: boolean; message?: string }> {
+    try {
+        const response = await apiSocket.request(`/v1/machines/${machineId}`, {
+            method: 'DELETE'
+        });
+        if (response.ok) {
+            return { success: true };
+        }
+        const error = await response.text();
+        return { success: false, message: error || 'Failed to delete machine' };
+    } catch (error) {
+        return {
+            success: false,
+            message: error instanceof Error ? error.message : 'Unknown error'
+        };
+    }
+}
+
+/**
  * Stop the daemon on a specific machine
  */
 export async function machineStopDaemon(machineId: string): Promise<{ message: string }> {

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -168,6 +168,7 @@ interface StorageState {
     nativeUpdateStatus: { available: boolean; updateUrl?: string } | null;
     applySessions: (sessions: (Omit<Session, 'presence'> & { presence?: "online" | number })[]) => void;
     applyMachines: (machines: Machine[], replace?: boolean) => void;
+    deleteMachine: (machineId: string) => void;
     applyLoaded: () => void;
     applyReady: () => void;
     applyMessages: (sessionId: string, messages: NormalizedMessage[]) => { changed: string[], hasReadyEvent: boolean };
@@ -1010,6 +1011,17 @@ export const storage = create<StorageState>()((set, get) => {
                 ...state,
                 machines: mergedMachines,
                 sessionListViewData
+            };
+        }),
+        deleteMachine: (machineId: string) => set((state) => {
+            if (!state.machines[machineId]) {
+                return state;
+            }
+            const { [machineId]: _removed, ...remaining } = state.machines;
+            return {
+                ...state,
+                machines: remaining,
+                sessionListViewData: buildSessionListViewData(state.sessions)
             };
         }),
         // Artifact methods

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -2003,6 +2003,16 @@ class Sync {
 
             // Update storage using applyMachines which rebuilds sessionListViewData
             storage.getState().applyMachines([updatedMachine]);
+        } else if (updateData.body.t === 'delete-machine') {
+            const machineId = updateData.body.machineId;
+            log.log(`🗑️ Delete machine update received for ${machineId}`);
+            if (!storage.getState().machines[machineId]) {
+                log.log(`Machine ${machineId} not in storage, skipping delete`);
+            } else {
+                storage.getState().deleteMachine(machineId);
+                this.encryption.removeMachineEncryption(machineId);
+                this.machineDataKeys.delete(machineId);
+            }
         } else if (updateData.body.t === 'relationship-updated') {
             log.log('👥 Received relationship-updated update');
             const relationshipUpdate = updateData.body;

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -103,6 +103,8 @@ export const en = {
         connectAccount: 'Connect account',
         github: 'GitHub',
         machines: 'Machines',
+        showOfflineMachines: ({ count }: { count: number }) => count === 1 ? 'Show 1 offline machine' : `Show ${count} offline machines`,
+        hideOfflineMachines: 'Hide offline machines',
         features: 'Features',
         social: 'Social',
         account: 'Account',
@@ -759,6 +761,12 @@ export const en = {
         lastDetected: 'Last Detected',
         untitledSession: 'Untitled Session',
         back: 'Back',
+        dangerZone: 'Danger Zone',
+        delete: 'Delete Machine',
+        deleteFooter: 'Remove this machine from your account. Session history will be preserved, but you will not be able to start new sessions on this machine.',
+        deleteConfirmTitle: 'Delete this machine?',
+        deleteConfirmMessage: 'The machine will be removed from your account. Session history will be preserved, but you will not be able to start new sessions until you reconnect the daemon.',
+        deleteFailed: 'Failed to delete machine.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -104,6 +104,8 @@ export const ca: TranslationStructure = {
         connectAccount: 'Connectar compte',
         github: 'GitHub',
         machines: 'Màquines',
+        showOfflineMachines: ({ count }: { count: number }) => count === 1 ? 'Mostra 1 màquina fora de línia' : `Mostra ${count} màquines fora de línia`,
+        hideOfflineMachines: 'Amaga màquines fora de línia',
         features: 'Funcions',
         social: 'Social',
         account: 'Compte',
@@ -760,6 +762,12 @@ export const ca: TranslationStructure = {
         lastDetected: 'Última detecció',
         untitledSession: 'Sessió sense títol',
         back: 'Enrere',
+        dangerZone: 'Zona de perill',
+        delete: 'Elimina la màquina',
+        deleteFooter: 'Elimina aquesta màquina del teu compte. L\'historial de sessions es conservarà, però no podràs iniciar noves sessions en aquesta màquina.',
+        deleteConfirmTitle: 'Eliminar aquesta màquina?',
+        deleteConfirmMessage: 'La màquina s\'eliminarà del teu compte. L\'historial de sessions es conservarà, però no podràs iniciar noves sessions fins que tornis a connectar el dimoni.',
+        deleteFailed: 'No s\'ha pogut eliminar la màquina.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -119,6 +119,8 @@ export const en: TranslationStructure = {
         connectAccount: 'Connect account',
         github: 'GitHub',
         machines: 'Machines',
+        showOfflineMachines: ({ count }: { count: number }) => count === 1 ? 'Show 1 offline machine' : `Show ${count} offline machines`,
+        hideOfflineMachines: 'Hide offline machines',
         features: 'Features',
         social: 'Social',
         account: 'Account',
@@ -774,6 +776,12 @@ export const en: TranslationStructure = {
         lastDetected: 'Last Detected',
         untitledSession: 'Untitled Session',
         back: 'Back',
+        dangerZone: 'Danger Zone',
+        delete: 'Delete Machine',
+        deleteFooter: 'Removes this machine from your account. Session history is preserved, but you will no longer be able to launch new sessions on it.',
+        deleteConfirmTitle: 'Delete this machine?',
+        deleteConfirmMessage: 'This removes the machine from your account. Session history is preserved, but you can no longer launch new sessions on it until you reconnect the daemon.',
+        deleteFailed: 'Failed to delete machine.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -104,6 +104,8 @@ export const es: TranslationStructure = {
         connectAccount: 'Conectar cuenta',
         github: 'GitHub',
         machines: 'Máquinas',
+        showOfflineMachines: ({ count }: { count: number }) => count === 1 ? 'Mostrar 1 máquina sin conexión' : `Mostrar ${count} máquinas sin conexión`,
+        hideOfflineMachines: 'Ocultar máquinas sin conexión',
         features: 'Características',
         social: 'Social',
         account: 'Cuenta',
@@ -760,6 +762,12 @@ export const es: TranslationStructure = {
         lastDetected: 'Última detección',
         untitledSession: 'Sesión sin título',
         back: 'Atrás',
+        dangerZone: 'Zona de peligro',
+        delete: 'Eliminar máquina',
+        deleteFooter: 'Elimina esta máquina de tu cuenta. El historial de sesiones se conservará, pero no podrás iniciar nuevas sesiones en esta máquina.',
+        deleteConfirmTitle: '¿Eliminar esta máquina?',
+        deleteConfirmMessage: 'La máquina se eliminará de tu cuenta. El historial de sesiones se conservará, pero no podrás iniciar nuevas sesiones hasta que vuelvas a conectar el daemon.',
+        deleteFailed: 'No se pudo eliminar la máquina.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -103,6 +103,8 @@ export const it: TranslationStructure = {
         connectAccount: 'Collega account',
         github: 'GitHub',
         machines: 'Macchine',
+        showOfflineMachines: ({ count }: { count: number }) => count === 1 ? 'Mostra 1 macchina offline' : `Mostra ${count} macchine offline`,
+        hideOfflineMachines: 'Nascondi macchine offline',
         features: 'Funzionalità',
         social: 'Social',
         account: 'Account',
@@ -758,6 +760,12 @@ export const it: TranslationStructure = {
         lastDetected: 'Ultimo rilevamento',
         untitledSession: 'Sessione senza titolo',
         back: 'Indietro',
+        dangerZone: 'Zona di pericolo',
+        delete: 'Elimina macchina',
+        deleteFooter: 'Rimuove questa macchina dal tuo account. La cronologia delle sessioni viene mantenuta, ma non potrai più avviare nuove sessioni su di essa.',
+        deleteConfirmTitle: 'Eliminare questa macchina?',
+        deleteConfirmMessage: 'La macchina verrà rimossa dal tuo account. La cronologia delle sessioni viene mantenuta, ma non potrai avviare nuove sessioni finché non riconnetti il daemon.',
+        deleteFailed: 'Impossibile eliminare la macchina.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -106,6 +106,8 @@ export const ja: TranslationStructure = {
         connectAccount: 'アカウントを接続',
         github: 'GitHub',
         machines: 'マシン',
+        showOfflineMachines: ({ count }: { count: number }) => `${count} 台のオフラインマシンを表示`,
+        hideOfflineMachines: 'オフラインマシンを非表示',
         features: '機能',
         social: 'ソーシャル',
         account: 'アカウント',
@@ -761,6 +763,12 @@ export const ja: TranslationStructure = {
         lastDetected: '最終検出',
         untitledSession: '無題のセッション',
         back: '戻る',
+        dangerZone: '危険ゾーン',
+        delete: 'マシンを削除',
+        deleteFooter: 'このマシンをアカウントから削除します。セッション履歴は保持されますが、このマシンで新しいセッションを起動できなくなります。',
+        deleteConfirmTitle: 'このマシンを削除しますか？',
+        deleteConfirmMessage: 'マシンがアカウントから削除されます。セッション履歴は保持されますが、デーモンを再接続するまで新しいセッションを起動できません。',
+        deleteFailed: 'マシンの削除に失敗しました。',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -115,6 +115,14 @@ export const pl: TranslationStructure = {
         connectAccount: 'Połącz konto',
         github: 'GitHub',
         machines: 'Maszyny',
+        showOfflineMachines: ({ count }: { count: number }) => {
+            const mod10 = count % 10;
+            const mod100 = count % 100;
+            if (count === 1) return 'Pokaż 1 maszynę offline';
+            if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return `Pokaż ${count} maszyny offline`;
+            return `Pokaż ${count} maszyn offline`;
+        },
+        hideOfflineMachines: 'Ukryj maszyny offline',
         features: 'Funkcje',
         social: 'Społeczność',
         account: 'Konto',
@@ -770,6 +778,12 @@ export const pl: TranslationStructure = {
         lastDetected: 'Ostatnio wykryto',
         untitledSession: 'Sesja bez nazwy',
         back: 'Wstecz',
+        dangerZone: 'Strefa niebezpieczna',
+        delete: 'Usuń maszynę',
+        deleteFooter: 'Usuń tę maszynę ze swojego konta. Historia sesji zostanie zachowana, ale nie będziesz mógł uruchamiać nowych sesji na tej maszynie.',
+        deleteConfirmTitle: 'Usunąć tę maszynę?',
+        deleteConfirmMessage: 'Maszyna zostanie usunięta z twojego konta. Historia sesji zostanie zachowana, ale nie będziesz mógł uruchamiać nowych sesji, dopóki ponownie nie podłączysz demona.',
+        deleteFailed: 'Nie udało się usunąć maszyny.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -104,6 +104,8 @@ export const pt: TranslationStructure = {
         connectAccount: 'Conectar conta',
         github: 'GitHub',
         machines: 'Máquinas',
+        showOfflineMachines: ({ count }: { count: number }) => count === 1 ? 'Mostrar 1 máquina offline' : `Mostrar ${count} máquinas offline`,
+        hideOfflineMachines: 'Ocultar máquinas offline',
         features: 'Recursos',
         social: 'Social',
         account: 'Conta',
@@ -759,6 +761,12 @@ export const pt: TranslationStructure = {
         lastDetected: 'Última detecção',
         untitledSession: 'Sessão sem título',
         back: 'Voltar',
+        dangerZone: 'Zona de perigo',
+        delete: 'Excluir máquina',
+        deleteFooter: 'Remove esta máquina da sua conta. O histórico de sessões será preservado, mas você não poderá iniciar novas sessões nesta máquina.',
+        deleteConfirmTitle: 'Excluir esta máquina?',
+        deleteConfirmMessage: 'A máquina será removida da sua conta. O histórico de sessões será preservado, mas você não poderá iniciar novas sessões até reconectar o daemon.',
+        deleteFailed: 'Falha ao excluir a máquina.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -86,6 +86,15 @@ export const ru: TranslationStructure = {
         connectAccount: 'Подключить аккаунт',
         github: 'GitHub',
         machines: 'Машины',
+        showOfflineMachines: ({ count }: { count: number }) => {
+            const lastTwo = count % 100;
+            const lastOne = count % 10;
+            if (lastTwo >= 11 && lastTwo <= 14) return `Показать ${count} оффлайн-машин`;
+            if (lastOne === 1) return `Показать ${count} оффлайн-машину`;
+            if (lastOne >= 2 && lastOne <= 4) return `Показать ${count} оффлайн-машины`;
+            return `Показать ${count} оффлайн-машин`;
+        },
+        hideOfflineMachines: 'Скрыть оффлайн-машины',
         features: 'Функции',
         social: 'Социальное',
         account: 'Аккаунт',
@@ -757,6 +766,12 @@ export const ru: TranslationStructure = {
         lastDetected: 'Последнее обнаружение',
         untitledSession: 'Безымянная сессия',
         back: 'Назад',
+        dangerZone: 'Опасная зона',
+        delete: 'Удалить машину',
+        deleteFooter: 'Удаляет машину из вашего аккаунта. История сессий сохраняется, но вы больше не сможете запускать новые сессии на ней.',
+        deleteConfirmTitle: 'Удалить эту машину?',
+        deleteConfirmMessage: 'Машина будет удалена из вашего аккаунта. История сессий сохраняется, но вы больше не сможете запускать новые сессии, пока не подключите демон заново.',
+        deleteFailed: 'Не удалось удалить машину.',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -106,6 +106,8 @@ export const zhHans: TranslationStructure = {
         connectAccount: '连接账户',
         github: 'GitHub',
         machines: '设备',
+        showOfflineMachines: ({ count }: { count: number }) => `显示 ${count} 台离线设备`,
+        hideOfflineMachines: '隐藏离线设备',
         features: '功能',
         social: '社交',
         account: '账户',
@@ -761,6 +763,12 @@ export const zhHans: TranslationStructure = {
         lastDetected: '最近检测',
         untitledSession: '无标题会话',
         back: '返回',
+        dangerZone: '危险区域',
+        delete: '删除设备',
+        deleteFooter: '从您的账户中移除此设备。会话历史将保留，但您无法再在此设备上启动新会话。',
+        deleteConfirmTitle: '删除此设备？',
+        deleteConfirmMessage: '设备将从您的账户中移除。会话历史将保留，但在您重新连接守护进程之前，您将无法启动新会话。',
+        deleteFailed: '删除设备失败。',
     },
 
     message: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -105,6 +105,8 @@ export const zhHant: TranslationStructure = {
         connectAccount: '連結帳戶',
         github: 'GitHub',
         machines: '裝置',
+        showOfflineMachines: ({ count }: { count: number }) => `顯示 ${count} 台離線裝置`,
+        hideOfflineMachines: '隱藏離線裝置',
         features: '功能',
         social: '社交',
         account: '帳戶',
@@ -760,6 +762,12 @@ export const zhHant: TranslationStructure = {
         lastDetected: '最近偵測',
         untitledSession: '無標題工作階段',
         back: '返回',
+        dangerZone: '危險區域',
+        delete: '刪除裝置',
+        deleteFooter: '從您的帳戶中移除此裝置。工作階段歷史將保留,但您將無法在此裝置上啟動新的工作階段。',
+        deleteConfirmTitle: '刪除此裝置?',
+        deleteConfirmMessage: '裝置將從您的帳戶中移除。工作階段歷史將保留,但在您重新連接守護程序之前,您將無法啟動新的工作階段。',
+        deleteFailed: '刪除裝置失敗。',
     },
 
     message: {

--- a/packages/happy-server/sources/app/api/routes/machinesRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/machinesRoutes.ts
@@ -2,10 +2,11 @@ import { eventRouter } from "@/app/events/eventRouter";
 import { Fastify } from "../types";
 import { z } from "zod";
 import { db } from "@/storage/db";
+import { inTx, afterTx } from "@/storage/inTx";
 import { log } from "@/utils/log";
 import { randomKeyNaked } from "@/utils/randomKeyNaked";
 import { allocateUserSeq } from "@/storage/seq";
-import { buildNewMachineUpdate, buildUpdateMachineUpdate } from "@/app/events/eventRouter";
+import { buildNewMachineUpdate, buildUpdateMachineUpdate, buildDeleteMachineUpdate } from "@/app/events/eventRouter";
 
 export function machinesRoutes(app: Fastify) {
     app.post('/v1/machines', {
@@ -172,6 +173,56 @@ export function machinesRoutes(app: Fastify) {
                 updatedAt: machine.updatedAt.getTime()
             }
         };
+    });
+
+    // DELETE /v1/machines/:id - Remove a machine and its access keys.
+    // Sessions spawned by this machine are preserved so history is not lost.
+    app.delete('/v1/machines/:id', {
+        preHandler: app.authenticate,
+        schema: {
+            params: z.object({
+                id: z.string()
+            })
+        }
+    }, async (request, reply) => {
+        const userId = request.userId;
+        const { id } = request.params;
+
+        const deleted = await inTx(async (tx) => {
+            const machine = await tx.machine.findFirst({
+                where: { accountId: userId, id }
+            });
+            if (!machine) {
+                return false;
+            }
+
+            await tx.accessKey.deleteMany({
+                where: { accountId: userId, machineId: id }
+            });
+
+            await tx.machine.delete({
+                where: { id }
+            });
+
+            afterTx(tx, async () => {
+                const updSeq = await allocateUserSeq(userId);
+                const updatePayload = buildDeleteMachineUpdate(id, updSeq, randomKeyNaked(12));
+                eventRouter.emitUpdate({
+                    userId,
+                    payload: updatePayload,
+                    recipientFilter: { type: 'user-scoped-only' }
+                });
+                log({ module: 'machines', machineId: id, userId }, 'Machine deleted');
+            });
+
+            return true;
+        });
+
+        if (!deleted) {
+            return reply.code(404).send({ error: 'Machine not found' });
+        }
+
+        return reply.send({ success: true });
     });
 
 }

--- a/packages/happy-server/sources/app/events/eventRouter.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.ts
@@ -108,6 +108,9 @@ export type UpdateEvent = {
     };
     activeAt?: number;
 } | {
+    type: 'delete-machine';
+    machineId: string;
+} | {
     type: 'new-artifact';
     artifactId: string;
     seq: number;
@@ -447,6 +450,18 @@ export function buildUpdateMachineUpdate(machineId: string, updateSeq: number, u
             machineId,
             metadata,
             daemonState
+        },
+        createdAt: Date.now()
+    };
+}
+
+export function buildDeleteMachineUpdate(machineId: string, updateSeq: number, updateId: string): UpdatePayload {
+    return {
+        id: updateId,
+        seq: updateSeq,
+        body: {
+            t: 'delete-machine',
+            machineId
         },
         createdAt: Date.now()
     };


### PR DESCRIPTION
## Summary

Users had dead/zombie machines cluttering their machine list after daemon reauthentications ([reported on Discord](https://discord.com/) by `ratio [CLAW]`). This adds a way to clean them up without affecting session history.

- **Settings → Machines**: offline machines hidden by default, with a toggle to reveal them (shows count)
- **Machine detail screen**: new Danger Zone with a delete button, confirmation modal, navigates back on success
- **Server** `DELETE /v1/machines/:id`: removes the machine + its access keys, preserves sessions, broadcasts a new `delete-machine` event to all the user's connected clients
- **Client sync**: handles `delete-machine` event → removes machine from storage, drops encryption keys and `machineDataKeys`, guarded on local presence so stale events are no-ops

## Backwards compatibility

Old clients (pre-upgrade) on the same account will receive the new `delete-machine` event but will safely ignore it — `handleUpdate` uses `safeParse` and drops unknown discriminants. They'll see the deleted machine disappear on next full fetch / reconnect. No hard break.

## Notes for reviewer

- Machine deletion intentionally preserves past sessions — the server has no FK from Session to Machine (machineId lives in encrypted session metadata), so nothing cascades.
- AccessKeys must be deleted first because they have a composite FK to Machine — handled inside a single `inTx` block.
- All 10 locale files updated (`en`, `ru`, `it`, `ja`, `zh-Hans`, `zh-Hant`, `ca`, `pl`, `es`, `pt`). Polish uses proper plural rules (1, 2-4, 5+, with 11-14 special case).
- CHANGELOG bumped to v9 and `changelog.json` regenerated.

## Test plan

- [ ] App builds and `pnpm typecheck` passes in both `happy-app` and `happy-server`
- [ ] Settings → machine list shows only online machines by default; toggle reveals offline ones with correct count
- [ ] Delete machine from detail screen → confirmation modal → machine vanishes from list → navigation back works
- [ ] Delete event propagates to a second device on same account (machine disappears without restart)
- [ ] Session history for deleted machine is still viewable
- [ ] Translations render correctly in at least one non-English locale (plural count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)