### PR TITLE
feat(happy-agent): add --wait-timeout-seconds flag for `send --wait`

### DIFF
--- a/packages/happy-agent/src/index.ts
+++ b/packages/happy-agent/src/index.ts
@@ -376,8 +376,9 @@ program
     .argument('<message>', 'Message text')
     .option('--yolo', 'Send with permissionMode=yolo')
     .option('--wait', 'Wait for agent to become idle')
+    .option('--wait-timeout-seconds <n>', 'Timeout for --wait in seconds (default: 300)', (v: string) => parseInt(v, 10))
     .option('--json', 'Output as JSON')
-    .action(async (sessionId: string, message: string, opts: { yolo?: boolean; wait?: boolean; json?: boolean }) => {
+    .action(async (sessionId: string, message: string, opts: { yolo?: boolean; wait?: boolean; waitTimeoutSeconds?: number; json?: boolean }) => {
         const config = loadConfig();
         const creds = requireCredentials(config);
         const session = await resolveSession(config, creds, sessionId);
@@ -386,7 +387,8 @@ program
         const client = createClient(session, creds, config);
         try {
             await client.waitForConnect();
-            const completion = opts.wait ? client.waitForTurnCompletion() : null;
+            const waitTimeoutMs = opts.waitTimeoutSeconds !== undefined ? opts.waitTimeoutSeconds * 1000 : undefined;
+            const completion = opts.wait ? client.waitForTurnCompletion(waitTimeoutMs) : null;
             client.sendMessage(message, permissionMode ? { permissionMode } : undefined);
 
             if (completion) {


### PR DESCRIPTION
## Summary

`happy-agent send --wait` reports failure at 5 minutes for any turn that exceeds the default `waitForTurnCompletion` timeout, even when the agent completes successfully on the daemon side. This PR adds an opt-in `--wait-timeout-seconds <n>` flag so orchestrators driving `happy-agent` non-interactively can wait for long turns without false-failure noise.

## Problem

`packages/happy-agent/src/index.ts` calls `client.waitForTurnCompletion()` with no argument when `--wait` is set. That falls through to `session.ts`'s default `timeoutMs = 300_000` (5 minutes). Long turns (multi-file refactors, big builds, long bash sleeps in tool use) hit the timeout even though the daemon-side agent finishes the turn cleanly. The CLI exit status disagrees with the actual session state — the worst outcome for automation.

## Change

Add `--wait-timeout-seconds <n>` to `send`. When provided, multiply by 1000 and forward to `waitForTurnCompletion`. When omitted, behaviour is identical (300s default preserved).

4 added / 2 changed lines in `packages/happy-agent/src/index.ts`. No changes to `session.ts` or any shared API surface.

## Alternative designs considered

- **(A, this PR)** Opt-in flag, keep 300s default. Minimum diff, fully backward compatible.
- **(B)** Drop the 300s default in `waitForTurnCompletion` — "if the user said `--wait`, wait." Cleaner semantics but a breaking change for any caller relying on the existing default.
- **(C)** Add `HAPPY_AGENT_WAIT_TIMEOUT` env var so orchestrators don't thread the flag through every call.

Happy to switch to (B) or add (C) if maintainers prefer.

## Proof it works

Two clean Happy sessions, same prompt that triggers a ~360s foreground bash loop. Without the flag the CLI times out at exactly the 5-min default while the daemon keeps running the turn; with `--wait-timeout-seconds 600` the CLI correctly waits for the actual turn completion.

### Test 1 — default behaviour (regression case)

```
$ time happy-agent send <session-A> "Run this Bash command in the FOREGROUND ...
deadline=\$((\$(date +%s) + 360)); until [ \$(date +%s) -ge \$deadline ]; do sleep 5; done; echo done.
After the command returns, reply with just the word done." --yolo --wait

Timeout waiting for agent turn completion

real    5m1.734s
user    0m0.309s
sys     0m0.051s
exit:   1
```

`happy-agent history <session-A>` confirms the daemon-side tool call was still running when the CLI exited — `tool-call-start` recorded but no `tool-call-end` at the 5-min mark.

### Test 2 — same prompt, `--wait-timeout-seconds 600`

```
$ time happy-agent send <session-B> "Run this Bash command in the FOREGROUND ...
deadline=\$((\$(date +%s) + 360)); until [ \$(date +%s) -ge \$deadline ]; do sleep 5; done; echo done.
After the command returns, reply with just the word done." --yolo --wait --wait-timeout-seconds 600

## Message Sent
- Session ID: <session-B>
- Permission Mode: yolo
- Waited For Idle: yes

real    6m11.737s
user    0m0.346s
sys     0m0.076s
exit:   0
```

`happy-agent history <session-B>`:
- `tool-call-start` at 04:50:27.940
- `tool-call-end`   at 04:56:28.509 (≈360.6s for the polling loop)
- `text: "done"`     at 04:56:31.349
- `turn-end status=completed` at 04:56:31.515

Default behaviour preserved, opt-in long-wait works. `pnpm --filter happy-agent build` regenerates `dist/index.cjs` cleanly and `happy-agent send --help` shows the new flag.

## Test plan

- [x] `pnpm --filter happy-agent build` succeeds (verified locally)
- [x] `happy-agent send --help` lists the new flag
- [x] Default behaviour unchanged when flag omitted (Test 1 above — fails at exactly 5m as before)
- [x] `--wait-timeout-seconds 600` allows a turn that takes ~6 minutes to complete cleanly (Test 2 above)