### PR TITLE
fix(happy-cli): support proxy env for websocket connections

### DIFF
--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -98,6 +98,19 @@ happy connect status
 | `HAPPY_DISABLE_CAFFEINATE` | Disable macOS sleep prevention |
 | `HAPPY_EXPERIMENTAL` | Enable experimental features |
 
+### Using Happy behind an HTTP proxy
+
+If your machine needs an HTTP or HTTPS proxy to reach Happy's relay server, set standard proxy environment variables:
+
+```bash
+export HTTPS_PROXY=http://127.0.0.1:5901
+export HTTP_PROXY=http://127.0.0.1:5901
+```
+
+Happy also supports `ALL_PROXY` and lowercase variants such as `https_proxy`, `http_proxy`, and `all_proxy`.
+
+This applies to both daemon machine connections and active session connections. It is useful for remote servers, containers, SSH reverse tunnels, corporate networks, or restricted outbound networks.
+
 ### Sandbox (experimental)
 
 Happy can run agents inside an OS-level sandbox to restrict file system and network access.

--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -107,7 +107,7 @@ export HTTPS_PROXY=http://127.0.0.1:5901
 export HTTP_PROXY=http://127.0.0.1:5901
 ```
 
-Happy also supports `ALL_PROXY` and lowercase variants such as `https_proxy`, `http_proxy`, and `all_proxy`.
+Happy also supports `ALL_PROXY`, `NO_PROXY`, and lowercase variants such as `https_proxy`, `http_proxy`, `all_proxy`, and `no_proxy`.
 
 This applies to both daemon machine connections and active session connections. It is useful for remote servers, containers, SSH reverse tunnels, corporate networks, or restricted outbound networks.
 

--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -90,6 +90,7 @@
     "fastify-type-provider-zod": "4.0.2",
     "http-proxy": "^1.18.1",
     "http-proxy-middleware": "^3.0.5",
+    "https-proxy-agent": "^9.0.0",
     "ink": "^6.5.1",
     "inquirer": "^13.2.2",
     "open": "^10.2.0",

--- a/packages/happy-cli/src/api/apiMachine.test.ts
+++ b/packages/happy-cli/src/api/apiMachine.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiMachineClient } from './apiMachine';
+import type { Machine } from './types';
+
+const { mockIo } = vi.hoisted(() => ({
+    mockIo: vi.fn(),
+}));
+
+vi.mock('socket.io-client', () => ({
+    io: mockIo,
+}));
+
+vi.mock('@/configuration', () => ({
+    configuration: {
+        serverUrl: 'https://server.test',
+        currentCliVersion: 'test',
+    },
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+        debugLargeJson: vi.fn(),
+    },
+}));
+
+vi.mock('@/api/rpc/RpcHandlerManager', () => ({
+    RpcHandlerManager: class {
+        registerHandler = vi.fn();
+        unregisterHandler = vi.fn();
+        hasHandler = vi.fn(() => false);
+        onSocketConnect = vi.fn();
+        onSocketDisconnect = vi.fn();
+        handleRequest = vi.fn(async () => '');
+    },
+}));
+
+vi.mock('@/modules/common/registerCommonHandlers', () => ({
+    registerCommonHandlers: vi.fn(),
+}));
+
+vi.mock('@/utils/time', () => ({
+    backoff: vi.fn(async <T>(callback: () => Promise<T>) => callback()),
+}));
+
+vi.mock('@/utils/detectCLI', () => ({
+    detectCLIAvailability: vi.fn(async () => ({ claude: false, codex: false, gemini: false, openclaw: false })),
+}));
+
+vi.mock('@/resume/localHappyAgentAuth', () => ({
+    detectResumeSupport: vi.fn(async () => ({
+        rpcAvailable: false,
+        requiresSameMachine: false,
+        requiresHappyAgentAuth: false,
+        happyAgentAuthenticated: false,
+    })),
+}));
+
+vi.mock('@/utils/lidState', () => ({
+    shouldReconnect: vi.fn(() => true),
+}));
+
+function makeMachine(): Machine {
+    return {
+        id: 'test-machine-id',
+        encryptionKey: new Uint8Array(32),
+        encryptionVariant: 'legacy',
+        metadata: {
+            host: 'localhost',
+            platform: 'linux',
+            happyCliVersion: 'test',
+            homeDir: '/home/user',
+            happyHomeDir: '/home/user/.happy',
+            happyLibDir: '/home/user/.happy/lib',
+        },
+        metadataVersion: 0,
+        daemonState: null,
+        daemonStateVersion: 0,
+    };
+}
+
+describe('ApiMachineClient proxy support', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockIo.mockReturnValue({
+            on: vi.fn(),
+            io: {
+                on: vi.fn(),
+            },
+            emit: vi.fn(),
+            emitWithAck: vi.fn(async () => ({ result: 'error' })),
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.restoreAllMocks();
+    });
+
+    it('passes a websocket proxy agent when proxy env is configured', () => {
+        vi.stubEnv('HTTPS_PROXY', 'http://127.0.0.1:5901');
+
+        new ApiMachineClient('fake-token', makeMachine()).connect();
+
+        const socketOptions = mockIo.mock.calls[0][1];
+        expect(socketOptions.transportOptions.websocket.agent).toBeDefined();
+    });
+});

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -14,6 +14,7 @@ import { RpcHandlerManager } from './rpc/RpcHandlerManager';
 import { detectCLIAvailability, CLIAvailability } from '@/utils/detectCLI';
 import { detectResumeSupport, type ResumeSupport } from '@/resume/localHappyAgentAuth';
 import { shouldReconnect } from '@/utils/lidState';
+import { createProxyAgentFromEnv, getProxyUrlFromEnv, maskProxyUrl } from './proxy';
 
 interface ServerToDaemonEvents {
     update: (data: Update) => void;
@@ -266,7 +267,13 @@ export class ApiMachineClient {
         const serverUrl = configuration.serverUrl.replace(/^http/, 'ws');
         logger.debug(`[API MACHINE] Connecting to ${serverUrl}`);
 
-        this.socket = io(serverUrl, {
+        const proxyUrl = getProxyUrlFromEnv();
+        const proxyAgent = createProxyAgentFromEnv();
+        if (proxyAgent && proxyUrl) {
+            logger.debug(`[API MACHINE] Using proxy agent: ${maskProxyUrl(proxyUrl)}`);
+        }
+
+        const socketOptions: NonNullable<Parameters<typeof io>[1]> = {
             transports: ['websocket'],
             auth: {
                 token: this.token,
@@ -276,7 +283,16 @@ export class ApiMachineClient {
             },
             path: '/v1/updates',
             reconnection: false,
-        });
+        };
+        if (proxyAgent) {
+            socketOptions.transportOptions = {
+                websocket: {
+                    agent: proxyAgent,
+                },
+            };
+        }
+
+        this.socket = io(serverUrl, socketOptions);
 
         this.socket.on('connect', () => {
             logger.debug('[API MACHINE] Connected to server');

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -267,8 +267,8 @@ export class ApiMachineClient {
         const serverUrl = configuration.serverUrl.replace(/^http/, 'ws');
         logger.debug(`[API MACHINE] Connecting to ${serverUrl}`);
 
-        const proxyUrl = getProxyUrlFromEnv();
-        const proxyAgent = createProxyAgentFromEnv();
+        const proxyUrl = getProxyUrlFromEnv(serverUrl);
+        const proxyAgent = createProxyAgentFromEnv(serverUrl);
         if (proxyAgent && proxyUrl) {
             logger.debug(`[API MACHINE] Using proxy agent: ${maskProxyUrl(proxyUrl)}`);
         }

--- a/packages/happy-cli/src/api/apiSession.test.ts
+++ b/packages/happy-cli/src/api/apiSession.test.ts
@@ -169,6 +169,7 @@ describe('ApiSessionClient v3 messages API migration', () => {
     });
 
     afterEach(() => {
+        vi.unstubAllEnvs();
         vi.restoreAllMocks();
     });
 
@@ -179,6 +180,24 @@ describe('ApiSessionClient v3 messages API migration', () => {
         expect(mockSocket.on).toHaveBeenCalledWith('disconnect', expect.any(Function));
         expect(mockSocket.on).toHaveBeenCalledWith('update', expect.any(Function));
         expect(mockSocket.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes a websocket proxy agent when proxy env is configured', () => {
+        vi.stubEnv('HTTPS_PROXY', 'http://127.0.0.1:5901');
+
+        new ApiSessionClient('fake-token', session);
+
+        const socketOptions = mockIo.mock.calls[0][1];
+        expect(socketOptions.transportOptions.websocket.agent).toBeDefined();
+    });
+
+    it('does not pass a websocket proxy agent when proxy env is invalid', () => {
+        vi.stubEnv('HTTPS_PROXY', 'http://user:pass@%');
+
+        new ApiSessionClient('fake-token', session);
+
+        const socketOptions = mockIo.mock.calls[0][1];
+        expect(socketOptions.transportOptions).toBeUndefined();
     });
 
     it('queues codex message to v3 outbox, sends once, and drains outbox', async () => {

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -133,8 +133,8 @@ export class ApiSessionClient extends EventEmitter {
         // Create socket
         //
 
-        const proxyUrl = getProxyUrlFromEnv();
-        const proxyAgent = createProxyAgentFromEnv();
+        const proxyUrl = getProxyUrlFromEnv(configuration.serverUrl);
+        const proxyAgent = createProxyAgentFromEnv(configuration.serverUrl);
         if (proxyAgent && proxyUrl) {
             logger.debug(`[API] Using proxy agent: ${maskProxyUrl(proxyUrl)}`);
         }

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -20,6 +20,7 @@ import {
 } from '@/claude/utils/sessionProtocolMapper';
 import { InvalidateSync } from '@/utils/sync';
 import axios from 'axios';
+import { createProxyAgentFromEnv, getProxyUrlFromEnv, maskProxyUrl } from './proxy';
 
 /**
  * ACP (Agent Communication Protocol) message data types.
@@ -132,7 +133,13 @@ export class ApiSessionClient extends EventEmitter {
         // Create socket
         //
 
-        this.socket = io(configuration.serverUrl, {
+        const proxyUrl = getProxyUrlFromEnv();
+        const proxyAgent = createProxyAgentFromEnv();
+        if (proxyAgent && proxyUrl) {
+            logger.debug(`[API] Using proxy agent: ${maskProxyUrl(proxyUrl)}`);
+        }
+
+        const socketOptions: NonNullable<Parameters<typeof io>[1]> = {
             auth: {
                 token: this.token,
                 clientType: 'session-scoped' as const,
@@ -144,7 +151,16 @@ export class ApiSessionClient extends EventEmitter {
             transports: ['websocket'],
             withCredentials: true,
             autoConnect: false
-        });
+        };
+        if (proxyAgent) {
+            socketOptions.transportOptions = {
+                websocket: {
+                    agent: proxyAgent,
+                },
+            };
+        }
+
+        this.socket = io(configuration.serverUrl, socketOptions);
 
         //
         // Handlers

--- a/packages/happy-cli/src/api/proxy.test.ts
+++ b/packages/happy-cli/src/api/proxy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createProxyAgentFromEnv, getProxyUrlFromEnv, maskProxyUrl } from './proxy';
+
+describe('proxy helpers', () => {
+    it('falls back through standard proxy environment variables in order', () => {
+        const ordered = [
+            'HTTPS_PROXY',
+            'https_proxy',
+            'HTTP_PROXY',
+            'http_proxy',
+            'ALL_PROXY',
+            'all_proxy',
+        ] as const;
+
+        for (const [index, key] of ordered.entries()) {
+            expect(getProxyUrlFromEnv({
+                [key]: `http://127.0.0.1:${5901 + index}`,
+            })).toBe(`http://127.0.0.1:${5901 + index}`);
+        }
+    });
+
+    it('returns undefined when no proxy environment variable is set', () => {
+        expect(getProxyUrlFromEnv({})).toBeUndefined();
+    });
+
+    it('creates a proxy agent when a proxy URL is configured', () => {
+        expect(createProxyAgentFromEnv({
+            HTTPS_PROXY: 'http://127.0.0.1:5901',
+        })).toBeDefined();
+    });
+
+    it('redacts proxy URL credentials', () => {
+        const masked = maskProxyUrl('http://user:pass@127.0.0.1:5901');
+
+        expect(masked).toContain('***');
+        expect(masked).not.toContain('user');
+        expect(masked).not.toContain('pass');
+    });
+
+    it('does not leak invalid proxy URLs', () => {
+        expect(maskProxyUrl('http://user:pass@%')).toBe('<invalid proxy url>');
+    });
+});

