### PR TITLE
feat(happy-cli): write remote session prompts to history.jsonl for /resume discovery

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -83,6 +83,13 @@ export async function claudeRemote(opts: {
         });
     }
 
+    // Override CLAUDE_CODE_ENTRYPOINT so /resume can discover remote sessions.
+    // Can't use "cli" — Claude Code v2.1.119+ rewrites "cli" to "sdk-cli" in SDK mode.
+    // "happy-remote" is a custom value that passes both checks:
+    //   1. Ka8() only rewrites "cli", so "happy-remote" is preserved as-is
+    //   2. /resume only filters sdk-ts|sdk-py|sdk-cli|local-agent
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'happy-remote';
+
     // Get initial message
     const initial = await opts.nextMessage();
     if (!initial) { // No initial message - exit

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -15,6 +15,8 @@ import { RawJSONLines } from "@/claude/types";
 import { OutgoingMessageQueue } from "./utils/OutgoingMessageQueue";
 import { getToolName } from "./utils/getToolName";
 import { getAskUserQuestionToolCallIds } from "./utils/questionNotification";
+import { appendPromptToHistory, readFirstUserPrompt } from "./utils/historyJsonl";
+import { getProjectPath } from "./utils/path";
 
 interface PermissionsField {
     date: number;
@@ -125,6 +127,21 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
 
         // Write to message log
         formatClaudeMessageForInk(message, messageBuffer);
+
+        // Append user prompts to history.jsonl so /resume can discover remote sessions.
+        // Claude Code's interactive CLI writes to history.jsonl on every prompt via its
+        // internal Mb6() function, but in SDK mode (stream-json) that path is never hit.
+        // Skip when sessionId is not yet known — the first prompt is back-filled in onSessionFound.
+        if (message.type === 'user' && session.sessionId) {
+            const userMsg = message as SDKUserMessage;
+            if (userMsg.message.role === 'user' && typeof userMsg.message.content === 'string') {
+                appendPromptToHistory({
+                    sessionId: session.sessionId,
+                    project: session.path,
+                    display: userMsg.message.content,
+                });
+            }
+        }
 
         // Track active tool calls
         if (message.type === 'assistant') {
@@ -340,6 +357,19 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                         // Update converter's session ID when new session is found
                         sdkToLogConverter.updateSessionId(sessionId);
                         session.onSessionFound(sessionId);
+
+                        // Back-fill the first user prompt into history.jsonl.
+                        // The first message arrives before sessionId is known (skipped in onMessage),
+                        // so we read it from the JSONL file that Claude Code has already written.
+                        const projectDir = getProjectPath(session.path);
+                        const firstPrompt = readFirstUserPrompt(projectDir, sessionId);
+                        if (firstPrompt) {
+                            appendPromptToHistory({
+                                sessionId,
+                                project: session.path,
+                                display: firstPrompt,
+                            });
+                        }
                     },
                     onSDKMetadata: (metadata) => {
                         logger.debug('[remote] SDK metadata received, updating session:', metadata);

--- a/packages/happy-cli/src/claude/utils/historyJsonl.ts
+++ b/packages/happy-cli/src/claude/utils/historyJsonl.ts
@@ -1,0 +1,66 @@
+import { appendFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { logger } from '@/ui/logger';
+
+/**
+ * Append a prompt entry to Claude Code's history.jsonl.
+ *
+ * Mirrors the native CLI behavior: each user prompt gets one entry.
+ * This enables /resume discovery, Ctrl+R search, and arrow-key recall
+ * for sessions created via the SDK (remote mode).
+ *
+ * Claude Code's interactive CLI calls its internal Mb6() on every prompt,
+ * buffering entries and flushing to history.jsonl on exit. In SDK mode
+ * (--output-format stream-json) messages are piped in and Mb6() is never
+ * called, so history.jsonl is never written. This function fills that gap.
+ *
+ * Format matches Claude Code's internal schema exactly:
+ * { display, pastedContents, timestamp, project, sessionId }
+ */
+export function appendPromptToHistory(opts: {
+    sessionId: string;
+    project: string;    // absolute path to working directory
+    display: string;    // user prompt text
+}): void {
+    try {
+        const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+        const historyPath = join(claudeConfigDir, 'history.jsonl');
+
+        const entry = JSON.stringify({
+            display: opts.display,
+            pastedContents: {},
+            timestamp: Date.now(),
+            project: opts.project,
+            sessionId: opts.sessionId,
+        });
+
+        appendFileSync(historyPath, entry + '\n', { mode: 0o600 });
+        logger.debug(`[history] Appended prompt to ${historyPath} for session ${opts.sessionId}`);
+    } catch (e) {
+        // Non-fatal: never break the session over a history write failure
+        logger.debug(`[history] Failed to append to history.jsonl: ${e}`);
+    }
+}
+
+/**
+ * Read the first user prompt from a session JSONL file.
+ * Used to back-fill the history entry when onSessionFound fires
+ * (the first user message arrives before the session ID is known).
+ */
+export function readFirstUserPrompt(projectDir: string, sessionId: string): string | null {
+    try {
+        const jsonlPath = join(projectDir, `${sessionId}.jsonl`);
+        const content = readFileSync(jsonlPath, 'utf-8');
+        for (const line of content.split('\n')) {
+            if (!line.trim()) continue;
+            const obj = JSON.parse(line);
+            if (obj.type === 'user' && obj.message?.role === 'user' && typeof obj.message.content === 'string') {
+                return obj.message.content;
+            }
+        }
+    } catch (e) {
+        logger.debug(`[history] Failed to read first user prompt from session ${sessionId}: ${e}`);
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary

- When Claude Code runs via the SDK (remote mode, spawned by daemon for mobile app sessions), its non-interactive code path never calls the internal prompt history function (`Mb6()`). This means `history.jsonl` is never updated, so `/resume` cannot discover these sessions.
- Additionally, Claude Code v2.1.119+ rewrites `CLAUDE_CODE_ENTRYPOINT` from `"cli"` to `"sdk-cli"` in SDK mode, and `/resume` filters out `sdk-*` entrypoints — so even if history entries existed, remote sessions would still be hidden.
- Added `appendPromptToHistory()` utility that writes entries matching Claude Code's native schema exactly (`{ display, pastedContents, timestamp, project, sessionId }`)
- Wired it into `claudeRemoteLauncher.ts`'s `onMessage` handler for user-type messages, mirroring the native CLI's per-prompt behavior
- Override `CLAUDE_CODE_ENTRYPOINT` to `'happy-remote'` — a custom value that passes through both Claude Code's internal rewrite and `/resume`'s entrypoint filter

This enables:
- `/resume` session picker to list remote-created sessions
- `Ctrl+R` history search to find remote session prompts  
- Arrow-key prompt recall to include remote session prompts

### Root cause analysis

Claude Code CLI bundle internal flow:
1. Interactive CLI: each user prompt → `Mb6()` → buffer in memory → flush to `history.jsonl` on exit
2. SDK mode (`--output-format stream-json --input-format stream-json`): messages piped in, `Mb6()` never called → `history.jsonl` never written

Additionally:
3. In SDK mode, Claude Code rewrites `CLAUDE_CODE_ENTRYPOINT` from `"cli"` to `"sdk-cli"` via `Ka8()`, and `/resume` filters out sessions with `sdk-ts|sdk-py|sdk-cli|local-agent` entrypoints

The session JSONL file (`~/.claude/projects/<id>.jsonl`) IS written correctly in SDK mode — only `history.jsonl` is missed because it's tied to the interactive prompt input handler.

### Files changed

| File | Change |
|------|--------|
| `packages/happy-cli/src/claude/utils/historyJsonl.ts` | New utility — `appendPromptToHistory()` + `readFirstUserPrompt()` |
| `packages/happy-cli/src/claude/claudeRemoteLauncher.ts` | Call `appendPromptToHistory` in `onMessage` for user prompts; back-fill first prompt in `onSessionFound` |
| `packages/happy-cli/src/claude/claudeRemote.ts` | Override `CLAUDE_CODE_ENTRYPOINT` to `'happy-remote'` |

Closes #621, closes #685, closes #574, closes #478

## Test plan

- [ ] From Happy mobile app, start a remote session on a project directory and send several messages
- [ ] Verify `~/.claude/history.jsonl` contains entries for each prompt with the correct session ID
- [ ] Run `claude --resume` in the same project directory and confirm the remote session appears in the session picker
- [ ] Select and resume the session — verify context is fully preserved
- [ ] Verify `Ctrl+R` history search finds remote session prompts
- [ ] Verify write failure (e.g. read-only fs) does not crash the session