### PR TITLE
Support using global claude by default

### DIFF
--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -3,10 +3,30 @@
  * Maps internal QueryOptions to official SDK Options
  */
 
+import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { query as sdkQuery, type Options, type Query } from '@anthropic-ai/claude-agent-sdk'
 import type { QueryOptions, QueryPrompt, SDKMessage } from './types'
 import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
 import { ensureLocalProxyBypass } from '../utils/proxyBypass'
+
+/**
+ * Finds the globally installed claude binary path.
+ * Checks HAPPY_CLAUDE_PATH env var first, then falls back to `which claude`.
+ * This ensures the SDK uses the user's configured claude (e.g. a custom-patched
+ * version with TLS proxy support) rather than the SDK's own bundled binary.
+ */
+function findGlobalClaudePath(): string | null {
+    const envPath = process.env.HAPPY_CLAUDE_PATH
+    if (envPath && existsSync(envPath)) {
+        return envPath
+    }
+    try {
+        return execSync('which claude', { encoding: 'utf8' }).trim() || null
+    } catch {
+        return null
+    }
+}
 
 /**
  * Wraps the official SDK query() with our QueryOptions adapter
@@ -42,6 +62,7 @@ export function query(params: { prompt: QueryPrompt; options?: QueryOptions }): 
         settings: opts?.settingsPath,
         strictMcpConfig: opts?.strictMcpConfig,
         sessionId: undefined,
+        pathToClaudeCodeExecutable: findGlobalClaudePath() ?? undefined,
     }
 
     // Map abort signal -> AbortController


### PR DESCRIPTION
This will address some corner cases that when a customized claude code is used.

Without this change, we may hit `Invalid API key` error.