### PR TITLE
fix: await rpc-registered ack to eliminate registration race

### DIFF
--- a/deploy/integration-tests/test-ack-registration-inprocess.mjs
+++ b/deploy/integration-tests/test-ack-registration-inprocess.mjs
@@ -1,0 +1,204 @@
+// In-process evidence test for issue #1118
+//
+// Simulates Redis adapter latency by wrapping socket.join() with async delay.
+// Proves fire-and-forget registration drops calls while await-ack does not.
+//
+// Usage: node deploy/integration-tests/test-ack-registration-inprocess.mjs
+
+import { Server } from "socket.io";
+import { io as ioc } from "socket.io-client";
+
+const JOIN_DELAY_MS = 50; // simulate Redis adapter cross-replica sync latency
+
+// --- Create server with delayed join (simulates Redis adapter) ---
+
+const ioServer = new Server({
+    pingInterval: 10000,
+    pingTimeout: 5000,
+});
+
+import http from "http";
+
+const httpServer = http.createServer();
+ioServer.attach(httpServer, { path: "/v1/updates" });
+
+// Remove adapter patch — instead delay join directly in the handler
+
+// Auth middleware (minimal — just sets userId)
+ioServer.use((socket, next) => {
+    socket.data.userId = "test-user";
+    next();
+});
+
+// RPC handler (same logic as production rpcHandler.ts)
+ioServer.on("connection", (socket) => {
+    const userId = socket.data.userId;
+
+    socket.on("rpc-register", (data) => {
+        const { method } = data ?? {};
+        if (!method) return;
+        // Simulate async Redis adapter: join and ack are delayed
+        setTimeout(() => {
+            socket.join(`rpc:${userId}:${method}`);
+            socket.emit("rpc-registered", { method });
+        }, JOIN_DELAY_MS);
+    });
+
+    socket.on("rpc-call", (data, callback) => {
+        const { method, params } = data ?? {};
+        if (!method) { callback?.({ ok: false, error: "no method" }); return; }
+        const room = `rpc:${userId}:${method}`;
+        const sockets = ioServer.sockets.adapter.rooms.get(room);
+        if (!sockets || sockets.size === 0) {
+            callback?.({ ok: false, error: "RPC method not available" });
+            return;
+        }
+        // Find a target that isn't the caller
+        for (const sid of sockets) {
+            if (sid !== socket.id) {
+                const target = ioServer.sockets.sockets.get(sid);
+                if (target) {
+                    target.timeout(5000).emitWithAck("rpc-request", { method, params })
+                        .then((resp) => callback?.({ ok: true, result: resp }))
+                        .catch((e) => callback?.({ ok: false, error: e.message }));
+                    return;
+                }
+            }
+        }
+        callback?.({ ok: false, error: "no target" });
+    });
+});
+
+// --- Test runner ---
+
+const ROUNDS = 30;
+
+function createClient(type, extra = {}) {
+    return new Promise((resolve, reject) => {
+        const s = ioc("http://127.0.0.1:0", {
+            transports: ["websocket"],
+            autoConnect: false,
+            auth: { token: "test", clientType: type, ...extra },
+        });
+        // Override to connect to our in-process server
+        s.io.engine.opts = s.io.engine.opts || {};
+
+        // We need to connect through the server directly
+        const timer = setTimeout(() => reject(new Error("connect timeout")), 5000);
+        s.on("connect", () => { clearTimeout(timer); resolve(s); });
+        s.on("connect_error", (e) => { clearTimeout(timer); reject(e); });
+
+        // Monkey-patch: connect directly to our server
+        s.io.engine = { close: () => {} }; // dummy
+        // Actually use server-side attach
+        reject(new Error("use server attach"));
+    });
+}
+
+// --- Better approach: use server.sockets.on("connection") and ioServer.attach ---
+
+await new Promise(r => httpServer.listen(0, r));
+const port = httpServer.address().port;
+
+console.log(`In-process server on port ${port}, join delay = ${JOIN_DELAY_MS}ms\n`);
+
+function connectToServer(type, extra = {}) {
+    return new Promise((resolve, reject) => {
+        const s = ioc(`http://127.0.0.1:${port}`, {
+            path: "/v1/updates",
+            transports: ["websocket"],
+            reconnection: false,
+            auth: { token: "test", clientType: type, ...extra },
+        });
+        const timer = setTimeout(() => reject(new Error("connect timeout")), 5000);
+        s.once("connect", () => { clearTimeout(timer); resolve(s); });
+        s.once("connect_error", (e) => { clearTimeout(timer); reject(e); });
+    });
+}
+
+// === OLD: fire-and-forget ===
+async function testFireAndForget() {
+    let success = 0, fail = 0;
+    const errors = new Map();
+
+    for (let i = 0; i < ROUNDS; i++) {
+        const sessionId = `faf-${i}`;
+        const METHOD = `${sessionId}:echo`;
+
+        const daemon = await connectToServer("session-scoped", { sessionId });
+        daemon.on("rpc-request", (data, cb) => cb("pong"));
+
+        // OLD: fire-and-forget
+        daemon.emit("rpc-register", { method: METHOD });
+
+        // Caller connects and fires RPC IMMEDIATELY
+        const caller = await connectToServer("user-scoped");
+        try {
+            const result = await caller.timeout(3000).emitWithAck("rpc-call", { method: METHOD, params: "test" });
+            if (result.ok) success++;
+            else { fail++; errors.set(result.error, (errors.get(result.error) || 0) + 1); }
+        } catch (e) {
+            fail++; errors.set(e.message, (errors.get(e.message) || 0) + 1);
+        }
+        daemon.disconnect();
+        caller.disconnect();
+    }
+    return { success, fail, errors, label: "fire-and-forget (OLD)" };
+}
+
+// === NEW: await rpc-registered ack ===
+async function testAwaitAck() {
+    let success = 0, fail = 0;
+    const errors = new Map();
+
+    for (let i = 0; i < ROUNDS; i++) {
+        const sessionId = `ack-${i}`;
+        const METHOD = `${sessionId}:echo`;
+
+        const daemon = await connectToServer("session-scoped", { sessionId });
+        daemon.on("rpc-request", (data, cb) => cb("pong"));
+
+        // NEW: await ack
+        await new Promise((resolve) => {
+            const t = setTimeout(() => resolve(), 5000);
+            daemon.once("rpc-registered", () => { clearTimeout(t); resolve(); });
+            daemon.emit("rpc-register", { method: METHOD });
+        });
+
+        const caller = await connectToServer("user-scoped");
+        try {
+            const result = await caller.timeout(3000).emitWithAck("rpc-call", { method: METHOD, params: "test" });
+            if (result.ok) success++;
+            else { fail++; errors.set(result.error, (errors.get(result.error) || 0) + 1); }
+        } catch (e) {
+            fail++; errors.set(e.message, (errors.get(e.message) || 0) + 1);
+        }
+        daemon.disconnect();
+        caller.disconnect();
+    }
+    return { success, fail, errors, label: "await-ack (NEW)" };
+}
+
+// --- Run both ---
+const old = await testFireAndForget();
+console.log(`${old.label}:`);
+console.log(`  success=${old.success}/${ROUNDS} fail=${old.fail}/${ROUNDS}`);
+for (const [err, n] of old.errors) console.log(`  error: "${err}" ×${n}`);
+
+const next = await testAwaitAck();
+console.log(`\n${next.label}:`);
+console.log(`  success=${next.success}/${ROUNDS} fail=${next.fail}/${ROUNDS}`);
+for (const [err, n] of next.errors) console.log(`  error: "${err}" ×${n}`);
+
+console.log("\n" + "=".repeat(50));
+if (old.fail > 0 && next.fail === 0) {
+    console.log(`✅ PROOF: fire-and-forget fails ${(old.fail/ROUNDS*100).toFixed(0)}%, await-ack fixes it to 0%`);
+} else if (old.fail > next.fail) {
+    console.log(`✅ IMPROVEMENT: ${(old.fail/ROUNDS*100).toFixed(0)}% → ${(next.fail/ROUNDS*100).toFixed(0)}%`);
+} else {
+    console.log("⚠️  No difference observed — try increasing JOIN_DELAY_MS");
+}
+
+ioServer.close();
+httpServer.close();
+process.exit(old.fail > 0 && next.fail === 0 ? 0 : 1);

