### PR TITLE
fix(codex): use the correct MCP title tool in the first turn

### DIFF
--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -21,7 +21,7 @@ import { startHappyServer } from '@/claude/utils/startHappyServer';
 import { MessageBuffer } from "@/ui/ink/messageBuffer";
 import { CodexDisplay } from "@/ui/ink/CodexDisplay";
 import { trimIdent } from "@/utils/trimIdent";
-import { CHANGE_TITLE_INSTRUCTION } from '@/gemini/constants';
+import { CODEX_CHANGE_TITLE_INSTRUCTION } from './titleInstruction';
 import { notifyDaemonSessionStarted } from "@/daemon/controlClient";
 import { registerKillSessionHandler } from "@/claude/registerKillSessionHandler";
 import { connectionState } from '@/utils/serverConnectionErrors';
@@ -604,7 +604,7 @@ export async function runCodex(opts: {
                 }
 
                 const turnPrompt = first
-                    ? message.message + '\n\n' + CHANGE_TITLE_INSTRUCTION
+                    ? message.message + '\n\n' + CODEX_CHANGE_TITLE_INSTRUCTION
                     : message.message;
 
                 const result = await client.sendTurnAndWait(turnPrompt, {

--- a/packages/happy-cli/src/codex/titleInstruction.test.ts
+++ b/packages/happy-cli/src/codex/titleInstruction.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { CODEX_CHANGE_TITLE_INSTRUCTION } from './titleInstruction';
+
+describe('CODEX_CHANGE_TITLE_INSTRUCTION', () => {
+  it('uses the Codex MCP tool name', () => {
+    expect(CODEX_CHANGE_TITLE_INSTRUCTION).toContain('change_title');
+    expect(CODEX_CHANGE_TITLE_INSTRUCTION).not.toContain('happy__change_title');
+  });
+});

--- a/packages/happy-cli/src/codex/titleInstruction.ts
+++ b/packages/happy-cli/src/codex/titleInstruction.ts
@@ -1,0 +1,4 @@
+export const CODEX_CHANGE_TITLE_INSTRUCTION = [
+  'Based on this message, call the `change_title` tool from the `happy` MCP server to set a concise chat title.',
+  'If the task changes significantly, call it again to update the title.',
+].join('\n');


### PR DESCRIPTION
This fixes the Codex startup prompt so it no longer reuses Gemini's title instruction.

Root cause:
- `runCodex` was appending the Gemini title prompt on the first turn.
- That prompt points to the wrong tool name for the Codex session, so Codex reported that it could not access the title-change function instead of updating the chat title.

Change:
- Split the Codex title instruction into a Codex-specific constant.
- Target the `change_title` tool exposed by the Happy MCP server.
- Add a regression test to lock the tool name.

Verification:
- `git diff --cached --check`