### PR TITLE
fix(happy-cli): stabilize daemon version tracking and startup readiness

### DIFF
--- a/packages/happy-cli/src/cliVersion.test.ts
+++ b/packages/happy-cli/src/cliVersion.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn(),
+  mockProjectPath: vi.fn(),
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readFileSync: mocks.mockReadFileSync,
+  };
+});
+
+vi.mock('@/projectPath', () => ({
+  projectPath: mocks.mockProjectPath,
+}));
+
+describe('cliVersion', () => {
+  it('prefers the installed package.json version on disk', async () => {
+    mocks.mockProjectPath.mockReturnValue('/tmp/happy');
+    mocks.mockReadFileSync.mockReturnValue(JSON.stringify({ version: '9.9.9' }));
+
+    const { getInstalledCliVersion } = await import('./cliVersion');
+
+    expect(getInstalledCliVersion()).toBe('9.9.9');
+    expect(mocks.mockReadFileSync).toHaveBeenCalledWith('/tmp/happy/package.json', 'utf-8');
+  });
+
+  it('falls back to the bundled package version when disk lookup fails', async () => {
+    mocks.mockProjectPath.mockReturnValue('/tmp/happy');
+    mocks.mockReadFileSync.mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const { getInstalledCliVersion } = await import('./cliVersion');
+
+    expect(getInstalledCliVersion()).toBe('1.1.7');
+  });
+});

--- a/packages/happy-cli/src/cliVersion.ts
+++ b/packages/happy-cli/src/cliVersion.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import packageJson from '../package.json';
+import { projectPath } from '@/projectPath';
+
+/**
+ * Read the installed CLI version from package.json on disk.
+ *
+ * We intentionally prefer the runtime package.json over the bundled JSON import:
+ * the bundled value can lag behind during upgrades or partial rebuilds, while the
+ * daemon/version-check logic needs a single runtime source of truth.
+ */
+export function getInstalledCliVersion(): string {
+  try {
+    const packageJsonPath = join(projectPath(), 'package.json');
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    if (typeof parsed.version === 'string' && parsed.version.length > 0) {
+      return parsed.version;
+    }
+  } catch {
+    // Fall back to the bundled version if runtime package.json is unavailable.
+  }
+
+  return packageJson.version;
+}
+
+/**
+ * Snapshot of the CLI version observed when the current process started.
+ *
+ * This is what the daemon should persist into state so that later heartbeats can
+ * detect "the installed version changed underneath me" without mixing sources.
+ */
+export const startedCliVersion = getInstalledCliVersion();

--- a/packages/happy-cli/src/configuration.ts
+++ b/packages/happy-cli/src/configuration.ts
@@ -8,7 +8,7 @@
 import { existsSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import packageJson from '../package.json'
+import { startedCliVersion } from '@/cliVersion'
 
 class Configuration {
   public readonly serverUrl: string
@@ -54,7 +54,7 @@ class Configuration {
     this.isExperimentalEnabled = ['true', '1', 'yes'].includes(process.env.HAPPY_EXPERIMENTAL?.toLowerCase() || '');
     this.disableCaffeinate = ['true', '1', 'yes'].includes(process.env.HAPPY_DISABLE_CAFFEINATE?.toLowerCase() || '');
 
-    this.currentCliVersion = packageJson.version
+    this.currentCliVersion = startedCliVersion
 
     // Visual indicator on CLI startup (only if not daemon process to avoid log clutter)
     const variant = process.env.HAPPY_VARIANT || 'stable'

--- a/packages/happy-cli/src/daemon/controlClient.ts
+++ b/packages/happy-cli/src/daemon/controlClient.ts
@@ -6,10 +6,7 @@
 import { logger } from '@/ui/logger';
 import { clearDaemonState, readDaemonState } from '@/persistence';
 import { Metadata } from '@/api/types';
-import { projectPath } from '@/projectPath';
-import { readFileSync } from 'fs';
-import { join } from 'path';
-import { configuration } from '@/configuration';
+import { getInstalledCliVersion } from '@/cliVersion';
 
 async function daemonPost(path: string, body?: any): Promise<{ error?: string } | any> {
   const state = await readDaemonState();
@@ -176,10 +173,7 @@ export async function isDaemonRunningCurrentlyInstalledHappyVersion(): Promise<b
   }
   
   try {
-    // Read package.json on demand from disk - so we are guaranteed to get the latest version
-    const packageJsonPath = join(projectPath(), 'package.json');
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-    const currentCliVersion = packageJson.version;
+    const currentCliVersion = getInstalledCliVersion();
     
     logger.debug(`[DAEMON CONTROL] Current CLI version: ${currentCliVersion}, Daemon started with version: ${state.startedWithCliVersion}`);
     return currentCliVersion === state.startedWithCliVersion;
@@ -204,6 +198,23 @@ export async function isDaemonRunningCurrentlyInstalledHappyVersion(): Promise<b
     logger.debug('[DAEMON CONTROL] Error checking daemon version', error);
     return false;
   }
+}
+
+export async function waitForDaemonReady(
+  timeoutMs: number = 5000,
+  pollIntervalMs: number = 100,
+): Promise<boolean> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    if (await isDaemonRunningCurrentlyInstalledHappyVersion()) {
+      return true;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+  }
+
+  return await isDaemonRunningCurrentlyInstalledHappyVersion();
 }
 
 export async function cleanupDaemonState(): Promise<void> {

--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   mockLoggerDebug: vi.fn(),
   mockIsDaemonRunningCurrentlyInstalledHappyVersion: vi.fn(),
+  mockWaitForDaemonReady: vi.fn(),
   mockSpawnHappyCLI: vi.fn(),
 }))
 
