### PR TITLE
fix(cli): set UTF-8 code page on Windows to fix garbled box-drawing chars

### DIFF
--- a/packages/happy-cli/scripts/claude_local_launcher.cjs
+++ b/packages/happy-cli/scripts/claude_local_launcher.cjs
@@ -1,4 +1,14 @@
 const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Set UTF-8 code page on Windows to fix garbled box-drawing characters
+if (process.platform === 'win32') {
+    try {
+        execSync('chcp 65001', { stdio: 'pipe' });
+    } catch (e) {
+        // Non-critical: some Windows environments don't support chcp
+    }
+}
 
 // Disable autoupdater (never works really)
 process.env.DISABLE_AUTOUPDATER = '1';


### PR DESCRIPTION
## Summary

Windows consoles default to a legacy code page (e.g. 437, 936) which causes Unicode box-drawing characters used by Claude Code's terminal UI to render as mojibake.

This PR runs `chcp 65001` at launcher startup on Windows to switch the console to UTF-8. Non-critical: silently ignores errors in environments where `chcp` is unavailable (e.g. some Docker containers).

Fixes #904

## Test plan

- [x] `pnpm --filter happy build` passes
- [x] Manual verification on Windows: `chcp 65001` succeeds and doesn't break anything
- [x] Non-Windows platforms: no code changes executed (guarded by `process.platform === 'win32'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)