### PR TITLE
fix(happy-cli): replace workspace:* with semver pin to fix npm install

### DIFF
--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -73,7 +73,7 @@
     "@noble/ed25519": "^3.0.0",
     "@noble/hashes": "^2.0.1",
     "@paralleldrive/cuid2": "^2.2.2",
-    "@slopus/happy-wire": "workspace:*",
+    "@slopus/happy-wire": "^0.1.0",
     "@stablelib/base64": "^2.0.1",
     "@stablelib/hex": "^2.0.1",
     "@types/cross-spawn": "^6.0.6",


### PR DESCRIPTION
## Problem

`npm i -g happy-coder@1.1.8` fails with:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
```

The published tarball for `happy-coder@1.1.8` ships with `"@slopus/happy-wire": "workspace:*"` in its `package.json`. The `workspace:` protocol is a pnpm/Yarn‑Berry feature that the npm CLI does not understand, so any user trying to install via `npm` (or any tool that shells out to npm under the hood) hits this error.

Closes #1200

## Root cause

`packages/happy-cli/package.json` declares the dep as `workspace:*`. `pnpm publish` rewrites this to a real semver before publishing, but other publish paths (e.g. `npm publish`, or `npm pack` followed by `npm publish`) leave the literal `workspace:*` string in the published artifact.

Evidence that this only affects one of the two published names:

- `npm view happy@1.1.8 dependencies` → `"@slopus/happy-wire": "0.1.0"` (correctly substituted)
- `npm view happy-coder@1.1.8 dependencies` → `"@slopus/happy-wire": "workspace:*"` (broken)

Both come from the same source `packages/happy-cli/package.json`, so something in the publish flow for `happy-coder` skipped the substitution.

## Fix

Replace the `workspace:*` spec with a real semver range matching the only published version of `@slopus/happy-wire` (`0.1.0`):

```diff
- "@slopus/happy-wire": "workspace:*",
+ "@slopus/happy-wire": "^0.1.0",
```

This makes the publish output insensitive to which tool runs the publish, while preserving local monorepo development:

- pnpm's default `link-workspace-packages=true` still resolves the dep to the in-tree `packages/happy-wire` workspace package as long as its version satisfies `^0.1.0`.
- `npm publish` / `pnpm publish` / `npm pack` all now produce a tarball with a spec that npm can resolve.

## Verification

Reproduced locally with `npm pack happy-coder@1.1.8` → patched the dep → `npm install -g <tarball>` succeeded and `happy --version` reports `1.1.8`.

## Notes

- If you'd rather keep `workspace:*` in source for the auto-bump behaviour, an alternative is to standardize on `pnpm publish` from `packages/happy-cli` (which substitutes `workspace:*`). Happy to switch the PR to that approach instead — let me know.
- A future bump of `@slopus/happy-wire` will require updating this range in lockstep, same as any other inter-package dep declared with semver.