### PR TITLE
fix(cli): upgrade @modelcontextprotocol/sdk to 1.29.0

### DIFF
--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -69,7 +69,7 @@
     "@agentclientprotocol/sdk": "^0.14.1",
     "@anthropic-ai/claude-agent-sdk": "^0.2.96",
     "@anthropic-ai/sandbox-runtime": "^0.0.37",
-    "@modelcontextprotocol/sdk": "1.25.3",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@noble/ed25519": "^3.0.0",
     "@noble/hashes": "^2.0.1",
     "@paralleldrive/cuid2": "^2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,8 +838,8 @@ importers:
         specifier: ^0.0.37
         version: 0.0.37
       '@modelcontextprotocol/sdk':
-        specifier: 1.25.3
-        version: 1.25.3(hono@4.12.12)(zod@3.25.76)
+        specifier: 1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@noble/ed25519':
         specifier: ^3.0.0
         version: 3.0.0
@@ -3351,16 +3351,6 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
-
-  '@modelcontextprotocol/sdk@1.25.3':
-    resolution: {integrity: sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -7415,12 +7405,6 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
-
-  express-rate-limit@7.5.1:
-    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -14604,28 +14588,6 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@modelcontextprotocol/sdk@1.25.3(hono@4.12.12)(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.12)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
-      jose: 6.2.2
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - hono
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.12)
@@ -19331,10 +19293,6 @@ snapshots:
       - utf-8-validate
 
   exponential-backoff@3.1.3: {}
-
-  express-rate-limit@7.5.1(express@5.2.1):
-    dependencies:
-      express: 5.2.1
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrade `packages/happy-cli` direct dependency `@modelcontextprotocol/sdk` from `1.25.3` to `1.29.0`
- Refresh `pnpm-lock.yaml` so the vulnerable direct `1.25.3` entry is removed
- Keep the change scoped to dependency metadata only (`packages/happy-cli/package.json` + `pnpm-lock.yaml`)

Refs #1224.

## Background

`happy@1.1.8` currently pins `@modelcontextprotocol/sdk@1.25.3`, which is covered by:

- `GHSA-345p-7cg4-v4c7`
- `CVE-2026-25536`

The patched upstream range starts at `1.26.0`.

This repo's lockfile already contains `@modelcontextprotocol/sdk@1.29.0` transitively via `@anthropic-ai/claude-agent-sdk`, so aligning the direct `happy-cli` dependency to `1.29.0` removes the vulnerable direct pin without introducing a second MCP SDK version.

## Why `1.29.0`

- It is already present in the workspace lockfile transitively
- It is outside the affected advisory range
- It keeps the diff minimal by converging on the version the repo is already partially using

## Validation

- [x] `pnpm --filter @slopus/happy-wire build`
- [x] `pnpm --filter happy typecheck`
- [x] `pnpm --filter happy build`
- [x] `pnpm --filter happy postinstall`
- [x] `pnpm --filter happy exec vitest run src/modules/difftastic/index.test.ts`
- [x] `pnpm --filter happy exec vitest run src/modules/ripgrep/index.test.ts`
- [x] `pnpm --filter happy list @modelcontextprotocol/sdk --depth 1` resolves `1.29.0`
- [x] A reduced `npm audit` for the updated `happy-cli` dependency set no longer reports `GHSA-345p-7cg4-v4c7`

## Scope / non-goals

- No intended runtime behavior change beyond consuming the patched MCP SDK version
- No unrelated dependency upgrades
- No architecture claims about whether Happy is or is not exploitable in practice; this PR only removes the confirmed vulnerable direct dependency pin

## Notes

`pnpm --filter happy test` still reports existing environment-dependent integration failures that do not look caused by this dependency bump, including:

- Claude quota-limited integration tests (`You've hit your limit`)
- Codex integration assertions
- `daemon` / `openclaw` integration environment startup failures

The focused build, typecheck, and module-level validation above passed after the dependency update.
