### PR TITLE
fix(cli): detect Claude Code native binary (2.1.113+)

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -33,16 +33,52 @@ function resolvePathSafe(filePath) {
 }
 
 /**
+ * Resolve the Claude Code entrypoint inside a package directory.
+ *
+ * Prior to @anthropic-ai/claude-code@2.1.113 the package shipped a JS
+ * entrypoint (`cli.js`) at the root. Starting with 2.1.113 the package
+ * ships a platform-specific native binary declared in package.json `bin`
+ * (e.g. `bin/claude.exe` on Windows, `bin/claude` elsewhere) and no
+ * longer contains `cli.js`.
+ *
+ * @param {string} pkgDir - Path to the @anthropic-ai/claude-code directory
+ * @returns {string|null} Path to the entrypoint, or null if not resolvable
+ */
+function resolveClaudeEntrypoint(pkgDir) {
+    // Legacy: cli.js at package root (< 2.1.113)
+    const legacyCliPath = path.join(pkgDir, 'cli.js');
+    if (fs.existsSync(legacyCliPath)) {
+        return legacyCliPath;
+    }
+
+    // Current: native binary declared via package.json "bin" (>= 2.1.113)
+    const pkgJsonPath = path.join(pkgDir, 'package.json');
+    if (!fs.existsSync(pkgJsonPath)) {
+        return null;
+    }
+    try {
+        const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+        const binRel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.claude;
+        if (!binRel) return null;
+        const binPath = path.join(pkgDir, binRel);
+        if (fs.existsSync(binPath)) {
+            return binPath;
+        }
+    } catch (e) {
+        // Malformed package.json — treat as not found
+    }
+    return null;
+}
+
+/**
  * Find path to npm globally installed Claude Code CLI
- * @returns {string|null} Path to cli.js or null if not found
+ * @returns {string|null} Path to cli.js or native binary, or null if not found
  */
 function findNpmGlobalCliPath() {
     try {
         const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
-        const globalCliPath = path.join(globalRoot, '@anthropic-ai', 'claude-code', 'cli.js');
-        if (fs.existsSync(globalCliPath)) {
-            return globalCliPath;
-        }
+        const pkgDir = path.join(globalRoot, '@anthropic-ai', 'claude-code');
+        return resolveClaudeEntrypoint(pkgDir);
     } catch (e) {
         // npm root -g failed
     }
@@ -80,11 +116,12 @@ function findClaudeInPath() {
             const isExecutable = resolvedPath.endsWith('.js') || resolvedPath.endsWith('.cjs') || resolvedPath.endsWith('.exe');
             if (!isExecutable) {
                 const shimDir = path.dirname(claudePath);
-                const cliJsPath = path.join(shimDir, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
-                if (fs.existsSync(cliJsPath)) {
-                    return { path: cliJsPath, source: 'npm' };
+                const pkgDir = path.join(shimDir, 'node_modules', '@anthropic-ai', 'claude-code');
+                const entrypoint = resolveClaudeEntrypoint(pkgDir);
+                if (entrypoint) {
+                    return { path: entrypoint, source: 'npm' };
                 }
-                // Shim found but no cli.js next to it — skip and let other finders handle it
+                // Shim found but no resolvable entrypoint — skip and let other finders handle it
                 return null;
             }
 


### PR DESCRIPTION
## Summary

Fixes #1139 — `happy` reports `Claude Code is not installed` even when a working `claude` CLI is installed via `npm install -g @anthropic-ai/claude-code`.

## Root cause

Starting with `@anthropic-ai/claude-code@2.1.113` the npm package no longer ships a JS entrypoint (`cli.js`). It now ships a platform-specific native binary declared via `package.json`'s `bin` field (e.g. `bin/claude.exe` on Windows, `bin/claude` elsewhere).

The detector in `claude_version_utils.cjs` hard-coded `cli.js` at the package root in two places, so the package was invisible to it:

1. `findNpmGlobalCliPath()` — primary npm-global lookup.
2. `findClaudeInPath()` — shim-fallback branch that resolves shell shims back to `cli.js` inside the adjacent `node_modules`.

## Fix

Adds a single helper, `resolveClaudeEntrypoint(pkgDir)`, that tries both shapes in order:

1. `<pkgDir>/cli.js` — legacy (< 2.1.113).
2. `<pkgDir>/<bin.claude>` read from `<pkgDir>/package.json` — current (>= 2.1.113). Supports both object (`{ claude: "..." }`) and string forms of `bin`.

Both affected call sites now delegate to this helper. `runClaudeCli()` already knows how to `spawn()` a non-JS entrypoint, so no changes were needed there.

## Repro

\`\`\`bash
npm install -g @anthropic-ai/claude-code@2.1.114
npm install -g happy
claude -v        # works: "2.1.114 (Claude Code)"
happy            # before: "Claude Code is not installed"; after: launches normally
\`\`\`

Reproduced and verified on Windows 11 with npm-global install.

## Known limitation (out of scope)

\`getVersion(cliPath)\` reads \`package.json\` from \`path.dirname(cliPath)\`. For the native binary (\`<pkgDir>/bin/claude.exe\`) that resolves to \`<pkgDir>/bin/\`, where no \`package.json\` exists — so the version line prints as \`Using Claude Code from npm\` without the version suffix. The CLI still launches correctly. Happy to address in a follow-up PR if desired; left out here to keep the fix minimal and focused on the \"not installed\" regression.

## Tests

The existing test file (\`claude_version_utils.test.ts\`) covers \`detectSourceFromPath\` via string assertions but does not mock \`fs\`/\`execSync\` for the finder functions, so an integration-style test for this path would require broader test scaffolding. Manual repro above confirms the fix.