### PR TITLE
fix: rebind remote permission handlers after session swap

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -98,6 +98,9 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
 
     // Create permission handler
     const permissionHandler = new PermissionHandler(session);
+    session.addSessionFoundCallback(() => {
+        permissionHandler.updateSession(session);
+    });
 
     // Create outgoing message queue
     const messageQueue = new OutgoingMessageQueue(

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -188,6 +188,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Variable to track current session instance (updated via onSessionReady callback)
     // Used by hook server to notify Session when Claude changes session ID
     let currentSession: Session | null = null;
+    let currentApiSession = session;
 
     // Start Hook server for receiving Claude session notifications
     const hookServer = await startHookServer({
@@ -422,7 +423,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         cleanup();
     });
 
-    registerKillSessionHandler(session.rpcHandlerManager, cleanup);
+    registerKillSessionHandler(currentApiSession.rpcHandlerManager, cleanup);
 
     // Create claude loop
     const exitCode = await loop({
@@ -434,8 +435,8 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         api,
         allowedTools: happyServer.toolNames.map(toolName => `mcp__happy__${toolName}`),
         onModeChange: (newMode) => {
-            session.sendSessionEvent({ type: 'switch', mode: newMode });
-            session.updateAgentState((currentState) => ({
+            currentApiSession.sendSessionEvent({ type: 'switch', mode: newMode });
+            currentApiSession.updateAgentState((currentState) => ({
                 ...currentState,
                 controlledByUser: newMode === 'local'
             }));
@@ -443,6 +444,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         onSessionReady: (sessionInstance) => {
             // Store reference for hook server callback
             currentSession = sessionInstance;
+            currentSession.updateClient(currentApiSession);
         },
         mcpServers: {
             'happy': {

--- a/packages/happy-cli/src/claude/session.ts
+++ b/packages/happy-cli/src/claude/session.ts
@@ -9,7 +9,7 @@ export class Session {
     readonly path: string;
     readonly logPath: string;
     readonly api: ApiClient;
-    readonly client: ApiSessionClient;
+    client: ApiSessionClient;
     readonly queue: MessageQueue2<EnhancedMode>;
     readonly claudeEnvVars?: Record<string, string>;
     claudeArgs?: string[];  // Made mutable to allow filtering
@@ -25,10 +25,10 @@ export class Session {
     sessionId: string | null;
     mode: 'local' | 'remote' = 'local';
     thinking: boolean = false;
-    
+
     /** Callbacks to be notified when session ID is found/changed */
     private sessionFoundCallbacks: ((sessionId: string) => void)[] = [];
-    
+
     /** Keep alive interval reference for cleanup */
     private keepAliveInterval: NodeJS.Timeout;
 
@@ -71,7 +71,7 @@ export class Session {
             this.client.keepAlive(this.thinking, this.mode);
         }, 2000);
     }
-    
+
     /**
      * Cleanup resources (call when session is no longer needed)
      */
@@ -79,6 +79,12 @@ export class Session {
         clearInterval(this.keepAliveInterval);
         this.sessionFoundCallbacks = [];
         logger.debug('[Session] Cleaned up resources');
+    }
+
+    updateClient = (client: ApiSessionClient): void => {
+        this.client = client;
+        this.client.keepAlive(this.thinking, this.mode);
+        logger.debug(`[Session] Session client updated to ${client.sessionId}`);
     }
 
     onThinkingChange = (thinking: boolean) => {
@@ -94,38 +100,38 @@ export class Session {
 
     /**
      * Called when Claude session ID is discovered or changed.
-     * 
+     *
      * This is triggered by the SessionStart hook when:
      * - Claude starts a new session (fresh start)
      * - Claude resumes a session (--continue, --resume flags)
      * - Claude forks a session (/compact, double-escape fork)
-     * 
+     *
      * Updates internal state, syncs to API metadata, and notifies
      * all registered callbacks (e.g., SessionScanner) about the change.
      */
     onSessionFound = (sessionId: string) => {
         this.sessionId = sessionId;
-        
+
         // Update metadata with Claude Code session ID
         this.client.updateMetadata((metadata) => ({
             ...metadata,
             claudeSessionId: sessionId
         }));
         logger.debug(`[Session] Claude Code session ID ${sessionId} added to metadata`);
-        
+
         // Notify all registered callbacks
         for (const callback of this.sessionFoundCallbacks) {
             callback(sessionId);
         }
     }
-    
+
     /**
      * Register a callback to be notified when session ID is found/changed
      */
     addSessionFoundCallback = (callback: (sessionId: string) => void): void => {
         this.sessionFoundCallbacks.push(callback);
     }
-    
+
     /**
      * Remove a session found callback
      */
@@ -150,16 +156,16 @@ export class Session {
      */
     consumeOneTimeFlags = (): void => {
         if (!this.claudeArgs) return;
-        
+
         const filteredArgs: string[] = [];
         for (let i = 0; i < this.claudeArgs.length; i++) {
             const arg = this.claudeArgs[i];
-            
+
             if (arg === '--continue') {
                 logger.debug('[Session] Consumed --continue flag');
                 continue;
             }
-            
+
             if (arg === '--resume') {
                 // Check if next arg looks like a UUID (contains dashes and alphanumeric)
                 if (i + 1 < this.claudeArgs.length) {
@@ -179,10 +185,10 @@ export class Session {
                 }
                 continue;
             }
-            
+
             filteredArgs.push(arg);
         }
-        
+
         this.claudeArgs = filteredArgs.length > 0 ? filteredArgs : undefined;
         logger.debug(`[Session] Consumed one-time flags, remaining args:`, this.claudeArgs);
     }

--- a/packages/happy-cli/src/claude/utils/permissionHandler.test.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PermissionHandler } from './permissionHandler';
+
+vi.mock('@/lib', () => ({
+    logger: {
+        debug: vi.fn(),
+    },
+}));
+
+function createClientMock(sessionId: string) {
+    const handlers = new Map<string, (message: any) => Promise<void> | void>();
+
+    return {
+        sessionId,
+        getMetadata: vi.fn(() => ({})),
+        updateAgentState: vi.fn(),
+        rpcHandlerManager: {
+            registerHandler: vi.fn((name: string, handler: (message: any) => Promise<void> | void) => {
+                handlers.set(name, handler);
+            }),
+        },
+        getHandler: (name: string) => handlers.get(name),
+    };
+}
+
+function createSessionMock(client: ReturnType<typeof createClientMock>) {
+    return {
+        client,
+        api: {
+            push: () => ({
+                sendSessionNotification: vi.fn(),
+            }),
+        },
+        addSessionFoundCallback: vi.fn(),
+    };
+}
+
+describe('Claude PermissionHandler', () => {
+    it('re-registers permission RPC handler when session client changes', () => {
+        const initialClient = createClientMock('session-1');
+        const updatedClient = createClientMock('session-2');
+        const session = createSessionMock(initialClient);
+        const handler = new PermissionHandler(session as any);
+
+        const initialRegisteredHandler = initialClient.getHandler('permission');
+        expect(initialRegisteredHandler).toBeTypeOf('function');
+
+        (session as any).client = updatedClient;
+        handler.updateSession(session as any);
+
+        const updatedRegisteredHandler = updatedClient.getHandler('permission');
+        expect(updatedRegisteredHandler).toBeTypeOf('function');
+        expect(updatedRegisteredHandler).not.toBe(initialRegisteredHandler);
+        expect(updatedClient.rpcHandlerManager.registerHandler).toHaveBeenCalledWith('permission', expect.any(Function));
+    });
+});

--- a/packages/happy-cli/src/claude/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.ts
@@ -46,6 +46,11 @@ export class PermissionHandler {
         this.setupClientHandler();
     }
 
+    updateSession(session: Session): void {
+        this.session = session;
+        this.setupClientHandler();
+    }
+
     /**
      * Set callback to trigger when permission request is made
      */


### PR DESCRIPTION
  Closes #1123                                                                
                                                                              
  ## Summary                                                                  
                                                                              
  This PR fixes a remote permission approval issue where tapping approve/deny 
  on iOS could stay stuck in a loading state after a session/client change. 
                                                                              
  The root cause was that Claude-side permission handling could remain bound  
  to an outdated session client after session swap, so permission responses no
   longer matched the active pending request.                                 
                                                                            
  ## Changes                                                                  
   
  - make `Session.client` updatable in the Claude remote flow                 
  - add `Session.updateClient()` to sync the active API session client      
  - add `PermissionHandler.updateSession()` so the `permission` RPC handler   
  can be rebound after session changes                                        
  - rebind the Claude permission handler when the session changes             
  - update Claude remote flow to use the current API session reference for    
  session events/state updates                                                
  - add a minimal unit test covering permission handler rebinding after       
  session swap                                                                
  ## Why this fixes the issue                                               
                                                                              
  Remote permission approvals depend on a session-scoped `permission` RPC   
  channel. After a session/client change, the old handler could still be      
  registered against the stale client, which meant iOS approval responses   
  would not resolve the active pending request.                               
                                                                            
  By rebinding the permission handler and updating the active session client
  reference, approval responses are routed back to the current session        
  correctly.                                                          
                                                                              
  ## Validation                                                             
                                                                              
  - built `packages/happy-wire`
  - ran `packages/happy-cli` typecheck successfully                           
  - added and ran a minimal unit test:                                      
    - `src/claude/utils/permissionHandler.test.ts`                            
                                                                              
  ## Notes                                                                    
                                                                              
  In my local repro flow, this also resolved the similar approval-loading     
  symptom I was seeing with Codex, although this PR is focused on fixing the  
  Claude-side session swap gap directly.                                    