### PR TITLE
fix(server): add cluster-adapter round-trip barrier to rpc-register

### DIFF
--- a/packages/happy-server/sources/app/api/socket/rpcHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/rpcHandler.ts
@@ -27,6 +27,10 @@ const RPC_LOOKUP_FETCH_TIMEOUT_MS = 2_000;
 // so a dead replica doesn't stall each poll for the full adapter heartbeatTimeout
 // (10s). 500ms keeps daemon-death detection responsive (~1s).
 const RPC_PRESENCE_FETCH_TIMEOUT_MS = 500;
+// Timeout for the post-register barrier fetchSockets. Short enough that a dead
+// peer replica doesn't stall every registration for the full heartbeatTimeout
+// (10s), long enough to absorb typical streams backlog under load.
+const RPC_REGISTER_BARRIER_TIMEOUT_MS = 1_000;
 // How long an rpc-call waits for the daemon socket to appear in the room when
 // the room is empty at call time (e.g. brief daemon reconnect window). With
 // RPC_LOOKUP_FETCH_TIMEOUT_MS at 2s + RPC_RECONNECT_POLL_MS at 200ms, each
@@ -127,14 +131,32 @@ async function waitForRoomMember(io: Server, room: string, maxMs: number, metric
 
 export function rpcHandler(userId: string, socket: Socket, io: Server) {
 
-    socket.on('rpc-register', (data: any) => {
+    socket.on('rpc-register', async (data: any) => {
         try {
             const { method } = data ?? {};
             if (!method || typeof method !== 'string') {
                 socket.emit('rpc-error', { type: 'register', error: 'Invalid method name' });
                 return;
             }
-            socket.join(rpcRoom(userId, method));
+            const room = rpcRoom(userId, method);
+            socket.join(room);
+            // Force a cluster-adapter round-trip before acking, so peer
+            // replicas drain their Redis-streams XREAD cursor past this point.
+            // Without it, a caller that fires rpc-call on another replica
+            // immediately after rpc-registered can hit either an empty
+            // fetchSockets (peer backlog) or a stalled cross-replica
+            // emitWithAck (ack-path cursor lag). fetchSockets publishes a
+            // FETCH_SOCKETS message and waits for every peer to respond —
+            // when it resolves, every known peer has XREAD at least up to
+            // our request, which implicitly drains any earlier backlog.
+            //
+            // Single-replica deployments short-circuit inside the adapter
+            // (expectedResponseCount === 0), so this is effectively free
+            // there. Under load, it adapts to actual streams RTT instead of
+            // a fixed sleep. On timeout fetchRoomSockets returns [] + logs;
+            // we still ack (best effort) — worse than a confirmed barrier
+            // but no worse than a fixed-sleep fallback.
+            await fetchRoomSockets(io, room, RPC_REGISTER_BARRIER_TIMEOUT_MS);
             socket.emit('rpc-registered', { method });
         } catch (error) {
             log({ module: 'websocket', level: 'error' }, `Error in rpc-register: ${error}`);


### PR DESCRIPTION
## Summary

- Add a cluster-adapter round-trip barrier inside the `rpc-register` handler: after `socket.join(room)`, await `io.in(room).fetchSockets()` before emitting `rpc-registered`
- 1-second timeout on the barrier; on timeout the handler still acks (best-effort, no worse than today)
- 1 file changed, +24 / -2 — `packages/happy-server/sources/app/api/socket/rpcHandler.ts`

## Root cause

After PR #1042 moved RPC routing to Socket.IO rooms and PR #1046 scaled to 3 replicas, the `rpc-register` handler acked immediately after a local `socket.join()`:

```ts
socket.on('rpc-register', (data) => {
    socket.join(rpcRoom(userId, method));
    socket.emit('rpc-registered', { method });  // acked before propagation
});
```

`socket.join()` mutates local adapter state only. When a caller lands on a peer replica and fires `rpc-call` immediately after receiving `rpc-registered`, the caller's `fetchSockets()` has to round-trip through the Redis streams adapter. Under streams backlog (noise from concurrent daemon reconnects, churn during rolling deploys), the peer replica's XREAD cursor may not yet have processed the registration-adjacent events, producing two observed symptoms — both documented in #1118:

1. **`RPC method not available`** — `fetchSockets()` returns `[]` before the daemon becomes visible cross-replica
2. **`operation has timed out`** — `fetchSockets()` finds the daemon but the cross-replica `emitWithAck` response comes back after the 6s caller timeout

#1075 (cross-replica fetch timeout 500ms→2s) addressed some of the lookup-side lag but left the ack-path cursor lag unmitigated. This PR closes that last gap for the common registration path.

## Fix

Force one cluster-adapter round-trip before acking:

```ts
socket.on('rpc-register', async (data) => {
    const room = rpcRoom(userId, method);
    socket.join(room);
    await fetchRoomSockets(io, room, RPC_REGISTER_BARRIER_TIMEOUT_MS);
    socket.emit('rpc-registered', { method });
});
```

`ClusterAdapter.fetchSockets()` publishes a `FETCH_SOCKETS` message on the stream and waits for every known peer to respond. Because streams consumers advance their XREAD cursor strictly in-order, any peer that responds to this request has necessarily read every earlier entry on the stream. When the barrier resolves, each peer's cursor is caught up past the point of `socket.join()`, so the caller's subsequent `fetchSockets()` from any replica is guaranteed to see the daemon.

Single-replica deployments short-circuit inside the adapter (`expectedResponseCount === 0`, `socket.io-adapter/cluster-adapter.js:374-376`) — zero additional latency. Under load the barrier is adaptive to actual streams RTT instead of a wall-clock heuristic. On barrier timeout `fetchRoomSockets` returns `[]` + logs and the handler still acks (best-effort degradation — no regression vs. current behavior).

## What changed

**File**: `packages/happy-server/sources/app/api/socket/rpcHandler.ts` (1 file, no client changes)

| Constant | Value | Why |
|----------|-------|-----|
| `RPC_REGISTER_BARRIER_TIMEOUT_MS` | `1_000` (new) | Short enough that a dead peer doesn't stall every registration for the adapter's 10s `heartbeatTimeout`; long enough to absorb typical streams backlog |

Handler signature changes from sync to `async`. Semantics of the ack are unchanged — it still emits `rpc-registered { method }` on success and `rpc-error` on validation failure. The `try/catch` continues to cover the whole body; `fetchRoomSockets` already swallows its own timeout (returns `[]` + logs), so the catch arm is unreachable from the new code path.

## What this does NOT change

- **Client (daemon) code**: zero changes. Daemon's registration loop behaves identically — it still fires `rpc-register` per method and listens for `rpc-registered`
- **Wire protocol**: no new events, no payload changes
- **`rpc-call` path**: unchanged (`waitForRoomMember` + 15s grace window remains as the second line of defense)
- **Single-replica / standalone**: barrier is a no-op via adapter short-circuit
- **`rpc-unregister`**: untouched; symmetrical concern is de minimis in practice (stale room membership resolves on next reconnect)

## Alternative considered

A pure daemon-side fix (await `rpc-registered` ack on the client) — proposed in #1119 — does not address the scenario here: even if the daemon awaits the ack, the current server code still emits that ack before peers have consumed the join-adjacent events, so the caller on another replica can still race. The two approaches are complementary; this PR fixes the server side only.

## Test plan

- [x] Typecheck: `pnpm --filter happy-server build`
- [x] Local standalone (`pnpm standalone:dev`): single-process, no Redis — no regression
- [x] Multi-replica validation: minikube 3-replica cluster with Redis streams adapter — results below

## Test results

Validated with a local minikube cluster: 3 `handy-server` replicas + Redis streams adapter, using the existing `deploy/integration-tests/` harness pattern from PR #1075.

Harness: 10 noise daemons churning connect → register-10-methods → disconnect every 200–600ms across 3 pods, plus 1 victim daemon per round doing `register 10 methods on POD1` → `caller on POD2 fires 10 concurrent rpc-calls`. Two independent runs of 120 rounds × 10 methods each:

```
=== Load test: 10 noise daemons + victim over 120 rounds ===

Per-method victim results:
idx method                     ok   fail  errors
 0  spawn-happy-session     120     0
 1  stop-session            120     0
 2  stop-daemon             120     0
 3  bash                    120     0
 4  readFile                120     0
 5  writeFile               120     0
 6  listDirectory           120     0
 7  getDirectoryTree        120     0
 8  ripgrep                 120     0
 9  difftastic              120     0

Total failures: 0/1200 (0.0%)  ── run 1
Total failures: 0/1200 (0.0%)  ── run 2
```

Comparable main-without-this-fix baseline runs (same harness, pre-fix image) previously hit `1/600` on METHODS[0] with `operation has timed out`.

Fixes #1118

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)