### PR TITLE
fix(server): replace wildcard allowedHeaders with explicit list

### DIFF
--- a/packages/happy-server/sources/app/api/api.ts
+++ b/packages/happy-server/sources/app/api/api.ts
@@ -38,7 +38,7 @@ export async function startApi() {
     });
     app.register(import('@fastify/cors'), {
         origin: '*',
-        allowedHeaders: '*',
+        allowedHeaders: ['Content-Type', 'Authorization', 'x-happy-client'],
         methods: ['GET', 'POST', 'DELETE']
     });
     app.get('/', function (request, reply) {

--- a/packages/happy-server/sources/app/api/socket.ts
+++ b/packages/happy-server/sources/app/api/socket.ts
@@ -21,7 +21,7 @@ export function startSocket(app: Fastify) {
             origin: "*",
             methods: ["GET", "POST", "OPTIONS"],
             credentials: true,
-            allowedHeaders: ["*"]
+            allowedHeaders: ["Content-Type", "Authorization", "x-happy-client"]
         },
         transports: ['websocket', 'polling'],
         pingTimeout: 45000,


### PR DESCRIPTION
## Summary

- Replace \`allowedHeaders: '*'\` with an explicit list in both HTTP CORS (\`@fastify/cors\`) and Socket.IO CORS config
- Explicit headers: \`Content-Type\`, \`Authorization\`, \`x-happy-client\`

## Motivation

Browser milestone 97 will stop honoring \`*\` in \`Access-Control-Allow-Headers\` for credentialed requests. The browser already emits a deprecation warning:

> Authorization will not be covered by the wildcard symbol (*) in CORS Access-Control-Allow-Headers handling.

This is a subset of the broader CORS issue tracked in #1088. The \`origin: '*'\` + \`credentials: true\` combination (the main concern in #1088) is out of scope here — fixing that requires knowing the allowed origins at deploy time. This PR only addresses the \`allowedHeaders\` deprecation which has a safe, non-breaking fix.

## Changes

| File | Change |
|------|--------|
| \`sources/app/api/api.ts\` | \`allowedHeaders: '*'\` → \`['Content-Type', 'Authorization', 'x-happy-client']\` |
| \`sources/app/api/socket.ts\` | \`allowedHeaders: ["*"]\` → \`["Content-Type", "Authorization", "x-happy-client"]\` |

## Testing

```
Test Files  1 failed | 8 passed (9)
     Tests  1 failed | 61 passed (62)
  Duration  344ms
```

The 1 failure is `processImage > should resize image` — a pre-existing issue caused by a missing test fixture (`__testdata__/image.jpg`), tracked in #1100. Unrelated to this change.

- `pnpm build` (TypeScript typecheck) ✅
- All 61 tests unrelated to this change pass ✅

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)