### PR TITLE
fix(docker): run containers as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ WORKDIR /repo
 
 RUN apt-get update && apt-get install -y ffmpeg curl && rm -rf /var/lib/apt/lists/*
 
+RUN addgroup --system --gid 1001 appgroup && \
+    adduser --system --uid 1001 --ingroup appgroup appuser
+
 ENV NODE_ENV=production
 ENV DATA_DIR=/data
 ENV PGLITE_DIR=/data/pglite
@@ -53,7 +56,9 @@ COPY --from=builder /repo/node_modules /repo/node_modules
 COPY --from=builder /repo/packages/happy-wire /repo/packages/happy-wire
 COPY --from=builder /repo/packages/happy-server /repo/packages/happy-server
 
+RUN mkdir -p /data && chown -R appuser:appgroup /data /repo
 VOLUME /data
 EXPOSE 3005
 
+USER appuser
 CMD ["sh", "-c", "node_modules/.bin/tsx packages/happy-server/sources/standalone.ts migrate && exec node_modules/.bin/tsx packages/happy-server/sources/standalone.ts serve"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -44,6 +44,9 @@ WORKDIR /repo
 RUN apt-get update && apt-get install -y python3 ffmpeg && rm -rf /var/lib/apt/lists/*
 RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
 
+RUN addgroup --system --gid 1001 appgroup && \
+    adduser --system --uid 1001 --ingroup appgroup appuser
+
 # Set environment to production
 ENV NODE_ENV=production
 
@@ -52,9 +55,12 @@ COPY --from=builder /repo/node_modules /repo/node_modules
 COPY --from=builder /repo/packages/happy-wire /repo/packages/happy-wire
 COPY --from=builder /repo/packages/happy-server /repo/packages/happy-server
 
+RUN chown -R appuser:appgroup /repo
+
 # Expose the port the app will run on
 EXPOSE 3000
 
 # Command to run the application
 COPY --from=builder /repo/package.json /repo/pnpm-workspace.yaml /repo/
+USER appuser
 CMD ["pnpm", "--filter", "happy-server", "start"]


### PR DESCRIPTION
## Summary

Adds a non-root user (`appuser`, UID 1001) to both `Dockerfile` and `Dockerfile.server` so the application process no longer runs as root inside the container.

## Problem

Neither Dockerfile includes a `USER` directive. The application runs as UID 0 (root), which means:

- A container escape via a dependency vulnerability grants root privileges on the host
- The process can modify any file in the container filesystem, including runtime binaries
- This violates container security best practices from Docker, Kubernetes, and OWASP

## Changes

| File | Change |
|------|--------|
| `Dockerfile` | Add `appgroup`/`appuser` creation, `chown /data /repo`, `USER appuser` before CMD |
| `Dockerfile.server` | Add `appgroup`/`appuser` creation, `chown /repo`, `USER appuser` before CMD |

Both use the same UID/GID (1001) for consistency across deployment targets.

## Why UID 1001

- Avoids collision with system users (typically UID < 1000)
- Matches the convention used by official Node.js Docker images and Vercel/Next.js examples
- Works with Kubernetes `runAsNonRoot: true` security context

## Test plan

- [ ] `docker build -f Dockerfile -t happy-standalone .` succeeds
- [ ] `docker run happy-standalone` starts the server (migrations + serve)
- [ ] `docker exec <container> whoami` returns `appuser`, not `root`
- [ ] `/data` volume is writable by the application (PGLite data persistence)
- [ ] Same checks for `Dockerfile.server`

Fixes #1090