### PR TITLE
fix(gemini): implement write-operation check in safe-yolo mode

### DIFF
--- a/packages/happy-cli/src/gemini/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/gemini/utils/permissionHandler.ts
@@ -73,10 +73,12 @@ export class GeminiPermissionHandler extends BasePermissionHandler {
             case 'yolo':
                 // Auto-approve everything in yolo mode
                 return true;
-            case 'safe-yolo':
+            case 'safe-yolo': {
                 // Auto-approve read-only operations, ask for write operations
-                // For now, we'll auto-approve everything (can be enhanced later)
-                return true;
+                const safeYoloWriteTools = ['write', 'edit', 'create', 'delete', 'patch', 'fs-edit'];
+                const isSafeYoloWriteTool = safeYoloWriteTools.some(wt => toolName.toLowerCase().includes(wt));
+                return !isSafeYoloWriteTool;
+            }
             case 'read-only':
                 // Deny all write operations - only allow read operations
                 // Check if tool is a write operation (can be enhanced with tool metadata)


### PR DESCRIPTION
## Summary

Implements the documented behavior for `safe-yolo` permission mode in the Gemini handler. Previously, `safe-yolo` auto-approved **all** operations (identical to `yolo`), despite being documented as "auto-approve read-only operations, ask for write operations."

## Problem

In `packages/happy-cli/src/gemini/utils/permissionHandler.ts:76-79`:

```typescript
case 'safe-yolo':
    // Auto-approve read-only operations, ask for write operations
    // For now, we'll auto-approve everything (can be enhanced later)
    return true;
```

The comment described read-only auto-approve with write prompts, but the implementation returned `true` unconditionally — making `safe-yolo` functionally identical to `yolo`. Users selecting this mode expected write-operation protection but got none.

## Solution

Reuse the same `writeTools` pattern already proven in the `read-only` mode (lines 80-85) to check whether a tool performs write operations:

```typescript
case 'safe-yolo': {
    const safeYoloWriteTools = ['write', 'edit', 'create', 'delete', 'patch', 'fs-edit'];
    const isSafeYoloWriteTool = safeYoloWriteTools.some(wt => toolName.toLowerCase().includes(wt));
    return !isSafeYoloWriteTool;
}
```

Read-only tools are auto-approved; write tools require explicit user permission.

## Test plan

- [ ] `happy gemini --permission-mode safe-yolo` → read operations (list files, search) auto-approved
- [ ] Write operations (create file, edit, delete) prompt for permission
- [ ] `yolo` mode still auto-approves everything (unchanged)
- [ ] `read-only` mode still denies writes (unchanged — same pattern, no regression)

Fixes #1084