### PR TITLE
fix(codex,gemini): use exact match for auto-approve tool names

### DIFF
--- a/packages/happy-cli/src/codex/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/codex/utils/permissionHandler.ts
@@ -38,11 +38,11 @@ export class CodexPermissionHandler extends BasePermissionHandler {
     }
 
     private shouldAutoApprove(toolName: string, toolCallId: string): boolean {
-        if (CodexPermissionHandler.ALWAYS_AUTO_APPROVE_NAMES.some((name) => toolName.toLowerCase().includes(name.toLowerCase()))) {
+        if (CodexPermissionHandler.ALWAYS_AUTO_APPROVE_NAMES.some((name) => toolName.toLowerCase() === name.toLowerCase())) {
             return true;
         }
 
-        if (CodexPermissionHandler.ALWAYS_AUTO_APPROVE_IDS.some((id) => toolCallId.toLowerCase().includes(id.toLowerCase()))) {
+        if (CodexPermissionHandler.ALWAYS_AUTO_APPROVE_IDS.some((id) => toolCallId.toLowerCase() === id.toLowerCase())) {
             return true;
         }
 

--- a/packages/happy-cli/src/gemini/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/gemini/utils/permissionHandler.ts
@@ -59,13 +59,13 @@ export class GeminiPermissionHandler extends BasePermissionHandler {
         const alwaysAutoApproveNames = ['change_title', 'happy__change_title', 'GeminiReasoning', 'CodexReasoning', 'think', 'save_memory'];
         const alwaysAutoApproveIds = ['change_title', 'save_memory'];
         
-        // Check by tool name
-        if (alwaysAutoApproveNames.some(name => toolName.toLowerCase().includes(name.toLowerCase()))) {
+        // Check by tool name (exact match to prevent substring bypass)
+        if (alwaysAutoApproveNames.some(name => toolName.toLowerCase() === name.toLowerCase())) {
             return true;
         }
-        
-        // Check by toolCallId (Gemini CLI may send change_title as "other" but toolCallId contains "change_title")
-        if (alwaysAutoApproveIds.some(id => toolCallId.toLowerCase().includes(id.toLowerCase()))) {
+
+        // Check by toolCallId (exact match)
+        if (alwaysAutoApproveIds.some(id => toolCallId.toLowerCase() === id.toLowerCase())) {
             return true;
         }
         


### PR DESCRIPTION
## Summary

Replaces `.includes()` substring matching with exact `===` comparison in both Codex and Gemini auto-approve permission handlers.

## Problem

Both handlers use `.includes()` to check if a tool name should be auto-approved:

```typescript
// Codex (permissionHandler.ts:41)
toolName.toLowerCase().includes(name.toLowerCase())

// Gemini (permissionHandler.ts:63)
alwaysAutoApproveNames.some(name => toolName.toLowerCase().includes(name.toLowerCase()))
```

This means any tool whose name **contains** an auto-approved substring would bypass approval. For example, a hypothetical MCP tool named `change_title_and_run_command` would match `change_title` and be auto-approved.

The same issue applies to `toolCallId` matching.

## Solution

Switch to exact match (`===`) instead of substring match (`.includes()`):

```typescript
// Before
toolName.toLowerCase().includes(name.toLowerCase())

// After
toolName.toLowerCase() === name.toLowerCase()
```

Applied to both Codex and Gemini handlers for consistency.

## Why this is safe

The current auto-approve lists contain full tool names (`change_title`, `happy__change_title`, `GeminiReasoning`, `think`, `save_memory`). These are the exact names used by the MCP tools — no partial matching is needed. PR #935 introduced the auto-approve list to fix the `change_title` deadlock, and the tool is always called with the exact name `change_title`.

## Test plan

- [ ] `happy codex` → `change_title` tool still auto-approved (exact match hits)
- [ ] `happy gemini` → `change_title`, `think`, `save_memory` still auto-approved
- [ ] A tool with a name *containing* `change_title` as substring would now require approval

Fixes #1085