### PR TITLE
feat: prometheus metrics for RPC handler

### DIFF
--- a/packages/happy-server/sources/app/api/socket/rpcHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/rpcHandler.ts
@@ -2,6 +2,7 @@ import { log } from "@/utils/log";
 import { Server, Socket } from "socket.io";
 import type { RemoteSocket } from "socket.io";
 import type { DefaultEventsMap } from "socket.io/dist/typed-events";
+import { Counter, Histogram, register } from 'prom-client';
 
 // RPC routing uses Socket.IO rooms. A daemon registering method M for user U
 // joins room `rpc:U:M`. Callers look the daemon up cross-replica via
@@ -34,6 +35,36 @@ const RPC_PRESENCE_FETCH_TIMEOUT_MS = 500;
 const RPC_RECONNECT_GRACE_MS = 15_000;
 const RPC_RECONNECT_POLL_MS = 200;
 
+const rpcCallCounter = new Counter({
+    name: 'rpc_calls_total',
+    help: 'Total RPC calls by method and outcome',
+    labelNames: ['method', 'result'] as const,
+    registers: [register]
+});
+
+const rpcCallDuration = new Histogram({
+    name: 'rpc_call_duration_seconds',
+    help: 'RPC call duration from receipt to response',
+    labelNames: ['method', 'result'] as const,
+    buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30],
+    registers: [register]
+});
+
+const rpcLookupRetries = new Histogram({
+    name: 'rpc_lookup_retries',
+    help: 'Number of grace-window polls before finding daemon (0 = instant)',
+    labelNames: ['method'] as const,
+    buckets: [0, 1, 2, 3, 4, 5, 6, 7],
+    registers: [register]
+});
+
+const rpcFetchSocketsTimeouts = new Counter({
+    name: 'rpc_fetchsockets_timeouts_total',
+    help: 'Cross-replica fetchSockets timeouts by context',
+    labelNames: ['context'] as const,
+    registers: [register]
+});
+
 function rpcRoom(userId: string, method: string): string {
     return `${RPC_ROOM_PREFIX}${userId}:${method}`;
 }
@@ -49,12 +80,13 @@ type RoomSockets = RemoteSocket<DefaultEventsMap, any>[];
  * + grace window) and RPC_PRESENCE_FETCH_TIMEOUT_MS for in-flight presence
  * polling.
  */