@@ -14,6 +15,7 @@ vi.mock('@/ui/logger', () => ({
 
 vi.mock('./controlClient', () => ({
   isDaemonRunningCurrentlyInstalledHappyVersion: mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion,
+  waitForDaemonReady: mocks.mockWaitForDaemonReady,
 }))
 
 vi.mock('@/utils/spawnHappyCLI', () => ({
@@ -28,6 +30,7 @@ describe('ensureDaemonRunning', () => {
     mocks.mockSpawnHappyCLI.mockReturnValue({
       unref: vi.fn(),
     })
+    mocks.mockWaitForDaemonReady.mockResolvedValue(true)
   })
 
   it('returns without spawning when the daemon is already running', async () => {
@@ -55,7 +58,15 @@ describe('ensureDaemonRunning', () => {
       stdio: 'ignore',
       env: process.env,
     })
+    expect(mocks.mockWaitForDaemonReady).toHaveBeenCalledWith()
     expect(mockUnref).toHaveBeenCalled()
     expect(mocks.mockLoggerDebug).toHaveBeenCalledWith('Starting Happy background service...')
+  })
+
+  it('throws when the daemon never becomes ready', async () => {
+    mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(false)
+    mocks.mockWaitForDaemonReady.mockResolvedValue(false)
+
+    await expect(ensureDaemonRunning()).rejects.toThrow('Happy daemon failed to become ready')
   })
 })

--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/ui/logger'
-import { isDaemonRunningCurrentlyInstalledHappyVersion } from './controlClient'
+import { isDaemonRunningCurrentlyInstalledHappyVersion, waitForDaemonReady } from './controlClient'
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI'
 
 export async function ensureDaemonRunning(): Promise<void> {
@@ -18,6 +18,8 @@ export async function ensureDaemonRunning(): Promise<void> {
   })
   daemonProcess.unref()
 
-  // Give daemon a moment to write PID & port file before first notification.
-  await new Promise(resolve => setTimeout(resolve, 200))
+  const started = await waitForDaemonReady()
+  if (!started) {
+    throw new Error('Happy daemon failed to become ready')
+  }
 }

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -10,14 +10,13 @@ import { logger } from '@/ui/logger';
 import { authAndSetupMachineIfNeeded } from '@/ui/auth';
 import { configuration } from '@/configuration';
 import { startCaffeinate, stopCaffeinate } from '@/utils/caffeinate';
-import packageJson from '../../package.json';
 import { getEnvironmentInfo } from '@/ui/doctor';
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI';
 import { writeDaemonState, DaemonLocallyPersistedState, readDaemonState, acquireDaemonLock, releaseDaemonLock } from '@/persistence';
+import { getInstalledCliVersion, startedCliVersion } from '@/cliVersion';
 
 import { cleanupDaemonState, isDaemonRunningCurrentlyInstalledHappyVersion, stopDaemon } from './controlClient';
 import { startDaemonControlServer } from './controlServer';
-import { readFileSync } from 'fs';
 import { join } from 'path';
 import { projectPath } from '@/projectPath';
 import { getTmuxUtilities, isTmuxAvailable, parseTmuxSessionIdentifier, formatTmuxSessionIdentifier } from '@/utils/tmux';
@@ -35,7 +34,7 @@ const hostSuffix = process.env.HAPPY_VARIANT === 'dev' ? '-dev' : '';
 export const initialMachineMetadata: MachineMetadata = {
   host: os.hostname() + hostSuffix,
   platform: os.platform(),
-  happyCliVersion: packageJson.version,
+  happyCliVersion: startedCliVersion,
   homeDir: os.homedir(),
   happyHomeDir: configuration.happyHomeDir,
   happyLibDir: projectPath(),
@@ -639,7 +638,7 @@ export async function startDaemon(): Promise<void> {
       pid: process.pid,
       httpPort: controlPort,
       startTime: new Date().toLocaleString(),
-      startedWithCliVersion: packageJson.version,
+      startedWithCliVersion: startedCliVersion,
       daemonLogPath: logger.logFilePath
     };
     writeDaemonState(fileState);
@@ -710,8 +709,8 @@ export async function startDaemon(): Promise<void> {
       // Check if daemon needs update
       // If version on disk is different from the one in package.json - we need to restart
       // BIG if - does this get updated from underneath us on npm upgrade?
-      const projectVersion = JSON.parse(readFileSync(join(projectPath(), 'package.json'), 'utf-8')).version;
-      if (projectVersion !== configuration.currentCliVersion) {
+      const installedCliVersion = getInstalledCliVersion();
+      if (installedCliVersion !== fileState.startedWithCliVersion) {
         // TODO: We probably do not want to keep this in-process self-restart logic long-term.
         // A native service manager would make startup and upgrades much simpler: the CLI would
         // ask the OS to start the latest daemon instead of hand-rolling respawn/kill behavior here.
@@ -755,7 +754,7 @@ export async function startDaemon(): Promise<void> {
           pid: process.pid,
           httpPort: controlPort,
           startTime: fileState.startTime,
-          startedWithCliVersion: packageJson.version,
+          startedWithCliVersion: fileState.startedWithCliVersion,
           lastHeartbeat: new Date().toLocaleString(),
           daemonLogPath: fileState.daemonLogPath
         };

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -15,7 +15,7 @@ import { authAndSetupMachineIfNeeded } from './ui/auth'
 import packageJson from '../package.json'
 import { z } from 'zod'
 import { startDaemon } from './daemon/run'
-import { checkIfDaemonRunningAndCleanupStaleState, isDaemonRunningCurrentlyInstalledHappyVersion, stopDaemon } from './daemon/controlClient'
+import { stopDaemon, waitForDaemonReady } from './daemon/controlClient'
 import { getLatestDaemonLog } from './ui/logger'
 import { killRunawayHappyProcesses } from './daemon/doctor'
 import { install } from './daemon/install'
@@ -483,15 +483,7 @@ import { handleCodexCommand } from './commands/codexCommand'
       });
       child.unref();
 
-      // Wait for daemon to write state file (up to 5 seconds)
-      let started = false;
-      for (let i = 0; i < 50; i++) {
-        if (await checkIfDaemonRunningAndCleanupStaleState()) {
-          started = true;
-          break;
-        }
-        await new Promise(resolve => setTimeout(resolve, 100));
-      }
+      const started = await waitForDaemonReady();
 
       if (started) {
         console.log('Daemon started successfully');


### PR DESCRIPTION
## Summary

This PR fixes a daemon/session startup issue in `happy-cli` that could leave mobile Codex sessions stuck at “Starting task...” or “Waiting for messages...”.

The root cause was a mismatch between two different version sources used by the daemon lifecycle:

- `startedWithCliVersion` was written from a bundled/package-import version
- current CLI version checks were reading `package.json` from disk at runtime

When those diverged after an upgrade or partial replacement, the daemon could incorrectly mark itself as outdated and repeatedly restart. That in turn caused downstream session startup failures such as:

- `Daemon version mismatch detected`
- `Daemon is outdated, triggering self-restart`
- `No daemon running, no state file found`

This PR also improves daemon startup synchronization so `happy codex` does not continue before the daemon is actually ready.

## Changes

- added a single version source helper in `packages/happy-cli/src/cliVersion.ts`
- made daemon startup snapshot (`startedWithCliVersion`) use the same version source
- made daemon version comparisons consistently use the installed runtime version
- changed daemon self-outdated checks to compare the installed version against the persisted startup snapshot
- replaced the fixed `200ms` sleep in daemon/session startup with explicit readiness polling
- reused the same readiness wait path for both `happy daemon start` and `happy codex`
- added minimal regression tests for:
  - CLI version source behavior
  - daemon readiness waiting behavior

## Validation

- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm exec vitest run src/cliVersion.test.ts src/daemon/ensureDaemonRunning.test.ts`

Confirmed locally that:
- daemon state version matches `happy --version`
- daemon no longer enters version mismatch restart loops
- mobile `happy codex` can successfully run `pwd` and `ls`

## Risk

This is intentionally a minimal fix and does not redesign daemon upgrade behavior.