### PR TITLE
fix(cli): add resolveClaudeEntrypoint tests + fix getVersion for native binary

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -469,10 +469,16 @@ function findGlobalClaudeCliPath() {
  */
 function getVersion(cliPath) {
     try {
-        const pkgPath = path.join(path.dirname(cliPath), 'package.json');
-        if (fs.existsSync(pkgPath)) {
-            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-            return pkg.version;
+        let pkgDir = path.dirname(cliPath);
+        const pkgPath = path.join(pkgDir, 'package.json');
+        // When entrypoint is in a subdirectory (e.g. bin/claude.exe), look one level up
+        if (!fs.existsSync(pkgPath)) {
+            pkgDir = path.dirname(pkgDir);
+        }
+        const parentPkgPath = path.join(pkgDir, 'package.json');
+        if (fs.existsSync(parentPkgPath)) {
+            const pkg = JSON.parse(fs.readFileSync(parentPkgPath, 'utf8'));
+            return pkg.version || null;
         }
     } catch (e) {}
     return null;
@@ -555,6 +561,7 @@ function runClaudeCli(cliPath) {
 }
 
 module.exports = {
+    resolveClaudeEntrypoint,
     findGlobalClaudeCliPath,
     findClaudeInPath,
     detectSourceFromPath,

--- a/packages/happy-cli/scripts/claude_version_utils.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import {
+  resolveClaudeEntrypoint,
   findGlobalClaudeCliPath,
   findClaudeInPath,
   detectSourceFromPath,
@@ -10,7 +13,7 @@ import {
   findNativeInstallerCliPath,
   getVersion,
   compareVersions
-} from '../scripts/claude_version_utils.cjs';
+} from './claude_version_utils.cjs';
 
 describe('Claude Version Utils - Cross-Platform Detection', () => {
 
@@ -369,5 +372,112 @@ describe('HAPPY_CLAUDE_PATH env var', () => {
     process.env.HAPPY_CLAUDE_PATH = '/nonexistent/path/claude';
     const result = findGlobalClaudeCliPath();
     expect(result?.source).not.toBe('HAPPY_CLAUDE_PATH');
+  });
+});
+
+describe('resolveClaudeEntrypoint', () => {
+  const tmpDir = path.join(os.tmpdir(), 'happy-test-entrypoint');
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should return legacy cli.js when it exists', () => {
+    const cliJs = path.join(tmpDir, 'cli.js');
+    fs.writeFileSync(cliJs, '// legacy');
+    expect(resolveClaudeEntrypoint(tmpDir)).toBe(cliJs);
+  });
+
+  it('should resolve entrypoint from package.json bin as string', () => {
+    const pkgJson = { name: '@anthropic-ai/claude-code', version: '2.1.113', bin: 'bin/claude.exe' };
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(pkgJson));
+    fs.mkdirSync(path.join(tmpDir, 'bin'), { recursive: true });
+    const exePath = path.join(tmpDir, 'bin', 'claude.exe');
+    fs.writeFileSync(exePath, 'binary');
+    expect(resolveClaudeEntrypoint(tmpDir)).toBe(exePath);
+  });
+
+  it('should resolve entrypoint from package.json bin as object', () => {
+    const pkgJson = { name: '@anthropic-ai/claude-code', version: '2.1.113', bin: { claude: 'bin/claude' } };
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(pkgJson));
+    fs.mkdirSync(path.join(tmpDir, 'bin'), { recursive: true });
+    const binPath = path.join(tmpDir, 'bin', 'claude');
+    fs.writeFileSync(binPath, 'binary');
+    expect(resolveClaudeEntrypoint(tmpDir)).toBe(binPath);
+  });
+
+  it('should prefer legacy cli.js over bin when both exist', () => {
+    const cliJs = path.join(tmpDir, 'cli.js');
+    fs.writeFileSync(cliJs, '// legacy');
+    const pkgJson = { name: '@anthropic-ai/claude-code', version: '2.1.113', bin: 'bin/claude.exe' };
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(pkgJson));
+    fs.mkdirSync(path.join(tmpDir, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'bin', 'claude.exe'), 'binary');
+    expect(resolveClaudeEntrypoint(tmpDir)).toBe(cliJs);
+  });
+
+  it('should return null when neither cli.js nor bin exists', () => {
+    const pkgJson = { name: '@anthropic-ai/claude-code', version: '2.1.113', bin: 'bin/nonexistent' };
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(pkgJson));
+    expect(resolveClaudeEntrypoint(tmpDir)).toBeNull();
+  });
+
+  it('should return null when package.json does not exist', () => {
+    expect(resolveClaudeEntrypoint(tmpDir)).toBeNull();
+  });
+
+  it('should return null when package.json has no bin field', () => {
+    const pkgJson = { name: '@anthropic-ai/claude-code', version: '2.1.113' };
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(pkgJson));
+    expect(resolveClaudeEntrypoint(tmpDir)).toBeNull();
+  });
+
+  it('should return null when package.json is malformed', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{invalid json');
+    expect(resolveClaudeEntrypoint(tmpDir)).toBeNull();
+  });
+});
+
+describe('getVersion', () => {
+  const tmpDir = path.join(os.tmpdir(), 'happy-test-getversion');
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should read version from package.json next to cli.js', () => {
+    const cliJs = path.join(tmpDir, 'cli.js');
+    fs.writeFileSync(cliJs, '// cli');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '2.1.100' }));
+    expect(getVersion(cliJs)).toBe('2.1.100');
+  });
+
+  it('should read version from parent directory when binary is in bin/', () => {
+    fs.mkdirSync(path.join(tmpDir, 'bin'), { recursive: true });
+    const exePath = path.join(tmpDir, 'bin', 'claude.exe');
+    fs.writeFileSync(exePath, 'binary');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '2.1.119' }));
+    expect(getVersion(exePath)).toBe('2.1.119');
+  });
+
+  it('should return null when no package.json exists anywhere', () => {
+    const cliJs = path.join(tmpDir, 'cli.js');
+    fs.writeFileSync(cliJs, '// cli');
+    expect(getVersion(cliJs)).toBeNull();
+  });
+
+  it('should return null when package.json has no version field', () => {
+    const cliJs = path.join(tmpDir, 'cli.js');
+    fs.writeFileSync(cliJs, '// cli');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'test' }));
+    expect(getVersion(cliJs)).toBeNull();
   });
 });

