### PR TITLE
fix(sync): ignore subagent turn events when updating main thinking state

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -1769,27 +1769,35 @@ class Sync {
                             type?: string;
                             data?: {
                                 type?: string;
+                                isSidechain?: boolean;
                                 ev?: { t?: string };
+                                subagent?: string | null;
                             }
                         }
                     } | null;
                     const contentType = rawContent?.content?.type;
                     const dataType = rawContent?.content?.data?.type;
                     const sessionEventType = rawContent?.content?.data?.ev?.t;
-                    
+                    // Subagent turn-start/turn-end must NOT flip the main session's
+                    // thinking state — only top-level turns matter.
+                    const isSubagentEvent =
+                        rawContent?.content?.data?.subagent != null ||
+                        rawContent?.content?.data?.isSidechain === true;
+
                     // Debug logging to trace lifecycle events
                     if (dataType === 'task_complete' || dataType === 'turn_aborted' || dataType === 'task_started' || sessionEventType === 'turn-start' || sessionEventType === 'turn-end') {
-                        console.log(`🔄 [Sync] Lifecycle event detected: contentType=${contentType}, dataType=${dataType}, sessionEventType=${sessionEventType}`);
+                        console.log(`🔄 [Sync] Lifecycle event detected: contentType=${contentType}, dataType=${dataType}, sessionEventType=${sessionEventType}, isSubagent=${isSubagentEvent}`);
                     }
-                    
-                    const isTaskComplete = 
-                        ((contentType === 'acp' || contentType === 'codex') && 
-                            (dataType === 'task_complete' || dataType === 'turn_aborted')) ||
-                        (contentType === 'session' && sessionEventType === 'turn-end');
-                    
-                    const isTaskStarted = 
-                        ((contentType === 'acp' || contentType === 'codex') && dataType === 'task_started') ||
-                        (contentType === 'session' && sessionEventType === 'turn-start');
+
+                    const isTaskComplete =
+                        ((contentType === 'acp' || contentType === 'codex') &&
+                            (dataType === 'task_complete' || dataType === 'turn_aborted') &&
+                            !isSubagentEvent) ||
+                        (contentType === 'session' && sessionEventType === 'turn-end' && !isSubagentEvent);
+
+                    const isTaskStarted =
+                        ((contentType === 'acp' || contentType === 'codex') && dataType === 'task_started' && !isSubagentEvent) ||
+                        (contentType === 'session' && sessionEventType === 'turn-start' && !isSubagentEvent);
                     
                     if (isTaskComplete || isTaskStarted) {
                         console.log(`🔄 [Sync] Updating thinking state: isTaskComplete=${isTaskComplete}, isTaskStarted=${isTaskStarted}`);


### PR DESCRIPTION
## Bug

The `new-message` handler in `sync.ts` uses session `turn-start` / `turn-end` events (and ACP/Codex `task_started` / `task_complete` / `turn_aborted` events) to flip the `thinking` flag on the parent session. But when Claude Code dispatches a sub-task, the subagent emits its own `turn-start` / `turn-end` events — and those were treated as if the main session itself had started/stopped thinking.

Net effect: the thinking indicator flickers off as soon as a subagent completes, even though the main agent is still working; and it can flicker on for purely subagent turns when the main agent is idle.

## Fix

Detect subagent lifecycle events by looking at either `data.subagent` (non-null) or `data.isSidechain === true` on the raw content, and gate both `isTaskComplete` and `isTaskStarted` on `!isSubagentEvent`. Only top-level turns now move the main session's `thinking` flag.

## Scope

- 1 file, +19 / -11
- No public API changes
- `pnpm typecheck` passes on `upstream/main + this change`

## Repro

1. Ask Claude Code a question whose answer dispatches a subagent (e.g. "use the general-purpose agent to search for X").
2. Watch the thinking indicator in the session header.
3. Before the fix: indicator flickers off/on whenever the subagent starts or finishes a turn, even though the parent agent is still working.
4. After the fix: indicator stays on continuously for the parent turn.