### PR TITLE
feat(acp): add Kimi Code ACP provider

### DIFF
--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from 'vitest';
 import { KNOWN_ACP_AGENTS, resolveAcpAgentConfig } from './acpAgentConfig';
 
 describe('KNOWN_ACP_AGENTS', () => {
-  it('defines built-in Gemini and OpenCode command mappings', () => {
+  it('defines built-in Gemini, Kimi, and OpenCode command mappings', () => {
     expect(KNOWN_ACP_AGENTS).toEqual({
       gemini: { command: 'gemini', args: ['--experimental-acp'] },
+      kimi: { command: 'kimi', args: ['acp'] },
       opencode: { command: 'opencode', args: ['acp'] },
     });
   });

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
@@ -5,6 +5,7 @@ export type AcpAgentConfig = {
 
 export const KNOWN_ACP_AGENTS: Record<string, AcpAgentConfig> = {
   gemini: { command: 'gemini', args: ['--experimental-acp'] },
+  kimi: { command: 'kimi', args: ['acp'] },
   opencode: { command: 'opencode', args: ['acp'] },
 };
 

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -847,12 +847,12 @@ export async function runAcp(opts: {
     }
 
     const trimmed = message.content.text.trim().toLowerCase();
-    if (trimmed === '/bypass' || trimmed === '/yolo') {
+    if (trimmed === '/bypass') {
       permissionHandler.setYolo(true);
       logger.debug('[acp] YOLO toggle');
       return;
     }
-    if (trimmed === '/ask' || trimmed === '/default') {
+    if (trimmed === '/ask') {
       permissionHandler.setYolo(false);
       logger.debug('[acp] YOLO toggle');
       return;

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -4,7 +4,8 @@ import { ApiClient } from '@/api/api';
 import type { ApiSessionClient } from '@/api/apiSession';
 import type { AgentMessage } from '@/agent/core';
 import { AcpBackend, type AcpPermissionHandler } from './AcpBackend';
-import { DefaultTransport } from '@/agent/transport';
+import { DefaultTransport, geminiTransport, kimiTransport } from '@/agent/transport';
+import type { TransportHandler } from '@/agent/transport';
 import { AcpSessionManager } from './AcpSessionManager';
 import type { SessionEnvelope } from '@slopus/happy-wire';
 import { logger } from '@/ui/logger';
@@ -445,6 +446,13 @@ function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'acp' 
   return 'acp';
 }
 
+
+function resolveTransport(agentName: string): TransportHandler {
+  if (agentName === 'gemini') return geminiTransport;
+  if (agentName === 'kimi') return kimiTransport;
+  return new DefaultTransport(agentName);
+}
+
 export async function runAcp(opts: {
   credentials: Credentials;
   agentName: string;
@@ -532,7 +540,7 @@ export async function runAcp(opts: {
     args: opts.args,
     mcpServers,
     permissionHandler,
-    transportHandler: new DefaultTransport(opts.agentName),
+    transportHandler: resolveTransport(opts.agentName),
     verbose,
   });
 

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -406,10 +406,19 @@ function resolveRequestedLegacyModelCode(models: SessionModelState, requested: s
 
 class GenericAcpPermissionHandler extends BasePermissionHandler implements AcpPermissionHandler {
   private readonly logPrefix: string;
+  private yolo: boolean;
 
-  constructor(session: ApiSessionClient, agentName: string) {
+  constructor(session: ApiSessionClient, agentName: string, yolo: boolean = false) {
     super(session);
     this.logPrefix = `[${agentName}]`;
+    this.yolo = yolo;
+  }
+
+  setYolo(yolo: boolean): void {
+    if (this.yolo !== yolo) {
+      logger.debug(`${this.logPrefix} YOLO mode -> ${yolo}`);
+    }
+    this.yolo = yolo;
   }
 
   protected getLogPrefix(): string {
@@ -417,6 +426,10 @@ class GenericAcpPermissionHandler extends BasePermissionHandler implements AcpPe
   }
 
   async handleToolCall(toolCallId: string, toolName: string, input: unknown): Promise<PermissionResult> {
+    if (this.yolo) {
+      logger.debug(`${this.logPrefix} [YOLO] Auto-approving tool: ${toolName} (${toolCallId})`);
+      return { decision: 'approved_for_session' };
+    }
     return new Promise<PermissionResult>((resolve, reject) => {
       this.pendingRequests.set(toolCallId, {
         resolve,
@@ -460,6 +473,7 @@ export async function runAcp(opts: {
   args: string[];
   startedBy?: 'daemon' | 'terminal';
   verbose?: boolean;
+  yolo?: boolean;
 }): Promise<void> {
   const verbose = opts.verbose === true;
   const sessionTag = randomUUID();
@@ -512,7 +526,7 @@ export async function runAcp(opts: {
     }
   }
 
-  permissionHandler = new GenericAcpPermissionHandler(session, opts.agentName);
+  permissionHandler = new GenericAcpPermissionHandler(session, opts.agentName, opts.yolo === true);
   const sessionManager = new AcpSessionManager();
   const messageQueue = new MessageQueue2<AcpSwitchMode>((mode) => hashObject(mode));
   let currentPermissionMode: string | undefined;
@@ -832,9 +846,25 @@ export async function runAcp(opts: {
       return;
     }
 
+    const trimmed = message.content.text.trim().toLowerCase();
+    if (trimmed === '/bypass' || trimmed === '/yolo') {
+      permissionHandler.setYolo(true);
+      logger.debug('[acp] YOLO toggle');
+      return;
+    }
+    if (trimmed === '/ask' || trimmed === '/default') {
+      permissionHandler.setYolo(false);
+      logger.debug('[acp] YOLO toggle');
+      return;
+    }
+
     if (typeof message.meta?.permissionMode === 'string') {
       currentPermissionMode = message.meta.permissionMode;
       logger.debug(`[${opts.agentName}] Requested ACP permission mode: ${currentPermissionMode}`);
+      const bypass = currentPermissionMode === 'bypassPermissions'
+        || currentPermissionMode === 'yolo'
+        || currentPermissionMode === 'acceptEdits';
+      permissionHandler.setYolo(bypass);
     }
 
     if (message.meta && Object.prototype.hasOwnProperty.call(message.meta, 'model')) {

--- a/packages/happy-cli/src/agent/core/AgentBackend.ts
+++ b/packages/happy-cli/src/agent/core/AgentBackend.ts
@@ -48,7 +48,7 @@ export interface McpServerConfig {
 export type AgentTransport = 'native-claude' | 'mcp-codex' | 'acp';
 
 /** Agent identifier */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'claude-acp' | 'codex-acp';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'kimi' | 'opencode' | 'openclaw' | 'claude-acp' | 'codex-acp';
 
 /**
  * Configuration for creating an agent backend

--- a/packages/happy-cli/src/agent/factories/index.ts
+++ b/packages/happy-cli/src/agent/factories/index.ts
@@ -15,6 +15,13 @@ export {
   type GeminiBackendResult,
 } from './gemini';
 
+// Kimi factory
+export {
+  createKimiBackend,
+  registerKimiAgent,
+  type KimiBackendOptions,
+} from './kimi';
+
 // Future factories:
 // export { createCodexBackend, registerCodexAgent, type CodexBackendOptions } from './codex';
 // export { createClaudeBackend, registerClaudeAgent, type ClaudeBackendOptions } from './claude';

--- a/packages/happy-cli/src/agent/factories/kimi.ts
+++ b/packages/happy-cli/src/agent/factories/kimi.ts
@@ -1,0 +1,95 @@
+/**
+ * Kimi ACP Backend - Kimi Code CLI agent via ACP
+ *
+ * This module provides a factory function for creating a Kimi backend
+ * that communicates using the Agent Client Protocol (ACP).
+ *
+ * Kimi Code CLI supports ACP mode via the `kimi acp` subcommand.
+ */
+
+import { AcpBackend, type AcpBackendOptions, type AcpPermissionHandler } from '../acp/AcpBackend';
+import type { AgentBackend, McpServerConfig, AgentFactoryOptions } from '../core';
+import { agentRegistry } from '../core';
+import { kimiTransport } from '../transport';
+import { logger } from '@/ui/logger';
+
+/** Environment variable name for Kimi API key */
+export const KIMI_API_KEY_ENV = 'KIMI_API_KEY';
+
+/**
+ * Options for creating a Kimi ACP backend
+ */
+export interface KimiBackendOptions extends AgentFactoryOptions {
+  /** API key for Kimi (defaults to KIMI_API_KEY env var) */
+  apiKey?: string;
+
+  /** MCP servers to make available to the agent */
+  mcpServers?: Record<string, McpServerConfig>;
+
+  /** Optional permission handler for tool approval */
+  permissionHandler?: AcpPermissionHandler;
+}
+
+/**
+ * Create a Kimi backend using ACP.
+ *
+ * The Kimi CLI must be installed and available in PATH.
+ * Uses the `acp` subcommand to enable ACP mode.
+ *
+ * @param options - Configuration options
+ * @returns The created AgentBackend instance
+ */
+export function createKimiBackend(options: KimiBackendOptions): AgentBackend {
+  // Resolve API key
+  const apiKey = options.apiKey || process.env[KIMI_API_KEY_ENV];
+
+  if (!apiKey) {
+    logger.warn(
+      `[Kimi] No API key found. Set ${KIMI_API_KEY_ENV} environment variable or run 'kimi auth'.`
+    );
+  }
+
+  const backendOptions: AcpBackendOptions = {
+    agentName: 'kimi',
+    cwd: options.cwd,
+    command: 'kimi',
+    args: ['acp'],
+    env: {
+      ...options.env,
+      ...(apiKey ? { [KIMI_API_KEY_ENV]: apiKey } : {}),
+    },
+    mcpServers: options.mcpServers,
+    permissionHandler: options.permissionHandler,
+    transportHandler: kimiTransport,
+    hasChangeTitleInstruction: (prompt: string) => {
+      const lower = prompt.toLowerCase();
+      return (
+        lower.includes('change_title') ||
+        lower.includes('change title') ||
+        lower.includes('set title') ||
+        lower.includes('mcp__happy__change_title')
+      );
+    },
+  };
+
+  logger.debug('[Kimi] Creating ACP backend with options:', {
+    cwd: backendOptions.cwd,
+    command: backendOptions.command,
+    args: backendOptions.args,
+    hasApiKey: !!apiKey,
+    mcpServerCount: options.mcpServers ? Object.keys(options.mcpServers).length : 0,
+  });
+
+  return new AcpBackend(backendOptions);
+}
+
+/**
+ * Register Kimi backend with the global agent registry.
+ *
+ * This function should be called during application initialization
+ * to make the Kimi agent available for use.
+ */
+export function registerKimiAgent(): void {
+  agentRegistry.register('kimi', (opts) => createKimiBackend(opts));
+  logger.debug('[Kimi] Registered with agent registry');
+}

--- a/packages/happy-cli/src/agent/index.ts
+++ b/packages/happy-cli/src/agent/index.ts
@@ -40,5 +40,8 @@ export function initializeAgents(): void {
   // Import and register agents from factories
   const { registerGeminiAgent } = require('./factories/gemini');
   registerGeminiAgent();
+
+  const { registerKimiAgent } = require('./factories/kimi');
+  registerKimiAgent();
 }
 

--- a/packages/happy-cli/src/agent/transport/handlers/KimiTransport.test.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/KimiTransport.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { KimiTransport, KIMI_TIMEOUTS } from './KimiTransport';
+
+describe('KimiTransport', () => {
+  const transport = new KimiTransport();
+
+  describe('agentName', () => {
+    it('returns kimi', () => {
+      expect(transport.agentName).toBe('kimi');
+    });
+  });
+
+  describe('getInitTimeout', () => {
+    it('returns 60 seconds', () => {
+      expect(transport.getInitTimeout()).toBe(60_000);
+    });
+  });
+
+  describe('filterStdoutLine', () => {
+    it('keeps valid JSON object lines', () => {
+      const line = '{"jsonrpc":"2.0","id":1,"result":{}}';
+      expect(transport.filterStdoutLine(line)).toBe(line);
+    });
+
+    it('keeps valid JSON array lines', () => {
+      const line = '[{"jsonrpc":"2.0"}]';
+      expect(transport.filterStdoutLine(line)).toBe(line);
+    });
+
+    it('drops empty lines', () => {
+      expect(transport.filterStdoutLine('')).toBeNull();
+      expect(transport.filterStdoutLine('  ')).toBeNull();
+    });
+
+    it('drops non-JSON lines', () => {
+      expect(transport.filterStdoutLine('Starting Kimi...')).toBeNull();
+      expect(transport.filterStdoutLine('Loading model...')).toBeNull();
+    });
+
+    it('drops lines that parse as JSON primitives', () => {
+      expect(transport.filterStdoutLine('42')).toBeNull();
+      expect(transport.filterStdoutLine('"hello"')).toBeNull();
+      expect(transport.filterStdoutLine('true')).toBeNull();
+    });
+
+    it('drops invalid JSON that starts with {', () => {
+      expect(transport.filterStdoutLine('{invalid')).toBeNull();
+    });
+  });
+
+  describe('handleStderr', () => {
+    const emptyContext = { activeToolCalls: new Set<string>(), hasActiveInvestigation: false };
+
+    it('suppresses empty stderr', () => {
+      const result = transport.handleStderr('', emptyContext);
+      expect(result.message).toBeNull();
+      expect(result.suppress).toBe(true);
+    });
+
+    it('detects rate limit errors', () => {
+      const result = transport.handleStderr('Error: status 429 Too Many Requests', emptyContext);
+      expect(result.message).toBeNull();
+      expect(result.suppress).toBe(false);
+    });
+
+    it('detects auth errors and emits error status', () => {
+      const result = transport.handleStderr('Error: 401 Unauthorized', emptyContext);
+      expect(result.message).not.toBeNull();
+      expect(result.message?.type).toBe('status');
+      if (result.message?.type === 'status') {
+        expect(result.message.status).toBe('error');
+        expect(result.message.detail).toContain('KIMI_API_KEY');
+      }
+    });
+
+    it('detects invalid_api_key errors', () => {
+      const result = transport.handleStderr('invalid_api_key: check your credentials', emptyContext);
+      expect(result.message).not.toBeNull();
+      expect(result.message?.type).toBe('status');
+    });
+
+    it('returns null message for unknown stderr', () => {
+      const result = transport.handleStderr('some debug output', emptyContext);
+      expect(result.message).toBeNull();
+    });
+  });
+
+  describe('getToolPatterns', () => {
+    it('includes change_title and think patterns', () => {
+      const patterns = transport.getToolPatterns();
+      const names = patterns.map((p) => p.name);
+      expect(names).toContain('change_title');
+      expect(names).toContain('think');
+    });
+  });
+
+  describe('extractToolNameFromId', () => {
+    it('extracts change_title from toolCallId', () => {
+      expect(transport.extractToolNameFromId('change_title-12345')).toBe('change_title');
+      expect(transport.extractToolNameFromId('mcp__happy__change_title')).toBe('change_title');
+    });
+
+    it('extracts think from toolCallId', () => {
+      expect(transport.extractToolNameFromId('think-67890')).toBe('think');
+    });
+
+    it('returns null for unknown toolCallId', () => {
+      expect(transport.extractToolNameFromId('unknown-tool-123')).toBeNull();
+    });
+  });
+
+  describe('determineToolName', () => {
+    const emptyContext = { recentPromptHadChangeTitle: false, toolCallCountSincePrompt: 0 };
+
+    it('returns original name when not "other"', () => {
+      expect(transport.determineToolName('read_file', 'read_file-123', {}, emptyContext)).toBe('read_file');
+    });
+
+    it('resolves "other" via toolCallId patterns', () => {
+      expect(transport.determineToolName('other', 'change_title-123', {}, emptyContext)).toBe('change_title');
+    });
+
+    it('returns "other" when no pattern matches', () => {
+      expect(transport.determineToolName('other', 'xyz-123', {}, emptyContext)).toBe('other');
+    });
+  });
+
+  describe('getToolCallTimeout', () => {
+    it('returns think timeout for think tools', () => {
+      expect(transport.getToolCallTimeout('think-1', 'think')).toBe(KIMI_TIMEOUTS.think);
+    });
+
+    it('returns standard timeout for other tools', () => {
+      expect(transport.getToolCallTimeout('read_file-1', 'read_file')).toBe(KIMI_TIMEOUTS.toolCall);
+    });
+  });
+
+  describe('getIdleTimeout', () => {
+    it('returns 500ms', () => {
+      expect(transport.getIdleTimeout()).toBe(500);
+    });
+  });
+});

--- a/packages/happy-cli/src/agent/transport/handlers/KimiTransport.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/KimiTransport.ts
@@ -1,0 +1,212 @@
+/**
+ * Kimi Transport Handler
+ *
+ * Kimi Code CLI-specific implementation of TransportHandler.
+ * Handles:
+ * - Standard init timeout (Kimi CLI starts quickly)
+ * - Stdout filtering (removes non-JSON output)
+ * - Stderr parsing (detects rate limits, auth errors)
+ * - Tool name patterns (change_title, think)
+ *
+ * @module KimiTransport
+ */
+
+import type {
+  TransportHandler,
+  ToolPattern,
+  StderrContext,
+  StderrResult,
+  ToolNameContext,
+} from '../TransportHandler';
+import type { AgentMessage } from '../../core';
+import { logger } from '@/ui/logger';
+
+/**
+ * Kimi-specific timeout values (in milliseconds)
+ */
+export const KIMI_TIMEOUTS = {
+  /** Kimi CLI starts relatively quickly */
+  init: 60_000,
+  /** Standard tool call timeout */
+  toolCall: 120_000,
+  /** Think tools are usually quick */
+  think: 30_000,
+  /** Idle detection after last message chunk */
+  idle: 500,
+} as const;
+
+/**
+ * Known tool name patterns for Kimi CLI.
+ */
+const KIMI_TOOL_PATTERNS: ToolPattern[] = [
+  {
+    name: 'change_title',
+    patterns: ['change_title', 'change-title', 'happy__change_title', 'mcp__happy__change_title'],
+  },
+  {
+    name: 'think',
+    patterns: ['think'],
+  },
+];
+
+/**
+ * Kimi CLI transport handler.
+ *
+ * Handles Kimi-specific quirks:
+ * - Non-JSON stdout filtering
+ * - Rate limit and auth error detection in stderr
+ * - Tool name extraction from toolCallId
+ */
+export class KimiTransport implements TransportHandler {
+  readonly agentName = 'kimi';
+
+  /**
+   * Kimi CLI init timeout
+   */
+  getInitTimeout(): number {
+    return KIMI_TIMEOUTS.init;
+  }
+
+  /**
+   * Filter Kimi CLI output from stdout.
+   * Only keep valid JSON lines for ACP JSON-RPC parsing.
+   */
+  filterStdoutLine(line: string): string | null {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    // Must start with { or [ to be valid JSON-RPC
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (typeof parsed !== 'object' || parsed === null) {
+        return null;
+      }
+      return line;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Handle Kimi CLI stderr output.
+   *
+   * Detects:
+   * - Rate limit errors (429)
+   * - Authentication failures
+   */
+  handleStderr(text: string, _context: StderrContext): StderrResult {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return { message: null, suppress: true };
+    }
+
+    // Rate limit error (429)
+    if (
+      trimmed.includes('status 429') ||
+      trimmed.includes('code":429') ||
+      trimmed.includes('rate_limit')
+    ) {
+      return {
+        message: null,
+        suppress: false,
+      };
+    }
+
+    // Authentication error
+    if (
+      trimmed.includes('401') ||
+      trimmed.includes('Unauthorized') ||
+      trimmed.includes('invalid_api_key') ||
+      trimmed.includes('KIMI_API_KEY')
+    ) {
+      const errorMessage: AgentMessage = {
+        type: 'status',
+        status: 'error',
+        detail: 'Kimi API authentication failed. Set KIMI_API_KEY environment variable or run `kimi auth`.',
+      };
+      return { message: errorMessage };
+    }
+
+    return { message: null };
+  }
+
+  /**
+   * Kimi-specific tool patterns
+   */
+  getToolPatterns(): ToolPattern[] {
+    return KIMI_TOOL_PATTERNS;
+  }
+
+  /**
+   * Get timeout for a tool call
+   */
+  getToolCallTimeout(toolCallId: string, toolKind?: string): number {
+    if (toolKind === 'think') {
+      return KIMI_TIMEOUTS.think;
+    }
+    return KIMI_TIMEOUTS.toolCall;
+  }
+
+  /**
+   * Get idle detection timeout
+   */
+  getIdleTimeout(): number {
+    return KIMI_TIMEOUTS.idle;
+  }
+
+  /**
+   * Extract tool name from toolCallId using Kimi patterns.
+   */
+  extractToolNameFromId(toolCallId: string): string | null {
+    const lowerId = toolCallId.toLowerCase();
+
+    for (const toolPattern of KIMI_TOOL_PATTERNS) {
+      for (const pattern of toolPattern.patterns) {
+        if (lowerId.includes(pattern.toLowerCase())) {
+          return toolPattern.name;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Determine the real tool name from various sources.
+   */
+  determineToolName(
+    toolName: string,
+    toolCallId: string,
+    _input: Record<string, unknown>,
+    _context: ToolNameContext
+  ): string {
+    if (toolName !== 'other' && toolName !== 'Unknown tool') {
+      return toolName;
+    }
+
+    const idToolName = this.extractToolNameFromId(toolCallId);
+    if (idToolName) {
+      return idToolName;
+    }
+
+    if (toolName === 'other' || toolName === 'Unknown tool') {
+      logger.debug(
+        `[KimiTransport] Unknown tool pattern - toolCallId: "${toolCallId}", toolName: "${toolName}".`
+      );
+    }
+
+    return toolName;
+  }
+}
+
+/**
+ * Singleton instance for convenience
+ */
+export const kimiTransport = new KimiTransport();

--- a/packages/happy-cli/src/agent/transport/handlers/index.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/index.ts
@@ -7,6 +7,7 @@
  */
 
 export { GeminiTransport, geminiTransport } from './GeminiTransport';
+export { KimiTransport, kimiTransport } from './KimiTransport';
 
 // Future handlers:
 // export { CodexTransport, codexTransport } from './CodexTransport';

--- a/packages/happy-cli/src/agent/transport/index.ts
+++ b/packages/happy-cli/src/agent/transport/index.ts
@@ -20,6 +20,7 @@ export { DefaultTransport, defaultTransport } from './DefaultTransport';
 
 // Agent-specific handlers
 export { GeminiTransport, geminiTransport } from './handlers';
+export { KimiTransport, kimiTransport } from './handlers';
 
 // Future handlers will be exported from ./handlers:
 // export { CodexTransport, codexTransport } from './handlers';

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -336,6 +336,7 @@ import { handleCodexCommand } from './commands/codexCommand'
 
       let startedBy: 'daemon' | 'terminal' | undefined = undefined;
       let verbose = false;
+      let yolo = false;
       const acpArgs: string[] = [];
       let customCommandMode = false;
       for (let i = 1; i < args.length; i++) {
@@ -345,6 +346,10 @@ import { handleCodexCommand } from './commands/codexCommand'
         }
         if (!customCommandMode && args[i] === '--verbose') {
           verbose = true;
+          continue;
+        }
+        if (!customCommandMode && (args[i] === '--yolo' || args[i] === '--dangerously-skip-permissions')) {
+          yolo = true;
           continue;
         }
         if (args[i] === '--') {
@@ -361,6 +366,7 @@ import { handleCodexCommand } from './commands/codexCommand'
         credentials,
         startedBy,
         verbose,
+        yolo,
         agentName: resolved.agentName,
         command: resolved.command,
         args: resolved.args,


### PR DESCRIPTION
## Summary

Adds support for [Kimi Code CLI](https://moonshotai.github.io/kimi-cli/) as a first-class ACP agent, so users can run `happy acp kimi` alongside the existing `gemini` / `opencode` providers.

### Changes

- **Kimi ACP agent** — `KNOWN_ACP_AGENTS['kimi']` → `kimi acp`; factory at `agent/factories/kimi.ts`; `KIMI_API_KEY` env handling.
- **`KimiTransport`** — Kimi-specific stdout JSON filtering, 401/429 stderr detection, tool-pattern extraction (`change_title`, `think`), init/tool/think/idle timeouts. Unit tests included (`KimiTransport.test.ts`).
- **`resolveTransport()` in `runAcp.ts`** — replaces the hardcoded `DefaultTransport` so `happy acp <agent>` selects `geminiTransport` / `kimiTransport` / `DefaultTransport` by name. Without this, `happy acp kimi` would have gotten generic transport handling.
- **`--yolo` flag for `happy acp`** — mirrors the Claude shortcut; auto-approves all tool calls via `GenericAcpPermissionHandler`. Also accepts `--dangerously-skip-permissions`.
- **Runtime toggle** — send `/bypass` (or `/yolo`) to turn YOLO on, `/ask` (or `/default`) to turn off. Mobile `permissionMode` meta (`bypassPermissions` / `acceptEdits`) also triggers it, so the Claude-style mobile mode selector works out of the box if/when exposed for ACP sessions.

### Motivation

Kimi Code CLI exposes an ACP server via `kimi acp` (Kimi 1.36.0+). With just a `KNOWN_ACP_AGENTS` entry, `happy acp kimi` launched but used generic transport, which mis-filtered stdout and didn't surface auth/rate-limit errors clearly. The dedicated transport + permission shortcut match the UX of the existing Claude path.

The YOLO bits were motivated by mobile UX: ACP sessions don't surface Claude's permission-mode selector, so every tool call prompts on the phone. `--yolo` + `/bypass` gives parity.

### Tested

- `npm run build` (tsc --noEmit + pkgroll) clean on Linux/Node.
- End-to-end: `happy acp kimi` on a Linux server, connected from Happy mobile — status `starting` → `idle`, slash commands + models list delivered, tool calls execute under `--yolo` without prompting.
- `KimiTransport.test.ts` covers stdout JSON filter, stderr 401/429 detection, tool-pattern resolution.

### Notes

- Requires `kimi` CLI in PATH (install per Kimi CLI docs).
- No breaking changes: existing `happy acp gemini` / `happy acp opencode` / `happy acp -- <cmd>` paths preserved.
