### PR TITLE
fix(server): increase cross-replica fetchSockets timeout to prevent false "RPC method not available"

### DIFF
--- a/packages/happy-server/sources/app/api/socket/rpcHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/rpcHandler.ts
@@ -15,17 +15,23 @@ import type { DefaultEventsMap } from "socket.io/dist/typed-events";
 const RPC_ROOM_PREFIX = 'rpc:';
 const RPC_CALL_TIMEOUT_MS = 30_000;
 const RPC_PRESENCE_POLL_MS = 1_000;
-// Timeout for presence-poll fetchSockets. Must be << RPC_CALL_TIMEOUT_MS so a
-// dead replica that never replies to FETCH_SOCKETS doesn't itself stall the
-// poll for the cluster-adapter default of 5s.
+// Timeout for cross-replica fetchSockets during initial daemon lookup and the
+// reconnect grace window. Must be long enough for the full Redis streams
+// round-trip (XADD → peer XREAD → process → XADD response → local XREAD)
+// across all replicas. The cluster-adapter default heartbeatTimeout is 10s;
+// 2s is well above typical healthy latency (~50-200ms) while still allowing
+// ~6-7 polls within the grace window.
+const RPC_LOOKUP_FETCH_TIMEOUT_MS = 2_000;
+// Timeout for in-flight presence-poll fetchSockets. Must be << RPC_CALL_TIMEOUT_MS
+// so a dead replica doesn't stall each poll for the full adapter heartbeatTimeout
+// (10s). 500ms keeps daemon-death detection responsive (~1s).
 const RPC_PRESENCE_FETCH_TIMEOUT_MS = 500;
 // How long an rpc-call waits for the daemon socket to appear in the room when
