### PR TITLE
fix: update session scanner path when Claude enters worktree

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -27,6 +27,12 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
     };
     session.addSessionFoundCallback(scannerSessionCallback);
 
+    // Register callback to update scanner when Claude changes cwd (e.g. worktree)
+    const scannerCwdCallback = (newCwd: string) => {
+        scanner.updateWorkingDirectory(newCwd);
+    };
+    session.addCwdChangeCallback(scannerCwdCallback);
+
 
     // Handle abort
     let exitReason: LauncherResult | null = null;
@@ -160,6 +166,7 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
         
         // Remove session found callback
         session.removeSessionFoundCallback(scannerSessionCallback);
+        session.removeCwdChangeCallback(scannerCwdCallback);
 
         // Cleanup
         await scanner.cleanup();

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -193,7 +193,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     const hookServer = await startHookServer({
         onSessionHook: (sessionId, data) => {
             logger.debug(`[START] Session hook received: ${sessionId}`, data);
-            
+
             // Update session ID in the Session instance
             if (currentSession) {
                 const previousSessionId = currentSession.sessionId;
@@ -201,6 +201,12 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
                     logger.debug(`[START] Claude session ID changed: ${previousSessionId} -> ${sessionId}`);
                     currentSession.onSessionFound(sessionId);
                 }
+            }
+
+            // Update working directory when Claude changes cwd (e.g. worktree)
+            if (data.cwd && data.cwd !== workingDirectory) {
+                logger.debug(`[START] Claude cwd changed: ${workingDirectory} -> ${data.cwd}`);
+                currentSession?.onCwdChange(data.cwd);
             }
         }
     });

--- a/packages/happy-cli/src/claude/session.ts
+++ b/packages/happy-cli/src/claude/session.ts
@@ -28,6 +28,9 @@ export class Session {
     
     /** Callbacks to be notified when session ID is found/changed */
     private sessionFoundCallbacks: ((sessionId: string) => void)[] = [];
+
+    /** Callbacks to be notified when Claude changes cwd (e.g. worktree) */
+    private cwdChangeCallbacks: ((newCwd: string) => void)[] = [];
     
     /** Keep alive interval reference for cleanup */
     private keepAliveInterval: NodeJS.Timeout;
@@ -78,6 +81,7 @@ export class Session {
     cleanup = (): void => {
         clearInterval(this.keepAliveInterval);
         this.sessionFoundCallbacks = [];
+        this.cwdChangeCallbacks = [];
         logger.debug('[Session] Cleaned up resources');
     }
 
@@ -133,6 +137,34 @@ export class Session {
         const index = this.sessionFoundCallbacks.indexOf(callback);
         if (index !== -1) {
             this.sessionFoundCallbacks.splice(index, 1);
+        }
+    }
+
+    /**
+     * Called when Claude's working directory changes (e.g. entering a worktree).
+     * Notifies all registered callbacks so the session scanner can update its path.
+     */
+    onCwdChange = (newCwd: string) => {
+        logger.debug(`[Session] Claude cwd changed to ${newCwd}`);
+        for (const callback of this.cwdChangeCallbacks) {
+            callback(newCwd);
+        }
+    }
+
+    /**
+     * Register a callback to be notified when Claude's cwd changes
+     */
+    addCwdChangeCallback = (callback: (newCwd: string) => void): void => {
+        this.cwdChangeCallbacks.push(callback);
+    }
+
+    /**
+     * Remove a cwd change callback
+     */
+    removeCwdChangeCallback = (callback: (newCwd: string) => void): void => {
+        const index = this.cwdChangeCallbacks.indexOf(callback);
+        if (index !== -1) {
+            this.cwdChangeCallbacks.splice(index, 1);
         }
     }
 

--- a/packages/happy-cli/src/claude/utils/sessionScanner.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.ts
@@ -23,8 +23,8 @@ export async function createSessionScanner(opts: {
     onMessage: (message: RawJSONLines) => void
 }) {
 
-    // Resolve project directory
-    const projectDir = getProjectPath(opts.workingDirectory);
+    // Resolve project directory (mutable — updated when worktree changes cwd)
+    let projectDir = getProjectPath(opts.workingDirectory);
 
     // Finished, pending finishing and current session
     let finishedSessions = new Set<string>();
@@ -117,6 +117,19 @@ export async function createSessionScanner(opts: {
             watchers.clear();
             await sync.invalidateAndAwait();
             sync.stop();
+        },
+        /**
+         * Update the working directory when Claude changes cwd (e.g. worktree).
+         * Stops old watchers pointing to the wrong directory and re-syncs.
+         */
+        updateWorkingDirectory: (newCwd: string) => {
+            const newProjectDir = getProjectPath(newCwd);
+            if (newProjectDir === projectDir) return;
+            logger.debug(`[SESSION_SCANNER] Working directory changed, updating projectDir: ${projectDir} -> ${newProjectDir}`);
+            for (const w of watchers.values()) w();
+            watchers.clear();
+            projectDir = newProjectDir;
+            sync.invalidate();
         },
         onNewSession: (sessionId: string) => {
             if (currentSessionId === sessionId) {


### PR DESCRIPTION
## Summary
- Session scanner now updates its `projectDir` when Claude's `SessionStart` hook reports a cwd change (e.g. entering a worktree)
- Adds `onCwdChange` callback mechanism to `Session` class (same pattern as existing `sessionFoundCallbacks`)
- Hook handler in `runClaude.ts` passes `data.cwd` to session, which notifies scanner
- Scanner stops old watchers, updates path, and re-syncs

## Test plan
- [x] Code review confirms the cwd-change callback pattern matches existing `sessionFoundCallbacks`
- [x] Cleanup (`removeCwdChangeCallback`) is called in `finally` block
- [x] Scanner re-uses existing `sync.invalidate()` after path update

Fixes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)