### PR TITLE
docs(daemon): explain shell-init auto-start and the macOS launchd auth gotcha

### DIFF
--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -53,6 +53,28 @@ happy daemon list
 
 The daemon starts automatically when you run `happy`, so you usually don't need to manage it manually.
 
+### Keeping the daemon running across reboots
+
+If you want the daemon to come back automatically after a reboot — without opening a `happy` session first — start it from your shell profile so it inherits your normal user session context (PATH, keychain access, OAuth credentials):
+
+```bash
+# ~/.zshrc or ~/.bashrc
+if [[ -o interactive ]] && [[ -z "$HAPPY_DAEMON_CHECKED" ]]; then
+    export HAPPY_DAEMON_CHECKED=1
+    () {
+        local state=$HOME/.happy/daemon.state.json
+        local pid=$(grep -oE '"pid"[[:space:]]*:[[:space:]]*[0-9]+' "$state" 2>/dev/null | grep -oE '[0-9]+')
+        if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+            happy daemon start >/dev/null 2>&1
+        fi
+    } &!
+fi
+```
+
+The first interactive shell after a reboot triggers the start; subsequent shells short-circuit because the daemon is already running.
+
+> **macOS users:** prefer this shell-init approach over a `launchd` LaunchAgent. A LaunchAgent runs in an agent domain that is **detached from your GUI/Aqua login session**, which means the bundled `claude-agent-sdk` cannot reach the macOS keychain and silently fails authentication ("Failed to authenticate. API Error: 401 terminated", `duration_api_ms: 0`). If you must use launchd, your wrapper has to read the OAuth access token from `~/.claude/.credentials.json` and export it as `CLAUDE_CODE_OAUTH_TOKEN` before exec'ing the daemon — and you'll need to handle token rotation yourself.
+
 ## Authentication
 
 ```bash


### PR DESCRIPTION
## Summary

- Document the recommended shell-init pattern for keeping the daemon running across reboots
- Call out a real silent-failure mode I just hit on macOS: a `launchd` LaunchAgent runs detached from the user's GUI/Aqua login session, so the bundled `claude-agent-sdk` cannot reach the keychain and **every spawned session 401s with `Failed to authenticate. API Error: 401 terminated`** and `duration_api_ms: 0` — no useful diagnostic, no hint at the cause

## Why this matters

Spent ~3h yesterday debugging this exact path: kernel panic → reboot → set up LaunchAgent for auto-start → web UI sessions silently 401. The token in `~/.claude/.credentials.json` was valid the whole time (curl returned 429 rate-limit, not 401). The SDK was reading from keychain, getting an opaque failure under launchd, and emitting a `model: <synthetic>` assistant message with the misleading "API Error: 401 terminated" string. The actual fix on a launchd setup is to inject `CLAUDE_CODE_OAUTH_TOKEN` from the credentials file in a wrapper, but that introduces a token-rotation problem the user has to handle.

The simpler answer for most users — and what the upstream README should recommend — is **start the daemon from your shell profile**. Shell context inherits the user's session, the SDK picks up credentials normally, and token refresh is transparent.

## What this PR adds

A subsection under `## Daemon` in `packages/happy-cli/README.md`:

1. A drop-in `~/.zshrc` / `~/.bashrc` snippet that idempotently starts the daemon on the first interactive shell after a reboot.
2. A `> macOS users:` callout explaining why launchd is **not** recommended, what the failure mode looks like, and the (cumbersome) workaround for users who really need it.

Doc-only — no behavior changes.

## Test plan

- [x] Markdown renders cleanly on GitHub
- [x] Snippet was tested on macOS 26.4.1 / zsh — first shell starts the daemon, subsequent shells skip, kill-then-shell respawns correctly

## Possible follow-ups (not in this PR)

If reviewers want, I'd be happy to file a separate change that emits a runtime warning from the daemon when it starts in a likely-broken context (e.g., on macOS with no `SHELL`/`LOGNAME` and no `CLAUDE_CODE_OAUTH_TOKEN`). That would surface the issue at startup instead of inside the first failing session message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)