### PR TITLE
fix(session-protocol): preserve Claude tool_result content on tool-call-end

### DIFF
--- a/packages/happy-app/sources/sync/typesRaw.spec.ts
+++ b/packages/happy-app/sources/sync/typesRaw.spec.ts
@@ -1706,6 +1706,36 @@ describe('Zod Transform - WOLOG Content Normalization', () => {
             }
         });
 
+        it('preserves tool-call-end output and isError on the normalized tool-result', () => {
+            const normalized = normalizeRawMessage('db-output', null, 1, {
+                ...base,
+                content: {
+                    type: 'session',
+                    data: {
+                        id: 'env-output',
+                        time: 1,
+                        role: 'agent',
+                        turn: 'turn-1',
+                        ev: {
+                            t: 'tool-call-end',
+                            call: 'call-output',
+                            output: 'src/auth/index.ts',
+                            isError: true
+                        }
+                    }
+                }
+            });
+            expect(normalized).toBeTruthy();
+            if (normalized && normalized.role === 'agent') {
+                expect(normalized.content[0]).toMatchObject({
+                    type: 'tool-result',
+                    tool_use_id: 'call-output',
+                    content: 'src/auth/index.ts',
+                    is_error: true
+                });
+            }
+        });
+
         it('maps turn-end to ready event and drops turn-start', () => {
             const turnStart = normalizeRawMessage('db-5', null, 1, {
                 ...base,

--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -54,6 +54,8 @@ const sessionToolCallStartEventSchema = z.object({
 const sessionToolCallEndEventSchema = z.object({
     t: z.literal('tool-call-end'),
     call: z.string(),
+    output: z.string().optional(),
+    isError: z.boolean().optional(),
 });
 
 const sessionFileEventSchema = z.object({
@@ -650,8 +652,8 @@ function normalizeSessionEnvelope(
             content: [{
                 type: 'tool-result',
                 tool_use_id: envelope.ev.call,
-                content: null,
-                is_error: false,
+                content: envelope.ev.output ?? null,
+                is_error: envelope.ev.isError === true,
                 uuid: contentUUID,
                 parentUUID
             }],

--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
@@ -75,10 +75,91 @@ describe('mapClaudeLogMessageToSessionEnvelopes', () => {
         expect(ended.envelopes).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
-                    ev: { t: 'tool-call-end', call: 'tool-1' },
+                    ev: { t: 'tool-call-end', call: 'tool-1', output: 'ok' },
                 }),
             ]),
         );
+    });
+
+    it('forwards tool_result content as output on tool-call-end', () => {
+        const stringResult = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'user',
+            uuid: 'u-output-string',
+            message: {
+                role: 'user',
+                content: [
+                    { type: 'tool_result', tool_use_id: 'tool-string', content: 'src/auth/index.ts' },
+                ],
+            },
+        } as any, { currentTurnId: 'turn-output' });
+
+        expect(stringResult.envelopes.find((e) => e.ev.t === 'tool-call-end')?.ev).toEqual({
+            t: 'tool-call-end',
+            call: 'tool-string',
+            output: 'src/auth/index.ts',
+        });
+
+        const arrayResult = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'user',
+            uuid: 'u-output-array',
+            message: {
+                role: 'user',
+                content: [
+                    {
+                        type: 'tool_result',
+                        tool_use_id: 'tool-array',
+                        content: [
+                            { type: 'text', text: 'line one' },
+                            { type: 'text', text: 'line two' },
+                        ],
+                    },
+                ],
+            },
+        } as any, { currentTurnId: 'turn-output' });
+
+        expect(arrayResult.envelopes.find((e) => e.ev.t === 'tool-call-end')?.ev).toEqual({
+            t: 'tool-call-end',
+            call: 'tool-array',
+            output: 'line one\nline two',
+        });
+    });
+
+    it('marks isError on tool-call-end when tool_result is an error', () => {
+        const result = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'user',
+            uuid: 'u-err',
+            message: {
+                role: 'user',
+                content: [
+                    { type: 'tool_result', tool_use_id: 'tool-err', content: 'boom', is_error: true },
+                ],
+            },
+        } as any, { currentTurnId: 'turn-err' });
+
+        expect(result.envelopes.find((e) => e.ev.t === 'tool-call-end')?.ev).toEqual({
+            t: 'tool-call-end',
+            call: 'tool-err',
+            output: 'boom',
+            isError: true,
+        });
+    });
+
+    it('omits output when tool_result content is empty', () => {
+        const result = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'user',
+            uuid: 'u-empty',
+            message: {
+                role: 'user',
+                content: [
+                    { type: 'tool_result', tool_use_id: 'tool-empty', content: '' },
+                ],
+            },
+        } as any, { currentTurnId: 'turn-empty' });
+
+        expect(result.envelopes.find((e) => e.ev.t === 'tool-call-end')?.ev).toEqual({
+            t: 'tool-call-end',
+            call: 'tool-empty',
+        });
     });
 
     it('exposes the generated session subagent id on Agent tool calls', () => {

--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
@@ -420,6 +420,26 @@ function toToolArgs(input: unknown): Record<string, unknown> {
     return { input };
 }
 
+// Claude tool_result content is `string | Array<{ type: 'text', text: string }>`.
+function extractToolResultText(content: unknown): string | undefined {
+    if (typeof content === 'string') {
+        return content.length > 0 ? content : undefined;
+    }
+    if (Array.isArray(content)) {
+        const parts: string[] = [];
+        for (const part of content) {
+            if (part && typeof part === 'object' && (part as { type?: unknown }).type === 'text') {
+                const text = (part as { text?: unknown }).text;
+                if (typeof text === 'string' && text.length > 0) {
+                    parts.push(text);
+                }
+            }
+        }
+        return parts.length > 0 ? parts.join('\n') : undefined;
+    }
+    return undefined;
+}
+
 export function closeClaudeTurnWithStatus(
     state: ClaudeSessionProtocolState,
     status: SessionTurnEndStatus,
@@ -581,9 +601,13 @@ function mapClaudeLogMessageToSessionEnvelopesInternal(
                         maybeEmitSubagentStop(state, turnId, sessionSubagentForToolResult, envelopes);
                     }
                 }
+                const output = extractToolResultText((block as { content?: unknown }).content);
+                const isError = (block as { is_error?: unknown }).is_error === true;
                 envelopes.push(createEnvelope('agent', {
                     t: 'tool-call-end',
                     call: block.tool_use_id,
+                    ...(output !== undefined ? { output } : {}),
+                    ...(isError ? { isError: true } : {}),
                 }, { turn: turnId, subagent }));
                 continue;
             }

--- a/packages/happy-wire/src/sessionProtocol.test.ts
+++ b/packages/happy-wire/src/sessionProtocol.test.ts
@@ -22,6 +22,8 @@ describe('session protocol schemas', () => {
         args: { command: 'ls -la' },
       },
       { t: 'tool-call-end', call: 'call-1' },
+      { t: 'tool-call-end', call: 'call-2', output: 'src/auth/index.ts' },
+      { t: 'tool-call-end', call: 'call-3', output: 'boom', isError: true },
       { t: 'file', ref: 'upload-1', name: 'report.txt', size: 1024, mimeType: 'text/plain' },
       {
         t: 'file',
@@ -51,6 +53,8 @@ describe('session protocol schemas', () => {
     expect(sessionEventSchema.safeParse({ t: 'start', title: 1 }).success).toBe(false);
     expect(sessionEventSchema.safeParse({ t: 'service' }).success).toBe(false);
     expect(sessionEventSchema.safeParse({ t: 'not-real' }).success).toBe(false);
+    expect(sessionEventSchema.safeParse({ t: 'tool-call-end', call: 'c', output: 1 }).success).toBe(false);
+    expect(sessionEventSchema.safeParse({ t: 'tool-call-end', call: 'c', isError: 'yes' }).success).toBe(false);
   });
 
   it('validates envelopes that include turn/subagent', () => {

--- a/packages/happy-wire/src/sessionProtocol.ts
+++ b/packages/happy-wire/src/sessionProtocol.ts
@@ -41,6 +41,8 @@ export const sessionToolCallStartEventSchema = z.object({
 export const sessionToolCallEndEventSchema = z.object({
   t: z.literal('tool-call-end'),
   call: z.string(),
+  output: z.string().optional(),
+  isError: z.boolean().optional(),
 });
 
 export const sessionFileEventSchema = z.object({


### PR DESCRIPTION
## Summary

In remote Claude sessions, the mobile/web client shows tool calls completing with no output — `Bash`, `Read`, `Grep`, etc. all render empty bodies after the spinner stops.

The Claude session-protocol mapper drops `tool_result.content` when it converts a SDK `user`/`tool_result` block into an envelope. Only `{ t: 'tool-call-end', call }` is emitted, so the app's reducer marks the tool completed and writes `result = null`. The legacy `role: 'agent', content: { type: 'output', data }` fallback that used to carry the raw message was removed in the same change, so the content is gone end-to-end.

Reproduces on every remote Claude session ≥ 1.1.7. The codex mapper does not have this bug because it emits the content as a separate text envelope before `tool-call-end`.

## Root cause

Introduced in [`36bcc1c`](https://github.com/slopus/happy/commit/36bcc1cb0cd46e0c6f9640a37713f5c0b15263a7) (`feat(session-protocol): finalize subagent lifecycle protocol`):

- `packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts` was added with the lossy `tool_result → tool-call-end` mapping.
- `packages/happy-cli/src/api/apiSession.ts` lost the `role: 'agent', content: { type: 'output', data: body }` raw-passthrough branch in the same commit, so there is no other channel carrying the result.

The codex mapper added at the same time (`b0c781c`) intentionally pre-emits the content as a `text` envelope. The Claude side appears to have just been missed — this is consistent with the docs/example in `docs/session-protocol-claude.md` (Example 1) where the input `tool_result.content` literally has no corresponding output envelope.

Tracking issue: #615.

## Fix

Carry the result on the `tool-call-end` envelope itself, so the wire format has a single source of truth for the tool's lifecycle (rather than a sibling text block that the reducer would have to associate by ordering).

- `happy-wire`: extend `sessionToolCallEndEventSchema` with optional `output: string` and `isError: boolean`.
- `happy-cli`: in the Claude mapper, populate `output` from the SDK `tool_result.content` (`string | Array<{ type: 'text', text }>`) and set `isError` when `is_error: true`.
- `happy-app`: in `normalizeSessionEnvelope`, forward `output` / `isError` into the normalized `tool-result` content. Reducer logic for `result` and the running → completed/error transition is unchanged.

Both fields are optional and additive, so older clients that only see `{ t: 'tool-call-end', call }` keep working.

## Test plan

- [x] `pnpm --filter @slopus/happy-wire test` — 19/19 (existing + new envelope-shape cases for `output` / `isError`).
- [x] `pnpm vitest run src/claude/utils/sessionProtocolMapper.test.ts` in `happy-cli` — 14/14, including new cases for string content, array-of-text content, error results, and empty content.
- [x] `pnpm vitest run sources/sync/typesRaw.spec.ts` in `happy-app` — 60/60, including the new `tool-call-end → tool-result` round-trip with `output`/`isError`.
- [x] `pnpm typecheck` (happy-app) clean.
- [x] Verified the four pre-existing test-file failures on `main` (`apiGithub.spec.ts`, `modelModeOptions.test.ts`, `parseMarkdownBlock.test.ts`, `settings.spec.ts`) are unrelated and unchanged by this PR.

## Notes for reviewers

- I left the codex mapper alone — it still emits content as a text envelope. A follow-up could converge it on the same `output` field if desired, but I didn't want to bundle a behavior change for codex into a Claude bug fix.
- The "frozen" comment at the top of `packages/happy-wire/src/sessionProtocol.ts` looks stale relative to actual usage (`sendClaudeSessionMessage` is wholly on the envelope path); happy to drop or update it in a separate PR if you'd like.