### PR TITLE
fix(reducer): preserve agent text when message has both text and internal tool-call

### DIFF
--- a/packages/happy-app/sources/sync/reducer/messageToEvent.ts
+++ b/packages/happy-app/sources/sync/reducer/messageToEvent.ts
@@ -28,6 +28,13 @@ export function parseMessageAsEvent(msg: NormalizedMessage): AgentEvent | null {
 
     // Check for agent messages that should become events
     if (msg.role === 'agent') {
+        // Check if the message has meaningful text content alongside tool calls.
+        // If so, do NOT convert to event — let the text display normally.
+        const hasText = msg.content.some(
+            c => c.type === 'text' && c.text.trim().length > 0
+                && !c.text.match(/^Claude AI usage limit reached\|\d+$/)
+        );
+
         for (const content of msg.content) {
             // Check for Claude AI usage limit messages
             if (content.type === 'text') {
@@ -41,9 +48,14 @@ export function parseMessageAsEvent(msg: NormalizedMessage): AgentEvent | null {
                         } as AgentEvent;
                     }
                 }
-                
+
             }
-            
+
+            // Only convert tool-call-only messages to events.
+            // When the message also contains text, let it go through normal
+            // processing so the text is displayed to the user.
+            if (hasText) continue;
+
             // Check for mcp__happy__change_title tool calls
             if (content.type === 'tool-call' && content.name === 'mcp__happy__change_title') {
                 const title = content.input?.title;

--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -721,6 +721,9 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
         if (msg.role === 'agent') {
             for (let c of msg.content) {
                 if (c.type === 'tool-call') {
+                    // Skip internal tool calls that should not appear in UI
+                    if (c.name === 'mcp__happy__change_title') continue;
+
                     // Direct lookup by tool ID (since permission ID = tool ID now)
                     const existingMessageId = state.toolIdToMessageId.get(c.id);
 

--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -723,6 +723,7 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
                 if (c.type === 'tool-call') {
                     // Skip internal tool calls that should not appear in UI
                     if (c.name === 'mcp__happy__change_title') continue;
+                    if (c.name === 'EnterPlanMode' || c.name === 'enter_plan_mode') continue;
 
                     // Direct lookup by tool ID (since permission ID = tool ID now)
                     const existingMessageId = state.toolIdToMessageId.get(c.id);
@@ -938,6 +939,10 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
                     state.messages.set(mid, textMsg);
                     existingSidechain.push(textMsg);
                 } else if (c.type === 'tool-call') {
+                    // Skip internal tool calls that should not appear in UI
+                    if (c.name === 'mcp__happy__change_title') continue;
+                    if (c.name === 'EnterPlanMode' || c.name === 'enter_plan_mode') continue;
+
                     // Check if there's already a permission message for this tool
                     const existingPermissionMessageId = state.toolIdToMessageId.get(c.id);
 


### PR DESCRIPTION
## Problem

When a Claude agent message contains **both** text content and a tool call to `mcp__happy__change_title`, `EnterPlanMode`, or `enter_plan_mode`, the user's visible text is silently discarded.

### Call path
1. `shouldSkipNormalProcessing(msg)` is evaluated early in message processing.
2. It calls `parseMessageAsEvent(msg)` — if any content item is a `change_title` / `EnterPlanMode` tool-call, the whole message is converted to an event like `"Title changed to X"` or `"Entering plan mode"`.
3. `shouldSkipNormalProcessing` returns `true`, and the reducer never sees the original message. The text content the agent emitted is gone.

In practice, Claude often outputs something like:

> "I'll rename this session so it's easier to find later." → `change_title({title: "…"})`

After this PR: the user sees the explanatory text AND the title updates. Before this PR: the text is silently dropped and the user just sees `Title changed to …`.

## Fix

Two coordinated changes that must land together:

**1. `sync/reducer/messageToEvent.ts`** — in `parseMessageAsEvent`, if the message has meaningful text content alongside tool calls, return `null` so the message goes through normal rendering. A `hasText` check excludes the `Claude AI usage limit reached|<ts>` sentinel (which is legitimately text-only and should still become an event).

**2. `sync/reducer/reducer.ts`** — when `parseMessageAsEvent` returns `null`, the reducer would otherwise create a visible tool-call UI element for `mcp__happy__change_title` / `EnterPlanMode` (now reaching Phase 2 and Phase 4 sidechain processing). Skip these internal tool names in both phases so the text renders cleanly without tool-icon clutter.

Without change (2), change (1) alone would introduce a regression (text appears, but the tool icon is also shown).

## Test coverage

No new tests in this PR. The existing reducer spec suite passes; the regression this fixes is invisible to the current tests because they don't assert that text content survives message-to-event conversion. Happy to add a case if the reviewer would like one.

## Scope

- 2 files, 25 lines changed (22 added / 3 removed effectively; see diff).
- No type changes, no API changes, no behavior change when message has **only** text or **only** internal tool calls.
- Behavior change: when both are present, text is preserved.

## Origin

These two commits were carried on a fork for several weeks and proved stable in production use. Extracted onto a clean branch off `upstream/main` for this PR.

---

Co-authored-by: Claude (Happy AI pair-programming session) <noreply@anthropic.com>