--- a/packages/happy-cli/src/api/proxy.test.ts
+++ b/packages/happy-cli/src/api/proxy.test.ts
@@ -1,30 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { createProxyAgentFromEnv, getProxyUrlFromEnv, maskProxyUrl } from './proxy';
+import { createProxyAgentFromEnv, getProxyUrlFromEnv, maskProxyUrl, shouldBypassProxy } from './proxy';
 
 describe('proxy helpers', () => {
-    it('falls back through standard proxy environment variables in order', () => {
-        const ordered = [
-            'HTTPS_PROXY',
-            'https_proxy',
-            'HTTP_PROXY',
-            'http_proxy',
-            'ALL_PROXY',
-            'all_proxy',
-        ] as const;
+    it('selects HTTPS proxy variables first for secure targets', () => {
+        expect(getProxyUrlFromEnv('wss://server.test', {
+            HTTPS_PROXY: 'http://127.0.0.1:5901',
+            HTTP_PROXY: 'http://127.0.0.1:5902',
+        })).toBe('http://127.0.0.1:5901');
+    });
 
-        for (const [index, key] of ordered.entries()) {
-            expect(getProxyUrlFromEnv({
-                [key]: `http://127.0.0.1:${5901 + index}`,
-            })).toBe(`http://127.0.0.1:${5901 + index}`);
-        }
+    it('selects HTTP proxy variables first for plain targets', () => {
+        expect(getProxyUrlFromEnv('ws://server.test', {
+            HTTPS_PROXY: 'http://127.0.0.1:5901',
+            HTTP_PROXY: 'http://127.0.0.1:5902',
+        })).toBe('http://127.0.0.1:5902');
+    });
+
+    it('falls back to ALL_PROXY when scheme-specific proxy variables are unset', () => {
+        expect(getProxyUrlFromEnv('wss://server.test', {
+            ALL_PROXY: 'http://127.0.0.1:5903',
+        })).toBe('http://127.0.0.1:5903');
     });
 
     it('returns undefined when no proxy environment variable is set', () => {
-        expect(getProxyUrlFromEnv({})).toBeUndefined();
+        expect(getProxyUrlFromEnv('wss://server.test', {})).toBeUndefined();
     });
 
     it('creates a proxy agent when a proxy URL is configured', () => {
-        expect(createProxyAgentFromEnv({
+        expect(createProxyAgentFromEnv('wss://server.test', {
             HTTPS_PROXY: 'http://127.0.0.1:5901',
         })).toBeDefined();
     });
@@ -39,5 +42,29 @@ describe('proxy helpers', () => {
 
     it('does not leak invalid proxy URLs', () => {
         expect(maskProxyUrl('http://user:pass@%')).toBe('<invalid proxy url>');
+    });
+
+    it('bypasses all targets when NO_PROXY is wildcard', () => {
+        expect(shouldBypassProxy('wss://server.test', {
+            NO_PROXY: '*',
+        })).toBe(true);
+    });
+
+    it('bypasses exact hosts, host ports, and dot-prefixed domains', () => {
+        const env = {
+            NO_PROXY: 'localhost,server.test:443,.internal.test',
+        };
+
+        expect(shouldBypassProxy('ws://localhost:3005', env)).toBe(true);
+        expect(shouldBypassProxy('wss://server.test:443', env)).toBe(true);
+        expect(shouldBypassProxy('wss://api.internal.test', env)).toBe(true);
+        expect(shouldBypassProxy('wss://external.test', env)).toBe(false);
+    });
+
+    it('does not create a proxy agent for NO_PROXY targets', () => {
+        expect(createProxyAgentFromEnv('wss://server.test', {
+            HTTPS_PROXY: 'http://127.0.0.1:5901',
+            NO_PROXY: 'server.test',
+        })).toBeUndefined();
     });
 });

--- a/packages/happy-cli/src/api/proxy.ts
+++ b/packages/happy-cli/src/api/proxy.ts
@@ -11,8 +11,69 @@ const PROXY_ENV_KEYS = [
 
 export type HappyProxyAgent = HttpsProxyAgent<string>;
 
-export function getProxyUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
-    for (const key of PROXY_ENV_KEYS) {
+function getProxyEnvKeys(targetUrl?: string): readonly typeof PROXY_ENV_KEYS[number][] {
+    if (!targetUrl) {
+        return PROXY_ENV_KEYS;
+    }
+
+    try {
+        const url = new URL(targetUrl);
+        if (url.protocol === 'http:' || url.protocol === 'ws:') {
+            return ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy', 'ALL_PROXY', 'all_proxy'];
+        }
+        if (url.protocol === 'https:' || url.protocol === 'wss:') {
+            return ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy', 'ALL_PROXY', 'all_proxy'];
+        }
+    } catch {
+        // Fall back to the default proxy env order when the target is not parseable.
+    }
+
+    return PROXY_ENV_KEYS;
+}
+
+export function shouldBypassProxy(targetUrl: string, env: NodeJS.ProcessEnv = process.env): boolean {
+    const noProxy = env.NO_PROXY ?? env.no_proxy;
+    if (!noProxy) {
+        return false;
+    }
+
+    const patterns = noProxy.split(',').map((pattern) => pattern.trim().toLowerCase()).filter(Boolean);
+    if (patterns.includes('*')) {
+        return true;
+    }
+
+    try {
+        const url = new URL(targetUrl);
+        const hostname = url.hostname.toLowerCase();
+        let port = url.port;
+        if (!port && (url.protocol === 'https:' || url.protocol === 'wss:')) {
+            port = '443';
+        } else if (!port && (url.protocol === 'http:' || url.protocol === 'ws:')) {
+            port = '80';
+        }
+        const hostWithPort = port ? `${hostname}:${port}` : hostname;
+
+        return patterns.some((pattern) => {
+            if (pattern === hostWithPort || pattern === hostname) {
+                return true;
+            }
+            if (pattern.startsWith('.')) {
+                const domain = pattern.slice(1);
+                return hostname === domain || hostname.endsWith(pattern);
+            }
+            return hostname.endsWith(`.${pattern}`);
+        });
+    } catch {
+        return false;
+    }
+}
+
+export function getProxyUrlFromEnv(targetUrl?: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+    if (targetUrl && shouldBypassProxy(targetUrl, env)) {
+        return undefined;
+    }
+
+    for (const key of getProxyEnvKeys(targetUrl)) {
         const value = env[key];
         if (value) {
             return value;
@@ -22,8 +83,8 @@ export function getProxyUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string
     return undefined;
 }
 
-export function createProxyAgentFromEnv(env: NodeJS.ProcessEnv = process.env): HappyProxyAgent | undefined {
-    const proxyUrl = getProxyUrlFromEnv(env);
+export function createProxyAgentFromEnv(targetUrl?: string, env: NodeJS.ProcessEnv = process.env): HappyProxyAgent | undefined {
+    const proxyUrl = getProxyUrlFromEnv(targetUrl, env);
     if (!proxyUrl) {
         return undefined;
     }

--- a/packages/happy-cli/src/api/proxy.ts
+++ b/packages/happy-cli/src/api/proxy.ts
@@ -1,0 +1,49 @@
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+const PROXY_ENV_KEYS = [
+    'HTTPS_PROXY',
+    'https_proxy',
+    'HTTP_PROXY',
+    'http_proxy',
+    'ALL_PROXY',
+    'all_proxy',
+] as const;
+
+export type HappyProxyAgent = HttpsProxyAgent<string>;
+
+export function getProxyUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
+    for (const key of PROXY_ENV_KEYS) {
+        const value = env[key];
+        if (value) {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
+export function createProxyAgentFromEnv(env: NodeJS.ProcessEnv = process.env): HappyProxyAgent | undefined {
+    const proxyUrl = getProxyUrlFromEnv(env);
+    if (!proxyUrl) {
+        return undefined;
+    }
+
+    try {
+        return new HttpsProxyAgent(proxyUrl);
+    } catch {
+        return undefined;
+    }
+}
+
+export function maskProxyUrl(proxyUrl: string): string {
+    try {
+        const url = new URL(proxyUrl);
+        if (url.username || url.password) {
+            url.username = '***';
+            url.password = '***';
+        }
+        return url.toString();
+    } catch {
+        return '<invalid proxy url>';
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -888,6 +888,9 @@ importers:
       http-proxy-middleware:
         specifier: ^3.0.5
         version: 3.0.5
+      https-proxy-agent:
+        specifier: ^9.0.0
+        version: 9.0.0
       ink:
         specifier: ^6.5.1
         version: 6.6.0(@types/react@19.2.14)(react-devtools-core@6.1.5)(react@19.2.0)
@@ -5395,6 +5398,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
+
   ai@5.0.123:
     resolution: {integrity: sha512-V3Imb0tg0pHCa6a/VsoW/FZpT07mwUw/4Hj6nexJC1Nvf1eyKQJyaYVkl+YTLnA8cKQSUkoarKhXWbFy4CSgjw==}
     engines: {node: '>=18'}
@@ -7872,6 +7879,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@9.0.0:
+    resolution: {integrity: sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==}
+    engines: {node: '>= 20'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -16822,6 +16833,8 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  agent-base@9.0.0: {}
+
   ai@5.0.123(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 2.0.29(zod@3.25.76)
@@ -19715,6 +19728,13 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@9.0.0:
+    dependencies:
+      agent-base: 9.0.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

Happy CLI already relies on standard proxy environment variables for HTTP API calls through axios, but its Socket.IO websocket connections did not use those proxy settings. This caused the daemon machine connection and active session connection to fail in environments where outbound access must go through `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY`.

This PR adds standard proxy env support for the CLI websocket connections used by the daemon and active sessions, chooses proxy variables based on the websocket target scheme, respects `NO_PROXY`/`no_proxy`, masks proxy credentials in logs, and ignores invalid proxy URLs.

## Proof

Tested locally with standard proxy environment variables pointing at a local HTTP proxy:

```bash
HTTPS_PROXY=http://127.0.0.1:5901 HTTP_PROXY=http://127.0.0.1:5901 happy daemon start
happy daemon status
happy doctor
```

Daemon status showed the local build running successfully:

```text
Daemon is running
Version: 1.1.8-1
```

Daemon logs showed the websocket connection using the proxy and connecting successfully:

```text
[API MACHINE] Using proxy agent: http://127.0.0.1:5901/
[API MACHINE] Connected to server
[API MACHINE] Keep-alive started
```

I was also able to start a session and exchange messages successfully through the proxy.

## Tests

```bash
pnpm --filter happy exec vitest run src/api/proxy.test.ts src/api/apiSession.test.ts src/api/apiMachine.test.ts --project unit
pnpm --filter happy build
git diff --check origin/main...HEAD
git diff --check
```