### PR TITLE
fix: avoid stack overflow in encodeBase64 for large buffers

### DIFF
--- a/packages/happy-app/sources/encryption/base64.test.ts
+++ b/packages/happy-app/sources/encryption/base64.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { encodeBase64, decodeBase64 } from './base64';
+
+describe('encodeBase64 large buffers', () => {
+    it('encodes a 1MB buffer without stack overflow', () => {
+        const size = 1024 * 1024;
+        const input = new Uint8Array(size);
+        for (let i = 0; i < size; i++) input[i] = (i * 37) % 256;
+
+        const encoded = encodeBase64(input);
+        const decoded = decodeBase64(encoded);
+
+        expect(decoded.length).toBe(size);
+        expect(decoded[0]).toBe(input[0]);
+        expect(decoded[size - 1]).toBe(input[size - 1]);
+    });
+
+    it('encodes a 5MB buffer without stack overflow', () => {
+        const size = 5 * 1024 * 1024;
+        const input = new Uint8Array(size);
+        for (let i = 0; i < size; i++) input[i] = i & 0xff;
+
+        const encoded = encodeBase64(input);
+        const decoded = decodeBase64(encoded);
+
+        expect(decoded.length).toBe(size);
+        expect(decoded[size - 1]).toBe(input[size - 1]);
+    });
+
+    it('produces identical output to the small-buffer path at the chunk boundary', () => {
+        for (const size of [8191, 8192, 8193, 16383, 16384, 16385]) {
+            const input = new Uint8Array(size);
+            for (let i = 0; i < size; i++) input[i] = (i * 17 + 3) & 0xff;
+            const decoded = decodeBase64(encodeBase64(input));
+            expect(decoded).toEqual(input);
+        }
+    });
+});

--- a/packages/happy-app/sources/encryption/base64.ts
+++ b/packages/happy-app/sources/encryption/base64.ts
@@ -24,7 +24,14 @@ export function decodeBase64(base64: string, encoding: 'base64' | 'base64url' = 
 }
 
 export function encodeBase64(buffer: Uint8Array, encoding: 'base64' | 'base64url' = 'base64'): string {
-    const binaryString = String.fromCharCode.apply(null, Array.from(buffer));
+    // Process in chunks to avoid stack overflow with large buffers (e.g. images)
+    const chunks: string[] = [];
+    const chunkSize = 8192;
+    for (let i = 0; i < buffer.length; i += chunkSize) {
+        const chunk = buffer.subarray(i, Math.min(i + chunkSize, buffer.length));
+        chunks.push(String.fromCharCode.apply(null, Array.from(chunk)));
+    }
+    const binaryString = chunks.join('');
     const base64 = btoa(binaryString);
     
     if (encoding === 'base64url') {


### PR DESCRIPTION
## Summary

`encodeBase64` in `packages/happy-app/sources/encryption/base64.ts` (the web path — the native path via `base64.native.ts` uses `react-native-quick-base64` and is unaffected) calls `String.fromCharCode.apply(null, Array.from(buffer))`, which hits V8's argument limit once the buffer exceeds roughly half a megabyte.

### Reproducer (Node 20 / V8)

```js
const buf = new Uint8Array(500_000);
String.fromCharCode.apply(null, Array.from(buf));
// RangeError: Maximum call stack size exceeded
```

A typical JPEG screenshot is 1–3 MB, so any code path that base64-encodes an image on web currently throws. The fix processes the buffer in 8 KB chunks and joins the pieces.

## Changes

- `encodeBase64` now iterates the buffer in 8 KB windows and joins the resulting strings — output is byte-identical to the previous implementation for inputs below the old limit.
- New `base64.test.ts` with regression tests:
  - 1 MB and 5 MB round-trip
  - Boundary sizes 8191 / 8192 / 8193 / 16383 / 16384 / 16385 to cover the internal chunk edge

I verified the tests fail on `main` with `RangeError` on the 1 MB and 5 MB cases and pass on this branch (the boundary cases pass on both — they're just sanity).

## Test plan

- [x] `pnpm --filter happy-app exec vitest run sources/encryption/base64.test.ts` — 3/3 passing
- [x] Reverted `base64.ts` to `origin/main`; confirmed the 1 MB and 5 MB tests fail with `RangeError: Maximum call stack size exceeded`
- [x] 10 MB round-trip (ad-hoc) completes in ~110 ms with correct byte-for-byte result

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)