### PR TITLE
fix(openclaw): isolate per-Happy-session gateway sessionKey

### DIFF
--- a/packages/happy-cli/src/openclaw/OpenClawBackend.ts
+++ b/packages/happy-cli/src/openclaw/OpenClawBackend.ts
@@ -39,6 +39,44 @@ export interface OpenClawBackendOptions {
   clientMode?: OpenClawSocketOptions['clientMode'];
   displayName?: string;
   log?: (msg: string) => void;
+  /**
+   * Per-Happy-session unique tag, used to construct an isolated gateway
+   * sessionKey (`agent:<agentId>:happy:<sessionTag>`). Without this, every
+   * Happy session collapses onto the gateway's shared `agent:<id>:main`
+   * session, which queues turns and merges transcripts across tabs/devices.
+   * Mirrors the per-chat scoping used by Telegram/Discord channels.
+   */
+  sessionTag?: string;
+}
+
+/**
+ * Build a per-Happy-session gateway sessionKey from the gateway-provided
+ * main key (e.g. `agent:main:main`) and a unique tag. The gateway accepts
+ * arbitrary suffixes — see Telegram's `agent:<id>:telegram:group:<chatId>`
+ * pattern. Falls back to mainKey if parsing fails (defensive).
+ */
+export function buildHappySessionKey(mainKey: string, sessionTag: string): string {
+  // mainKey is `agent:<agentId>:<mainKey>` (typically `agent:main:main`).
+  const parts = mainKey.split(':');
+  if (parts.length < 3 || parts[0] !== 'agent' || !parts[1]) return mainKey;
+  return `agent:${parts[1]}:happy:${sessionTag}`;
+}
+
+/**
+ * Resolve the gateway sessionKey for a Happy session. Priority:
+ *   1. `HAPPY_OPENCLAW_SESSION_KEY` env override (any string)
+ *   2. Per-tag isolation: `agent:<agentId>:happy:<sessionTag>` derived from mainKey
+ *   3. Legacy: gateway-provided mainKey (shared across all Happy sessions)
+ */
+export function resolveOpenClawSessionKey(params: {
+  mainKey: string;
+  sessionTag?: string;
+  envOverride?: string;
+}): string {
+  const trimmedOverride = params.envOverride?.trim();
+  if (trimmedOverride) return trimmedOverride;
+  if (params.sessionTag) return buildHappySessionKey(params.mainKey, params.sessionTag);
+  return params.mainKey;
 }
 
 function extractTextFromMessage(message?: OpenClawChatMessage): string {
@@ -59,6 +97,7 @@ export class OpenClawBackend implements AgentBackend {
   private gatewayConfig: OpenClawGatewayConfig;
   private handlers = new Set<AgentMessageHandler>();
   private sessionKey: string | null = null;
+  private sessionTag: string | undefined;
   private lastDeltaText: string | null = null;
   private log: (msg: string) => void;
 
@@ -75,6 +114,7 @@ export class OpenClawBackend implements AgentBackend {
   constructor(opts: OpenClawBackendOptions) {
     this.log = opts.log ?? (() => {});
     this.gatewayConfig = opts.gatewayConfig;
+    this.sessionTag = opts.sessionTag;
     this.socket = new OpenClawSocket({
       homeDir: opts.homeDir,
       clientId: opts.clientId,
@@ -101,13 +141,22 @@ export class OpenClawBackend implements AgentBackend {
     this.socket.connect(this.gatewayConfig);
     await this.connectionReady;
 
-    this.sessionKey = this.socket.getMainSessionKey();
-    if (!this.sessionKey) {
+    const mainKey = this.socket.getMainSessionKey();
+    if (!mainKey) {
       throw new Error('No main session key from gateway');
     }
 
+    // Per-Happy-session isolation: derive a unique sessionKey per spawn so
+    // multiple Happy tabs/devices don't collapse onto the gateway's single
+    // `agent:<id>:main` session (which serializes turns and merges history).
+    this.sessionKey = resolveOpenClawSessionKey({
+      mainKey,
+      sessionTag: this.sessionTag,
+      envOverride: process.env.HAPPY_OPENCLAW_SESSION_KEY,
+    });
+
     const sessionId = this.sessionKey;
-    this.log(`Session started: ${sessionId}`);
+    this.log(`Session started: ${sessionId} (mainKey=${mainKey})`);
     return { sessionId };
   }
 

--- a/packages/happy-cli/src/openclaw/OpenClawBackend.ts
+++ b/packages/happy-cli/src/openclaw/OpenClawBackend.ts
@@ -261,6 +261,14 @@ export class OpenClawBackend implements AgentBackend {
     if (event !== 'chat') return;
 
     const chatEvent = payload as OpenClawChatEventPayload;
+    // Filter chat events by sessionKey: the gateway broadcasts chat events to
+    // every connected socket, so without this filter every Happy session on
+    // the same daemon receives every other session's deltas — even when the
+    // gateway sessionKey is correctly isolated. The sessionKey field is
+    // normalized server-side to lowercase, so we compare case-insensitively.
+    if (this.sessionKey && chatEvent.sessionKey && chatEvent.sessionKey.toLowerCase() !== this.sessionKey.toLowerCase()) {
+      return;
+    }
     const state = chatEvent.state;
 
     if (state === 'started') {

--- a/packages/happy-cli/src/openclaw/openclawSessionKey.test.ts
+++ b/packages/happy-cli/src/openclaw/openclawSessionKey.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { buildHappySessionKey, resolveOpenClawSessionKey } from './OpenClawBackend';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { buildHappySessionKey, resolveOpenClawSessionKey, OpenClawBackend } from './OpenClawBackend';
+import type { OpenClawGatewayConfig } from './openclawTypes';
 
 describe('buildHappySessionKey', () => {
   it('builds an isolated per-Happy-session key from the gateway main key', () => {
@@ -61,5 +62,55 @@ describe('resolveOpenClawSessionKey', () => {
     const a = resolveOpenClawSessionKey({ mainKey: 'agent:main:main', sessionTag: 'tag-A' });
     const b = resolveOpenClawSessionKey({ mainKey: 'agent:main:main', sessionTag: 'tag-B' });
     expect(a).not.toBe(b);
+  });
+});
+
+describe('OpenClawBackend chat-event sessionKey filter', () => {
+  const gatewayConfig: OpenClawGatewayConfig = { url: 'ws://127.0.0.1:1' };
+  const baseOpts = { homeDir: '/tmp', gatewayConfig, sessionTag: 'tag-A' };
+
+  const makeBackendWithKey = (sessionKey: string) => {
+    const backend = new OpenClawBackend(baseOpts);
+    // The filter compares against `this.sessionKey`, normally set by startSession()
+    // after the gateway hello. Inject it here so we can unit-test handleEvent in isolation.
+    (backend as unknown as { sessionKey: string | null }).sessionKey = sessionKey;
+    return backend;
+  };
+
+  it('drops chat events whose sessionKey does not match this backend', () => {
+    const backend = makeBackendWithKey('agent:main:happy:tag-A');
+    const handler = vi.fn();
+    backend.onMessage(handler);
+
+    // Simulate a delta event for a DIFFERENT session (case-insensitive normalization on gateway side)
+    (backend as unknown as { handleEvent: (e: string, p: unknown) => void }).handleEvent('chat', {
+      runId: 'r1', sessionKey: 'agent:main:happy:tag-B', seq: 0, state: 'delta',
+      message: { content: [{ type: 'text', text: 'leaked' }] },
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('forwards chat events whose sessionKey matches', () => {
+    const backend = makeBackendWithKey('agent:main:happy:tag-A');
+    const handler = vi.fn();
+    backend.onMessage(handler);
+
+    (backend as unknown as { handleEvent: (e: string, p: unknown) => void }).handleEvent('chat', {
+      runId: 'r1', sessionKey: 'agent:main:happy:tag-A', seq: 0, state: 'delta',
+      message: { content: [{ type: 'text', text: 'mine' }] },
+    });
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('compares case-insensitively (gateway lowercases keys)', () => {
+    const backend = makeBackendWithKey('agent:main:happy:Tag-A');
+    const handler = vi.fn();
+    backend.onMessage(handler);
+
+    (backend as unknown as { handleEvent: (e: string, p: unknown) => void }).handleEvent('chat', {
+      runId: 'r1', sessionKey: 'agent:main:happy:tag-a', seq: 0, state: 'delta',
+      message: { content: [{ type: 'text', text: 'mine' }] },
+    });
+    expect(handler).toHaveBeenCalled();
   });
 });

--- a/packages/happy-cli/src/openclaw/openclawSessionKey.test.ts
+++ b/packages/happy-cli/src/openclaw/openclawSessionKey.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { buildHappySessionKey, resolveOpenClawSessionKey } from './OpenClawBackend';
+
+describe('buildHappySessionKey', () => {
+  it('builds an isolated per-Happy-session key from the gateway main key', () => {
+    expect(buildHappySessionKey('agent:main:main', 'abc-123')).toBe('agent:main:happy:abc-123');
+  });
+
+  it('preserves a non-default agentId', () => {
+    expect(buildHappySessionKey('agent:research:main', 'tag-xyz')).toBe('agent:research:happy:tag-xyz');
+  });
+
+  it('falls back to mainKey when the format is unexpected', () => {
+    expect(buildHappySessionKey('main', 'tag')).toBe('main');
+    expect(buildHappySessionKey('agent::main', 'tag')).toBe('agent::main');
+    expect(buildHappySessionKey('not-an-agent-key', 'tag')).toBe('not-an-agent-key');
+  });
+});
+
+describe('resolveOpenClawSessionKey', () => {
+  const ORIGINAL_ENV = process.env.HAPPY_OPENCLAW_SESSION_KEY;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) delete process.env.HAPPY_OPENCLAW_SESSION_KEY;
+    else process.env.HAPPY_OPENCLAW_SESSION_KEY = ORIGINAL_ENV;
+  });
+
+  it('returns the env override verbatim when set', () => {
+    expect(
+      resolveOpenClawSessionKey({
+        mainKey: 'agent:main:main',
+        sessionTag: 'tag-1',
+        envOverride: 'agent:main:custom-key',
+      }),
+    ).toBe('agent:main:custom-key');
+  });
+
+  it('isolates per Happy session by default', () => {
+    expect(
+      resolveOpenClawSessionKey({ mainKey: 'agent:main:main', sessionTag: 'tag-1' }),
+    ).toBe('agent:main:happy:tag-1');
+  });
+
+  it('falls back to mainKey when no sessionTag and no env override (legacy behavior)', () => {
+    expect(
+      resolveOpenClawSessionKey({ mainKey: 'agent:main:main' }),
+    ).toBe('agent:main:main');
+  });
+
+  it('treats blank env override as unset', () => {
+    expect(
+      resolveOpenClawSessionKey({
+        mainKey: 'agent:main:main',
+        sessionTag: 'tag-1',
+        envOverride: '   ',
+      }),
+    ).toBe('agent:main:happy:tag-1');
+  });
+
+  it('produces unique keys across distinct Happy sessions', () => {
+    const a = resolveOpenClawSessionKey({ mainKey: 'agent:main:main', sessionTag: 'tag-A' });
+    const b = resolveOpenClawSessionKey({ mainKey: 'agent:main:main', sessionTag: 'tag-B' });
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/happy-cli/src/openclaw/runOpenClaw.ts
+++ b/packages/happy-cli/src/openclaw/runOpenClaw.ts
@@ -233,6 +233,7 @@ export async function runOpenClaw(opts: RunOpenClawOptions): Promise<void> {
     homeDir: os.homedir(),
     gatewayConfig,
     log,
+    sessionTag,
   });
 
   const onBackendMessage = (msg: AgentMessage) => {


### PR DESCRIPTION
Fixes #1185.

`OpenClawBackend.startSession()` was hardcoding `socket.getMainSessionKey()`, so every Happy session — all tabs, all devices on one daemon — pinned to the gateway's shared `agent:<id>:main` session. A slow turn in one tab queued every other Happy session, transcripts merged across tabs, and each subsequent turn re-sent the combined history (prompt-cost inflation). This patch constructs an isolated per-Happy-session gateway sessionKey of shape `agent:<agentId>:happy:<sessionTag>`, mirroring how Telegram/Discord channels already scope per-chat. `<sessionTag>` is the UUID already generated per `runOpenClaw` spawn, so each Happy session naturally lands on its own gateway session.

The fix lives entirely in happy-cli — the OpenClaw gateway already routes any `agent:<id>:<rest>` shape through `toAgentStoreSessionKey` to a per-key store (see `dist/session-key-Cn2QoOyX.js:106-117`). No server, RPC, or encryption changes.

`HAPPY_OPENCLAW_SESSION_KEY` env var added as an opt-out for users who want the legacy shared-session behavior or a custom key.

## Files

- `packages/happy-cli/src/openclaw/OpenClawBackend.ts` — `sessionTag` option + `buildHappySessionKey` / `resolveOpenClawSessionKey` helpers.
- `packages/happy-cli/src/openclaw/runOpenClaw.ts` — pass `sessionTag` to backend.
- `packages/happy-cli/src/openclaw/openclawSessionKey.test.ts` — 8 unit tests covering env override, sessionTag isolation, legacy fallback, and edge cases.

## Background

Restores the per-chat isolation that the original Clawdbot prototype (#481) explicitly implemented as *"New chat creates isolated sessions (not using main session)"* — that design was dropped during the OpenClaw rebrand (#816).

Proof of multi-session isolation (before/after) attached as a comment.
