### PR TITLE
feat: add Opus 4.7 and GPT 5.5 model options

### DIFF
--- a/packages/codium/sources/app/components/ModelPicker.tsx
+++ b/packages/codium/sources/app/components/ModelPicker.tsx
@@ -12,9 +12,9 @@ interface ModelOption {
 const MODELS: ModelOption[] = [
     { id: 'gpt-5-5',            label: '5.5',         group: 'OpenAI' },
     { id: 'gpt-5-4',            label: '5.4',         group: 'OpenAI' },
+    { id: 'claude-opus-4-7',    label: 'Opus 4.7',    group: 'Anthropic' },
     { id: 'claude-sonnet-4-6',  label: 'Sonnet 4.6',  group: 'Anthropic' },
     { id: 'claude-opus-4-6',    label: 'Opus 4.6',    group: 'Anthropic' },
-    { id: 'claude-opus-4-7',    label: 'Opus 4.7',    group: 'Anthropic' },
 ]
 
 function ChevronDown() {

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -76,7 +76,7 @@ export function getGeminiPermissionModes(translate: Translate): PermissionMode[]
 export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
-        { key: 'opus', name: 'opus 4.6', description: null },
+        { key: 'opus', name: 'opus 4.7', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },
     ];
@@ -85,6 +85,7 @@ export function getClaudeModelModes(): ModelMode[] {
 export function getCodexModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
+        { key: 'gpt-5.5', name: 'gpt-5.5', description: null },
         { key: 'gpt-5.4', name: 'gpt-5.4', description: null },
         { key: 'gpt-5.3-codex', name: 'gpt-5.3-codex', description: null },
         { key: 'gpt-5.2-codex', name: 'gpt-5.2-codex', description: null },


### PR DESCRIPTION
## Summary
- Added Claude Opus 4.7 to model selection (happy-app & codium)
- Added GPT 5.5 to Codex model options (happy-app & codium)