### PR TITLE
fix(permissions): plumb dontAsk mode through wire/cli/app enums

### DIFF
--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -147,7 +147,7 @@ const rawToolResultContentSchema = z.object({
     permissions: z.object({
         date: z.number(),
         result: z.enum(['approved', 'denied']),
-        mode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo']).optional(),
+        mode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'read-only', 'safe-yolo', 'yolo']).optional(),
         allowedTools: z.array(z.string()).optional(),
         decision: z.enum(['approved', 'approved_for_session', 'denied', 'abort']).optional(),
     }).optional(),

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -32,7 +32,7 @@ export type {
  * - safe-yolo → default
  * - read-only → default
  */
-export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo'
+export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'read-only' | 'safe-yolo' | 'yolo'
 
 /**
  * Usage data type from Claude
@@ -188,7 +188,7 @@ export type Machine = {
  */
 export const MessageMetaSchema = z.object({
   sentFrom: z.string().optional(), // Source identifier
-  permissionMode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo']).optional(), // Permission mode for this message
+  permissionMode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'read-only', 'safe-yolo', 'yolo']).optional(), // Permission mode for this message
   model: z.string().nullable().optional(), // Model name for this message (null = reset)
   fallbackModel: z.string().nullable().optional(), // Fallback model for this message (null = reset)
   customSystemPrompt: z.string().nullable().optional(), // Custom system prompt for this message (null = reset)

--- a/packages/happy-cli/src/claude/sdk/types.ts
+++ b/packages/happy-cli/src/claude/sdk/types.ts
@@ -35,7 +35,7 @@ export interface QueryOptions {
     disallowedTools?: string[]
     maxTurns?: number
     mcpServers?: Record<string, unknown>
-    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'
+    permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk'
     continue?: boolean
     resume?: string
     model?: string

--- a/packages/happy-cli/src/claude/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.ts
@@ -169,7 +169,7 @@ export class PermissionHandler {
         // Handle special cases
         //
 
-        if (this.permissionMode === 'bypassPermissions') {
+        if (this.permissionMode === 'bypassPermissions' || this.permissionMode === 'dontAsk') {
             return { behavior: 'allow', updatedInput: input as Record<string, unknown> };
         }
 

--- a/packages/happy-cli/src/claude/utils/permissionMode.test.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.test.ts
@@ -33,16 +33,20 @@ describe('mapToClaudeMode', () => {
         it('passes through plan', () => {
             expect(mapToClaudeMode('plan')).toBe('plan');
         });
+
+        it('passes through dontAsk', () => {
+            expect(mapToClaudeMode('dontAsk')).toBe('dontAsk');
+        });
     });
 
-    describe('all 7 PermissionMode values are handled', () => {
+    describe('all 8 PermissionMode values are handled', () => {
         const allModes: PermissionMode[] = [
-            'default', 'acceptEdits', 'bypassPermissions', 'plan',  // Claude modes
+            'default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk',  // Claude modes
             'read-only', 'safe-yolo', 'yolo'  // Codex modes
         ];
 
         it('returns a valid Claude mode for every PermissionMode', () => {
-            const validClaudeModes = ['default', 'acceptEdits', 'bypassPermissions', 'plan'];
+            const validClaudeModes = ['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk'];
 
             allModes.forEach(mode => {
                 const result = mapToClaudeMode(mode);

--- a/packages/happy-cli/src/claude/utils/permissionMode.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.ts
@@ -5,7 +5,7 @@ import type { PermissionMode } from '@/api/types';
 export type ClaudeSdkPermissionMode = NonNullable<QueryOptions['permissionMode']>;
 
 /**
- * Map any PermissionMode (7 modes) to a Claude-compatible mode (4 modes)
+ * Map any PermissionMode (8 modes) to a Claude-compatible mode (5 modes)
  * This is the ONLY place where Codex modes are mapped to Claude equivalents.
  *
  * Mapping:
@@ -14,7 +14,7 @@ export type ClaudeSdkPermissionMode = NonNullable<QueryOptions['permissionMode']
  * - read-only → default (Claude doesn't support read-only)
  *
  * Claude modes pass through unchanged:
- * - default, acceptEdits, bypassPermissions, plan
+ * - default, acceptEdits, bypassPermissions, plan, dontAsk
  */
 export function mapToClaudeMode(mode: PermissionMode): ClaudeSdkPermissionMode {
     const codexToClaudeMap: Record<string, ClaudeSdkPermissionMode> = {
@@ -30,6 +30,7 @@ const VALID_PERMISSION_MODES: readonly PermissionMode[] = [
     'acceptEdits',
     'bypassPermissions',
     'plan',
+    'dontAsk',
     'read-only',
     'safe-yolo',
     'yolo',

--- a/packages/happy-wire/README.md
+++ b/packages/happy-wire/README.md
@@ -248,7 +248,7 @@ Notes:
 ```ts
 {
   sentFrom?: string;
-  permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo';
+  permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'dontAsk' | 'read-only' | 'safe-yolo' | 'yolo';
   model?: string | null;
   fallbackModel?: string | null;
   customSystemPrompt?: string | null;

--- a/packages/happy-wire/src/messageMeta.ts
+++ b/packages/happy-wire/src/messageMeta.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 export const MessageMetaSchema = z.object({
   sentFrom: z.string().optional(),
-  permissionMode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo']).optional(),
+  permissionMode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'read-only', 'safe-yolo', 'yolo']).optional(),
   model: z.string().nullable().optional(),
   fallbackModel: z.string().nullable().optional(),
   customSystemPrompt: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary

The `dontAsk` permission mode was exposed in the Claude permission-mode selector UI (`packages/happy-app/sources/components/modelModeOptions.ts:52`) and had translated labels in every supported language, but the wire, CLI and app Zod enums all rejected it. Selecting "don't ask" in the UI therefore silently fell back to `default` — permission prompts kept appearing. This is the `dontAsk` half of #1156 (not tackling `auto` in this PR).

Related reports: #1164, #625, #648.

## Changes

- `packages/happy-wire/src/messageMeta.ts` + `README.md` — add `'dontAsk'` to `MessageMetaSchema.permissionMode` enum and the documented type union.
- `packages/happy-cli/src/api/types.ts` — extend `PermissionMode` union and `MessageMetaSchema.permissionMode` enum.
- `packages/happy-cli/src/claude/utils/permissionMode.ts` — add `'dontAsk'` to `VALID_PERMISSION_MODES`; update JSDoc to reflect 8-mode input / 5-mode Claude output. `mapToClaudeMode` already passes Claude-native modes through unchanged.
- `packages/happy-cli/src/claude/sdk/types.ts` — extend internal `QueryOptions.permissionMode` from 4 to 5 modes to match `@anthropic-ai/claude-agent-sdk@0.2.96`'s native `PermissionMode` (minus `auto`, which is out of scope here).
- `packages/happy-cli/src/claude/utils/permissionHandler.ts` — in `canCallTool`, treat `'dontAsk'` the same as `'bypassPermissions'`: auto-allow, don't prompt (matches SDK semantics).
- `packages/happy-app/sources/sync/typesRaw.ts` — add `'dontAsk'` to the mirror Zod enum used on sync inbound.
- `packages/happy-cli/src/claude/utils/permissionMode.test.ts` — add `dontAsk` passthrough case; extend `all 7` → `all 8` invariant.

## Release coordination

`happy-wire` is published separately and consumed by `happy-server`. A server with the old enum will reject `meta.permissionMode: 'dontAsk'` at validation. Suggested sequence:

1. Merge + publish `@slopus/happy-wire` with the new value.
2. Deploy `happy-server` against the new wire package.
3. Ship updated CLI + app.

Until step 2 completes, selecting "don't ask" will keep failing against the old server — i.e. no regression vs. today.

## Test plan

- [x] `pnpm -F happy-cli typecheck` — passes
- [x] `pnpm -F happy-cli test -- src/claude/utils/permissionMode.test.ts` — 18/18 pass
- [x] `pnpm -F happy-app typecheck` — passes
- [x] `pnpm -F @slopus/happy-wire build` — passes
- [ ] Manual: pick "don't ask" in Claude session → run a tool → no prompt appears (requires server-side rollout to fully verify end-to-end)

## Not in scope / known issues

- `'auto'` mode from SDK 0.2.96 — left for a follow-up PR per #1156.
- Pre-existing `packages/happy-app/sources/components/modelModeOptions.test.ts` failure at line 26 (test expected order `['default','acceptEdits','plan','dontAsk','bypassPermissions']` doesn't match source order `['default','plan','dontAsk','acceptEdits','bypassPermissions']`). Reproduces on `main`, untouched by this PR.
- `PermissionModeSelector.tsx` rendering only an icon with no label (line 64–66) — separate UX bug, separate fix.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)