### PR TITLE
fix(cli): kill spawned claude binary when launcher exits (orphan / 'two cursors' bug)

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -548,7 +548,28 @@ function runClaudeCli(cliPath) {
             stdio: 'inherit',
             env: process.env
         });
+        // Forward signals from launcher to child so the spawned claude binary
+        // exits when the launcher does. Without this, an interrupted launcher
+        // (terminal close, parent crash, kill -TERM) leaves the child running
+        // attached to the same TTY foreground process group; on the next
+        // launch in the same pane two claude processes share the pts and the
+        // kernel race-distributes keystrokes between them ("two cursors" /
+        // "characters alternating" symptom).
+        const forward = (sig) => { try { child.kill(sig); } catch (e) {} };
+        ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'].forEach((s) =>
+            process.on(s, () => forward(s))
+        );
+        process.on('exit', () => forward('SIGTERM'));
+        // Detect ungraceful parent death (e.g. happy crashed without sending
+        // a signal). When our parent dies, ppid is reset to 1; poll for that
+        // and clean up the child. Interval is unref'd so it doesn't keep the
+        // event loop alive past child exit.
+        const ppidWatch = setInterval(() => {
+            if (process.ppid === 1) { forward('SIGTERM'); process.exit(0); }
+        }, 1000);
+        ppidWatch.unref();
         child.on('exit', (code) => {
+            clearInterval(ppidWatch);
             process.exit(code || 0);
         });
     }


### PR DESCRIPTION
## Symptom

When happy is installed against a binary `claude` (Homebrew or the native installer at `~/.local/share/claude/versions/<v>/`), users intermittently report that typing produces characters at two alternating cursor positions in the same pane, making input impossible. Often described as "two cursors" or "tmux is broken." It isn't tmux.

## Root cause

`runClaudeCli` in `packages/happy-cli/scripts/claude_version_utils.cjs` has two branches:

- **`.js`/`.cjs` claude:** `import(importUrl)` -- runs in-process, no orphan possible.
- **Binary claude:** `spawn(cliPath, args, { stdio: 'inherit' })` with only a `child.on('exit', ...)` handler. **No signal forwarders, no parent-death detection.**

When the launcher process dies for any reason -- terminal SIGHUP on pane close, `kill -TERM`, an OOM, an uncaught exception in the launcher's fetch interceptor, or the parent (`happy`) crashing without sending signals down the chain -- the spawned claude binary keeps running. Linux reparents it to PID 1, but it stays in the TTY's foreground process group (`STAT=Sl+`).

Next time happy launches a session in the same pane, a second claude binds to the same `/dev/pts/N`. Both are in the foreground PG, so the kernel race-distributes each keystroke between them. That's the "two cursors" symptom.

Reproduction on a machine with a binary claude install:

```bash
ps -eo pid,ppid,stat,tty,cmd | grep -E 'claude/versions' | grep -v grep
# look for: PPID=1, STAT=Sl+, multiple instances on same pts/N
```

## Fix

In the binary branch of `runClaudeCli`:

1. Forward `SIGINT`/`SIGTERM`/`SIGHUP`/`SIGQUIT` from launcher to the spawned child.
2. On launcher `'exit'`, send `SIGTERM` to the child (covers natural exit).
3. 1Hz `ppidWatch` that fires when the launcher's `process.ppid === 1` (covers ungraceful parent death where no signal is propagated). Interval is `unref()`'d so it doesn't keep the event loop alive after normal child exit.

21 lines added, no behavior change for the existing happy path.

## Verified locally

Synthetic launcher mirroring `runClaudeCli`'s spawn pattern, with a long-lived `/bin/sleep` as the fake child:

| Test | Scenario | Result |
|------|----------|--------|
| 1 | UNPATCHED control: `kill -TERM` launcher | child alive, **PPID=1** (bug reproduced) |
| 2 | PATCHED + `kill -TERM` launcher | child dies |
| 3 | PATCHED + `kill -HUP` launcher (terminal-close case) | child dies |
| 4 | PATCHED + `kill -KILL` launcher's parent shell | child dies within 1s via ppid watch |

## Notes

- Doesn't change the `.js`/`.cjs` import-path branch, since orphans are impossible there.
- Could alternatively use `prctl(PR_SET_PDEATHSIG)` via FFI for instant detection, but that's Linux-only and adds a native dep. The 1Hz polling is portable and adds negligible CPU.
- I'm happy to add a test if you want one -- the synthetic harness above is straightforward to port into the test suite.