### PR TITLE
fix(sync): prevent blank screen when machines sync hangs on init

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -227,14 +227,15 @@ class Sync {
         this.feedSync.invalidate();
         log.log('🔄 #init: All syncs invalidated, including artifacts');
 
-        // Wait for both sessions and machines to load, then mark as ready
-        Promise.all([
-            this.sessionsSync.awaitQueue(),
-            this.machinesSync.awaitQueue()
-        ]).then(() => {
+        // Mark UI ready as soon as sessions load. Machines sync may hang
+        // when encryption keys are unavailable (e.g. V1 auth fallback) —
+        // let it resolve in the background instead of blocking the UI.
+        this.sessionsSync.awaitQueue().then(() => {
             storage.getState().applyReady();
         }).catch((error) => {
-            console.error('Failed to load initial data:', error);
+            console.error('Failed to load sessions:', error);
+            // Still mark ready so the UI doesn't stay on a blank screen forever
+            storage.getState().applyReady();
         });
     }
 


### PR DESCRIPTION
## Summary

- The init sequence waited for both sessions and machines to load via `Promise.all` before calling `applyReady()`. If machines sync hangs (e.g. encryption keys unavailable during V1 auth fallback), the UI stays on a blank screen indefinitely with no recovery path — the catch handler only logged the error without calling `applyReady()`.
- Fix: only await sessions sync for UI readiness. Machines sync continues in the background. Also call `applyReady()` in the catch path so the UI is never permanently stuck.

## Details

In `sync.ts` `#init()`, the current code:

```typescript
Promise.all([
    this.sessionsSync.awaitQueue(),
    this.machinesSync.awaitQueue()
]).then(() => {
    storage.getState().applyReady();
}).catch((error) => {
    console.error('Failed to load initial data:', error);
    // applyReady() is never called — UI stays blank forever
});
```

If `machinesSync` throws (e.g. machine encryption keys not yet available), the Promise.all rejects, and the catch handler logs but never marks the UI as ready. The user sees a permanent blank screen with no way to recover except force-quitting the app.

The fix changes this to only wait for sessions (which are always needed for the UI) and lets machines sync resolve in the background:

```typescript
this.sessionsSync.awaitQueue().then(() => {
    storage.getState().applyReady();
}).catch((error) => {
    console.error('Failed to load sessions:', error);
    storage.getState().applyReady(); // Always unblock the UI
});
```

## Test plan

- [ ] Fresh login: verify UI loads normally (sessions appear, no blank screen)
- [ ] Simulate machines sync failure: verify UI still becomes interactive
- [ ] Verify machines appear once their sync completes in the background