### PR TITLE
fix(prompt): reframe options as conversation directions + user prompt dotfile

### DIFF
--- a/packages/happy-app/sources/sync/prompt/systemPrompt.ts
+++ b/packages/happy-app/sources/sync/prompt/systemPrompt.ts
@@ -3,18 +3,21 @@ import { trimIdent } from "@/utils/trimIdent";
 export const systemPrompt = trimIdent(`
     # Options
 
-    You have a way to give a user a easy way to answer your questions if you know possible answers. To provide this, you need to output in your final response an XML:
+    You can offer the user clickable options when there's a genuine decision point. Options represent **what the user might want to explore or discuss next** — they are conversation directions, not a menu of actions you can perform.
+
+    Output XML at the very end of your response:
 
     <options>
         <option>Option 1</option>
-        ...
         <option>Option N</option>
     </options>
 
-    You must output this in the very end of your response, not inside of any other text. Do not wrap it into a codeblock. Always dedicate "<options>" and "</options>" to a dedicated line. Never output anything like "custom", user always have an option to send a custom message. Do not enumerate options in both text and options block.
-    Always prefer to use the options mode to the text mode. Try to keep options minimal, better to clarify in a next steps.
-
-    # Plan mode with options
-
-    When you are in the plan mode, you must use the options mode to give the user a easy way to answer your questions if you know possible answers. Do not assume what is needed, when there is discrepancy between what you need and what you have, you must use the options mode.
+    Rules:
+    - Only at the very end, not inside other text. Do not wrap in a codeblock.
+    - Never include a "custom" option — the user can always type freely.
+    - Do not enumerate the same options in both text and the options block.
+    - Use options when there's a real fork — not as a default for every response. If one path is obviously right, just do it or propose it. Options are for genuine decision points with trade-offs, not menus of "what next."
+    - Keep them minimal (2-4 choices).
+    - Options should be things the user might want YOU to do, explain, or investigate. Never offer an option for something outside your capabilities, something the user must go do themselves, or something that amounts to "do nothing."
+    - Do not offer options that are actions in the real world (e.g. "close the trade", "restart the server") unless you actually have the tools and authorization to perform that action. When in doubt, frame the option as information or analysis ("show current positions", "explain the risk") rather than as a command.
 `);

--- a/packages/happy-cli/src/claude/utils/systemPrompt.ts
+++ b/packages/happy-cli/src/claude/utils/systemPrompt.ts
@@ -1,5 +1,9 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { trimIdent } from "@/utils/trimIdent";
 import { shouldIncludeCoAuthoredBy } from "./claudeSettings";
+import { logger } from '@/ui/logger';
 
 /**
  * Base system prompt shared across all configurations
@@ -24,15 +28,60 @@ const CO_AUTHORED_CREDITS = (() => trimIdent(`
 `))();
 
 /**
- * System prompt with conditional Co-Authored-By lines based on Claude's settings.json configuration.
- * Settings are read once on startup for performance.
+ * Load user's custom system prompt from a dotfile.
+ *
+ * Resolution order:
+ *   1. HAPPY_SYSTEM_PROMPT_FILE env var (explicit path)
+ *   2. $HAPPY_HOME_DIR/system-prompt.md (follows existing ~/.happy/ convention)
+ *   3. ~/.happy/system-prompt.md (default)
+ *
+ * Returns the file contents if found, or null.
+ */
+function loadUserSystemPrompt(): string | null {
+  const explicitPath = process.env.HAPPY_SYSTEM_PROMPT_FILE;
+  const happyHome = process.env.HAPPY_HOME_DIR?.replace(/^~/, homedir()) || join(homedir(), '.happy');
+  const defaultPath = join(happyHome, 'system-prompt.md');
+
+  const filePath = explicitPath || defaultPath;
+
+  try {
+    if (!existsSync(filePath)) {
+      if (explicitPath) {
+        logger.debug(`[SystemPrompt] HAPPY_SYSTEM_PROMPT_FILE set but file not found: ${filePath}`);
+      }
+      return null;
+    }
+
+    const content = readFileSync(filePath, 'utf-8').trim();
+    if (!content) {
+      return null;
+    }
+
+    logger.debug(`[SystemPrompt] Loaded user system prompt from ${filePath} (${content.length} chars)`);
+    return content;
+  } catch (error) {
+    logger.debug(`[SystemPrompt] Error reading ${filePath}: ${error}`);
+    return null;
+  }
+}
+
+/**
+ * System prompt assembled once on startup from:
+ *   - Base prompt (title-setting)
+ *   - Co-Authored-By credits (if enabled in Claude settings)
+ *   - User's custom system prompt file (if present)
  */
 export const systemPrompt = (() => {
-  const includeCoAuthored = shouldIncludeCoAuthoredBy();
-  
-  if (includeCoAuthored) {
-    return BASE_SYSTEM_PROMPT + '\n\n' + CO_AUTHORED_CREDITS;
-  } else {
-    return BASE_SYSTEM_PROMPT;
+  const parts = [BASE_SYSTEM_PROMPT];
+
+  if (shouldIncludeCoAuthoredBy()) {
+    parts.push(CO_AUTHORED_CREDITS);
   }
+
+  const userPrompt = loadUserSystemPrompt();
+  if (userPrompt) {
+    parts.push(userPrompt);
+  }
+
+  return parts.join('\n\n');
 })();


### PR DESCRIPTION
## Summary

- **Options prompt rewrite**: The current prompt tells bots to "always prefer options mode" and frames options as "a way to answer your questions if you know possible answers." This causes bots to offer real-world actions they can't perform — e.g. a stock trading bot offering "close the trade" as an option. Reframed to make clear that options are conversation directions the user might want to explore, not a menu of bot capabilities.
- **User system prompt dotfile**: Users can now create `~/.happy/system-prompt.md` to add custom system prompt instructions that get appended on daemon startup. Supports `HAPPY_SYSTEM_PROMPT_FILE` env var override and respects `HAPPY_HOME_DIR`. This is useful for per-user formatting preferences, device-specific instructions, or domain-specific guidance that only affects Happy sessions (not other Claude usage).

## Details

### Options prompt (happy-app)

Before: "You have a way to give a user a easy way to answer your questions if you know possible answers"
After: "Options represent what the user might want to explore or discuss next — they are conversation directions, not a menu of actions you can perform"

Key new rules:
- Don't offer options that are real-world actions unless tools exist for them
- Frame options as information/analysis rather than commands
- Only show options at genuine decision points, not as a default

### User system prompt (happy-cli)

Follows the existing pattern from `shouldIncludeCoAuthoredBy()` — read once at module load, cached for session lifetime. Resolution order:
1. `HAPPY_SYSTEM_PROMPT_FILE` env var (explicit path)
2. `$HAPPY_HOME_DIR/system-prompt.md`
3. `~/.happy/system-prompt.md` (default)

No file = no change to existing behavior.

## Test plan

- [ ] Verify options prompt: start a new chat, confirm bot offers conversation directions rather than action menus
- [ ] Verify dotfile: create `~/.happy/system-prompt.md` with test content, restart daemon, confirm content appears in system prompt
- [ ] Verify no dotfile: delete the file, restart, confirm no error and default behavior unchanged
- [ ] Verify env var override: set `HAPPY_SYSTEM_PROMPT_FILE=/tmp/test-prompt.md`, restart, confirm it loads from that path