### PR TITLE
fix: propagate real error when machineBash fails in createWorktree

### DIFF
--- a/packages/happy-app/sources/utils/worktree.ts
+++ b/packages/happy-app/sources/utils/worktree.ts
@@ -55,7 +55,9 @@ export async function createWorktree(
             success: false,
             worktreePath: '',
             branchName: '',
-            error: 'Not a Git repository'
+            error: gitCheck.exitCode === -1
+                ? (gitCheck.stderr || 'Failed to reach machine')
+                : 'Not a Git repository'
         };
     }
 


### PR DESCRIPTION
## Summary
- `createWorktree` now differentiates RPC/communication failures (`exitCode === -1`) from genuine "not a git repo" errors, propagating the real error message instead of always reporting "Not a Git repository"

## Test plan
- [ ] From web client, attempt worktree creation on an offline machine → should show "Failed to reach machine" or RPC error, not "Not a Git repository"
- [ ] From web client, attempt worktree creation on a non-git directory → should still show "Not a Git repository"

Fixes #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)