--- a/packages/happy-cli/vitest.config.ts
+++ b/packages/happy-cli/vitest.config.ts
@@ -21,6 +21,16 @@ export default defineConfig({
             {
                 extends: true,
                 test: {
+                    name: 'scripts',
+                    include: ['scripts/**/*.test.ts'],
+                    sequence: {
+                        groupOrder: 0,
+                    },
+                },
+            },
+            {
+                extends: true,
+                test: {
                     name: 'integration-empty',
                     fileParallelism: false,
                     hookTimeout: 120_000,


### PR DESCRIPTION
## Summary

Follow-up to #1140 which added `resolveClaudeEntrypoint()` to support `@anthropic-ai/claude-code@2.1.113+` (native binary in `bin/` instead of `cli.js`).

- **Add unit tests for `resolveClaudeEntrypoint()`** — 7 test cases covering legacy cli.js, bin-as-string, bin-as-object, preference for cli.js, missing files, missing package.json, and malformed JSON. Previously had zero test coverage.
- **Fix `getVersion()` for native binary entrypoints** — When the entrypoint is `bin/claude.exe`, `path.dirname()` returns the `bin/` subdirectory where no `package.json` exists. Now walks up one level to find it.
- **Export `resolveClaudeEntrypoint`** for testability.
- **Add `scripts` vitest project** so `scripts/**/*.test.ts` tests actually run (they were previously excluded by `include: ['src/**/*.test.ts']`).

## Proof it works

```
$ node -e "const u = require('./scripts/claude_version_utils.cjs'); const r = u.findGlobalClaudeCliPath(); console.log(u.getVersion(r.path));"
2.1.119
```

Before this fix, `getVersion()` returned `null` for native binary entrypoints.

## Test plan

- [x] `pnpm --filter happy build` passes
- [x] `vitest run --project scripts` — all new tests pass (51/60 pass; 9 pre-existing failures are Homebrew platform-mock tests unrelated to this change)
- [x] `vitest run --project unit` — no regressions
- [x] Manual verification: `getVersion()` returns correct version for `bin/claude.exe` path on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)