### PR TITLE
fix(sync): unread badge reset to zero on every new message

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -1830,9 +1830,6 @@ class Sync {
                 }
             }
 
-            // Ping session
-            this.onSessionVisible(updateData.body.sid);
-
         } else if (updateData.body.t === 'new-session') {
             log.log('🆕 New session update received');
             this.sessionsSync.invalidate();


### PR DESCRIPTION
## Bug

The WebSocket `new-message` handler in `sync.ts` calls `this.onSessionVisible(updateData.body.sid)` immediately after incrementing the unread count for that session. `onSessionVisible` triggers `markRead(sid)`, which resets the unread count back to zero.

Net effect: **unread badges can never accumulate** — every incoming message bumps the counter and then zeroes it in the same tick, so users never see "3 unread", only a momentary flicker.

## Fix

Remove the stray `this.onSessionVisible(updateData.body.sid)` call from the `new-message` branch. Session visibility pings should come from the UI (when the user actually opens/focuses the session), not from message arrival — and indeed `onSessionVisible` is still invoked from the correct UI-driven paths (`new-session` and other focus triggers remain untouched).

## Scope

- 1 file, 3 lines removed
- No behavior change beyond fixing the counter reset
- No test changes required; this is a removal of a buggy call

## Repro

1. Open the app in a browser, log in, keep session list visible but don't open any session.
2. Have another client send messages to a session.
3. Observe: unread badge briefly shows "1" then resets to "0" on each message.

After this fix, the badge correctly accumulates until the user opens the session.