-async function fetchRoomSockets(io: Server, room: string, timeoutMs: number): Promise<RoomSockets> {
+async function fetchRoomSockets(io: Server, room: string, timeoutMs: number, context: 'lookup' | 'presence' = 'lookup'): Promise<RoomSockets> {
     try {
         return await io.in(room)
             .timeout(timeoutMs)
             .fetchSockets();
     } catch (error) {
+        rpcFetchSocketsTimeouts.inc({ context });
         log({ module: 'websocket' }, `fetchSockets failed for ${room} (timeout=${timeoutMs}ms): ${error}`);
         return [];
     }
@@ -65,12 +97,20 @@ async function fetchRoomSockets(io: Server, room: string, timeoutMs: number): Pr
  * elapses. Used to give a daemon a brief window to reconnect when an
  * rpc-call arrives during a transient disconnect.
  */
-async function waitForRoomMember(io: Server, room: string, maxMs: number): Promise<RoomSockets> {
+async function waitForRoomMember(io: Server, room: string, maxMs: number, method: string): Promise<RoomSockets> {
     const deadline = Date.now() + maxMs;
+    let polls = 0;
     while (true) {
         const sockets = await fetchRoomSockets(io, room, RPC_LOOKUP_FETCH_TIMEOUT_MS);
-        if (sockets.length > 0) return sockets;
-        if (Date.now() >= deadline) return sockets;
+        if (sockets.length > 0) {
+            rpcLookupRetries.observe({ method }, polls);
+            return sockets;
+        }
+        if (Date.now() >= deadline) {
+            rpcLookupRetries.observe({ method }, polls);
+            return sockets;
+        }
+        polls++;
         await sleep(RPC_RECONNECT_POLL_MS);
     }
 }
@@ -108,9 +148,19 @@ export function rpcHandler(userId: string, socket: Socket, io: Server) {
     });
 
     socket.on('rpc-call', async (data: any, callback: (response: any) => void) => {
+        const startTime = Date.now();
+        const { method, params } = data ?? {};
+
+        const finish = (result: string) => {
+            const durationSec = (Date.now() - startTime) / 1000;
+            const m = method || 'unknown';
+            rpcCallCounter.inc({ method: m, result });
+            rpcCallDuration.observe({ method: m, result }, durationSec);
+        };
+
         try {
-            const { method, params } = data ?? {};
             if (!method || typeof method !== 'string') {
+                finish('invalid_params');
                 callback?.({ ok: false, error: 'Invalid parameters: method is required' });
                 return;
             }
@@ -122,10 +172,11 @@ export function rpcHandler(userId: string, socket: Socket, io: Server) {
             const room = rpcRoom(userId, method);
             let targets = await fetchRoomSockets(io, room, RPC_LOOKUP_FETCH_TIMEOUT_MS);
             if (targets.length === 0) {
-                targets = await waitForRoomMember(io, room, RPC_RECONNECT_GRACE_MS);
+                targets = await waitForRoomMember(io, room, RPC_RECONNECT_GRACE_MS, method);
             }
 
             if (targets.length === 0) {
+                finish('not_available');
                 callback?.({ ok: false, error: 'RPC method not available' });
                 return;
             }
@@ -136,6 +187,7 @@ export function rpcHandler(userId: string, socket: Socket, io: Server) {
 
             const target = targets[0];
             if (target.id === socket.id) {
+                finish('self_call');
                 callback?.({ ok: false, error: 'Cannot call RPC on the same socket' });
                 return;
             }
@@ -159,7 +211,7 @@ export function rpcHandler(userId: string, socket: Socket, io: Server) {
                 while (presenceAlive) {
                     await sleep(RPC_PRESENCE_POLL_MS);
                     if (!presenceAlive) return;
-                    const stillThere = await fetchRoomSockets(io, room, RPC_PRESENCE_FETCH_TIMEOUT_MS);
+                    const stillThere = await fetchRoomSockets(io, room, RPC_PRESENCE_FETCH_TIMEOUT_MS, 'presence');
                     if (!stillThere.some(s => s.id === target.id)) {
                         throw new Error('RPC target disconnected');
                     }
@@ -168,14 +220,17 @@ export function rpcHandler(userId: string, socket: Socket, io: Server) {
 
             try {
                 const response = await Promise.race([ackPromise, presencePoll]);
+                finish('success');
                 callback?.({ ok: true, result: response });
             } catch (error) {
                 const errorMsg = error instanceof Error ? error.message : 'RPC call failed';
+                finish(errorMsg === 'RPC target disconnected' ? 'target_disconnected' : 'timeout');
                 callback?.({ ok: false, error: errorMsg });
             } finally {
                 presenceAlive = false;
             }
         } catch (error) {
+            finish('internal_error');
             log({ module: 'websocket', level: 'error' }, `Error in rpc-call: ${error}`);
             callback?.({ ok: false, error: 'Internal error' });
         }


### PR DESCRIPTION
## Summary

- Adds 4 prometheus metrics to `rpcHandler.ts` for cross-replica RPC observability
- `rpc_calls_total{method, result}` — success/failure breakdown (`success`, `not_available`, `target_disconnected`, `timeout`, `internal_error`)
- `rpc_call_duration_seconds{method, result}` — latency histogram, 15s+ durations = grace window exhaustion
- `rpc_lookup_retries{method}` — how many polls before finding daemon (0 = instant, 7 = barely made it)
- `rpc_fetchsockets_timeouts_total{context}` — adapter timeout count split by `lookup` (2s) vs `presence` (500ms)
- All exposed on existing `:9090/metrics` endpoint via prom-client register

## Context

Still debugging intermittent "RPC method not available" errors after multi-process migration (#1042, #1074, #1075). Right now the error is a black hole — we don't know if it was a timeout, empty room, or dropped registration. These metrics split that apart.

## Test plan

- [x] `pnpm build` clean
- [ ] Verify metrics appear on `/metrics` endpoint after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)