### PR TITLE
fix(sync): handle new-machine updates and don't drop machine state without encryption keys

### DIFF
--- a/packages/happy-app/sources/sync/apiTypes.ts
+++ b/packages/happy-app/sources/sync/apiTypes.ts
@@ -4,6 +4,7 @@ import {
     ApiUpdateMachineStateSchema,
     ApiUpdateNewMessageSchema,
     ApiUpdateSessionStateSchema,
+    NewMachineBodySchema,
     type ApiMessage,
 } from '@slopus/happy-wire';
 import { GitHubProfileSchema, ImageRefSchema } from './profile';
@@ -126,6 +127,7 @@ export const ApiUpdateSchema = z.union([
     ApiUpdateAccountSchema,
     ApiUpdateMachineStateSchema,
     ApiDeleteMachineSchema,
+    NewMachineBodySchema,
     ApiNewArtifactSchema,
     ApiUpdateArtifactSchema,
     ApiDeleteArtifactSchema,

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -1957,7 +1957,7 @@ class Sync {
                     // Don't crash on settings sync errors, just log
                 }
             }
-        } else if (updateData.body.t === 'update-machine') {
+        } else if (updateData.body.t === 'update-machine' || updateData.body.t === 'new-machine') {
             const machineUpdate = updateData.body;
             const machineId = machineUpdate.machineId;  // Changed from .id to .machineId
             const machine = storage.getState().machines[machineId];
@@ -1976,38 +1976,40 @@ class Sync {
                 daemonStateVersion: machine?.daemonStateVersion ?? 0
             };
 
-            // Get machine-specific encryption (might not exist if machine wasn't initialized)
-            const machineEncryption = this.encryption.getMachineEncryption(machineId);
-            if (!machineEncryption) {
-                console.error(`Machine encryption not found for ${machineId} - cannot decrypt updates`);
-                return;
-            }
-
-            // If metadata is provided, decrypt and update it
-            const metadataUpdate = machineUpdate.metadata;
-            if (metadataUpdate) {
-                try {
-                    const metadata = await machineEncryption.decryptMetadata(metadataUpdate.version, metadataUpdate.value);
-                    updatedMachine.metadata = metadata;
-                    updatedMachine.metadataVersion = metadataUpdate.version;
-                } catch (error) {
-                    console.error(`Failed to decrypt machine metadata for ${machineId}:`, error);
+            // Decrypt encrypted fields if machine encryption is available.
+            // When encryption keys are missing (e.g. V1 auth fallback, or a machine
+            // registered before the client finished key setup), we still apply the
+            // machine record so that non-encrypted fields like `active` / `activeAt`
+            // are visible — this is critical for onboarding auto-detection and for
+            // the sessions list to correctly show machine online state.
+            const machineEncryption = this.encryption?.getMachineEncryption(machineId);
+            if (machineEncryption) {
+                const metadataUpdate = machineUpdate.metadata;
+                if (metadataUpdate) {
+                    try {
+                        const metadata = await machineEncryption.decryptMetadata(metadataUpdate.version, metadataUpdate.value);
+                        updatedMachine.metadata = metadata;
+                        updatedMachine.metadataVersion = metadataUpdate.version;
+                    } catch (error) {
+                        console.error(`Failed to decrypt machine metadata for ${machineId}:`, error);
+                    }
                 }
-            }
 
-            // If daemonState is provided, decrypt and update it
-            const daemonStateUpdate = machineUpdate.daemonState;
-            if (daemonStateUpdate) {
-                try {
-                    const daemonState = await machineEncryption.decryptDaemonState(daemonStateUpdate.version, daemonStateUpdate.value);
-                    updatedMachine.daemonState = daemonState;
-                    updatedMachine.daemonStateVersion = daemonStateUpdate.version;
-                } catch (error) {
-                    console.error(`Failed to decrypt machine daemonState for ${machineId}:`, error);
+                const daemonStateUpdate = machineUpdate.daemonState;
+                if (daemonStateUpdate) {
+                    try {
+                        const daemonState = await machineEncryption.decryptDaemonState(daemonStateUpdate.version, daemonStateUpdate.value);
+                        updatedMachine.daemonState = daemonState;
+                        updatedMachine.daemonStateVersion = daemonStateUpdate.version;
+                    } catch (error) {
+                        console.error(`Failed to decrypt machine daemonState for ${machineId}:`, error);
+                    }
                 }
+            } else {
+                console.warn(`Machine encryption not found for ${machineId} - applying without decrypted metadata`);
             }
 
-            // Update storage using applyMachines which rebuilds sessionListViewData
+            // Always update storage so non-encrypted fields (active, activeAt) are visible
             storage.getState().applyMachines([updatedMachine]);
         } else if (updateData.body.t === 'delete-machine') {
             const machineId = updateData.body.machineId;

--- a/packages/happy-wire/src/messages.ts
+++ b/packages/happy-wire/src/messages.ts
@@ -78,10 +78,22 @@ export const UpdateMachineBodySchema = z.object({
 });
 export type UpdateMachineBody = z.infer<typeof UpdateMachineBodySchema>;
 
+export const NewMachineBodySchema = z.object({
+  t: z.literal('new-machine'),
+  machineId: z.string(),
+  seq: z.number().optional(),
+  metadata: VersionedMachineEncryptedValueSchema.nullish(),
+  daemonState: VersionedMachineEncryptedValueSchema.nullish(),
+  active: z.boolean().optional(),
+  activeAt: z.number().optional(),
+}).passthrough();
+export type NewMachineBody = z.infer<typeof NewMachineBodySchema>;
+
 export const CoreUpdateBodySchema = z.discriminatedUnion('t', [
   UpdateNewMessageBodySchema,
   UpdateSessionBodySchema,
   UpdateMachineBodySchema,
+  NewMachineBodySchema,
 ]);
 export type CoreUpdateBody = z.infer<typeof CoreUpdateBodySchema>;
 


### PR DESCRIPTION
Two related bugs in the machine update path that together cause newly registered machines to stay invisible until a full refresh.

## Bug 1 — `new-machine` WebSocket updates silently dropped

The server sends a `'new-machine'` update when a machine first registers, but the client only had a schema for `'update-machine'`. New-machine updates failed validation in `ApiUpdateContainerSchema` and were silently discarded, so the client never saw newly registered machines over the WebSocket — it had to wait for the next `machinesSync` fetch to pick them up.

### Fix

- Add `NewMachineBodySchema` to `@slopus/happy-wire` with the same shape as `UpdateMachineBodySchema` plus optional `seq` and `.passthrough()` for forward-compat.
- Include it in both the `CoreUpdateBodySchema` discriminated union and the happy-app `ApiUpdateSchema` union.
- Broaden the handler in `sync.ts` to accept both `'update-machine'` and `'new-machine'` on the same branch (payload shape is identical for the client's purposes).

## Bug 2 — `update-machine` discards `active` / `activeAt` when encryption keys are missing

The `update-machine` handler was early-returning when `getMachineEncryption` returned undefined, discarding the entire update — including non-encrypted fields like `active` and `activeAt`. This hits V1-auth fallback users and, more commonly, the brief window after a machine registers but before the client has the machine's data key, so the activity state for brand-new machines never lands in local storage and onboarding auto-detection that depends on `active` can hang.

### Fix

- Only run decryption when machine encryption is available.
- Always apply the machine record so `active` / `activeAt` land in storage regardless.
- Log a warning instead of an error when keys are missing, since it's a legitimate transient state.

## Why bundled

The two bugs together cause the user-visible symptom (new machines invisible / onboarding hang). Landing only one leaves the remaining path broken — `new-machine` still rejected, or `update-machine` still discarded pre-key.

## Scope

- 3 files (`packages/happy-wire/src/messages.ts`, `packages/happy-app/sources/sync/apiTypes.ts`, `packages/happy-app/sources/sync/sync.ts`)
- +44 / -28
- `pnpm typecheck` passes on `upstream/main + this change`.

## Repro (bug 2)

1. Fresh-install happy-app with auth already set up on another device.
2. Register a new machine from the CLI on a second host.
3. Observe: before this fix, new-machine arrives but is rejected at schema validation (bug 1); even if it slipped through, `update-machine` followups drop `active` because keys haven't propagated yet (bug 2). The sessions list shows the machine as offline until a manual refresh.

After the fix, `active` / `activeAt` land on the first message and onboarding auto-detection unblocks without a refresh.