### PR TITLE
fix(doctor): show usage for `doctor clean --help` instead of running clean

### DIFF
--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -53,6 +53,18 @@ import { handleCodexCommand } from './commands/codexCommand'
   if (subcommand === 'doctor') {
     // Check for clean subcommand
     if (args[1] === 'clean') {
+      if (args.slice(2).some(a => a === '--help' || a === '-h')) {
+        console.log(`
+${chalk.bold('happy doctor clean')} - Kill all happy-related processes (daemon + sessions)
+
+${chalk.bold('Usage:')}
+  happy doctor clean
+
+${chalk.bold('Warning:')} This is destructive — it terminates the daemon and every running session.
+Conversation history is preserved on the server, but in-flight tool calls are interrupted.
+`)
+        process.exit(0)
+      }
       const result = await killRunawayHappyProcesses()
       console.log(`Cleaned up ${result.killed} runaway processes`)
       if (result.errors.length > 0) {


### PR DESCRIPTION
## Summary

- `happy doctor clean --help` currently kills the daemon and every running session because the `--help` flag is not parsed — only `args[1] === 'clean'` is checked, then `killRunawayHappyProcesses()` runs unconditionally.
- A CLI flag named `--help` should never trigger destructive behavior. Surprised the user (me) by wiping the daemon mid-debugging while looking for usage info.
- Print a short usage block (with a destructive-action warning) when `--help` or `-h` follows `doctor clean`, and only run the cleanup otherwise.

## Reproduction (before this patch)

```
$ happy doctor clean --help
Killing runaway process PID …
Killing runaway process PID …
…
Cleaned up 8 runaway processes
```

## After

```
$ happy doctor clean --help

happy doctor clean - Kill all happy-related processes (daemon + sessions)

Usage:
  happy doctor clean

Warning: This is destructive — it terminates the daemon and every running session.
Conversation history is preserved on the server, but in-flight tool calls are interrupted.
```

`happy doctor clean` (no flag) behaves exactly as before.

## Test plan

- [x] `happy doctor clean --help` prints usage, exits 0, leaves daemon alive
- [x] `happy doctor clean -h` same as above
- [x] `happy doctor clean` (no args) still kills runaway processes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)