--- a/packages/happy-cli/src/api/rpc/RpcHandlerManager.test.ts
+++ b/packages/happy-cli/src/api/rpc/RpcHandlerManager.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RpcHandlerManager } from './RpcHandlerManager';
+
+function mockSocket() {
+    const listeners: Record<string, Function[]> = {};
+    const socket = {
+        on: vi.fn((event: string, handler: Function) => {
+            if (!listeners[event]) listeners[event] = [];
+            listeners[event].push(handler);
+        }),
+        emit: vi.fn(),
+        timeout: vi.fn(() => socket),
+        emitWithAck: vi.fn(),
+        id: 'mock-socket-id',
+        _listeners: listeners,
+    };
+    return socket;
+}
+
+function createManager() {
+    const logs: string[] = [];
+    const manager = new RpcHandlerManager({
+        scopePrefix: 'test-scope',
+        encryptionKey: new Uint8Array(32),
+        encryptionVariant: 'legacy',
+        logger: (msg: string) => logs.push(msg),
+    });
+    return { manager, logs };
+}
+
+describe('RpcHandlerManager', () => {
+
+    describe('onSocketConnect', () => {
+        it('should await rpc-registered ack for each handler', async () => {
+            const { manager } = createManager();
+            const socket = mockSocket();
+
+            manager.registerHandler('method-a', async () => 'ok-a');
+            manager.registerHandler('method-b', async () => 'ok-b');
+
+            // emitWithAck resolves immediately for each registration
+            let ackCount = 0;
+            socket.emitWithAck.mockImplementation(() => {
+                ackCount++;
+                return Promise.resolve({ method: `test-scope:method-${ackCount}` });
+            });
+
+            manager.onSocketConnect(socket as any);
+
+            // Wait for async registration to complete
+            await vi.waitFor(() => {
+                expect(socket.emitWithAck).toHaveBeenCalledTimes(2);
+            });
+
+            expect(socket.emitWithAck).toHaveBeenCalledWith('rpc-register', { method: 'test-scope:method-a' });
+            expect(socket.emitWithAck).toHaveBeenCalledWith('rpc-register', { method: 'test-scope:method-b' });
+        });
+
+        it('should continue registering remaining handlers when one ack times out', async () => {
+            const { manager, logs } = createManager();
+            const socket = mockSocket();
+
+            manager.registerHandler('method-a', async () => 'ok-a');
+            manager.registerHandler('method-b', async () => 'ok-b');
+
+            let callIndex = 0;
+            socket.emitWithAck.mockImplementation(() => {
+                callIndex++;
+                if (callIndex === 1) {
+                    // First registration times out
+                    return new Promise((_, reject) => {
+                        const err = new Error('timeout');
+                        (err as any).message = 'timeout';
+                        reject(err);
+                    });
+                }
+                return Promise.resolve({ method: 'test-scope:method-b' });
+            });
+
+            manager.onSocketConnect(socket as any);
+
+            await vi.waitFor(() => {
+                expect(socket.emitWithAck).toHaveBeenCalledTimes(2);
+            });
+
+            // Both methods should have been attempted
+            expect(logs).toContainEqual(expect.stringContaining('Registration ack timeout'));
+            expect(logs).toContainEqual(expect.stringContaining('Registered 2 handlers'));
+        });
+
+        it('should abort if socket is replaced during registration', async () => {
+            const { manager } = createManager();
+            const socket1 = mockSocket();
+            const socket2 = mockSocket();
+
+            manager.registerHandler('method-a', async () => 'ok-a');
+            manager.registerHandler('method-b', async () => 'ok-b');
+
+            let callIndex = 0;
+            socket1.emitWithAck.mockImplementation(async () => {
+                callIndex++;
+                // After first registration, simulate reconnect replacing the socket
+                if (callIndex === 1) {
+                    manager.onSocketDisconnect();
+                    manager.onSocketConnect(socket2 as any);
+                }
+                return { method: `test-scope:method-${callIndex}` };
+            });
+
+            socket2.emitWithAck.mockResolvedValue({ method: 'test-scope:method-a' });
+
+            manager.onSocketConnect(socket1 as any);
+
+            // socket1 should only have registered once (then aborted)
+            await vi.waitFor(() => {
+                expect(socket1.emitWithAck).toHaveBeenCalledTimes(1);
+            });
+
+            // socket2 should have registered all methods
+            expect(socket2.emitWithAck).toHaveBeenCalled();
+        });
+    });
+
+    describe('registerHandler', () => {
+        it('should emit rpc-register when socket is connected', () => {
+            const { manager } = createManager();
+            const socket = mockSocket();
+
+            // Connect socket first
+            socket.emitWithAck.mockResolvedValue({});
+            manager.onSocketConnect(socket as any);
+
+            manager.registerHandler('new-method', async () => 'ok');
+
+            // Fire-and-forget emit for late registration
+            expect(socket.emit).toHaveBeenCalledWith('rpc-register', { method: 'test-scope:new-method' });
+        });
+
+        it('should not emit when socket is not connected', () => {
+            const { manager } = createManager();
+
+            manager.registerHandler('new-method', async () => 'ok');
+            // No socket, no emit — should not throw
+        });
+    });
+
+    describe('unregisterHandler', () => {
+        it('should emit rpc-unregister when socket is connected', () => {
+            const { manager } = createManager();
+            const socket = mockSocket();
+
+            socket.emitWithAck.mockResolvedValue({});
+            manager.onSocketConnect(socket as any);
+
+            manager.registerHandler('to-remove', async () => 'ok');
+            manager.unregisterHandler('to-remove');
+
+            expect(socket.emit).toHaveBeenCalledWith('rpc-unregister', { method: 'test-scope:to-remove' });
+        });
+    });
+
+    describe('hasHandler', () => {
+        it('should return true for registered handlers', () => {
+            const { manager } = createManager();
+            manager.registerHandler('exists', async () => 'ok');
+            expect(manager.hasHandler('exists')).toBe(true);
+            expect(manager.hasHandler('nope')).toBe(false);
+        });
+    });
+
+    describe('getHandlerCount', () => {
+        it('should return correct count', () => {
+            const { manager } = createManager();
+            expect(manager.getHandlerCount()).toBe(0);
+            manager.registerHandler('a', async () => 'ok');
+            manager.registerHandler('b', async () => 'ok');
+            expect(manager.getHandlerCount()).toBe(2);
+            manager.unregisterHandler('a');
+            expect(manager.getHandlerCount()).toBe(1);
+        });
+    });
+
+    describe('clearHandlers', () => {
+        it('should remove all handlers', () => {
+            const { manager } = createManager();
+            manager.registerHandler('a', async () => 'ok');
+            manager.registerHandler('b', async () => 'ok');
+            manager.clearHandlers();
+            expect(manager.getHandlerCount()).toBe(0);
+        });
+    });
+});

