### PR TITLE
fix: override restore-cursor to v5 under cli-cursor@4 for Node 25 ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         "overrides": {
             "whatwg-url": "14.2.0",
             "parse-path": "7.0.3",
-            "@types/parse-path": "7.0.3"
+            "@types/parse-path": "7.0.3",
+            "cli-cursor@4>restore-cursor": "^5.1.0"
         },
         "onlyBuiltDependencies": [
             "@more-tech/react-native-libsodium",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   whatwg-url: 14.2.0
   parse-path: 7.0.3
   '@types/parse-path': 7.0.3
+  cli-cursor@4>restore-cursor: ^5.1.0
 
 importers:
 
@@ -10664,10 +10665,6 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
-  restore-cursor@4.0.0:
-    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -17714,7 +17711,7 @@ snapshots:
 
   cli-cursor@4.0.0:
     dependencies:
-      restore-cursor: 4.0.0
+      restore-cursor: 5.1.0
 
   cli-cursor@5.0.0:
     dependencies:
@@ -23368,11 +23365,6 @@ snapshots:
       signal-exit: 3.0.7
 
   restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-
-  restore-cursor@4.0.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7


### PR DESCRIPTION
## Problem

On Node 25, the `happy` CLI crashes at startup with:

```
SyntaxError: The requested module 'signal-exit' does not provide an export named 'default'
    at restore-cursor/index.js
```

Node 25's ESM loader stopped synthesizing a default export for CommonJS-shaped named-only ESM packages. `signal-exit@4` is named-only ESM, and `restore-cursor@4` (pulled in transitively via `ink@6.6` → `cli-cursor@4`) imports it as `default` — so it dies on first load.

## Fix

Pin `cli-cursor@4`'s nested `restore-cursor` to `^5.1.0` via pnpm overrides. `restore-cursor@5` already uses the correct named `onExit` import from `signal-exit@4`, and is API-compatible with v4 for `cli-cursor`'s usage.

```diff
 "overrides": {
   "whatwg-url": "14.2.0",
   "parse-path": "7.0.3",
-  "@types/parse-path": "7.0.3"
+  "@types/parse-path": "7.0.3",
+  "cli-cursor@4>restore-cursor": "^5.1.0"
 }
```

## Scope

- Targeted override (`cli-cursor@4>restore-cursor`) — does not touch `cli-cursor@5` or any other consumer.
- Lockfile diff is minimal: 4 insertions, 11 deletions (just removes `restore-cursor@4` entries and flips the `cli-cursor@4` dep edge).

## Test plan

- [x] Node 25.x: CLI starts cleanly (no SyntaxError).
- [x] Node 22.x: still works (unchanged behavior).
- [x] Cursor restore on Ctrl+C / SIGINT: works as before.