### PR TITLE
fix(cli): map happy permission modes to Claude SDK form in handleModeChange

### DIFF
--- a/packages/happy-cli/src/claude/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.ts
@@ -10,6 +10,7 @@ import { PermissionResult } from "../sdk/types";
 import { Session } from "../session";
 import { EnhancedMode, PermissionMode } from "../loop";
 import { getToolDescriptor } from "./getToolDescriptor";
+import { mapToClaudeMode } from "./permissionMode";
 
 interface PermissionResponse {
     id: string;
@@ -54,7 +55,9 @@ export class PermissionHandler {
     }
 
     handleModeChange(mode: PermissionMode) {
-        this.permissionMode = mode;
+        // Normalize to Claude's 4-mode form; handleToolCall compares
+        // against 'bypassPermissions'/'acceptEdits' by literal equality.
+        this.permissionMode = mapToClaudeMode(mode);
     }
 
     /**


### PR DESCRIPTION
## Summary

`handleModeChange` stores the raw happy permission-mode value, but
`handleToolCall` checks it against Claude's 4-mode form — so when the
mobile/web app sends `meta.permissionMode: 'yolo'` (or any other
Codex-native mode that maps to a Claude mode), the bypass never fires
and users see Allow/Deny prompts even though they selected YOLO.

## Reproduction

Start a Claude session without `--yolo`, switch to YOLO from the mobile
app, send a message that triggers a tool call → Allow/Deny modal
appears. Reproduces on CLI v1.1.7 and upstream main (`d92157a3`).

## Root cause

`packages/happy-cli/src/claude/utils/permissionHandler.ts:56`:

```ts
handleModeChange(mode: PermissionMode) {
    this.permissionMode = mode;   // stores 'yolo', 'safe-yolo', ...
}
```

And `handleToolCall:172` only matches Claude's form:

```ts
if (this.permissionMode === 'bypassPermissions') { ... }
```

So `'yolo'` never hits the bypass branch and the request falls through
to the user-prompt path.

## Fix

Normalize the incoming mode through `mapToClaudeMode()` — the same
function already used at the SDK boundary in `claudeRemote.ts:122` —
before storing it. Three-line diff.

## Relation to #728

#728 includes this exact mapping change, plus two additional changes
that are out of scope here:

1. A "bypassPermissions is one-way" guard in `runClaude.ts` — flagged
   as P1 by the Codex bot review on that PR (it turns bypass into a
   sticky state users can't leave mid-session). Not included here.
2. A `--yolo` flag fix in `index.ts` — unrelated to the mid-session
   mobile-switch bug this PR targets.

#728 has been CONFLICTING for 2 months (paths still on the old `cli/`
layout) and the author has not responded to the P1 review. Isolating
the clean mapping change here so it can be reviewed on its own merits.
Happy to close this if #728 is revived and rebased.

## Test plan

- [ ] Existing test suite passes (no test directly covers
  `handleModeChange` today — grep confirms)
- [ ] Manual: start without `--yolo` → switch to YOLO from app →
  tool-using turn is auto-approved, no modal
- [ ] Manual: switch back from YOLO to default → subsequent tool calls
  prompt again (regression check — this PR must NOT introduce the
  one-way-state behavior #728 had)

## Related

- #521, #446, #29, #206 — symptom reports that all resolve to this
- #561, #702 — complementary fixes on adjacent permission-pipeline bugs
- #728 — the parent PR this is extracted from

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)