### PR TITLE
fix(cli): surface hook `systemMessage` in chat (was silently dropped)

### DIFF
--- a/packages/happy-app/sources/sync/typesRaw.spec.ts
+++ b/packages/happy-app/sources/sync/typesRaw.spec.ts
@@ -1995,4 +1995,191 @@ describe('Zod Transform - WOLOG Content Normalization', () => {
             expect(normalized).toBeNull();
         });
     });
+
+    describe('Hook system messages (subtype: hook_response)', () => {
+
+        const baseHook = {
+            role: 'agent' as const,
+            content: {
+                type: 'output' as const,
+                data: {
+                    type: 'system',
+                    subtype: 'hook_response',
+                    hook_id: 'h1',
+                    hook_name: 'UserPromptSubmit:workout',
+                    hook_event: 'UserPromptSubmit',
+                    uuid: 'hook-uuid-1',
+                    parentUuid: null,
+                    session_id: 's1',
+                }
+            }
+        };
+
+        it('surfaces systemMessage from a blocking hook (stderr + exit_code 2)', () => {
+            const stderrJson = JSON.stringify({
+                hookSpecificOutput: { decision: 'BLOCK' },
+                systemMessage: '⏰ Workout time! All sessions blocked until 06:40.'
+            });
+            const normalized = normalizeRawMessage('msg-hook-1', null, 1, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: stderrJson,
+                        stdout: '',
+                        stderr: stderrJson,
+                        exit_code: 2,
+                        outcome: 'error',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeTruthy();
+            expect(normalized?.role).toBe('agent');
+            if (normalized && normalized.role === 'agent') {
+                expect(normalized.content).toHaveLength(1);
+                expect(normalized.content[0]).toMatchObject({
+                    type: 'text',
+                    text: '⏰ Workout time! All sessions blocked until 06:40.',
+                    uuid: 'hook-uuid-1',
+                    parentUUID: null,
+                });
+            }
+        });
+
+        it('surfaces systemMessage from a passing hook (stdout + exit_code 0)', () => {
+            const stdoutJson = JSON.stringify({
+                continue: true,
+                systemMessage: '🚀 Session started'
+            });
+            const normalized = normalizeRawMessage('msg-hook-2', null, 2, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        hook_event: 'SessionStart',
+                        hook_name: 'SessionStart:summary',
+                        output: stdoutJson,
+                        stdout: stdoutJson,
+                        stderr: '',
+                        exit_code: 0,
+                        outcome: 'success',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeTruthy();
+            if (normalized && normalized.role === 'agent') {
+                expect(normalized.content[0]).toMatchObject({
+                    type: 'text',
+                    text: '🚀 Session started',
+                });
+            }
+        });
+
+        it('drops hook_response with no systemMessage (e.g. plain logging hooks)', () => {
+            const normalized = normalizeRawMessage('msg-hook-3', null, 3, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: 'Sync started in background\n',
+                        stdout: 'Sync started in background\n',
+                        stderr: '',
+                        exit_code: 0,
+                        outcome: 'success',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+
+        it('drops hook_response with non-JSON stderr', () => {
+            const normalized = normalizeRawMessage('msg-hook-4', null, 4, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: 'Error: command not found\n',
+                        stdout: '',
+                        stderr: 'Error: command not found\n',
+                        exit_code: 127,
+                        outcome: 'error',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+
+        it('drops hook_started / hook_progress (no systemMessage to show)', () => {
+            const started = normalizeRawMessage('msg-hook-5', null, 5, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        subtype: 'hook_started',
+                    }
+                }
+            } as any);
+            expect(started).toBeNull();
+
+            const progress = normalizeRawMessage('msg-hook-6', null, 6, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        subtype: 'hook_progress',
+                        stdout: 'progress',
+                        stderr: '',
+                        output: 'progress',
+                    }
+                }
+            } as any);
+            expect(progress).toBeNull();
+        });
+
+        it('drops other system subtypes (e.g. init) — they are not user-facing', () => {
+            const normalized = normalizeRawMessage('msg-hook-7', null, 7, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        subtype: 'init',
+                        cwd: '/tmp',
+                        model: 'claude-opus',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+
+        it('handles malformed JSON in stdout/stderr without throwing', () => {
+            const normalized = normalizeRawMessage('msg-hook-8', null, 8, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: '{not valid json',
+                        stdout: '{not valid json',
+                        stderr: '',
+                        exit_code: 0,
+                        outcome: 'success',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+    });
 });

--- a/packages/happy-app/sources/sync/typesRaw.spec.ts
+++ b/packages/happy-app/sources/sync/typesRaw.spec.ts
@@ -2007,4 +2007,191 @@ describe('Zod Transform - WOLOG Content Normalization', () => {
             expect(normalized).toBeNull();
         });
     });
+
+    describe('Hook system messages (subtype: hook_response)', () => {
+
+        const baseHook = {
+            role: 'agent' as const,
+            content: {
+                type: 'output' as const,
+                data: {
+                    type: 'system',
+                    subtype: 'hook_response',
+                    hook_id: 'h1',
+                    hook_name: 'UserPromptSubmit:workout',
+                    hook_event: 'UserPromptSubmit',
+                    uuid: 'hook-uuid-1',
+                    parentUuid: null,
+                    session_id: 's1',
+                }
+            }
+        };
+
+        it('surfaces systemMessage from a blocking hook (stderr + exit_code 2)', () => {
+            const stderrJson = JSON.stringify({
+                hookSpecificOutput: { decision: 'BLOCK' },
+                systemMessage: '⏰ Workout time! All sessions blocked until 06:40.'
+            });
+            const normalized = normalizeRawMessage('msg-hook-1', null, 1, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: stderrJson,
+                        stdout: '',
+                        stderr: stderrJson,
+                        exit_code: 2,
+                        outcome: 'error',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeTruthy();
+            expect(normalized?.role).toBe('agent');
+            if (normalized && normalized.role === 'agent') {
+                expect(normalized.content).toHaveLength(1);
+                expect(normalized.content[0]).toMatchObject({
+                    type: 'text',
+                    text: '⏰ Workout time! All sessions blocked until 06:40.',
+                    uuid: 'hook-uuid-1',
+                    parentUUID: null,
+                });
+            }
+        });
+
+        it('surfaces systemMessage from a passing hook (stdout + exit_code 0)', () => {
+            const stdoutJson = JSON.stringify({
+                continue: true,
+                systemMessage: '🚀 Session started'
+            });
+            const normalized = normalizeRawMessage('msg-hook-2', null, 2, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        hook_event: 'SessionStart',
+                        hook_name: 'SessionStart:summary',
+                        output: stdoutJson,
+                        stdout: stdoutJson,
+                        stderr: '',
+                        exit_code: 0,
+                        outcome: 'success',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeTruthy();
+            if (normalized && normalized.role === 'agent') {
+                expect(normalized.content[0]).toMatchObject({
+                    type: 'text',
+                    text: '🚀 Session started',
+                });
+            }
+        });
+
+        it('drops hook_response with no systemMessage (e.g. plain logging hooks)', () => {
+            const normalized = normalizeRawMessage('msg-hook-3', null, 3, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: 'Sync started in background\n',
+                        stdout: 'Sync started in background\n',
+                        stderr: '',
+                        exit_code: 0,
+                        outcome: 'success',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+
+        it('drops hook_response with non-JSON stderr', () => {
+            const normalized = normalizeRawMessage('msg-hook-4', null, 4, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: 'Error: command not found\n',
+                        stdout: '',
+                        stderr: 'Error: command not found\n',
+                        exit_code: 127,
+                        outcome: 'error',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+
+        it('drops hook_started / hook_progress (no systemMessage to show)', () => {
+            const started = normalizeRawMessage('msg-hook-5', null, 5, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        subtype: 'hook_started',
+                    }
+                }
+            } as any);
+            expect(started).toBeNull();
+
+            const progress = normalizeRawMessage('msg-hook-6', null, 6, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        subtype: 'hook_progress',
+                        stdout: 'progress',
+                        stderr: '',
+                        output: 'progress',
+                    }
+                }
+            } as any);
+            expect(progress).toBeNull();
+        });
+
+        it('drops other system subtypes (e.g. init) — they are not user-facing', () => {
+            const normalized = normalizeRawMessage('msg-hook-7', null, 7, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        subtype: 'init',
+                        cwd: '/tmp',
+                        model: 'claude-opus',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+
+        it('handles malformed JSON in stdout/stderr without throwing', () => {
+            const normalized = normalizeRawMessage('msg-hook-8', null, 8, {
+                ...baseHook,
+                content: {
+                    ...baseHook.content,
+                    data: {
+                        ...baseHook.content.data,
+                        output: '{not valid json',
+                        stdout: '{not valid json',
+                        stderr: '',
+                        exit_code: 0,
+                        outcome: 'success',
+                    }
+                }
+            } as any);
+
+            expect(normalized).toBeNull();
+        });
+    });
 });

--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -699,6 +699,29 @@ function normalizeSessionEnvelope(
     return null;
 }
 
+/**
+ * Extract a `systemMessage` value from a Claude SDK `hook_response` payload.
+ * Hooks emit JSON on either stdout (typical) or stderr (when exiting non-zero
+ * to block, e.g. exit code 2). The SDK forwards both verbatim. Try `output`
+ * first since the SDK populates it with whichever stream the hook used, then
+ * fall back to stdout/stderr.
+ */
+function extractHookSystemMessage(data: { output?: unknown; stdout?: unknown; stderr?: unknown }): string | null {
+    const candidates = [data.output, data.stdout, data.stderr];
+    for (const candidate of candidates) {
+        if (typeof candidate !== 'string' || candidate.length === 0) continue;
+        try {
+            const parsed = JSON.parse(candidate);
+            if (parsed && typeof parsed === 'object' && typeof parsed.systemMessage === 'string' && parsed.systemMessage.length > 0) {
+                return parsed.systemMessage;
+            }
+        } catch {
+            // Not JSON — hooks can also print plain text. Skip.
+        }
+    }
+    return null;
+}
+
 export function normalizeRawMessage(id: string, localId: string | null, createdAt: number, raw: RawRecord): NormalizedMessage | null {
     // Zod transform handles normalization during validation
     let parsed = rawRecordSchema.safeParse(raw);
@@ -759,6 +782,34 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
                         isSidechain: false,
                         meta: raw.meta,
                     } satisfies NormalizedMessage;
+                }
+                return null;
+            }
+
+            // Handle System messages — surface hook `systemMessage` so users see
+            // hook-generated notes (e.g. UserPromptSubmit/SessionStart hooks that
+            // set `systemMessage` in their JSON output). Claude Code's own UI
+            // shows these; without this branch they were silently dropped.
+            if (raw.content.data.type === 'system') {
+                const data = raw.content.data as any;
+                if (data.subtype === 'hook_response') {
+                    const systemMessage = extractHookSystemMessage(data);
+                    if (systemMessage) {
+                        return {
+                            id,
+                            localId,
+                            createdAt,
+                            role: 'agent',
+                            content: [{
+                                type: 'text' as const,
+                                text: systemMessage,
+                                uuid: data.uuid ?? id,
+                                parentUUID: data.parentUuid ?? null,
+                            }],
+                            isSidechain: false,
+                            meta: raw.meta,
+                        } satisfies NormalizedMessage;
+                    }
                 }
                 return null;
             }

--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -735,6 +735,29 @@ function normalizeSessionEnvelope(
     return null;
 }
 
+/**
+ * Extract a `systemMessage` value from a Claude SDK `hook_response` payload.
+ * Hooks emit JSON on either stdout (typical) or stderr (when exiting non-zero
+ * to block, e.g. exit code 2). The SDK forwards both verbatim. Try `output`
+ * first since the SDK populates it with whichever stream the hook used, then
+ * fall back to stdout/stderr.
+ */
+function extractHookSystemMessage(data: { output?: unknown; stdout?: unknown; stderr?: unknown }): string | null {
+    const candidates = [data.output, data.stdout, data.stderr];
+    for (const candidate of candidates) {
+        if (typeof candidate !== 'string' || candidate.length === 0) continue;
+        try {
+            const parsed = JSON.parse(candidate);
+            if (parsed && typeof parsed === 'object' && typeof parsed.systemMessage === 'string' && parsed.systemMessage.length > 0) {
+                return parsed.systemMessage;
+            }
+        } catch {
+            // Not JSON — hooks can also print plain text. Skip.
+        }
+    }
+    return null;
+}
+
 export function normalizeRawMessage(id: string, localId: string | null, createdAt: number, raw: RawRecord): NormalizedMessage | null {
     // Zod transform handles normalization during validation
     let parsed = rawRecordSchema.safeParse(raw);
@@ -795,6 +818,34 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
                         isSidechain: false,
                         meta: raw.meta,
                     } satisfies NormalizedMessage;
+                }
+                return null;
+            }
+
+            // Handle System messages — surface hook `systemMessage` so users see
+            // hook-generated notes (e.g. UserPromptSubmit/SessionStart hooks that
+            // set `systemMessage` in their JSON output). Claude Code's own UI
+            // shows these; without this branch they were silently dropped.
+            if (raw.content.data.type === 'system') {
+                const data = raw.content.data as any;
+                if (data.subtype === 'hook_response') {
+                    const systemMessage = extractHookSystemMessage(data);
+                    if (systemMessage) {
+                        return {
+                            id,
+                            localId,
+                            createdAt,
+                            role: 'agent',
+                            content: [{
+                                type: 'text' as const,
+                                text: systemMessage,
+                                uuid: data.uuid ?? id,
+                                parentUUID: data.parentUuid ?? null,
+                            }],
+                            isSidechain: false,
+                            meta: raw.meta,
+                        } satisfies NormalizedMessage;
+                    }
                 }
                 return null;
             }

--- a/packages/happy-cli/src/claude/utils/OutgoingMessageQueue.ts
+++ b/packages/happy-cli/src/claude/utils/OutgoingMessageQueue.ts
@@ -119,11 +119,13 @@ export class OutgoingMessageQueue {
                 break;
             }
             
-            // Send if not already sent
+            // Send if not already sent. The downstream session-protocol mapper
+            // decides which subtypes produce envelopes (e.g. `init` produces
+            // none, `hook_response` with a `systemMessage` produces a service
+            // envelope). Don't drop system messages here — that masked the
+            // mapper's hook_response path entirely before this fix.
             if (!item.sent) {
-                if (item.logMessage.type !== 'system') {
-                    this.sendFunction(item.logMessage);
-                }
+                this.sendFunction(item.logMessage);
                 item.sent = true;
             }
             

--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
@@ -339,6 +339,99 @@ describe('mapClaudeLogMessageToSessionEnvelopes', () => {
         expect(result.currentTurnId).toBe('turn-1');
         expect(result.envelopes).toHaveLength(0);
     });
+
+    describe('hook_response system messages', () => {
+        const baseHookResponse = {
+            type: 'system' as const,
+            subtype: 'hook_response',
+            hook_id: 'h1',
+            hook_name: 'UserPromptSubmit:test',
+            hook_event: 'UserPromptSubmit',
+            uuid: 'u1',
+            session_id: 's1',
+        };
+
+        it('emits a service envelope when stderr carries {systemMessage} (block hook, exit 2)', () => {
+            const stderrJson = JSON.stringify({
+                hookSpecificOutput: { decision: 'BLOCK' },
+                systemMessage: '⏰ Workout time! Sessions blocked until 06:40.',
+            });
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    output: stderrJson,
+                    stdout: '',
+                    stderr: stderrJson,
+                    exit_code: 2,
+                    outcome: 'error',
+                } as any,
+                { currentTurnId: null },
+            );
+            // turn-start + service
+            expect(result.envelopes.map(e => e.ev.t)).toEqual(['turn-start', 'service']);
+            const service = result.envelopes[1].ev as any;
+            expect(service.text).toBe('⏰ Workout time! Sessions blocked until 06:40.');
+        });
+
+        it('emits a service envelope when stdout carries {systemMessage} (passing hook, exit 0)', () => {
+            const stdoutJson = JSON.stringify({ continue: true, systemMessage: '🚀 Session started' });
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    hook_event: 'SessionStart',
+                    output: stdoutJson,
+                    stdout: stdoutJson,
+                    stderr: '',
+                    exit_code: 0,
+                    outcome: 'success',
+                } as any,
+                { currentTurnId: 'existing-turn' },
+            );
+            // existing turn reused → only service envelope
+            expect(result.envelopes.map(e => e.ev.t)).toEqual(['service']);
+            expect((result.envelopes[0].ev as any).text).toBe('🚀 Session started');
+        });
+
+        it('emits no envelopes for hook_response without a systemMessage payload', () => {
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    output: 'Sync started in background\n',
+                    stdout: 'Sync started in background\n',
+                    stderr: '',
+                    exit_code: 0,
+                    outcome: 'success',
+                } as any,
+                { currentTurnId: null },
+            );
+            expect(result.envelopes).toHaveLength(0);
+        });
+
+        it('emits no envelopes for non-JSON stderr', () => {
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    output: 'Error: command not found\n',
+                    stdout: '',
+                    stderr: 'Error: command not found\n',
+                    exit_code: 127,
+                    outcome: 'error',
+                } as any,
+                { currentTurnId: null },
+            );
+            expect(result.envelopes).toHaveLength(0);
+        });
+
+        it('emits no envelopes for system subtypes other than hook_response (init, hook_started, etc.)', () => {
+            for (const subtype of ['init', 'hook_started', 'hook_progress'] as const) {
+                const result = mapClaudeLogMessageToSessionEnvelopes(
+                    { type: 'system', subtype, uuid: 'u', session_id: 's' } as any,
+                    { currentTurnId: null },
+                );
+                expect(result.envelopes).toHaveLength(0);
+            }
+        });
+    });
 });
 
 describe('closeClaudeTurnWithStatus', () => {

--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
@@ -383,6 +383,99 @@ describe('mapClaudeLogMessageToSessionEnvelopes', () => {
         expect(result.currentTurnId).toBe('turn-1');
         expect(result.envelopes).toHaveLength(0);
     });
+
+    describe('hook_response system messages', () => {
+        const baseHookResponse = {
+            type: 'system' as const,
+            subtype: 'hook_response',
+            hook_id: 'h1',
+            hook_name: 'UserPromptSubmit:test',
+            hook_event: 'UserPromptSubmit',
+            uuid: 'u1',
+            session_id: 's1',
+        };
+
+        it('emits a service envelope when stderr carries {systemMessage} (block hook, exit 2)', () => {
+            const stderrJson = JSON.stringify({
+                hookSpecificOutput: { decision: 'BLOCK' },
+                systemMessage: '⏰ Workout time! Sessions blocked until 06:40.',
+            });
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    output: stderrJson,
+                    stdout: '',
+                    stderr: stderrJson,
+                    exit_code: 2,
+                    outcome: 'error',
+                } as any,
+                { currentTurnId: null },
+            );
+            // turn-start + service
+            expect(result.envelopes.map(e => e.ev.t)).toEqual(['turn-start', 'service']);
+            const service = result.envelopes[1].ev as any;
+            expect(service.text).toBe('⏰ Workout time! Sessions blocked until 06:40.');
+        });
+
+        it('emits a service envelope when stdout carries {systemMessage} (passing hook, exit 0)', () => {
+            const stdoutJson = JSON.stringify({ continue: true, systemMessage: '🚀 Session started' });
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    hook_event: 'SessionStart',
+                    output: stdoutJson,
+                    stdout: stdoutJson,
+                    stderr: '',
+                    exit_code: 0,
+                    outcome: 'success',
+                } as any,
+                { currentTurnId: 'existing-turn' },
+            );
+            // existing turn reused → only service envelope
+            expect(result.envelopes.map(e => e.ev.t)).toEqual(['service']);
+            expect((result.envelopes[0].ev as any).text).toBe('🚀 Session started');
+        });
+
+        it('emits no envelopes for hook_response without a systemMessage payload', () => {
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    output: 'Sync started in background\n',
+                    stdout: 'Sync started in background\n',
+                    stderr: '',
+                    exit_code: 0,
+                    outcome: 'success',
+                } as any,
+                { currentTurnId: null },
+            );
+            expect(result.envelopes).toHaveLength(0);
+        });
+
+        it('emits no envelopes for non-JSON stderr', () => {
+            const result = mapClaudeLogMessageToSessionEnvelopes(
+                {
+                    ...baseHookResponse,
+                    output: 'Error: command not found\n',
+                    stdout: '',
+                    stderr: 'Error: command not found\n',
+                    exit_code: 127,
+                    outcome: 'error',
+                } as any,
+                { currentTurnId: null },
+            );
+            expect(result.envelopes).toHaveLength(0);
+        });
+
+        it('emits no envelopes for system subtypes other than hook_response (init, hook_started, etc.)', () => {
+            for (const subtype of ['init', 'hook_started', 'hook_progress'] as const) {
+                const result = mapClaudeLogMessageToSessionEnvelopes(
+                    { type: 'system', subtype, uuid: 'u', session_id: 's' } as any,
+                    { currentTurnId: null },
+                );
+                expect(result.envelopes).toHaveLength(0);
+            }
+        });
+    });
 });
 
 describe('closeClaudeTurnWithStatus', () => {

--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
@@ -23,6 +23,29 @@ type ClaudeMapperResult = {
     envelopes: SessionEnvelope[];
 };
 
+/**
+ * Extract a `systemMessage` value from a Claude SDK `hook_response` payload.
+ * Hooks emit JSON on either stdout (typical) or stderr (when exiting non-zero
+ * to block, e.g. exit code 2). The SDK forwards both verbatim. Try `output`
+ * first since the SDK populates it with whichever stream the hook used, then
+ * fall back to stdout/stderr.
+ */
+function extractHookSystemMessage(data: { output?: unknown; stdout?: unknown; stderr?: unknown }): string | null {
+    const candidates = [data.output, data.stdout, data.stderr];
+    for (const candidate of candidates) {
+        if (typeof candidate !== 'string' || candidate.length === 0) continue;
+        try {
+            const parsed = JSON.parse(candidate);
+            if (parsed && typeof parsed === 'object' && typeof parsed.systemMessage === 'string' && parsed.systemMessage.length > 0) {
+                return parsed.systemMessage;
+            }
+        } catch {
+            // Not JSON — hooks can also print plain text. Skip.
+        }
+    }
+    return null;
+}
+
 function isSubagentTool(name: string): boolean {
     return name === 'Task' || name === 'Agent';
 }
@@ -466,6 +489,20 @@ function mapClaudeLogMessageToSessionEnvelopesInternal(
     }
 
     if (message.type === 'system') {
+        // Surface a hook's `systemMessage` to the chat (e.g. UserPromptSubmit
+        // hook that exits non-zero with `{"systemMessage": "..."}` to block,
+        // or SessionStart hook with a startup banner). The SDK delivers the
+        // JSON in `output`/`stdout` (success) or `stderr` (when the hook
+        // exits non-zero). Emit it as a `service` envelope so the existing
+        // app-side normalizer renders it as agent text.
+        const sysAny = message as any;
+        if (sysAny.subtype === 'hook_response') {
+            const systemMessage = extractHookSystemMessage(sysAny);
+            if (systemMessage) {
+                const turnId = ensureTurn(state, envelopes);
+                envelopes.push(createEnvelope('agent', { t: 'service', text: systemMessage }, { turn: turnId }));
+            }
+        }
         return {
             currentTurnId: state.currentTurnId,
             envelopes,

--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
@@ -23,6 +23,29 @@ type ClaudeMapperResult = {
     envelopes: SessionEnvelope[];
 };
 
+/**
+ * Extract a `systemMessage` value from a Claude SDK `hook_response` payload.
+ * Hooks emit JSON on either stdout (typical) or stderr (when exiting non-zero
+ * to block, e.g. exit code 2). The SDK forwards both verbatim. Try `output`
+ * first since the SDK populates it with whichever stream the hook used, then
+ * fall back to stdout/stderr.
+ */
+function extractHookSystemMessage(data: { output?: unknown; stdout?: unknown; stderr?: unknown }): string | null {
+    const candidates = [data.output, data.stdout, data.stderr];
+    for (const candidate of candidates) {
+        if (typeof candidate !== 'string' || candidate.length === 0) continue;
+        try {
+            const parsed = JSON.parse(candidate);
+            if (parsed && typeof parsed === 'object' && typeof parsed.systemMessage === 'string' && parsed.systemMessage.length > 0) {
+                return parsed.systemMessage;
+            }
+        } catch {
+            // Not JSON — hooks can also print plain text. Skip.
+        }
+    }
+    return null;
+}
+
 function isSubagentTool(name: string): boolean {
     return name === 'Task' || name === 'Agent';
 }
@@ -467,6 +490,20 @@ function mapClaudeLogMessageToSessionEnvelopesInternal(
     }
 
     if (message.type === 'system') {
+        // Surface a hook's `systemMessage` to the chat (e.g. UserPromptSubmit
+        // hook that exits non-zero with `{"systemMessage": "..."}` to block,
+        // or SessionStart hook with a startup banner). The SDK delivers the
+        // JSON in `output`/`stdout` (success) or `stderr` (when the hook
+        // exits non-zero). Emit it as a `service` envelope so the existing
+        // app-side normalizer renders it as agent text.
+        const sysAny = message as any;
+        if (sysAny.subtype === 'hook_response') {
+            const systemMessage = extractHookSystemMessage(sysAny);
+            if (systemMessage) {
+                const turnId = ensureTurn(state, envelopes);
+                envelopes.push(createEnvelope('agent', { t: 'service', text: systemMessage }, { turn: turnId }));
+            }
+        }
         return {
             currentTurnId: state.currentTurnId,
             envelopes,

--- a/packages/happy-cli/src/ui/messageFormatterInk.test.ts
+++ b/packages/happy-cli/src/ui/messageFormatterInk.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the Ink message formatter — specifically the hook_response branch
+ * that surfaces a hook's `systemMessage` to the terminal UI.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { formatClaudeMessageForInk } from './messageFormatterInk.js'
+import { MessageBuffer } from './ink/messageBuffer.js'
+
+function makeHookResponse(opts: {
+    output?: string
+    stdout?: string
+    stderr?: string
+    exit_code?: number
+    outcome?: 'success' | 'error' | 'cancelled'
+}): any {
+    return {
+        type: 'system',
+        subtype: 'hook_response',
+        hook_id: 'h1',
+        hook_name: 'UserPromptSubmit:test',
+        hook_event: 'UserPromptSubmit',
+        output: opts.output ?? '',
+        stdout: opts.stdout ?? '',
+        stderr: opts.stderr ?? '',
+        exit_code: opts.exit_code ?? 0,
+        outcome: opts.outcome ?? 'success',
+        uuid: 'u1',
+        session_id: 's1',
+    }
+}
+
+describe('formatClaudeMessageForInk — hook_response systemMessage', () => {
+
+    it('renders systemMessage from a blocking hook (stderr + exit_code 2)', () => {
+        const buf = new MessageBuffer()
+        const stderrJson = JSON.stringify({
+            hookSpecificOutput: { decision: 'BLOCK' },
+            systemMessage: '⏰ Workout time! All sessions blocked until 06:40.',
+        })
+        formatClaudeMessageForInk(
+            makeHookResponse({ output: stderrJson, stderr: stderrJson, exit_code: 2, outcome: 'error' }),
+            buf,
+        )
+        const messages = buf.getMessages()
+        expect(messages).toHaveLength(1)
+        expect(messages[0]).toMatchObject({
+            content: '⏺ ⏰ Workout time! All sessions blocked until 06:40.',
+            type: 'system',
+        })
+    })
+
+    it('renders systemMessage from a passing hook (stdout + exit_code 0)', () => {
+        const buf = new MessageBuffer()
+        const stdoutJson = JSON.stringify({ continue: true, systemMessage: '🚀 Session started' })
+        formatClaudeMessageForInk(
+            makeHookResponse({ output: stdoutJson, stdout: stdoutJson }),
+            buf,
+        )
+        const messages = buf.getMessages()
+        expect(messages).toHaveLength(1)
+        expect(messages[0].content).toBe('⏺ 🚀 Session started')
+    })
+
+    it('drops hook_response with no systemMessage (e.g. plain logging hooks)', () => {
+        const buf = new MessageBuffer()
+        formatClaudeMessageForInk(
+            makeHookResponse({ output: 'Sync started\n', stdout: 'Sync started\n' }),
+            buf,
+        )
+        expect(buf.getMessages()).toHaveLength(0)
+    })
+
+    it('drops hook_response with non-JSON stderr', () => {
+        const buf = new MessageBuffer()
+        formatClaudeMessageForInk(
+            makeHookResponse({ output: 'cmd not found', stderr: 'cmd not found', exit_code: 127, outcome: 'error' }),
+            buf,
+        )
+        expect(buf.getMessages()).toHaveLength(0)
+    })
+
+    it('handles malformed JSON without throwing', () => {
+        const buf = new MessageBuffer()
+        expect(() => formatClaudeMessageForInk(
+            makeHookResponse({ output: '{not valid', stdout: '{not valid' }),
+            buf,
+        )).not.toThrow()
+        expect(buf.getMessages()).toHaveLength(0)
+    })
+})

--- a/packages/happy-cli/src/ui/messageFormatterInk.ts
+++ b/packages/happy-cli/src/ui/messageFormatterInk.ts
@@ -5,6 +5,29 @@ import { logger } from './logger'
 export type OnAssistantResultInkCallback = (result: SDKResultMessage, messageBuffer: MessageBuffer) => void | Promise<void>
 
 /**
+ * Extract a `systemMessage` value from a Claude SDK `hook_response` payload.
+ * Hooks emit JSON on either stdout (typical) or stderr (when exiting non-zero
+ * to block, e.g. exit code 2). The SDK forwards both verbatim. Try `output`
+ * first since the SDK populates it with whichever stream the hook used, then
+ * fall back to stdout/stderr.
+ */
+function extractHookSystemMessage(data: { output?: unknown; stdout?: unknown; stderr?: unknown }): string | null {
+    const candidates = [data.output, data.stdout, data.stderr]
+    for (const candidate of candidates) {
+        if (typeof candidate !== 'string' || candidate.length === 0) continue
+        try {
+            const parsed = JSON.parse(candidate)
+            if (parsed && typeof parsed === 'object' && typeof parsed.systemMessage === 'string' && parsed.systemMessage.length > 0) {
+                return parsed.systemMessage
+            }
+        } catch {
+            // Not JSON — hooks can also print plain text. Skip.
+        }
+    }
+    return null
+}
+
+/**
  * Formats Claude SDK messages for Ink display
  */
 export function formatClaudeMessageForInk(
@@ -26,6 +49,16 @@ export function formatClaudeMessageForInk(
                     messageBuffer.addMessage(`  Tools: ${sysMsg.tools.join(', ')}`, 'status')
                 }
                 messageBuffer.addMessage('─'.repeat(40), 'status')
+            } else if ((sysMsg as any).subtype === 'hook_response') {
+                // Surface hook `systemMessage` so users see hook-generated notes
+                // (e.g. UserPromptSubmit/SessionStart hooks). Hook output JSON is
+                // delivered verbatim in `output`/`stdout` (success) or `stderr`
+                // (when the hook exits non-zero to block, e.g. exit code 2).
+                const hookData = sysMsg as any
+                const systemMessage = extractHookSystemMessage(hookData)
+                if (systemMessage) {
+                    messageBuffer.addMessage(`⏺ ${systemMessage}`, 'system')
+                }
             }
             break
         }


### PR DESCRIPTION
## Bug

Claude Code hooks can emit `{"systemMessage": "..."}` JSON to signal a user-visible note. For example a `UserPromptSubmit` hook that exits non-zero with:

```bash
echo '{"hookSpecificOutput":{"decision":"BLOCK"},"systemMessage":"⏰ Workout time!"}' >&2
exit 2
```

In `claude` (terminal), the user sees `⏺ Workout time!` and the prompt is blocked. In Happy (mobile/web), **the prompt is blocked but no message appears** — the user has no idea why their input vanished. Same for `SessionStart` summary hooks, `PreToolUse` warnings, etc.

## Root cause

For current `happy-cli`, every outgoing log message goes:

```
SDK message → sdkToLogConverter.convert() → OutgoingMessageQueue.enqueue()
            → sendFunction → apiSession.sendClaudeSessionMessage()
            → mapClaudeLogMessageToSessionEnvelopes() → service envelope → server → app
```

Two cuts on this path silently dropped hook output before it could ever reach the chat:

1. **`OutgoingMessageQueue.ts`** had `if (item.logMessage.type !== 'system') sendFunction(...)` — an unconditional drop, so *every* `type === 'system'` message (`init`, `hook_started`, `hook_progress`, **and** `hook_response`) was discarded before the mapper ran.
2. **`sessionProtocolMapper.ts`**'s `if (message.type === 'system')` branch returned no envelopes — even if the queue had let the message through, the mapper had no `hook_response` handler.

Two ancillary paths that aren't on the hot path also lacked handling:

3. **`typesRaw.ts:normalizeRawMessage`** (app-side, legacy raw-output format used by older clients) had no `type === 'system'` branch.
4. **`messageFormatterInk.ts`** (CLI Ink terminal renderer in remote mode) only handled `subtype: 'init'` for system messages.

## Fix

| File(s) | What |
|---|---|
| `OutgoingMessageQueue.ts` + `sessionProtocolMapper.ts` | **The user-visible fix.** Stop dropping `type === 'system'` at the queue and let the mapper decide which subtypes produce envelopes; emit a `service` envelope from `hook_response` carrying the `systemMessage` payload, extracted from `output`/`stdout`/`stderr`. The app's existing `normalizeSessionEnvelope` already renders service envelopes as agent text, so nothing new is needed app-side for the live path. |
| `typesRaw.ts` | App normalizer for the legacy raw-output format still used by older clients: extract `systemMessage` from the hook payload and render it as agent text. |
| `messageFormatterInk.ts` | CLI Ink terminal renderer: show `systemMessage` with a `⏺` prefix in remote-mode display. |

`sdkToLogConverter` already passes system messages through unchanged — no change needed there.

## Proof — live e2e on a real CLI ↔ server ↔ app stack

![BEFORE/AFTER side-by-side screenshot](https://github.com/chphch/happy/releases/download/pr-proofs/1212-systemmessage-live-e2e.png)

Same dev-token account on both halves: standalone `happy-server` (PGlite) + Expo web + a `HAPPY_HOME_DIR`-isolated `happy daemon`. A `SessionStart` hook in the user's global `~/.claude/settings.json` emits a startup banner (`{"continue":true,"systemMessage":"🚀 cwd Session started\n▸ Time:…\n▸ Directory:…"}`). Playwright drives the "Start New Session" modal, sends `hello there`, and screenshots the chat after the turn.

- **BEFORE (upstream/main)** — only the user prompt is visible. The hook fired (confirmed in the CLI session log) and the SDK emitted `hook_response`, but it never reached the server, so the chat shows nothing.
- **AFTER (this branch)** — the same hook's `systemMessage` renders as a chat bubble.

## Verification

- **17 vitest cases** across 3 spec files, all green: 5 in `sessionProtocolMapper.test.ts` (the live-path fix), 7 in `typesRaw.spec.ts` (legacy normalizer), 5 in `messageFormatterInk.test.ts` (CLI Ink). Cases cover blocking-hook stderr (exit 2), success-hook stdout (exit 0), hooks without `systemMessage`, non-JSON output, malformed JSON, `hook_started`/`hook_progress`, and other system subtypes.
- `pnpm typecheck` (CLI + app) clean — no new errors.
