### PR TITLE
docs: add note for installing from official registry due to mirror sync delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Step 2: Install CLI on your computer
 npm install -g happy
 ```
 
+> **Note:** If you're using a third-party registry mirror, the package may not be available immediately due to sync delays. In that case, install directly from the official npm registry:
+> ```bash
+> npm install -g happy@latest --registry https://registry.npmjs.org/
+> ```
+
 > Migrated from the `happy-coder` package. Thanks to [@franciscop](https://github.com/franciscop) for donating the `happy` package name!
 
 <h3 align="center">


### PR DESCRIPTION
Add a note in the installation section to inform users that if they're using a 
mirrored registry, the package may not be immediately available due to sync delays. 
Users can work around this by installing directly from the official npm registry 
using `--registry https://registry.npmjs.org/`.

Closes #1079 
Closes #1144
Closes #1153