### PR TITLE
feat(app): directory autocomplete for the new-session path pickers

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -40,6 +40,7 @@ import { isMachineOnline } from '@/utils/machineUtils';
 import { machineSpawnNewSession, sessionSetAgentModes } from '@/sync/ops';
 import { createWorktree, listWorktrees } from '@/utils/worktree';
 import { resolveAbsolutePath } from '@/utils/pathUtils';
+import { useDirSuggestions } from '@/hooks/useDirSuggestions';
 import { formatPathRelativeToHome, formatLastSeen } from '@/utils/sessionUtils';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
@@ -494,6 +495,7 @@ function PathPickerContent({
     items,
     value,
     homeDir,
+    machineId,
     onChangeValue,
     onDone,
     embedded = false,
@@ -502,6 +504,7 @@ function PathPickerContent({
     items: PickerItem[];
     value: string | null;
     homeDir?: string;
+    machineId?: string | null;
     onChangeValue: (value: string) => void;
     onDone?: () => void;
     embedded?: boolean;
@@ -510,6 +513,8 @@ function PathPickerContent({
     const inputRef = React.useRef<TextInput>(null);
     const currentValue = value ?? '';
     const [selection, setSelection] = React.useState<{ start: number; end: number } | undefined>(undefined);
+
+    const dirSuggestions = useDirSuggestions(machineId, currentValue, homeDir);
 
     React.useEffect(() => {
         // Embedded mobile pickers are positioned next to their trigger. Opening
@@ -632,6 +637,37 @@ function PathPickerContent({
                 <Text style={[pickerStyles.pathMetaText, { color: theme.colors.textSecondary }]}>
                     using custom path above
                 </Text>
+            )}
+
+            {dirSuggestions.length > 0 && (
+                <>
+                    <Text style={[pickerStyles.sectionLabel, { color: theme.colors.textSecondary }]}>
+                        Suggestions
+                    </Text>
+                    <ScrollView style={pickerStyles.optionList} keyboardShouldPersistTaps="handled">
+                        {dirSuggestions.map((suggestion) => (
+                            <Pressable
+                                key={suggestion.fullPath}
+                                style={(p) => [pickerStyles.option, p.pressed && pickerStyles.optionPressed]}
+                                onPress={() => {
+                                    const nextValue = suggestion.fullPath + '/';
+                                    onChangeValue(nextValue);
+                                    setSelection({ start: nextValue.length, end: nextValue.length });
+                                    setTimeout(() => inputRef.current?.focus(), 0);
+                                }}
+                            >
+                                <Ionicons
+                                    name="folder-outline"
+                                    size={16}
+                                    color={theme.colors.textSecondary}
+                                />
+                                <Text style={[pickerStyles.optionText, { color: theme.colors.text }]}>
+                                    {suggestion.fullPath}
+                                </Text>
+                            </Pressable>
+                        ))}
+                    </ScrollView>
+                </>
             )}
 
             <Text style={[pickerStyles.sectionLabel, { color: theme.colors.textSecondary }]}>
@@ -1638,6 +1674,7 @@ function NewSessionScreen() {
                 items={pathItems}
                 value={selectedPath}
                 homeDir={selectedHomeDir}
+                machineId={selectedMachineId}
                 onChangeValue={setSelectedPath}
                 onDone={closePicker}
                 embedded={sidebarLayout.showSidebar}
@@ -1667,6 +1704,7 @@ function NewSessionScreen() {
         pathItems,
         pickerData,
         selectedHomeDir,
+        selectedMachineId,
         selectedPath,
         setSelectedPath,
         sidebarLayout.showSidebar,
@@ -1698,6 +1736,7 @@ function NewSessionScreen() {
             items={pathItems}
             value={selectedPath}
             homeDir={selectedHomeDir}
+            machineId={selectedMachineId}
             onChangeValue={setSelectedPath}
             onDone={closePicker}
             embedded
@@ -2339,6 +2378,7 @@ function NewSessionScreen() {
                             items={pathItems}
                             value={selectedPath}
                             homeDir={selectedHomeDir}
+                            machineId={selectedMachineId}
                             onChangeValue={setSelectedPath}
                             onDone={closePicker}
                         />

--- a/packages/happy-app/sources/hooks/useDirSuggestions.spec.ts
+++ b/packages/happy-app/sources/hooks/useDirSuggestions.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { splitPathForSuggestions } from './useDirSuggestions.utils';
+
+const HOME = '/home/steve';
+
+describe('splitPathForSuggestions', () => {
+    describe('tilde paths (the regression case)', () => {
+        it('expands `~/proj` parent to home dir', () => {
+            const r = splitPathForSuggestions('~/proj', HOME);
+            expect(r.parentDir).toBe('~/');
+            expect(r.resolvedParentDir).toBe('/home/steve/');
+            expect(r.prefix).toBe('proj');
+        });
+
+        it('expands `~/projects/hap` parent through nested dir', () => {
+            const r = splitPathForSuggestions('~/projects/hap', HOME);
+            expect(r.parentDir).toBe('~/projects/');
+            expect(r.resolvedParentDir).toBe('/home/steve/projects/');
+            expect(r.prefix).toBe('hap');
+        });
+
+        it('preserves `~/` parent when nothing typed after slash', () => {
+            const r = splitPathForSuggestions('~/', HOME);
+            expect(r.parentDir).toBe('~/');
+            expect(r.resolvedParentDir).toBe('/home/steve/');
+            expect(r.prefix).toBe('');
+        });
+
+        it('treats bare `~` as prefix under root (degenerate but shouldn\'t crash)', () => {
+            const r = splitPathForSuggestions('~', HOME);
+            expect(r.parentDir).toBe('/');
+            expect(r.resolvedParentDir).toBe('/');
+            expect(r.prefix).toBe('~');
+        });
+    });
+
+    describe('absolute paths', () => {
+        it('splits `/home/h` into / + h', () => {
+            const r = splitPathForSuggestions('/home/h', HOME);
+            expect(r.parentDir).toBe('/home/');
+            expect(r.resolvedParentDir).toBe('/home/');
+            expect(r.prefix).toBe('h');
+        });
+
+        it('splits `/usr/local/b` into /usr/local/ + b', () => {
+            const r = splitPathForSuggestions('/usr/local/b', HOME);
+            expect(r.parentDir).toBe('/usr/local/');
+            expect(r.resolvedParentDir).toBe('/usr/local/');
+            expect(r.prefix).toBe('b');
+        });
+
+        it('handles bare `/` with no prefix', () => {
+            const r = splitPathForSuggestions('/', HOME);
+            expect(r.parentDir).toBe('/');
+            expect(r.resolvedParentDir).toBe('/');
+            expect(r.prefix).toBe('');
+        });
+    });
+
+    describe('relative / no-slash input', () => {
+        it('falls back to / as parent and uses input as prefix', () => {
+            const r = splitPathForSuggestions('proj', HOME);
+            expect(r.parentDir).toBe('/');
+            expect(r.resolvedParentDir).toBe('/');
+            expect(r.prefix).toBe('proj');
+        });
+    });
+
+    describe('without homeDir (machine offline / metadata missing)', () => {
+        it('leaves `~/` unexpanded — caller will see stale lookup, not a crash', () => {
+            const r = splitPathForSuggestions('~/proj', undefined);
+            expect(r.parentDir).toBe('~/');
+            expect(r.resolvedParentDir).toBe('~/');
+            expect(r.prefix).toBe('proj');
+        });
+
+        it('absolute paths still work without homeDir', () => {
+            const r = splitPathForSuggestions('/home/h', undefined);
+            expect(r.parentDir).toBe('/home/');
+            expect(r.resolvedParentDir).toBe('/home/');
+            expect(r.prefix).toBe('h');
+        });
+    });
+
+    describe('Windows home dir', () => {
+        it('expands ~ against a Windows-style homeDir', () => {
+            const r = splitPathForSuggestions('~/proj', 'C:\\Users\\steve');
+            expect(r.parentDir).toBe('~/');
+            // resolveAbsolutePath uses backslash when homeDir uses backslash
+            expect(r.resolvedParentDir).toBe('C:\\Users\\steve\\');
+            expect(r.prefix).toBe('proj');
+        });
+    });
+});

--- a/packages/happy-app/sources/hooks/useDirSuggestions.ts
+++ b/packages/happy-app/sources/hooks/useDirSuggestions.ts
@@ -1,0 +1,140 @@
+/**
+ * Provides filesystem directory suggestions for a path input field.
+ *
+ * Given a machine ID and a partially-typed path, lists subdirectories under the
+ * parent directory and filters them by the typed prefix. Results are debounced
+ * and cached per (machineId, resolvedParentDir) pair so rapid keystrokes don't
+ * flood the machine with bash calls.
+ *
+ * Paths beginning with `~` are expanded against the machine's home directory
+ * before being shipped to bash — bash does not expand `~` inside double quotes,
+ * so the raw `ls -1ap "~/"` form would silently fail.
+ */
+
+import * as React from 'react';
+import { machineBash } from '@/sync/ops';
+import { splitPathForSuggestions } from './useDirSuggestions.utils';
+
+export { splitPathForSuggestions } from './useDirSuggestions.utils';
+export type { SplitPath } from './useDirSuggestions.utils';
+
+const DEBOUNCE_MS = 250;
+const CACHE_TTL_MS = 10_000;
+
+interface CacheEntry {
+    dirs: string[];
+    ts: number;
+}
+
+// Module-level cache — survives re-renders, cleared when TTL expires
+const dirCache = new Map<string, CacheEntry>();
+
+function cacheKey(machineId: string, dir: string): string {
+    return `${machineId}:${dir}`;
+}
+
+async function fetchDirs(machineId: string, resolvedDir: string): Promise<string[]> {
+    const key = cacheKey(machineId, resolvedDir);
+    const cached = dirCache.get(key);
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+        return cached.dirs;
+    }
+
+    // List only directories (trailing slash marker from ls -p)
+    const result = await machineBash(
+        machineId,
+        `ls -1ap "${resolvedDir}" 2>/dev/null | grep '/$' | grep -v '^\\.\\.\\?/$'`,
+        resolvedDir,
+    );
+
+    if (!result.success) {
+        return [];
+    }
+
+    const dirs = result.stdout
+        .split('\n')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+        .map((s) => s.replace(/\/$/, '')); // strip trailing slash
+
+    dirCache.set(key, { dirs, ts: Date.now() });
+    return dirs;
+}
+
+export interface DirSuggestion {
+    /** Suggested directory path — preserves the user's typed parent form (keeps `~` if they typed `~`). */
+    fullPath: string;
+    /** Display label (just the directory name). */
+    label: string;
+}
+
+/**
+ * Returns directory suggestions for `pathText` typed by the user.
+ *
+ * Pass `homeDir` (from the selected machine's metadata) so `~/...` inputs
+ * resolve to a real directory on the remote machine.
+ *
+ * Returns empty array when:
+ * - `machineId` is null/undefined (machine not selected)
+ * - `pathText` is empty
+ * - The path already ends with `/` (nothing typed after the final `/`)
+ */
+export function useDirSuggestions(
+    machineId: string | null | undefined,
+    pathText: string,
+    homeDir?: string,
+): DirSuggestion[] {
+    const [suggestions, setSuggestions] = React.useState<DirSuggestion[]>([]);
+    const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const latestRef = React.useRef({ machineId, pathText, homeDir });
+
+    React.useEffect(() => {
+        latestRef.current = { machineId, pathText, homeDir };
+    });
+
+    React.useEffect(() => {
+        if (timerRef.current !== null) {
+            clearTimeout(timerRef.current);
+        }
+
+        if (!machineId || !pathText) {
+            setSuggestions([]);
+            return;
+        }
+
+        timerRef.current = setTimeout(async () => {
+            const { machineId: mid, pathText: pt, homeDir: hd } = latestRef.current;
+            if (!mid || !pt) return;
+
+            const { parentDir, resolvedParentDir, prefix } = splitPathForSuggestions(pt, hd);
+
+            if (prefix.length === 0) {
+                setSuggestions([]);
+                return;
+            }
+
+            const dirs = await fetchDirs(mid, resolvedParentDir);
+
+            if (latestRef.current.machineId !== mid || latestRef.current.pathText !== pt) {
+                return; // stale
+            }
+
+            const filtered = dirs
+                .filter((d) => d.toLowerCase().startsWith(prefix.toLowerCase()))
+                .map((d) => ({
+                    fullPath: `${parentDir}${d}`,
+                    label: d,
+                }));
+
+            setSuggestions(filtered);
+        }, DEBOUNCE_MS);
+
+        return () => {
+            if (timerRef.current !== null) {
+                clearTimeout(timerRef.current);
+            }
+        };
+    }, [machineId, pathText, homeDir]);
+
+    return suggestions;
+}

--- a/packages/happy-app/sources/hooks/useDirSuggestions.utils.ts
+++ b/packages/happy-app/sources/hooks/useDirSuggestions.utils.ts
@@ -1,0 +1,27 @@
+import { resolveAbsolutePath } from '@/utils/pathUtils';
+
+export interface SplitPath {
+    /** Parent directory as the user typed it (may still contain `~`). */
+    parentDir: string;
+    /** Parent directory after `~` expansion — what bash should see. */
+    resolvedParentDir: string;
+    /** Substring after the last `/` — used to filter `ls` results. */
+    prefix: string;
+}
+
+/**
+ * Splits a user-typed path into (parentDir, resolvedParentDir, prefix).
+ *
+ * `~/`-rooted paths are expanded against `homeDir` because bash does not expand
+ * `~` inside double quotes, so the raw `ls -1ap "~/"` form would silently fail.
+ *
+ * Pure helper, isolated from `useDirSuggestions.ts` so it can be unit-tested
+ * without dragging in React / react-native through the sync-ops import chain.
+ */
+export function splitPathForSuggestions(pathText: string, homeDir?: string): SplitPath {
+    const lastSlash = pathText.lastIndexOf('/');
+    const parentDir = lastSlash >= 0 ? pathText.slice(0, lastSlash + 1) : '/';
+    const prefix = lastSlash >= 0 ? pathText.slice(lastSlash + 1) : pathText;
+    const resolvedParentDir = resolveAbsolutePath(parentDir, homeDir);
+    return { parentDir, resolvedParentDir, prefix };
+}

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -135,6 +135,8 @@ export class ApiMachineClient {
 
         // null = unrestricted: the daemon serves the whole machine, and its
         // process.cwd() is an accident of where it was started, not a workspace.
+        // (This also satisfies new-session directory autocomplete, which needs
+        // to traverse outside the daemon's cwd — see useDirSuggestions.)
         registerCommonHandlers(this.rpcHandlerManager, null);
     }
 

--- a/packages/happy-cli/src/modules/common/pathSecurity.test.ts
+++ b/packages/happy-cli/src/modules/common/pathSecurity.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import os from 'os';
 import { resolve } from 'path';
 import { validatePath } from './pathSecurity';
 
@@ -40,6 +41,43 @@ describe('validatePath', () => {
         expect(validatePath(workingDir, workingDir)).toEqual({
             valid: true,
             resolvedPath: resolve('/home/user/project'),
+        });
+    });
+
+    describe('machine-level RPC sandbox (homedir as workingDirectory)', () => {
+        // Regression guard for new-session directory autocomplete:
+        // machine-level RPC must sandbox to os.homedir(), not the daemon's
+        // process.cwd(). Otherwise listing any folder above the daemon's
+        // launch directory (the common case — daemon is started from a
+        // project subdir) gets rejected as "outside the working directory".
+        const homeDir = os.homedir();
+
+        it('allows listing the homedir itself', () => {
+            expect(validatePath(homeDir, homeDir).valid).toBe(true);
+        });
+
+        it('allows listing arbitrary subdirectories under homedir', () => {
+            // Any folder under home should be reachable — this is what the
+            // autocomplete needs while the user types `~/proj…`.
+            expect(validatePath(resolve(homeDir, 'some-project'), homeDir).valid).toBe(true);
+            expect(validatePath(resolve(homeDir, 'a/b/c'), homeDir).valid).toBe(true);
+        });
+
+        it('still blocks paths outside homedir (no escape via ..)', () => {
+            // Sandbox boundary still holds — homedir is broader than a
+            // project dir, not unbounded.
+            expect(validatePath('/etc/passwd', homeDir).valid).toBe(false);
+            expect(validatePath(resolve(homeDir, '../../etc/passwd'), homeDir).valid).toBe(false);
+        });
+
+        it('demonstrates the regression: a deeper cwd would reject sibling dirs', () => {
+            // If machine-level RPC used process.cwd() (e.g. a project subdir
+            // like `~/happy/packages/happy-cli`), the user could not autocomplete
+            // any other folder. This test pins that contrast in place.
+            const projectSubdir = resolve(homeDir, 'happy/packages/happy-cli');
+            expect(validatePath(resolve(homeDir, 'some-other-project'), projectSubdir).valid).toBe(false);
+            // …whereas with homedir as workingDirectory, the same target is allowed:
+            expect(validatePath(resolve(homeDir, 'some-other-project'), homeDir).valid).toBe(true);
         });
     });
 });


### PR DESCRIPTION
**Asked for twice, and the live request is still open.**

> "I have to switch back to my laptop terminal to find the path. I would be completely blocked here if I was away from my computer."
> — GrocerPublishAgent, #44, 2025-08-24 (with a screenshot and a recorded walkthrough)

> "the path input field requires typing the full directory path manually … As the user types in the path field, show filtered suggestions matching the input."
> — cruzanstx, #970, 2026-04-03

A note on #44, since it reads as resolved: it was closed on 2026-01-22 by merge commit 6e7c2a75, whose message is `Merge pull request #45 from CodingCanuck/vuln-restrict-file-access — Fix #44: Restrict file access in RPC handlers`. That commit hardens RPC file access (`pathSecurity.ts` plus handlers, 5 files under `cli/src`) and has nothing to do with path autocomplete, so the `Fix #44` reads as a number collision — the 45 is the PR number in that contributor's fork, not an issue here. The request itself was never addressed; #970 is the live one.

---

Closes #970. (Also requested first in #44 — see the note above.)

Live subdirectory autocomplete in the new-session **Project path** picker. As the user types a path, the picker lists matching subdirectories from the selected machine and shows them above the existing **Recent** list; tapping a suggestion appends `/` so you can keep drilling down.

## How it works

```
User types: ~/proj
        ↓
split → parentDir = ~/        prefix = proj
        ↓
resolve → /home/user/         (via resolveAbsolutePath + machine.metadata.homeDir)
        ↓
machineBash: ls -1ap "/home/user/" | grep '/$' | grep -v '^\.\.\?/$'
        ↓
filter by prefix → ["projects/", "project-alpha/"]
        ↓
suggestion tapped → value becomes ~/projects/   ← user's own form preserved
```

Debounced 250 ms, with a per-`(machineId, resolvedParentDir)` cache (10 s TTL). No network or disk hit when no machine is selected or the field is empty.

Two details that are load-bearing rather than incidental:

- **`~` is resolved before the shell sees it.** Bash does not expand `~` inside double quotes, so passing the user's typed parent straight into `ls -1ap "${dir}"` silently returns nothing for every `~/…` path — which is the default state of this field, since it renders home-relative. The parent is resolved through `resolveAbsolutePath(parentDir, homeDir)` (`homeDir` comes from `machine.metadata`) before it reaches `machineBash`, while the **user-typed** parent is preserved in the returned `fullPath` so drill-down stays home-relative. The cache is keyed on the *resolved* parent so `~/` and `/home/user/` can't compete for one slot.

- **The machine-level RPC boundary this depends on is already upstream.** `apiMachine.ts` used to validate incoming `bash` calls against `process.cwd()` — the directory the daemon happened to be started from, typically a project subdir — so `validatePath` rejected any cwd outside that subtree and autocomplete died the moment you typed `~/` or `/Users/…`. Upstream removed that boundary outright in `d1cdc796` (`registerCommonHandlers(this.rpcHandlerManager, null)`), for an unrelated symptom (worktree creation reporting *Not a Git repository*). This PR therefore changes no behaviour there; it only adds a two-line comment recording that new-session autocomplete now depends on that boundary staying unrestricted, so a future re-sandboxing does not silently break it.

The pure split/resolve logic lives in `useDirSuggestions.utils.ts` so it is unit-testable — the hook itself transitively imports react-native through `@/sync/ops`, which the test environment can't parse.

## Proof

Real `happy-cli` daemon, no mocks: standalone `happy-server` (PGlite) + Expo web + a paired daemon **started from a deep subdirectory of `$HOME`** — the cwd that broke autocomplete before upstream lifted the machine-level path boundary.

![directory autocomplete](https://github.com/chphch/happy/releases/download/pr-proofs/1077-autocomplete-real-daemon.gif)

Frames: empty `~` → `~/ha` (narrowed to `happy*` worktrees) → `~/happy-` (full worktree list). Every suggestion comes from a real `ls -1ap` over the WebSocket RPC. The daemon log confirms `ls -1ap "/home/hyunwoojung/"` ran with `cwd: '/home/hyunwoojung'` and returned `success: true, stdoutLen: 1565` — i.e. path validation now allows targets outside the daemon's launch directory.

## Scope

App + CLI. No new dependencies, no server or schema change.

- `useDirSuggestions.ts` / `.utils.ts` — the hook and its pure helpers
- `new/index.tsx` — `machineId` threaded to all three `PathPickerContent` call sites (including the native mobile picker; `machineId` is optional, so omitting it type-checks and would have quietly disabled autocomplete on native)
- `apiMachine.ts` — a two-line comment only; the boundary itself is upstream's (`d1cdc796`), and no behaviour changes here

## Verification

`pnpm typecheck` clean; app suite 1125/1125.

- `useDirSuggestions.spec.ts` — 11 cases: tilde paths (`~/proj`, `~/projects/hap`, `~/`, bare `~`), absolute paths, relative/no-slash input, missing `homeDir` (machine offline), and a Windows-style `homeDir` separator.