### PR TITLE
feat(cli): add Codex startup defaults

### DIFF
--- a/docs/plans/codex-startup-defaults-prd.md
+++ b/docs/plans/codex-startup-defaults-prd.md
@@ -1,0 +1,110 @@
+# PRD: Codex CLI Startup Defaults and Dynamic Session Controls
+
+Status: Local draft, not published upstream.
+Date: 2026-05-04
+
+## Problem Statement
+
+Happy's Codex integration does not reliably honor the controls a user expects when starting or continuing a Codex session. A user can start `happy codex`, but cannot seed the session with Codex-native startup choices such as model, reasoning effort, or full yolo behavior. The mobile app already has model and permission controls, but routine app metadata can reset CLI-started defaults because the app always sends `permissionMode: default` and `model: null` when its selectors are on default. As a result, a user who starts Codex from the terminal with intended defaults can accidentally lose those defaults on the first mobile message.
+
+This is especially painful for remote use. The user wants to start Codex once with the right safety/model defaults, then move between terminal, mobile, and web without remembering to set controls before the first message.
+
+## Solution
+
+Add a narrow Codex CLI startup-default layer for `happy codex` that seeds model, reasoning effort, and permission mode before the first turn. Map Happy's Codex `yolo` mode to Codex's native `--dangerously-bypass-approvals-and-sandbox` semantics: no approvals and no sandbox. Keep model and permission changes from mobile/web working between turns, but do not let routine app defaults erase explicit CLI-started defaults.
+
+From the user's perspective:
+
+- `happy codex --model gpt-5.5 --effort medium --yolo` starts Codex with those defaults.
+- Mobile/web can still change model and permission mode during the session by selecting non-default values.
+- A stale or default mobile app does not accidentally downgrade a CLI-started model or yolo mode by sending `model: null` or `permissionMode: default`.
+
+## User Stories
+
+1. As a Codex user, I want to start `happy codex --model gpt-5.5`, so that the first Codex turn uses my intended model.
+2. As a Codex user, I want to start `happy codex --effort medium`, so that every Codex turn uses my intended reasoning effort until effort overrides are supported remotely.
+3. As a Codex user, I want to start `happy codex --yolo`, so that Codex runs without approvals or sandboxing when I explicitly choose that risk.
+4. As a Codex user, I want `--yolo` to mean the same safety posture as Codex's native dangerous bypass flag, so that Happy does not provide a weaker or surprising mode.
+5. As a Codex user, I want `happy codex --permission-mode yolo` to behave the same as `happy codex --yolo`, so that scripts can use the explicit form.
+6. As a Codex user, I want `happy codex --permission-mode read-only`, so that I can start a read-only remote session without touching the mobile selector.
+7. As a Codex user, I want `happy codex --permission-mode safe-yolo`, so that Codex can work automatically inside the workspace while still retaining a safer boundary than full yolo.
+8. As a Codex user, I want conflicting permission flags to fail clearly, so that I do not accidentally start a session with the wrong safety posture.
+9. As a Codex user, I want the first mobile message not to reset my CLI-started `--model`, so that a stale app model list does not downgrade the session.
+10. As a Codex user, I want the first mobile message not to reset my CLI-started `--yolo`, so that routine app defaults do not re-enable approvals.
+11. As a mobile user, I want selecting a non-default model to change Codex's model for the next turn, so that I can switch models without restarting the session.
+12. As a mobile user, I want selecting a non-default permission mode to change Codex's permission behavior for the next turn, so that I can tighten or loosen execution between turns.
+13. As a mobile user, I want default/null app metadata to preserve explicit CLI defaults, so that ordinary message sends do not have hidden side effects.
+14. As a terminal user, I want omitted startup flags to preserve current default behavior, so that `happy codex` remains familiar.
+15. As a daemon-resume user, I want resume-provided model and permission mode arguments to be honored by Codex, so that resumed sessions keep the chosen controls.
+16. As a contributor, I want this change to be CLI-only, so that the first upstream PR is focused and reviewable.
+17. As a maintainer, I want the mode mapping covered by tests, so that future permission changes do not silently weaken yolo or break defaults.
+18. As a maintainer, I want the argument parser covered by tests, so that startup flags remain predictable.
+19. As a maintainer, I want source-aware default behavior covered by tests, so that routine app metadata cannot regress into overriding explicit CLI settings.
+
+## Implementation Decisions
+
+- Build a Codex-specific startup options parser instead of reusing Claude argument pass-through behavior.
+- Support `--model <model>` and `--model=<model>` as Codex startup model defaults.
+- Support `--effort <level>` and `--effort=<level>` for Codex reasoning effort. Valid values are Codex app-server values: `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+- Support `--permission-mode <mode>` and `--permission-mode=<mode>` for Codex permission defaults. Valid Codex modes are `default`, `read-only`, `safe-yolo`, and `yolo`.
+- Support `--yolo` as sugar for `--permission-mode yolo`.
+- Treat conflicting permission flags as an error instead of last-flag-wins.
+- Keep `--resume` extraction behavior and thread it together with the new startup options.
+- Extend the Codex run loop's enhanced mode state to include reasoning effort.
+- Seed current model, permission mode, and effort from CLI startup options before reading the first queued message.
+- Pass model, permission-derived execution policy, and effort into thread start when a new Codex thread is created.
+- Pass model, permission-derived execution policy, and effort into every Codex turn.
+- Change Codex yolo execution policy to the native dangerous bypass equivalent: approval policy `never` and sandbox `danger-full-access`.
+- Keep `safe-yolo` as the softer automatic mode: workspace write with escalation behavior.
+- Add source-aware state handling for model and permission mode:
+  - CLI startup values are explicit startup defaults.
+  - Non-default app message metadata overrides current state and becomes sticky.
+  - Routine `permissionMode: default` does not clear an explicit CLI permission mode.
+  - Routine `model: null` does not clear an explicit CLI model.
+  - With no CLI startup value, routine app defaults preserve current default behavior.
+- Do not add mobile app schema or UI changes in this PR.
+- Do not add remote effort overrides in this PR because app message metadata does not currently carry effort.
+
+## Testing Decisions
+
+- Tests should verify external behavior through parser outputs, run-loop mode resolution helpers, and execution policy mapping rather than private implementation details.
+- Add parser tests for:
+  - model flag with separate and equals syntax
+  - effort flag with separate and equals syntax
+  - permission mode flag with separate and equals syntax
+  - `--yolo`
+  - `--resume` combined with model/effort/permission flags
+  - invalid effort
+  - invalid permission mode
+  - conflicting permission flags
+- Add command handler tests to verify parsed options are passed to the Codex runner.
+- Add execution policy tests for the full Codex ladder:
+  - `default`
+  - `read-only`
+  - `safe-yolo`
+  - `yolo`
+  - Happy-managed sandbox behavior
+- Add tests for source-aware state resolution:
+  - CLI model survives app `model: null`
+  - CLI yolo survives app `permissionMode: default`
+  - app non-default model overrides CLI model
+  - app non-default permission mode overrides CLI permission mode
+  - no CLI flags preserves default/null behavior
+- Existing prior art includes the Codex CLI arg tests, Codex command handler tests, and execution policy tests in the CLI package.
+
+## Out of Scope
+
+- Mobile app UI changes.
+- Shared message metadata schema changes for effort.
+- Mobile/web effort propagation.
+- Claude startup-default behavior changes.
+- Native Codex TUI embedding.
+- Terminal display or local input improvements.
+- Server, encryption, or sync protocol changes.
+- Large refactors of the Codex app-server client.
+
+## Further Notes
+
+The current Claude integration does not implement source-aware defaults either: routine app metadata can reset CLI-started Claude model and permission state. This PR should intentionally implement the intended behavior for Codex rather than copying that weakness. A later Claude parity PR can align Claude with the same source-aware default model.
+
+The current app always includes permission and model metadata on sends. `permissionMode: default` and `model: null` are routine app defaults, not reliable evidence that the user explicitly reset controls. Without an explicit reset signal from the app, preserving CLI-started defaults is the safer behavior.

--- a/packages/happy-cli/src/codex/__tests__/executionPolicy.test.ts
+++ b/packages/happy-cli/src/codex/__tests__/executionPolicy.test.ts
@@ -28,4 +28,22 @@ describe('resolveCodexExecutionPolicy', () => {
             sandbox: 'read-only',
         });
     });
+
+    it('maps safe-yolo mode to on-failure + workspace-write without managed sandbox', () => {
+        const policy = resolveCodexExecutionPolicy('safe-yolo', false);
+
+        expect(policy).toEqual({
+            approvalPolicy: 'on-failure',
+            sandbox: 'workspace-write',
+        });
+    });
+
+    it('maps yolo mode to native dangerous bypass without managed sandbox', () => {
+        const policy = resolveCodexExecutionPolicy('yolo', false);
+
+        expect(policy).toEqual({
+            approvalPolicy: 'never',
+            sandbox: 'danger-full-access',
+        });
+    });
 });

--- a/packages/happy-cli/src/codex/cliArgs.test.ts
+++ b/packages/happy-cli/src/codex/cliArgs.test.ts
@@ -1,32 +1,112 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractCodexResumeFlag } from './cliArgs';
+import { parseCodexStartupArgs } from './cliArgs';
 
-describe('extractCodexResumeFlag', () => {
+describe('parseCodexStartupArgs', () => {
     it('returns null and preserves args when resume flag is absent', () => {
-        const parsed = extractCodexResumeFlag(['--started-by', 'terminal']);
+        const parsed = parseCodexStartupArgs(['--started-by', 'terminal']);
 
         expect(parsed.resumeThreadId).toBeNull();
         expect(parsed.args).toEqual(['--started-by', 'terminal']);
     });
 
     it('extracts an explicit resume thread ID', () => {
-        const parsed = extractCodexResumeFlag(['--resume', 'thread-123', '--started-by', 'daemon']);
+        const parsed = parseCodexStartupArgs(['--resume', 'thread-123', '--started-by', 'daemon']);
 
         expect(parsed.resumeThreadId).toBe('thread-123');
         expect(parsed.args).toEqual(['--started-by', 'daemon']);
     });
 
     it('supports equals syntax', () => {
-        const parsed = extractCodexResumeFlag(['--resume=thread-456', '--started-by', 'terminal']);
+        const parsed = parseCodexStartupArgs(['--resume=thread-456', '--started-by', 'terminal']);
 
         expect(parsed.resumeThreadId).toBe('thread-456');
         expect(parsed.args).toEqual(['--started-by', 'terminal']);
     });
 
     it('throws when resume flag is missing a thread ID', () => {
-        expect(() => extractCodexResumeFlag(['--resume'])).toThrow(
+        expect(() => parseCodexStartupArgs(['--resume'])).toThrow(
             'Codex resume requires a thread ID: happy codex --resume <thread-id>',
+        );
+    });
+
+    it('parses model flag with separate and equals syntax', () => {
+        expect(parseCodexStartupArgs(['--model', 'gpt-5.5']).model).toBe('gpt-5.5');
+        expect(parseCodexStartupArgs(['--model=gpt-5.4']).model).toBe('gpt-5.4');
+    });
+
+    it('parses effort flag with separate and equals syntax', () => {
+        expect(parseCodexStartupArgs(['--effort', 'medium']).effort).toBe('medium');
+        expect(parseCodexStartupArgs(['--effort=xhigh']).effort).toBe('xhigh');
+    });
+
+    it('parses permission mode flag with separate and equals syntax', () => {
+        expect(parseCodexStartupArgs(['--permission-mode', 'read-only']).permissionMode).toBe('read-only');
+        expect(parseCodexStartupArgs(['--permission-mode=safe-yolo']).permissionMode).toBe('safe-yolo');
+    });
+
+    it('parses yolo sugar as yolo permission mode', () => {
+        expect(parseCodexStartupArgs(['--yolo']).permissionMode).toBe('yolo');
+    });
+
+    it('parses resume combined with model, effort, and permission flags', () => {
+        const parsed = parseCodexStartupArgs([
+            '--resume',
+            'thread-789',
+            '--model=gpt-5.5',
+            '--effort',
+            'high',
+            '--permission-mode',
+            'safe-yolo',
+            '--started-by',
+            'daemon',
+        ]);
+
+        expect(parsed).toEqual({
+            resumeThreadId: 'thread-789',
+            model: 'gpt-5.5',
+            effort: 'high',
+            permissionMode: 'safe-yolo',
+            args: ['--started-by', 'daemon'],
+        });
+    });
+
+    it('throws for invalid effort', () => {
+        expect(() => parseCodexStartupArgs(['--effort', 'huge'])).toThrow(
+            'Invalid Codex effort "huge". Expected one of: none, minimal, low, medium, high, xhigh.',
+        );
+    });
+
+    it('throws when startup flags using equals syntax have empty values', () => {
+        expect(() => parseCodexStartupArgs(['--model='])).toThrow(
+            'Codex model requires a value: happy codex --model <model>',
+        );
+        expect(() => parseCodexStartupArgs(['--effort='])).toThrow(
+            'Codex effort requires a value: happy codex --effort <level>',
+        );
+        expect(() => parseCodexStartupArgs(['--permission-mode='])).toThrow(
+            'Codex permission mode requires a value: happy codex --permission-mode <mode>',
+        );
+    });
+
+    it('throws for invalid permission mode', () => {
+        expect(() => parseCodexStartupArgs(['--permission-mode', 'bypassPermissions'])).toThrow(
+            'Invalid Codex permission mode "bypassPermissions". Expected one of: default, read-only, safe-yolo, yolo.',
+        );
+    });
+
+    it('throws for conflicting permission flags', () => {
+        expect(() => parseCodexStartupArgs(['--permission-mode', 'read-only', '--yolo'])).toThrow(
+            'Codex permission mode can only be provided once.',
+        );
+    });
+
+    it('throws for conflicting permission flags using equals syntax', () => {
+        expect(() => parseCodexStartupArgs(['--yolo', '--permission-mode=read-only'])).toThrow(
+            'Codex permission mode can only be provided once.',
+        );
+        expect(() => parseCodexStartupArgs(['--permission-mode=yolo', '--permission-mode=read-only'])).toThrow(
+            'Codex permission mode can only be provided once.',
         );
     });
 });

--- a/packages/happy-cli/src/codex/cliArgs.ts
+++ b/packages/happy-cli/src/codex/cliArgs.ts
@@ -1,6 +1,65 @@
-export function extractCodexResumeFlag(args: string[]): { resumeThreadId: string | null; args: string[] } {
+import type { ReasoningEffort } from './codexAppServerTypes';
+import type { CodexPermissionMode } from './modeState';
+
+const VALID_CODEX_EFFORTS: readonly ReasoningEffort[] = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+const VALID_CODEX_PERMISSION_MODES: readonly CodexPermissionMode[] = ['default', 'read-only', 'safe-yolo', 'yolo'];
+
+export type CodexStartupArgs = {
+    resumeThreadId: string | null;
+    model?: string;
+    effort?: ReasoningEffort;
+    permissionMode?: CodexPermissionMode;
+    args: string[];
+};
+
+function readFlagValue(args: string[], index: number, flag: string, usage: string): { value: string; nextIndex: number } {
+    const arg = args[index];
+    const equalsPrefix = `${flag}=`;
+    if (arg.startsWith(equalsPrefix)) {
+        const value = arg.slice(equalsPrefix.length).trim();
+        if (!value) {
+            throw new Error(usage);
+        }
+        return { value, nextIndex: index };
+    }
+
+    const nextArg = args[index + 1];
+    if (!nextArg || nextArg.startsWith('-')) {
+        throw new Error(usage);
+    }
+
+    return { value: nextArg, nextIndex: index + 1 };
+}
+
+function parseEffort(value: string): ReasoningEffort {
+    if (VALID_CODEX_EFFORTS.includes(value as ReasoningEffort)) {
+        return value as ReasoningEffort;
+    }
+
+    throw new Error(`Invalid Codex effort "${value}". Expected one of: ${VALID_CODEX_EFFORTS.join(', ')}.`);
+}
+
+function parsePermissionMode(value: string): CodexPermissionMode {
+    if (VALID_CODEX_PERMISSION_MODES.includes(value as CodexPermissionMode)) {
+        return value as CodexPermissionMode;
+    }
+
+    throw new Error(`Invalid Codex permission mode "${value}". Expected one of: ${VALID_CODEX_PERMISSION_MODES.join(', ')}.`);
+}
+
+function setPermissionMode(current: CodexPermissionMode | undefined, next: CodexPermissionMode): CodexPermissionMode {
+    if (current !== undefined) {
+        throw new Error('Codex permission mode can only be provided once.');
+    }
+    return next;
+}
+
+export function parseCodexStartupArgs(args: string[]): CodexStartupArgs {
     const remainingArgs: string[] = [];
     let resumeThreadId: string | null = null;
+    let model: string | undefined = undefined;
+    let effort: ReasoningEffort | undefined = undefined;
+    let permissionMode: CodexPermissionMode | undefined = undefined;
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
@@ -34,11 +93,42 @@ export function extractCodexResumeFlag(args: string[]): { resumeThreadId: string
             continue;
         }
 
+        if (arg === '--model' || arg.startsWith('--model=')) {
+            const parsed = readFlagValue(args, i, '--model', 'Codex model requires a value: happy codex --model <model>');
+            model = parsed.value;
+            i = parsed.nextIndex;
+            continue;
+        }
+
+        if (arg === '--effort' || arg.startsWith('--effort=')) {
+            const parsed = readFlagValue(args, i, '--effort', 'Codex effort requires a value: happy codex --effort <level>');
+            effort = parseEffort(parsed.value);
+            i = parsed.nextIndex;
+            continue;
+        }
+
+        if (arg === '--permission-mode' || arg.startsWith('--permission-mode=')) {
+            const parsed = readFlagValue(args, i, '--permission-mode', 'Codex permission mode requires a value: happy codex --permission-mode <mode>');
+            permissionMode = setPermissionMode(permissionMode, parsePermissionMode(parsed.value));
+            i = parsed.nextIndex;
+            continue;
+        }
+
+        if (arg === '--yolo') {
+            permissionMode = setPermissionMode(permissionMode, 'yolo');
+            continue;
+        }
+
         remainingArgs.push(arg);
     }
 
     return {
         resumeThreadId,
+        ...(model !== undefined ? { model } : {}),
+        ...(effort !== undefined ? { effort } : {}),
+        ...(permissionMode !== undefined ? { permissionMode } : {}),
         args: remainingArgs,
     };
 }
+
+export const extractCodexResumeFlag = parseCodexStartupArgs;

--- a/packages/happy-cli/src/codex/codexAppServerClient.test.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.test.ts
@@ -603,9 +603,10 @@ describe('CodexAppServerClient sandbox integration', () => {
             cwd: '/tmp/project',
             approvalPolicy: 'never',
             sandbox: 'danger-full-access',
+            effort: 'medium',
         });
 
-        await expect(client.sendTurnAndWait('patch the file')).resolves.toEqual({ aborted: false });
+        await expect(client.sendTurnAndWait('patch the file', { effort: 'medium' })).resolves.toEqual({ aborted: false });
 
         expect(events).toEqual(expect.arrayContaining([
             expect.objectContaining({
@@ -709,6 +710,120 @@ describe('CodexAppServerClient sandbox integration', () => {
                 },
             },
             reason: null,
+        }));
+
+        await client.disconnect();
+    });
+
+    it('passes reasoning effort through thread config and turn start requests', async () => {
+        const requests: MockRpcMessage[] = [];
+        const proc = createMockProcess({
+            pid: 3005,
+            onRequest: (msg, stdout) => {
+                requests.push(msg);
+                if (msg.method === 'thread/start' && msg.id != null) {
+                    setTimeout(() => {
+                        pushJsonLine(stdout, {
+                            id: msg.id,
+                            result: {
+                                thread: { id: 'thread-effort', path: '/tmp/thread-effort' },
+                                model: 'gpt-test',
+                                modelProvider: 'openai',
+                                cwd: '/tmp/project',
+                                approvalPolicy: 'never',
+                                sandbox: { type: 'dangerFullAccess' },
+                                reasoningEffort: 'medium',
+                            },
+                        });
+                    }, 0);
+                }
+                if (msg.method === 'turn/start' && msg.id != null) {
+                    setTimeout(() => {
+                        pushJsonLine(stdout, {
+                            id: msg.id,
+                            result: { turn: { id: 'turn-effort' } },
+                        });
+                        pushJsonLine(stdout, {
+                            method: 'turn/completed',
+                            params: {
+                                threadId: 'thread-effort',
+                                turnId: 'turn-effort',
+                                usage: null,
+                            },
+                        });
+                    }, 0);
+                }
+            },
+        });
+
+        mockSpawn.mockImplementation(() => proc);
+
+        const { CodexAppServerClient } = await import('./codexAppServerClient');
+        const client = new CodexAppServerClient();
+
+        await client.connect();
+        await client.startThread({
+            model: 'gpt-test',
+            approvalPolicy: 'never',
+            sandbox: 'danger-full-access',
+            effort: 'medium',
+        });
+        await expect(client.sendTurnAndWait('hello', { effort: 'medium' })).resolves.toEqual({ aborted: false });
+
+        expect(requests.find((msg) => msg.method === 'thread/start')?.params).toEqual(expect.objectContaining({
+            config: expect.objectContaining({
+                model_reasoning_effort: 'medium',
+            }),
+        }));
+        expect(requests.find((msg) => msg.method === 'turn/start')?.params).toEqual(expect.objectContaining({
+            effort: 'medium',
+        }));
+
+        await client.disconnect();
+    });
+
+    it('passes reasoning effort through resume thread config', async () => {
+        const requests: MockRpcMessage[] = [];
+        const proc = createMockProcess({
+            pid: 3006,
+            onRequest: (msg, stdout) => {
+                requests.push(msg);
+                if (msg.method === 'thread/resume' && msg.id != null) {
+                    setTimeout(() => {
+                        pushJsonLine(stdout, {
+                            id: msg.id,
+                            result: {
+                                thread: { id: 'thread-effort-resume', path: '/tmp/thread-effort-resume' },
+                                model: 'gpt-test',
+                                modelProvider: 'openai',
+                                cwd: '/tmp/project',
+                                approvalPolicy: 'never',
+                                sandbox: { type: 'dangerFullAccess' },
+                                reasoningEffort: 'medium',
+                            },
+                        });
+                    }, 0);
+                }
+            },
+        });
+
+        mockSpawn.mockImplementation(() => proc);
+
+        const { CodexAppServerClient } = await import('./codexAppServerClient');
+        const client = new CodexAppServerClient();
+
+        await client.connect();
+        await client.resumeThread({
+            threadId: 'thread-effort-resume',
+            effort: 'medium',
+            mcpServers: { happy: { command: 'happy-mcp' } },
+        });
+
+        expect(requests.find((msg) => msg.method === 'thread/resume')?.params).toEqual(expect.objectContaining({
+            config: expect.objectContaining({
+                mcp_servers: { happy: { command: 'happy-mcp' } },
+                model_reasoning_effort: 'medium',
+            }),
         }));
 
         await client.disconnect();

--- a/packages/happy-cli/src/codex/codexAppServerClient.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.ts
@@ -126,6 +126,7 @@ export class CodexAppServerClient {
         cwd?: string;
         approvalPolicy?: ApprovalPolicy;
         sandbox?: SandboxMode;
+        effort?: ReasoningEffort;
         mcpServers?: Record<string, unknown>;
     } | null = null;
 
@@ -549,8 +550,18 @@ export class CodexAppServerClient {
         await this.disconnectInternal();
     }
 
-    private buildThreadConfig(mcpServers?: Record<string, unknown>): Record<string, unknown> | null {
-        return mcpServers ? { mcp_servers: mcpServers } : null;
+    private buildThreadConfig(opts?: {
+        mcpServers?: Record<string, unknown>;
+        effort?: ReasoningEffort;
+    }): Record<string, unknown> | null {
+        const config: Record<string, unknown> = {};
+        if (opts?.mcpServers) {
+            config.mcp_servers = opts.mcpServers;
+        }
+        if (opts?.effort) {
+            config.model_reasoning_effort = opts.effort;
+        }
+        return Object.keys(config).length > 0 ? config : null;
     }
 
     private rememberThreadDefaults(opts: {
@@ -558,6 +569,7 @@ export class CodexAppServerClient {
         cwd?: string;
         approvalPolicy?: ApprovalPolicy;
         sandbox?: SandboxMode;
+        effort?: ReasoningEffort;
         mcpServers?: Record<string, unknown>;
     }): void {
         this.threadDefaults = {
@@ -565,6 +577,7 @@ export class CodexAppServerClient {
             cwd: opts.cwd,
             approvalPolicy: opts.approvalPolicy,
             sandbox: opts.sandbox,
+            effort: opts.effort,
             mcpServers: opts.mcpServers,
         };
     }
@@ -576,6 +589,7 @@ export class CodexAppServerClient {
         cwd?: string;
         approvalPolicy?: ApprovalPolicy;
         sandbox?: SandboxMode;
+        effort?: ReasoningEffort;
         mcpServers?: Record<string, unknown>;
     }): Promise<{ threadId: string; model: string }> {
         const params: NewConversationParams = {
@@ -585,7 +599,7 @@ export class CodexAppServerClient {
             cwd: opts.cwd ?? process.cwd(),
             approvalPolicy: opts.approvalPolicy ?? null,
             sandbox: opts.sandbox ?? null,
-            config: this.buildThreadConfig(opts.mcpServers),
+            config: this.buildThreadConfig({ mcpServers: opts.mcpServers, effort: opts.effort }),
             baseInstructions: null,
             developerInstructions: null,
             compactPrompt: null,
@@ -608,6 +622,7 @@ export class CodexAppServerClient {
         cwd?: string;
         approvalPolicy?: ApprovalPolicy;
         sandbox?: SandboxMode;
+        effort?: ReasoningEffort;
         mcpServers?: Record<string, unknown>;
     }): Promise<{ threadId: string; model: string }> {
         const threadId = opts?.threadId ?? this._threadId;
@@ -623,7 +638,10 @@ export class CodexAppServerClient {
             cwd: opts?.cwd ?? defaults.cwd ?? process.cwd(),
             approvalPolicy: opts?.approvalPolicy ?? defaults.approvalPolicy ?? null,
             sandbox: opts?.sandbox ?? defaults.sandbox ?? null,
-            config: this.buildThreadConfig(opts?.mcpServers ?? defaults.mcpServers),
+            config: this.buildThreadConfig({
+                mcpServers: opts?.mcpServers ?? defaults.mcpServers,
+                effort: opts?.effort ?? defaults.effort,
+            }),
             baseInstructions: null,
             developerInstructions: null,
             persistExtendedHistory: true,
@@ -637,6 +655,7 @@ export class CodexAppServerClient {
             cwd: opts?.cwd ?? defaults.cwd,
             approvalPolicy: opts?.approvalPolicy ?? defaults.approvalPolicy,
             sandbox: opts?.sandbox ?? defaults.sandbox,
+            effort: opts?.effort ?? defaults.effort,
             mcpServers: opts?.mcpServers ?? defaults.mcpServers,
         });
         logger.debug('[CodexAppServer] Thread resumed:', this._threadId);

--- a/packages/happy-cli/src/codex/executionPolicy.ts
+++ b/packages/happy-cli/src/codex/executionPolicy.ts
@@ -1,7 +1,8 @@
 import type { ApprovalPolicy, SandboxMode } from './codexAppServerTypes';
+import type { CodexPermissionMode } from './modeState';
 
 export function resolveCodexExecutionPolicy(
-    permissionMode: import('@/api/types').PermissionMode,
+    permissionMode: import('@/api/types').PermissionMode | CodexPermissionMode,
     sandboxManagedByHappy: boolean,
 ): { approvalPolicy: ApprovalPolicy; sandbox: SandboxMode } {
     if (sandboxManagedByHappy) {
@@ -17,7 +18,7 @@ export function resolveCodexExecutionPolicy(
             case 'default': return 'untrusted';                    // Ask for non-trusted commands
             case 'read-only': return 'never';                      // Never ask, read-only enforced by sandbox
             case 'safe-yolo': return 'on-failure';                 // Auto-run, ask only on failure
-            case 'yolo': return 'on-failure';                      // Auto-run, ask only on failure
+            case 'yolo': return 'never';                           // Native dangerous bypass
             // Defensive fallback for Claude-specific modes (backward compatibility)
             case 'bypassPermissions': return 'on-failure';         // Full access: map to yolo behavior
             case 'acceptEdits': return 'on-request';               // Let model decide (closest to auto-approve edits)

--- a/packages/happy-cli/src/codex/modeState.test.ts
+++ b/packages/happy-cli/src/codex/modeState.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { createCodexModeState, resolveCodexMessageMode } from './modeState';
+
+describe('resolveCodexMessageMode', () => {
+    it('preserves CLI model when app metadata sends model null', () => {
+        const state = createCodexModeState({ model: 'gpt-5.5' });
+
+        const resolved = resolveCodexMessageMode(state, { model: null });
+
+        expect(resolved.mode.model).toBe('gpt-5.5');
+        expect(resolved.state.currentModel).toBe('gpt-5.5');
+    });
+
+    it('preserves CLI yolo when app metadata sends default permission mode', () => {
+        const state = createCodexModeState({ permissionMode: 'yolo' });
+
+        const resolved = resolveCodexMessageMode(state, { permissionMode: 'default' });
+
+        expect(resolved.mode.permissionMode).toBe('yolo');
+        expect(resolved.state.currentPermissionMode).toBe('yolo');
+    });
+
+    it('allows app non-default model to override CLI model and become sticky', () => {
+        const state = createCodexModeState({ model: 'gpt-5.5' });
+
+        const first = resolveCodexMessageMode(state, { model: 'gpt-5.4' });
+        const second = resolveCodexMessageMode(first.state, { model: null });
+
+        expect(first.mode.model).toBe('gpt-5.4');
+        expect(second.mode.model).toBe('gpt-5.4');
+    });
+
+    it('allows app non-default permission mode to override CLI permission mode and become sticky', () => {
+        const state = createCodexModeState({ permissionMode: 'yolo' });
+
+        const first = resolveCodexMessageMode(state, { permissionMode: 'read-only' });
+        const second = resolveCodexMessageMode(first.state, { permissionMode: 'default' });
+
+        expect(first.mode.permissionMode).toBe('read-only');
+        expect(second.mode.permissionMode).toBe('read-only');
+    });
+
+    it('preserves default and null behavior when no CLI flags are set', () => {
+        const state = createCodexModeState({});
+
+        const resolved = resolveCodexMessageMode(state, {
+            permissionMode: 'default',
+            model: null,
+        });
+
+        expect(resolved.mode).toEqual({
+            permissionMode: 'default',
+            model: undefined,
+            effort: undefined,
+        });
+        expect(resolved.state.currentPermissionMode).toBeUndefined();
+        expect(resolved.state.currentModel).toBeUndefined();
+    });
+
+    it('carries CLI effort into every resolved mode', () => {
+        const state = createCodexModeState({ effort: 'medium' });
+
+        const resolved = resolveCodexMessageMode(state, {});
+
+        expect(resolved.mode.effort).toBe('medium');
+    });
+});

--- a/packages/happy-cli/src/codex/modeState.ts
+++ b/packages/happy-cli/src/codex/modeState.ts
@@ -1,0 +1,81 @@
+import type { MessageMeta } from '@/api/types';
+import type { ReasoningEffort } from './codexAppServerTypes';
+
+export type CodexPermissionMode = 'default' | 'read-only' | 'safe-yolo' | 'yolo';
+
+export type CodexMode = {
+    permissionMode: CodexPermissionMode;
+    model?: string;
+    effort?: ReasoningEffort;
+};
+
+export type CodexModeState = {
+    currentPermissionMode?: CodexPermissionMode;
+    currentModel?: string;
+    effort?: ReasoningEffort;
+    permissionSource: 'default' | 'startup' | 'remote';
+    modelSource: 'default' | 'startup' | 'remote';
+};
+
+export function createCodexModeState(opts: {
+    permissionMode?: CodexPermissionMode;
+    model?: string;
+    effort?: ReasoningEffort;
+}): CodexModeState {
+    return {
+        currentPermissionMode: opts.permissionMode,
+        currentModel: opts.model,
+        effort: opts.effort,
+        permissionSource: opts.permissionMode === undefined ? 'default' : 'startup',
+        modelSource: opts.model === undefined ? 'default' : 'startup',
+    };
+}
+
+const REMOTE_CODEX_PERMISSION_MODES: readonly CodexPermissionMode[] = [
+    'default',
+    'read-only',
+    'safe-yolo',
+    'yolo',
+];
+
+function isCodexPermissionMode(value: unknown): value is CodexPermissionMode {
+    return REMOTE_CODEX_PERMISSION_MODES.includes(value as CodexPermissionMode);
+}
+
+export function resolveCodexMessageMode(
+    state: CodexModeState,
+    meta: Pick<MessageMeta, 'permissionMode' | 'model'> | undefined,
+): { state: CodexModeState; mode: CodexMode; ignoredPermissionMode?: string } {
+    const nextState: CodexModeState = { ...state };
+    let ignoredPermissionMode: string | undefined;
+
+    if (meta?.permissionMode) {
+        if (isCodexPermissionMode(meta.permissionMode)) {
+            const isRoutineDefault = meta.permissionMode === 'default';
+            if (!isRoutineDefault || nextState.permissionSource === 'default') {
+                nextState.currentPermissionMode = isRoutineDefault ? undefined : meta.permissionMode;
+                nextState.permissionSource = isRoutineDefault ? 'default' : 'remote';
+            }
+        } else {
+            ignoredPermissionMode = String(meta.permissionMode);
+        }
+    }
+
+    if (meta && Object.prototype.hasOwnProperty.call(meta, 'model')) {
+        const incomingModel = meta.model || undefined;
+        if (incomingModel !== undefined || nextState.modelSource === 'default') {
+            nextState.currentModel = incomingModel;
+            nextState.modelSource = incomingModel === undefined ? 'default' : 'remote';
+        }
+    }
+
+    return {
+        state: nextState,
+        mode: {
+            permissionMode: nextState.currentPermissionMode ?? 'default',
+            model: nextState.currentModel,
+            effort: nextState.effort,
+        },
+        ...(ignoredPermissionMode !== undefined ? { ignoredPermissionMode } : {}),
+    };
+}

--- a/packages/happy-cli/src/codex/resumeExistingThread.ts
+++ b/packages/happy-cli/src/codex/resumeExistingThread.ts
@@ -1,9 +1,14 @@
 import { trimIdent } from '@/utils/trimIdent';
+import type { ApprovalPolicy, ReasoningEffort, SandboxMode } from './codexAppServerTypes';
 
 type ResumeThreadClient = {
     resumeThread: (opts: {
         threadId: string;
         cwd: string;
+        model?: string;
+        approvalPolicy?: ApprovalPolicy;
+        sandbox?: SandboxMode;
+        effort?: ReasoningEffort;
         mcpServers: Record<string, unknown>;
     }) => Promise<{ threadId: string; model: string }>;
 };
@@ -23,12 +28,20 @@ export async function resumeExistingThread(opts: {
     messageBuffer: ResumeThreadMessageBuffer;
     threadId: string;
     cwd: string;
+    model?: string;
+    approvalPolicy?: ApprovalPolicy;
+    sandbox?: SandboxMode;
+    effort?: ReasoningEffort;
     mcpServers: Record<string, unknown>;
 }): Promise<{ threadId: string; model: string }> {
     try {
         const resumedThread = await opts.client.resumeThread({
             threadId: opts.threadId,
             cwd: opts.cwd,
+            model: opts.model,
+            approvalPolicy: opts.approvalPolicy,
+            sandbox: opts.sandbox,
+            effort: opts.effort,
             mcpServers: opts.mcpServers,
         });
 

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -33,6 +33,14 @@ import { resolveCodexExecutionPolicy } from './executionPolicy';
 import { mapCodexMcpMessageToSessionEnvelopes, mapCodexProcessorMessageToSessionEnvelopes } from './utils/sessionProtocolMapper';
 import { resumeExistingThread } from './resumeExistingThread';
 import { emitReadyIfIdle } from './emitReadyIfIdle';
+import type { ReasoningEffort } from './codexAppServerTypes';
+import {
+    createCodexModeState,
+    resolveCodexMessageMode,
+    type CodexMode,
+    type CodexModeState,
+    type CodexPermissionMode,
+} from './modeState';
 
 /**
  * Extracts a human-readable error from a codex task_complete/turn_aborted event.
@@ -57,6 +65,9 @@ export async function runCodex(opts: {
     startedBy?: 'daemon' | 'terminal';
     noSandbox?: boolean;
     resumeThreadId?: string;
+    startupModel?: string;
+    startupEffort?: ReasoningEffort;
+    startupPermissionMode?: CodexPermissionMode;
 }): Promise<void> {
     // Early check: ensure Codex CLI is installed before proceeding
     try {
@@ -71,13 +82,6 @@ export async function runCodex(opts: {
         console.error('Alternatively, use Claude Code:');
         console.error('  \x1b[36mhappy claude\x1b[0m\n');
         process.exit(1);
-    }
-
-    // Use shared PermissionMode type for cross-agent compatibility
-    type PermissionMode = import('@/api/types').PermissionMode;
-    interface EnhancedMode {
-        permissionMode: PermissionMode;
-        model?: string;
     }
 
     //
@@ -203,63 +207,26 @@ export async function runCodex(opts: {
         }
     }
 
-    const messageQueue = new MessageQueue2<EnhancedMode>((mode) => hashObject({
+    const messageQueue = new MessageQueue2<CodexMode>((mode) => hashObject({
         permissionMode: mode.permissionMode,
         model: mode.model,
+        effort: mode.effort,
     }));
 
-    // Track current overrides to apply per message
-    // Use shared PermissionMode type from api/types for cross-agent compatibility
-    let currentPermissionMode: import('@/api/types').PermissionMode | undefined = undefined;
-    let currentModel: string | undefined = undefined;
-
-    // Valid Codex permission modes from remote messages. Matches the modes
-    // the mobile UI exposes for Codex sessions (see modelModeOptions.ts:
-    // getCodexPermissionModes) and mirrors the Gemini validation pattern at
-    // runGemini.ts:222. Anything outside this set is silently ignored — the
-    // previous code blindly cast `message.meta.permissionMode as PermissionMode`
-    // at runtime, meaning a crafted value like `'totally_unsafe'` would be
-    // accepted and then fall through to the `default` branch in
-    // resolveCodexExecutionPolicy() — or worse, an attacker-chosen valid value
-    // could escalate sandbox scope (issue #1092).
-    const VALID_REMOTE_PERMISSION_MODES: readonly PermissionMode[] = [
-        'default',
-        'read-only',
-        'safe-yolo',
-        'yolo',
-    ];
+    let modeState: CodexModeState = createCodexModeState({
+        permissionMode: opts.startupPermissionMode,
+        model: opts.startupModel,
+        effort: opts.startupEffort,
+    });
 
     session.onUserMessage((message) => {
-        // Resolve permission mode (validate against Codex-native modes)
-        let messagePermissionMode = currentPermissionMode;
-        if (message.meta?.permissionMode) {
-            const incoming = message.meta.permissionMode as PermissionMode;
-            if (VALID_REMOTE_PERMISSION_MODES.includes(incoming)) {
-                messagePermissionMode = incoming;
-                currentPermissionMode = messagePermissionMode;
-                logger.debug(`[Codex] Permission mode updated from user message to: ${currentPermissionMode}`);
-            } else {
-                logger.debug(`[Codex] Ignoring invalid permission mode from user message: ${String(message.meta.permissionMode)}`);
-            }
-        } else {
-            logger.debug(`[Codex] User message received with no permission mode override, using current: ${currentPermissionMode ?? 'default (effective)'}`);
+        const resolved = resolveCodexMessageMode(modeState, message.meta);
+        modeState = resolved.state;
+        if (resolved.ignoredPermissionMode) {
+            logger.debug(`[Codex] Ignoring invalid permission mode from user message: ${resolved.ignoredPermissionMode}`);
         }
-
-        // Resolve model; explicit null resets to default (undefined)
-        let messageModel = currentModel;
-        if (message.meta?.hasOwnProperty('model')) {
-            messageModel = message.meta.model || undefined;
-            currentModel = messageModel;
-            logger.debug(`[Codex] Model updated from user message: ${messageModel || 'reset to default'}`);
-        } else {
-            logger.debug(`[Codex] User message received with no model override, using current: ${currentModel || 'default'}`);
-        }
-
-        const enhancedMode: EnhancedMode = {
-            permissionMode: messagePermissionMode || 'default',
-            model: messageModel,
-        };
-        messageQueue.push(message.content.text, enhancedMode);
+        logger.debug(`[Codex] Resolved message mode: permission=${resolved.mode.permissionMode}, model=${resolved.mode.model ?? 'default'}, effort=${resolved.mode.effort ?? 'default'}`);
+        messageQueue.push(message.content.text, resolved.mode);
     });
     let thinking = false;
     let currentTurnId: string | null = null;
@@ -629,22 +596,30 @@ export async function runCodex(opts: {
         logger.debug('[codex]: client.connect done');
 
         if (opts.resumeThreadId) {
+            const startupExecutionPolicy = resolveCodexExecutionPolicy(
+                modeState.currentPermissionMode ?? 'default',
+                client.sandboxEnabled,
+            );
             await resumeExistingThread({
                 client,
                 session,
                 messageBuffer,
                 threadId: opts.resumeThreadId,
                 cwd: process.cwd(),
+                model: modeState.currentModel,
+                approvalPolicy: startupExecutionPolicy.approvalPolicy,
+                sandbox: startupExecutionPolicy.sandbox,
+                effort: modeState.effort,
                 mcpServers,
             });
             first = false;
         }
 
-        let pending: { message: string; mode: EnhancedMode; isolate: boolean; hash: string } | null = null;
+        let pending: { message: string; mode: CodexMode; isolate: boolean; hash: string } | null = null;
 
         while (!shouldExit) {
             logActiveHandles('loop-top');
-            let message: { message: string; mode: EnhancedMode; isolate: boolean; hash: string } | null = pending;
+            let message: { message: string; mode: CodexMode; isolate: boolean; hash: string } | null = pending;
             pending = null;
             if (!message) {
                 // Capture the current signal to distinguish idle-abort from queue close
@@ -686,6 +661,7 @@ export async function runCodex(opts: {
                         cwd: process.cwd(),
                         approvalPolicy: executionPolicy.approvalPolicy,
                         sandbox: executionPolicy.sandbox,
+                        effort: message.mode.effort,
                         mcpServers,
                     });
                     session.updateMetadata((currentMetadata) => ({
@@ -702,6 +678,7 @@ export async function runCodex(opts: {
                     model: message.mode.model,
                     approvalPolicy: executionPolicy.approvalPolicy,
                     sandbox: executionPolicy.sandbox,
+                    effort: message.mode.effort,
                 });
                 first = false;
 

--- a/packages/happy-cli/src/commands/codexCommand.test.ts
+++ b/packages/happy-cli/src/commands/codexCommand.test.ts
@@ -17,7 +17,7 @@ vi.mock('@/codex/runCodex', () => ({
 }))
 
 vi.mock('@/codex/cliArgs', () => ({
-  extractCodexResumeFlag: mocks.mockExtractCodexResumeFlag,
+  parseCodexStartupArgs: mocks.mockExtractCodexResumeFlag,
 }))
 
 vi.mock('@/utils/sandboxFlags', () => ({
@@ -80,6 +80,28 @@ describe('handleCodexCommand', () => {
       startedBy: 'daemon',
       noSandbox: true,
       resumeThreadId: 'thread-123',
+    })
+  })
+
+  it('passes parsed codex startup defaults through to runCodex', async () => {
+    mocks.mockExtractCodexResumeFlag.mockReturnValue({
+      resumeThreadId: null,
+      model: 'gpt-5.5',
+      effort: 'medium',
+      permissionMode: 'yolo',
+      args: ['--started-by', 'terminal'],
+    })
+
+    await handleCodexCommand(['--model', 'gpt-5.5', '--effort', 'medium', '--yolo', '--started-by', 'terminal'])
+
+    expect(mocks.mockRunCodex).toHaveBeenCalledWith({
+      credentials: { token: 'token' },
+      startedBy: 'terminal',
+      noSandbox: false,
+      resumeThreadId: undefined,
+      startupModel: 'gpt-5.5',
+      startupEffort: 'medium',
+      startupPermissionMode: 'yolo',
     })
   })
 })

--- a/packages/happy-cli/src/commands/codexCommand.ts
+++ b/packages/happy-cli/src/commands/codexCommand.ts
@@ -1,13 +1,13 @@
 import { authAndSetupMachineIfNeeded } from '@/ui/auth'
 import { runCodex } from '@/codex/runCodex'
-import { extractCodexResumeFlag } from '@/codex/cliArgs'
+import { parseCodexStartupArgs } from '@/codex/cliArgs'
 import { extractNoSandboxFlag } from '@/utils/sandboxFlags'
 import { ensureDaemonRunning } from '@/daemon/ensureDaemonRunning'
 
 export async function handleCodexCommand(args: string[]): Promise<void> {
   let startedBy: 'daemon' | 'terminal' | undefined = undefined
   const sandboxArgs = extractNoSandboxFlag(args)
-  const codexArgs = extractCodexResumeFlag(sandboxArgs.args)
+  const codexArgs = parseCodexStartupArgs(sandboxArgs.args)
 
   for (let i = 0; i < codexArgs.args.length; i++) {
     if (codexArgs.args[i] === '--started-by') {
@@ -23,5 +23,8 @@ export async function handleCodexCommand(args: string[]): Promise<void> {
     startedBy,
     noSandbox: sandboxArgs.noSandbox,
     resumeThreadId: codexArgs.resumeThreadId ?? undefined,
+    startupModel: codexArgs.model,
+    startupEffort: codexArgs.effort,
+    startupPermissionMode: codexArgs.permissionMode,
   })
 }

--- a/packages/happy-cli/src/daemon/codexResumeOptions.test.ts
+++ b/packages/happy-cli/src/daemon/codexResumeOptions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeCodexResumeOptions } from './codexResumeOptions';
+
+describe('normalizeCodexResumeOptions', () => {
+  it('omits app default model sentinel so Codex uses its configured default', () => {
+    expect(normalizeCodexResumeOptions({ model: 'default' })).toEqual({});
+  });
+
+  it('preserves explicit model selections', () => {
+    expect(normalizeCodexResumeOptions({ model: 'gpt-5.5' })).toEqual({
+      model: 'gpt-5.5',
+    });
+  });
+
+  it('omits app default and Claude-specific permission sentinels', () => {
+    expect(normalizeCodexResumeOptions({ permissionMode: 'default' })).toEqual({});
+    expect(normalizeCodexResumeOptions({ permissionMode: 'bypassPermissions' })).toEqual({});
+  });
+
+  it('preserves Codex-native non-default permission modes', () => {
+    expect(normalizeCodexResumeOptions({ permissionMode: 'read-only' })).toEqual({
+      permissionMode: 'read-only',
+    });
+    expect(normalizeCodexResumeOptions({ permissionMode: 'safe-yolo' })).toEqual({
+      permissionMode: 'safe-yolo',
+    });
+    expect(normalizeCodexResumeOptions({ permissionMode: 'yolo' })).toEqual({
+      permissionMode: 'yolo',
+    });
+  });
+});

--- a/packages/happy-cli/src/daemon/codexResumeOptions.ts
+++ b/packages/happy-cli/src/daemon/codexResumeOptions.ts
@@ -1,0 +1,33 @@
+import type { CodexPermissionMode } from '@/codex/modeState';
+
+export type ResumeControlOptions = {
+  model?: string;
+  permissionMode?: string;
+};
+
+export type NormalizedCodexResumeOptions = {
+  model?: string;
+  permissionMode?: CodexPermissionMode;
+};
+
+const CODEX_PERMISSION_MODES = new Set<CodexPermissionMode>([
+  'read-only',
+  'safe-yolo',
+  'yolo',
+]);
+
+export function normalizeCodexResumeOptions(options?: ResumeControlOptions): NormalizedCodexResumeOptions {
+  const normalized: NormalizedCodexResumeOptions = {};
+
+  const model = options?.model?.trim();
+  if (model && model !== 'default') {
+    normalized.model = model;
+  }
+
+  const permissionMode = options?.permissionMode?.trim();
+  if (permissionMode && CODEX_PERMISSION_MODES.has(permissionMode as CodexPermissionMode)) {
+    normalized.permissionMode = permissionMode as CodexPermissionMode;
+  }
+
+  return normalized;
+}

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -28,6 +28,7 @@ import { detectCLIAvailability } from '@/utils/detectCLI';
 import { buildResumeLaunch } from '@/resume/handleResumeCommand';
 import { detectResumeSupport } from '@/resume/localHappyAgentAuth';
 import { encodeBase64, decodeBase64, decrypt } from '@/api/encryption';
+import { normalizeCodexResumeOptions } from './codexResumeOptions';
 
 // Prepare initial metadata
 // Suffix host with `-dev` for the HAPPY_VARIANT=dev variant so the dev daemon
@@ -654,11 +655,21 @@ export async function startDaemon(): Promise<void> {
           { startedBy: 'daemon', claudeStartingMode: 'remote' },
         );
 
-        if (options?.model) {
-          launch.args.push('--model', options.model);
-        }
-        if (options?.permissionMode) {
-          launch.args.push('--permission-mode', options.permissionMode);
+        if (metadata.flavor === 'codex' || metadata.codexThreadId) {
+          const codexOptions = normalizeCodexResumeOptions(options);
+          if (codexOptions.model) {
+            launch.args.push('--model', codexOptions.model);
+          }
+          if (codexOptions.permissionMode) {
+            launch.args.push('--permission-mode', codexOptions.permissionMode);
+          }
+        } else {
+          if (options?.model) {
+            launch.args.push('--model', options.model);
+          }
+          if (options?.permissionMode) {
+            launch.args.push('--permission-mode', options.permissionMode);
+          }
         }
 
         await fs.access(launch.cwd);


### PR DESCRIPTION
## Summary
- Add `happy codex` startup defaults for model, reasoning effort, and permission mode.
- Map Codex `--yolo` / `--permission-mode yolo` to native dangerous bypass semantics.
- Preserve explicit CLI defaults when mobile/web sends routine default/null metadata.

## Test Plan
- `pnpm --filter happy exec vitest run --project unit`
- `pnpm --filter happy run build`
- `git diff --check`

## Notes
- This intentionally does not add mobile UI/schema support for remote effort overrides.
- App-server startup effort is sent through `config.model_reasoning_effort`; turn effort is sent through `effort`, matching Codex app-server 0.128.0 generated types.
