### PR TITLE
fix(app): add timeout + cache-control to server validation

### DIFF
--- a/packages/happy-app/sources/app/(app)/server.tsx
+++ b/packages/happy-app/sources/app/(app)/server.tsx
@@ -85,17 +85,22 @@ export default function ServerConfigScreen() {
     const [isValidating, setIsValidating] = useState(false);
 
     const validateServer = async (url: string): Promise<boolean> => {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10000);
         try {
             setIsValidating(true);
             setError(null);
-            
+
             const response = await fetch(url, {
                 method: 'GET',
+                signal: controller.signal,
                 headers: {
-                    'Accept': 'text/plain'
+                    'Accept': 'text/plain',
+                    'Cache-Control': 'no-cache',
+                    'Pragma': 'no-cache',
                 }
             });
-            
+
             if (!response.ok) {
                 setError(t('server.serverReturnedError'));
                 return false;
@@ -112,6 +117,7 @@ export default function ServerConfigScreen() {
             setError(t('server.failedToConnectToServer'));
             return false;
         } finally {
+            clearTimeout(timeout);
             setIsValidating(false);
         }
     };


### PR DESCRIPTION
## Summary

Fixes #1193

- Add `AbortController` with 10-second timeout to prevent `fetch()` hanging indefinitely when the server is unreachable
- Add `Cache-Control: no-cache` + `Pragma: no-cache` headers to bypass stale Android WebView cache that caused false positive validation results
- `clearTimeout()` in `finally` block to prevent timer leak

## Test plan

- [ ] Validate a reachable server → should pass as before
- [ ] Validate an unreachable/offline server → should fail within 10 seconds (previously hung forever)
- [ ] Validate same server twice after taking it offline → second check should fail (previously could pass due to cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)