### PR TITLE
fix(voice): resolve second-session disconnect via provider re-key

### DIFF
--- a/packages/happy-app/sources/realtime/RealtimeProvider.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeProvider.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { ElevenLabsProvider } from '@elevenlabs/react-native';
 import { RealtimeVoiceSession } from './RealtimeVoiceSession';
+import { useVoiceSessionGeneration } from '@/sync/storage';
 
 export const RealtimeProvider = ({ children }: { children: React.ReactNode }) => {
+    // Force ElevenLabsProvider to remount between sessions. The native SDK uses
+    // LiveKit, whose Room instance can't be reused after disconnect — second
+    // startSession silently fails. Children sit OUTSIDE the provider so the app
+    // tree isn't torn down on remount.
+    const generation = useVoiceSessionGeneration();
     return (
-        <ElevenLabsProvider>
-            <RealtimeVoiceSession />
+        <>
+            <ElevenLabsProvider key={generation}>
+                <RealtimeVoiceSession />
+            </ElevenLabsProvider>
             {children}
-        </ElevenLabsProvider>
+        </>
     );
 };

--- a/packages/happy-app/sources/realtime/RealtimeProvider.web.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeProvider.web.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import { RealtimeVoiceSession } from './RealtimeVoiceSession';
+import { useVoiceSessionGeneration } from '@/sync/storage';
 
 export const RealtimeProvider = ({ children }: { children: React.ReactNode }) => {
+    // Web SDK (@elevenlabs/react) uses a plain WebSocket — no LiveKit Room to
+    // go stale — so this re-key is mostly defensive. Kept symmetric with native.
+    const generation = useVoiceSessionGeneration();
     return (
         <>
-            <RealtimeVoiceSession />
+            <RealtimeVoiceSession key={generation} />
             {children}
         </>
     );

--- a/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
@@ -115,9 +115,16 @@ export const RealtimeVoiceSession: React.FC = () => {
         },
         onDisconnect: () => {
             console.log('Realtime session disconnected');
+            // Bump generation only when an active session ends — skipping the
+            // initial 'disconnected' state avoids remounting on cold launch
+            // (which previously caused a phantom keyboard).
+            const prev = storage.getState().realtimeStatus;
             storage.getState().setRealtimeStatus('disconnected');
             storage.getState().setRealtimeMode('idle', true);
             storage.getState().clearRealtimeModeDebounce();
+            if (prev === 'connected' || prev === 'connecting') {
+                storage.getState().incrementVoiceSessionGeneration();
+            }
         },
         onMessage: (data) => {
             console.log('Realtime message:', data);
@@ -127,7 +134,10 @@ export const RealtimeVoiceSession: React.FC = () => {
             // This prevents initialization errors from showing "Terminals error" on startup
             console.warn('Realtime voice not available:', error);
             // Don't set error status during initialization - just set disconnected
-            // This allows the app to continue working without voice features
+            // This allows the app to continue working without voice features.
+            // Don't bump generation here — onError can fire on transient/recoverable
+            // errors (LiveKit retries internally). onDisconnect is where we know
+            // the session is truly dead and a fresh provider is required.
             storage.getState().setRealtimeStatus('disconnected');
             storage.getState().setRealtimeMode('idle', true); // immediate mode change
         },

--- a/packages/happy-app/sources/realtime/RealtimeVoiceSession.web.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeVoiceSession.web.tsx
@@ -119,9 +119,13 @@ export const RealtimeVoiceSession: React.FC = () => {
         },
         onDisconnect: () => {
             console.log('Realtime session disconnected');
+            const prev = storage.getState().realtimeStatus;
             storage.getState().setRealtimeStatus('disconnected');
             storage.getState().setRealtimeMode('idle', true);
             storage.getState().clearRealtimeModeDebounce();
+            if (prev === 'connected' || prev === 'connecting') {
+                storage.getState().incrementVoiceSessionGeneration();
+            }
         },
         onMessage: (data) => {
             console.log('Realtime message:', data);
@@ -130,8 +134,7 @@ export const RealtimeVoiceSession: React.FC = () => {
             // Log but don't block app - voice features will be unavailable
             // This prevents initialization errors from showing "Terminals error" on startup
             console.warn('Realtime voice not available:', error);
-            // Don't set error status during initialization - just set disconnected
-            // This allows the app to continue working without voice features
+            // See native variant for why we don't bump generation in onError.
             storage.getState().setRealtimeStatus('disconnected');
             storage.getState().setRealtimeMode('idle', true); // immediate mode change
         },

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -160,6 +160,7 @@ interface StorageState {
     friendsLoaded: boolean;  // True after initial friends fetch
     realtimeStatus: 'disconnected' | 'connecting' | 'connected' | 'error';
     realtimeMode: 'idle' | 'agent-speaking' | 'user-speaking';
+    voiceSessionGeneration: number;
     socketStatus: 'disconnected' | 'connecting' | 'connected' | 'error';
     socketLastConnectedAt: number | null;
     socketLastDisconnectedAt: number | null;
@@ -185,6 +186,7 @@ interface StorageState {
     setRealtimeStatus: (status: 'disconnected' | 'connecting' | 'connected' | 'error') => void;
     setRealtimeMode: (mode: 'idle' | 'agent-speaking' | 'user-speaking', immediate?: boolean) => void;
     clearRealtimeModeDebounce: () => void;
+    incrementVoiceSessionGeneration: () => void;
     setSocketStatus: (status: 'disconnected' | 'connecting' | 'connected' | 'error') => void;
     getActiveSessions: () => Session[];
     updateSessionDraft: (sessionId: string, draft: string | null) => void;
@@ -350,6 +352,7 @@ export const storage = create<StorageState>()((set, get) => {
         sessionFileCache: {},
         realtimeStatus: 'disconnected',
         realtimeMode: 'idle',
+        voiceSessionGeneration: 0,
         socketStatus: 'disconnected',
         socketLastConnectedAt: null,
         socketLastDisconnectedAt: null,
@@ -858,6 +861,10 @@ export const storage = create<StorageState>()((set, get) => {
                 realtimeModeDebounceTimer = null;
             }
         },
+        incrementVoiceSessionGeneration: () => set((state) => ({
+            ...state,
+            voiceSessionGeneration: state.voiceSessionGeneration + 1
+        })),
         setSocketStatus: (status: 'disconnected' | 'connecting' | 'connected' | 'error') => set((state) => {
             const now = Date.now();
             const updates: Partial<StorageState> = {
@@ -1427,6 +1434,10 @@ export function useRealtimeStatus(): 'disconnected' | 'connecting' | 'connected'
 
 export function useRealtimeMode(): 'idle' | 'agent-speaking' | 'user-speaking' {
     return storage(useShallow((state) => state.realtimeMode));
+}
+
+export function useVoiceSessionGeneration(): number {
+    return storage(useShallow((state) => state.voiceSessionGeneration));
 }
 
 export function useSocketStatus() {

--- a/patches/fix-livekit-room-reuse.cjs
+++ b/patches/fix-livekit-room-reuse.cjs
@@ -1,14 +1,14 @@
 /**
- * Patches @livekit/components-react and @elevenlabs/react-native for two bugs:
+ * Patches @elevenlabs/react-native to force /rtc (v0) RTC path because
+ * ElevenLabs' LiveKit server returns 404 on /rtc/v1, and the v1→v0 retry
+ * delay breaks every session. Adds singlePeerConnection: false to the
+ * LiveKitRoom options.
  *
- * 1. Stale Room reuse: useLiveKitRoom's Room creation effect omits `token`
- *    from deps, so the same Room instance is reused across sessions. After
- *    disconnect(), reconnecting silently fails. Fix: add `token` to deps.
- *
- * 2. v1 RTC 404: ElevenLabs' LiveKit server doesn't support the /rtc/v1 path.
- *    LiveKit tries v1 first (when singlePeerConnection is true, the default),
- *    gets 404, then retries on v0 — slow and unreliable. Fix: add
- *    singlePeerConnection: false to LiveKitRoom options so v0 is used directly.
+ * NOTE: an earlier version of this patch also added `token` to the Room
+ * creation effect deps in @livekit/components-react. That's now reverted —
+ * it raced with provider re-keying (two Rooms overlapping, fingerprint
+ * mismatch errors). Provider re-key in app code handles stale Room reuse
+ * cleanly. We actively un-patch here to restore originals on existing installs.
  */
 const fs = require('fs');
 const path = require('path');
@@ -20,11 +20,10 @@ const nodeModulesRoots = [
     path.resolve(__dirname, '..', 'packages/happy-app/node_modules'),
 ];
 
-// --- Fix 1: Stale Room reuse in @livekit/components-react ---
+// --- Revert prior token-in-deps patch on @livekit/components-react ---
 
 for (const nodeModulesRoot of nodeModulesRoots) {
-    // ESM bundle: room-Bb6uLxS5.mjs
-    // Variables: e=token, r=passedRoom, t=options, T=roomOptionsStringifyReplacer
+    // ESM bundle: revert `[r, JSON.stringify(t, T), e]` back to `[r, JSON.stringify(t, T)]`
     const esmFile = path.join(
         nodeModulesRoot,
         '@livekit/components-react/dist/room-Bb6uLxS5.mjs'
@@ -33,8 +32,8 @@ for (const nodeModulesRoot of nodeModulesRoots) {
         let content = fs.readFileSync(esmFile, 'utf8');
         const original = content;
         content = content.replace(
-            /O\(r \?\? new U\(t\)\);\s*\}, \[r, JSON\.stringify\(t, T\)\]\)/,
-            'O(r ?? new U(t));\n  }, [r, JSON.stringify(t, T), e])'
+            /O\(r \?\? new U\(t\)\);\s*\}, \[r, JSON\.stringify\(t, T\), e\]\)/,
+            'O(r ?? new U(t));\n  }, [r, JSON.stringify(t, T)])'
         );
         if (content !== original) {
             fs.writeFileSync(esmFile, content, 'utf8');
@@ -42,8 +41,7 @@ for (const nodeModulesRoot of nodeModulesRoots) {
         }
     }
 
-    // CJS bundle: shared-BGiZtWPs.js
-    // Variables: t=token, f=passedRoom, s=options, M.roomOptionsStringifyReplacer
+    // CJS bundle: revert the same
     const cjsFile = path.join(
         nodeModulesRoot,
         '@livekit/components-react/dist/shared-BGiZtWPs.js'
@@ -52,8 +50,8 @@ for (const nodeModulesRoot of nodeModulesRoots) {
         let content = fs.readFileSync(cjsFile, 'utf8');
         const original = content;
         content = content.replace(
-            /I\(f\?\?new d\.Room\(s\)\)\}\,\[f,JSON\.stringify\(s,M\.roomOptionsStringifyReplacer\)\]\)/,
-            'I(f??new d.Room(s))},[f,JSON.stringify(s,M.roomOptionsStringifyReplacer),t])'
+            /I\(f\?\?new d\.Room\(s\)\)\}\,\[f,JSON\.stringify\(s,M\.roomOptionsStringifyReplacer\),t\]\)/,
+            'I(f??new d.Room(s))},[f,JSON.stringify(s,M.roomOptionsStringifyReplacer)])'
         );
         if (content !== original) {
             fs.writeFileSync(cjsFile, content, 'utf8');
@@ -61,7 +59,7 @@ for (const nodeModulesRoot of nodeModulesRoots) {
         }
     }
 
-    // Source file (Metro may resolve from src/)
+    // Source file: revert
     const srcFile = path.join(
         nodeModulesRoot,
         '@livekit/components-react/src/hooks/useLiveKitRoom.ts'
@@ -70,8 +68,8 @@ for (const nodeModulesRoot of nodeModulesRoots) {
         let content = fs.readFileSync(srcFile, 'utf8');
         const original = content;
         content = content.replace(
-            '}, [passedRoom, JSON.stringify(options, roomOptionsStringifyReplacer)]);',
-            '}, [passedRoom, JSON.stringify(options, roomOptionsStringifyReplacer), token]);'
+            '}, [passedRoom, JSON.stringify(options, roomOptionsStringifyReplacer), token]);',
+            '}, [passedRoom, JSON.stringify(options, roomOptionsStringifyReplacer)]);'
         );
         if (content !== original) {
             fs.writeFileSync(srcFile, content, 'utf8');
@@ -83,9 +81,14 @@ for (const nodeModulesRoot of nodeModulesRoots) {
     // Add singlePeerConnection: false to options so LiveKit skips the /rtc/v1 path
     // that returns 404 on ElevenLabs' server.
 
+    // Metro picks one of lib.{js,module,umd,modern}.js depending on resolution
+    // mode — patch all of them, otherwise the v1 RTC 404 retry will still fire
+    // through whichever bundle wasn't covered.
     const elNativeFiles = [
         '@elevenlabs/react-native/dist/lib.js',
         '@elevenlabs/react-native/dist/lib.module.js',
+        '@elevenlabs/react-native/dist/lib.umd.js',
+        '@elevenlabs/react-native/dist/lib.modern.js',
     ];
 
     for (const file of elNativeFiles) {
@@ -104,7 +107,8 @@ for (const nodeModulesRoot of nodeModulesRoots) {
         }
     }
 
-    // Also patch the source file
+    // Also patch the source file (idempotent: collapse any duplicates from prior
+    // non-idempotent runs, then ensure exactly one singlePeerConnection: false).
     const elNativeSrc = path.join(
         nodeModulesRoot,
         '@elevenlabs/react-native/src/components/LiveKitRoomWrapper.tsx'
@@ -113,7 +117,7 @@ for (const nodeModulesRoot of nodeModulesRoots) {
         let content = fs.readFileSync(elNativeSrc, 'utf8');
         const original = content;
         content = content.replace(
-            "adaptiveStream: { pixelDensity: 'screen' },",
+            /adaptiveStream: \{ pixelDensity: 'screen' \},(\n\s*singlePeerConnection: false,)*/,
             "adaptiveStream: { pixelDensity: 'screen' },\n        singlePeerConnection: false,"
         );
         if (content !== original) {


### PR DESCRIPTION
## Summary

Voice worked once after app kill, then every subsequent attempt failed silently. Two independent issues:

- **v1 RTC 404.** ElevenLabs' LiveKit gateway 404s on `/rtc/v1`; the v1→v0 fallback delay drops the conversation before initiation data arrives. The pre-existing patch only covered `lib.js`/`lib.module.js`, but Metro actually loads `lib.modern.js` (sometimes `lib.umd.js`), leaving v1 active. All four bundles are now patched, and the source-file edit is idempotent.
- **Stale Room reuse.** `ElevenLabsProvider` keeps the same LiveKit `Room` across sessions; after `disconnect()`, the next `connect()` silently fails. `ElevenLabsProvider` is now re-keyed on session end via a `voiceSessionGeneration` counter in storage, so the provider fully tears down and rebuilds with a fresh `Room`. Children sit outside the provider so the app tree isn't torn down.

The previous `token`-in-deps patch on `@livekit/components-react`'s `useLiveKitRoom` is reverted — it raced with provider re-keying, producing two PeerConnections with mismatched DTLS fingerprints and a `NegotiationError`.

Generation bump is gated on `prev status === 'connecting' | 'connected'` to avoid remounting on cold launch (which previously surfaced as a phantom keyboard) and only fires from `onDisconnect` — `onError` is transient and LiveKit retries internally.

## Test plan

- [x] Cold launch → first voice session connects via v0 (no `v1 RTC path not found` warnings)
- [x] End session → start new session → connects without stale-Room failure
- [x] Multiple session cycles in a row work without app reload
- [x] No phantom keyboard on cold launch
- [x] `pnpm typecheck` passes for happy-app