-// the room is empty at call time (e.g. brief daemon reconnect window). Set to
-// 10s — 2× the streams adapter's 5s heartbeat interval — so cross-replica
-// room discovery has time to converge after a pod restart. Lower values cause
-// transient "method not available" failures for ~5s after every rolling
-// deploy when the daemon's reconnect lands on a freshly-started replica.
-const RPC_RECONNECT_GRACE_MS = 10_000;
+// the room is empty at call time (e.g. brief daemon reconnect window). With
+// RPC_LOOKUP_FETCH_TIMEOUT_MS at 2s + RPC_RECONNECT_POLL_MS at 200ms, each
+// poll iteration takes ~2.2s. 15s gives ~6-7 iterations — enough to catch a
+// daemon mid-reconnect after a rolling deploy or transient network drop.
+const RPC_RECONNECT_GRACE_MS = 15_000;
 const RPC_RECONNECT_POLL_MS = 200;
 
 function rpcRoom(userId: string, method: string): string {
@@ -37,18 +43,19 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 type RoomSockets = RemoteSocket<DefaultEventsMap, any>[];
 
 /**
- * fetchSockets(room) wrapped with our short cross-replica timeout. Returns
- * `[]` and logs on failure (cluster-adapter request timeout, peer replica
- * unresponsive). Cluster-adapter default timeout is 5s; we cap at 500ms so a
- * single dead peer doesn't stall the caller for the entire grace window.
+ * fetchSockets(room) wrapped with a caller-specified timeout. Returns `[]`
+ * and logs on failure (cluster-adapter request timeout, peer replica
+ * unresponsive). Use RPC_LOOKUP_FETCH_TIMEOUT_MS for daemon lookups (initial
+ * + grace window) and RPC_PRESENCE_FETCH_TIMEOUT_MS for in-flight presence
+ * polling.
  */
-async function fetchRoomSockets(io: Server, room: string): Promise<RoomSockets> {
+async function fetchRoomSockets(io: Server, room: string, timeoutMs: number): Promise<RoomSockets> {
     try {
         return await io.in(room)
-            .timeout(RPC_PRESENCE_FETCH_TIMEOUT_MS)
+            .timeout(timeoutMs)
             .fetchSockets();
     } catch (error) {
-        log({ module: 'websocket' }, `fetchSockets failed for ${room}: ${error}`);
+        log({ module: 'websocket' }, `fetchSockets failed for ${room} (timeout=${timeoutMs}ms): ${error}`);
         return [];
     }
 }
@@ -61,7 +68,7 @@ async function fetchRoomSockets(io: Server, room: string): Promise<RoomSockets> 
 async function waitForRoomMember(io: Server, room: string, maxMs: number): Promise<RoomSockets> {
     const deadline = Date.now() + maxMs;
     while (true) {
-        const sockets = await fetchRoomSockets(io, room);
+        const sockets = await fetchRoomSockets(io, room, RPC_LOOKUP_FETCH_TIMEOUT_MS);
         if (sockets.length > 0) return sockets;
         if (Date.now() >= deadline) return sockets;
         await sleep(RPC_RECONNECT_POLL_MS);
@@ -113,7 +120,7 @@ export function rpcHandler(userId: string, socket: Socket, io: Server) {
             // unresponsive — fetchRoomSockets logs and returns []) fall
             // through to the wait-for-reconnect grace window.
             const room = rpcRoom(userId, method);
-            let targets = await fetchRoomSockets(io, room);
+            let targets = await fetchRoomSockets(io, room, RPC_LOOKUP_FETCH_TIMEOUT_MS);
             if (targets.length === 0) {
                 targets = await waitForRoomMember(io, room, RPC_RECONNECT_GRACE_MS);
             }
@@ -152,7 +159,7 @@ export function rpcHandler(userId: string, socket: Socket, io: Server) {
                 while (presenceAlive) {
                     await sleep(RPC_PRESENCE_POLL_MS);
                     if (!presenceAlive) return;
-                    const stillThere = await fetchRoomSockets(io, room);
+                    const stillThere = await fetchRoomSockets(io, room, RPC_PRESENCE_FETCH_TIMEOUT_MS);
                     if (!stillThere.some(s => s.id === target.id)) {
                         throw new Error('RPC target disconnected');
                     }


### PR DESCRIPTION
## Summary

- Split `fetchSockets()` timeout into two: **2s for daemon lookup** (initial + grace window) and **500ms for in-flight presence polling** (unchanged)
- Increase reconnect grace window from **10s → 15s** to maintain ~6-7 poll iterations per window
- Fix misleading comment about cluster-adapter default timeout (10s, not 5s)

## Root cause

PR #1042 rewrote RPC routing to use Socket.IO rooms + cross-replica `fetchSockets()`. PR #1046 scaled to 3 replicas. The combination caused intermittent "RPC method not available" errors when creating sessions from web/iOS.

The 500ms `fetchSockets()` timeout was too aggressive for cross-replica queries via the Redis streams adapter. The full round-trip (XADD → peer XREAD → process → XADD response → local XREAD) can exceed 500ms under normal load. When it does, `fetchRoomSockets` catches the timeout and returns `[]`. The 10s grace window polled ~14 times with the same 500ms timeout — all failing — resulting in "RPC method not available" even though the daemon was connected on another replica.

## What changed

**File**: `packages/happy-server/sources/app/api/socket/rpcHandler.ts` (1 file, no client changes)

| Constant | Before | After | Why |
|----------|--------|-------|-----|
| `RPC_LOOKUP_FETCH_TIMEOUT_MS` | (didn't exist, used 500ms) | `2_000` | Reliable cross-replica lookup |
| `RPC_PRESENCE_FETCH_TIMEOUT_MS` | `500` | `500` (unchanged) | Fast daemon-death detection |
| `RPC_RECONNECT_GRACE_MS` | `10_000` | `15_000` | Compensate for slower per-poll (~2.2s vs ~0.7s) |

`fetchRoomSockets()` now takes a `timeoutMs` parameter so callers specify the appropriate timeout:
- Initial lookup + grace window polling → `RPC_LOOKUP_FETCH_TIMEOUT_MS` (2s)
- In-flight presence poll → `RPC_PRESENCE_FETCH_TIMEOUT_MS` (500ms)

## What this does NOT change

- In-flight presence poll: stays at 500ms for fast dead-daemon detection (~1s)
- Client-side code: zero changes to daemon or web app
- RPC protocol: no wire format changes, no new events
- Single-replica behavior: local `fetchSockets` resolves instantly, fix is transparent

## Test plan

- [x] Typecheck: `pnpm --filter happy-server build` (verified — zero rpcHandler errors)
- [x] Local standalone (`pnpm standalone:dev`): single-process, no Redis — verified no regression
- [x] Multi-pod validation: minikube 2-replica cluster with Redis streams adapter — see results below

## Test results

Validated with a local minikube cluster: 2 `handy-server` replicas + Redis streams adapter, using the integration test scripts from `deploy/integration-tests/`.

**Forced cross-replica setup**: daemon connected to pod1, all callers connected to pod2 via direct port-forward — guaranteeing every RPC call crosses replica boundaries through Redis.

```
=== 强制跨副本 RPC 测试 (PR #1075 验证) ===

daemon → POD1 http://127.0.0.1:3001  (handy-server-6479bfd464-8tv9b)
callers → POD2 http://127.0.0.1:3002  (handy-server-6479bfd464-mwjlr)

✓ daemon connected: 4V-9Zio66HafnzyEAABX (pod1)
✓ 10 callers connected (pod2)

--- Parallel cross-replica RPC (50 calls) ---
  Success: 50/50  Failed: 0/50  Elapsed: 274ms

--- Sequential cross-replica RPC (20 calls) ---
  Success: 20/20  Failed: 0/20  Elapsed: 11325ms

========================================
              VERDICT
========================================
Parallel RPC:    50/50 ✅
Sequential RPC:  20/20 ✅
Cross-replica:   ✅ (daemon=pod1, callers=pod2)

✅ ALL PASSED — PR #1075 fix is effective
```

**Test script**: `deploy/integration-tests/test-cross-replica-forced.mjs` (daemon on pod1, callers on pod2 via kubectl port-forward)

**Note on 2s timeout value**: The 2s was chosen based on the Redis streams adapter round-trip (XADD → peer XREAD → XADD response → local XREAD). The POSTMORTEM in `deploy/integration-tests/POSTMORTEM.md` documents measured latencies; 2s provides ~4× headroom over the p99 observed round-trip (~450ms under load). Happy to adjust or make it configurable via env var if preferred.

Fixes #1074

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)