--- a/packages/happy-cli/src/api/rpc/RpcHandlerManager.ts
+++ b/packages/happy-cli/src/api/rpc/RpcHandlerManager.ts
@@ -44,6 +44,11 @@ export class RpcHandlerManager {
 
         if (this.socket) {
             this.socket.emit('rpc-register', { method: prefixedMethod });
+            // Best-effort: fire-and-forget is acceptable here because
+            // onSocketConnect already awaits acks for the bulk registration.
+            // Late single-method registrations are rare (only resume-happy-session
+            // via syncResumeSessionRpcRegistration) and will be re-registered
+            // on the next reconnect.
         }
     }
 
@@ -97,9 +102,25 @@ export class RpcHandlerManager {
 
     onSocketConnect(socket: Socket): void {
         this.socket = socket;
-        for (const [prefixedMethod] of this.handlers) {
-            socket.emit('rpc-register', { method: prefixedMethod });
+        void this.registerAllHandlers(socket);
+    }
+
+    /**
+     * Register all handlers with the server, awaiting ack for each.
+     * Ensures room membership is committed before RPC calls can arrive.
+     */
+    private async registerAllHandlers(socket: Socket): Promise<void> {
+        const methods = [...this.handlers.keys()];
+        for (const prefixedMethod of methods) {
+            // Abort if socket was replaced by a reconnect
+            if (this.socket !== socket) return;
+            try {
+                await socket.timeout(5_000).emitWithAck('rpc-register', { method: prefixedMethod });
+            } catch {
+                this.logger('[RPC] Registration ack timeout or error', { method: prefixedMethod });
+            }
         }
+        this.logger(`[RPC] Registered ${methods.length} handlers`);
     }
 
     onSocketDisconnect(): void {


### PR DESCRIPTION
## Summary
- `RpcHandlerManager.onSocketConnect` now awaits `rpc-registered` ack for each handler (5s timeout), instead of fire-and-forget
- Aborts early if socket is replaced by a reconnect mid-registration
- Late single-method registrations (`syncResumeSessionRpcRegistration`) remain fire-and-forget — re-registered on next reconnect

## Evidence

In-process test (`deploy/integration-tests/test-ack-registration-inprocess.mjs`) simulates Redis adapter cross-replica latency (50ms async delay on `rpc-register` processing):

```
fire-and-forget (OLD):  success=0/30  fail=30/30  → 100% failure
await-ack (NEW):        success=30/30 fail=0/30   → 0% failure
```

## Test plan
- [x] 9 new unit tests pass (ack-await, timeout tolerance, abort-on-replace)
- [x] 486 existing tests pass (no regression)
- [x] In-process evidence test proves fire-and-forget fails, await-ack fixes it

Fixes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)