### PR TITLE
fix(happy-cli): respect attribution.commit empty string setting

### DIFF
--- a/packages/happy-cli/src/claude/utils/claudeSettings.test.ts
+++ b/packages/happy-cli/src/claude/utils/claudeSettings.test.ts
@@ -91,5 +91,29 @@ describe('Claude Settings', () => {
       const result = shouldIncludeCoAuthoredBy();
       expect(result).toBe(true);
     });
+
+    it('returns false when attribution.commit is set to empty string', () => {
+      const settingsPath = join(testClaudeDir, 'settings.json');
+      writeFileSync(settingsPath, JSON.stringify({ attribution: { commit: '' } }));
+
+      const result = shouldIncludeCoAuthoredBy();
+      expect(result).toBe(false);
+    });
+
+    it('returns true when attribution.commit is set to a non-empty string', () => {
+      const settingsPath = join(testClaudeDir, 'settings.json');
+      writeFileSync(settingsPath, JSON.stringify({ attribution: { commit: 'Custom Attribution' } }));
+
+      const result = shouldIncludeCoAuthoredBy();
+      expect(result).toBe(true);
+    });
+
+    it('returns false when includeCoAuthoredBy is true but attribution.commit is empty string', () => {
+      const settingsPath = join(testClaudeDir, 'settings.json');
+      writeFileSync(settingsPath, JSON.stringify({ includeCoAuthoredBy: true, attribution: { commit: '' } }));
+
+      const result = shouldIncludeCoAuthoredBy();
+      expect(result).toBe(false);
+    });
   });
 });

--- a/packages/happy-cli/src/claude/utils/claudeSettings.ts
+++ b/packages/happy-cli/src/claude/utils/claudeSettings.ts
@@ -12,6 +12,10 @@ import { logger } from '@/ui/logger';
 
 export interface ClaudeSettings {
   includeCoAuthoredBy?: boolean;
+  attribution?: {
+    commit?: string;
+    pr?: string;
+  };
   [key: string]: any;
 }
 
@@ -58,12 +62,23 @@ export function readClaudeSettings(): ClaudeSettings | null {
  */
 export function shouldIncludeCoAuthoredBy(): boolean {
   const settings = readClaudeSettings();
-  
-  // If no settings file or includeCoAuthoredBy is not explicitly set,
-  // default to true to maintain backward compatibility
+
+  // If user explicitly set includeCoAuthoredBy to false, respect it
+  if (settings?.includeCoAuthoredBy === false) {
+    return false;
+  }
+
+  // If user explicitly set attribution.commit to empty string, skip Happy attribution
+  // This is the standard Claude Code setting for disabling commit attribution
+  if (settings?.attribution?.commit === "") {
+    return false;
+  }
+
+  // If no settings file or includeCoAuthoredBy not explicitly set, default to true
+  // (maintains backward compatibility for existing Happy users)
   if (!settings || settings.includeCoAuthoredBy === undefined) {
     return true;
   }
-  
+
   return settings.includeCoAuthoredBy;
 }


### PR DESCRIPTION
When users set attribution.commit to "" in their Claude settings.json, Happy now skips injecting Co-Authored-By trailers, letting Claude Code's own attribution handling work instead of overriding it.

Issue: #1180