### PR TITLE
fix(docker): set WORKDIR so tsx can resolve @/* path aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,6 @@ COPY --from=builder /repo/packages/happy-server /repo/packages/happy-server
 VOLUME /data
 EXPOSE 3005
 
-CMD ["sh", "-c", "node_modules/.bin/tsx packages/happy-server/sources/standalone.ts migrate && exec node_modules/.bin/tsx packages/happy-server/sources/standalone.ts serve"]
+WORKDIR /repo/packages/happy-server
+
+CMD ["sh", "-c", "../../node_modules/.bin/tsx sources/standalone.ts migrate && exec ../../node_modules/.bin/tsx sources/standalone.ts serve"]


### PR DESCRIPTION
## Summary
- The standalone Dockerfile runs `tsx` from `/repo`, but `tsconfig.json` (which defines the `@/*` → `./sources/*` path mapping) lives in `/repo/packages/happy-server`
- Without `WORKDIR` pointing there, `tsx` cannot resolve the alias and the container crashes with `ERR_MODULE_NOT_FOUND`
- Fix: add `WORKDIR /repo/packages/happy-server` and adjust the `CMD` paths accordingly

Fixes #1138

## Test plan
- [ ] Build standalone image: `docker build -t happy-server -f Dockerfile .`
- [ ] Run container: `docker run -p 3005:3005 -e HANDY_MASTER_SECRET=test -v happy-data:/data happy-server`
- [ ] Verify server starts without `ERR_MODULE_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)