### PR TITLE
fix(codex): validate permissionMode from remote messages against allowlist

### DIFF
--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -156,12 +156,18 @@ export async function runCodex(opts: {
     let currentModel: string | undefined = undefined;
 
     session.onUserMessage((message) => {
-        // Resolve permission mode (accept all modes, will be mapped in switch statement)
+        // Resolve permission mode (validate against allowlist to prevent remote escalation)
+        const VALID_REMOTE_MODES: import('@/api/types').PermissionMode[] = ['default', 'acceptEdits', 'plan', 'read-only', 'safe-yolo'];
         let messagePermissionMode = currentPermissionMode;
         if (message.meta?.permissionMode) {
-            messagePermissionMode = message.meta.permissionMode as import('@/api/types').PermissionMode;
-            currentPermissionMode = messagePermissionMode;
-            logger.debug(`[Codex] Permission mode updated from user message to: ${currentPermissionMode}`);
+            const requested = message.meta.permissionMode as import('@/api/types').PermissionMode;
+            if (VALID_REMOTE_MODES.includes(requested)) {
+                messagePermissionMode = requested;
+                currentPermissionMode = messagePermissionMode;
+                logger.debug(`[Codex] Permission mode updated from user message to: ${currentPermissionMode}`);
+            } else {
+                logger.debug(`[Codex] Rejected remote permission mode: ${message.meta.permissionMode} (not in allowlist)`);
+            }
         } else {
             logger.debug(`[Codex] User message received with no permission mode override, using current: ${currentPermissionMode ?? 'default (effective)'}`);
         }


### PR DESCRIPTION
## Summary

Adds runtime validation for `permissionMode` received from remote mobile app messages in the Codex handler. Previously, any mode (including `yolo` and `bypassPermissions`) was accepted via a raw TypeScript `as` cast with no runtime check.

## Problem

In `packages/happy-cli/src/codex/runCodex.ts:161-163`:

```typescript
if (message.meta?.permissionMode) {
    messagePermissionMode = message.meta.permissionMode as import('@/api/types').PermissionMode;
    currentPermissionMode = messagePermissionMode;
```

The `as PermissionMode` is a TypeScript-only assertion — it has zero runtime effect. Any string from the remote message is accepted, including `yolo` (which maps to `sandbox: 'danger-full-access'` + `approvalPolicy: 'on-failure'` in `executionPolicy.ts`).

For comparison, the Gemini path (`runGemini.ts:215-218`) already validates against an explicit allowlist before accepting the mode.

## Solution

Add an allowlist of modes that are safe to accept from remote messages:

```typescript
const VALID_REMOTE_MODES = ['default', 'acceptEdits', 'plan', 'read-only', 'safe-yolo'];

if (message.meta?.permissionMode) {
    const requested = message.meta.permissionMode as PermissionMode;
    if (VALID_REMOTE_MODES.includes(requested)) {
        messagePermissionMode = requested;
        currentPermissionMode = messagePermissionMode;
    } else {
        logger.debug(`[Codex] Rejected remote permission mode: ${message.meta.permissionMode}`);
    }
}
```

`yolo` and `bypassPermissions` are excluded — these should only be set at CLI startup via `--yolo` flag, not from a remote message.

## Why this matters

While all RPC messages are E2E encrypted (TweetNaCl), defense in depth dictates that the most dangerous permission modes should not be remotely settable. This aligns with #728 which addresses the same issue for the Claude path.

## Test plan

- [ ] `happy codex` with mobile app selecting `default` mode → works as before
- [ ] Mobile app sending `permissionMode: 'yolo'` → silently rejected, stays on current mode
- [ ] `happy codex --yolo` from CLI → still works (set at startup, not via remote message)

Fixes #1092