### PR TITLE
feat: add --name for happy codex sessions

### DIFF
--- a/packages/happy-cli/src/codex/cliArgs.test.ts
+++ b/packages/happy-cli/src/codex/cliArgs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractCodexResumeFlag } from './cliArgs';
+import { extractCodexNameFlag, extractCodexResumeFlag } from './cliArgs';
 
 describe('extractCodexResumeFlag', () => {
     it('returns null and preserves args when resume flag is absent', () => {
@@ -27,6 +27,35 @@ describe('extractCodexResumeFlag', () => {
     it('throws when resume flag is missing a thread ID', () => {
         expect(() => extractCodexResumeFlag(['--resume'])).toThrow(
             'Codex resume requires a thread ID: happy codex --resume <thread-id>',
+        );
+    });
+});
+
+describe('extractCodexNameFlag', () => {
+    it('returns null and preserves args when name flag is absent', () => {
+        const parsed = extractCodexNameFlag(['--started-by', 'terminal']);
+
+        expect(parsed.initialName).toBeNull();
+        expect(parsed.args).toEqual(['--started-by', 'terminal']);
+    });
+
+    it('extracts an explicit initial session name', () => {
+        const parsed = extractCodexNameFlag(['--name', 'ship happy codex pr', '--started-by', 'daemon']);
+
+        expect(parsed.initialName).toBe('ship happy codex pr');
+        expect(parsed.args).toEqual(['--started-by', 'daemon']);
+    });
+
+    it('supports equals syntax', () => {
+        const parsed = extractCodexNameFlag(['--name=triage issue 1127', '--started-by', 'terminal']);
+
+        expect(parsed.initialName).toBe('triage issue 1127');
+        expect(parsed.args).toEqual(['--started-by', 'terminal']);
+    });
+
+    it('throws when name flag is missing a value', () => {
+        expect(() => extractCodexNameFlag(['--name'])).toThrow(
+            'Codex name requires a title: happy codex --name <title>',
         );
     });
 });

--- a/packages/happy-cli/src/codex/cliArgs.ts
+++ b/packages/happy-cli/src/codex/cliArgs.ts
@@ -42,3 +42,48 @@ export function extractCodexResumeFlag(args: string[]): { resumeThreadId: string
         args: remainingArgs,
     };
 }
+
+export function extractCodexNameFlag(args: string[]): { initialName: string | null; args: string[] } {
+    const remainingArgs: string[] = [];
+    let initialName: string | null = null;
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        if (arg === '--name') {
+            if (initialName !== null) {
+                throw new Error('Codex name flag can only be provided once.');
+            }
+
+            const nextArg = args[i + 1];
+            if (!nextArg || nextArg.startsWith('-')) {
+                throw new Error('Codex name requires a title: happy codex --name <title>');
+            }
+
+            initialName = nextArg;
+            i++;
+            continue;
+        }
+
+        if (arg.startsWith('--name=')) {
+            if (initialName !== null) {
+                throw new Error('Codex name flag can only be provided once.');
+            }
+
+            const value = arg.slice('--name='.length).trim();
+            if (!value) {
+                throw new Error('Codex name requires a title: happy codex --name <title>');
+            }
+
+            initialName = value;
+            continue;
+        }
+
+        remainingArgs.push(arg);
+    }
+
+    return {
+        initialName,
+        args: remainingArgs,
+    };
+}

--- a/packages/happy-cli/src/codex/initialTitle.test.ts
+++ b/packages/happy-cli/src/codex/initialTitle.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CHANGE_TITLE_INSTRUCTION } from '@/gemini/constants';
+
+import { applyInitialCodexSessionTitle, buildInitialCodexTurnPrompt } from './initialTitle';
+
+describe('applyInitialCodexSessionTitle', () => {
+    it('writes a summary message when an initial title is provided', () => {
+        const sendClaudeSessionMessage = vi.fn();
+
+        const applied = applyInitialCodexSessionTitle(
+            { sendClaudeSessionMessage },
+            '  happy codex name support  ',
+        );
+
+        expect(applied).toBe('happy codex name support');
+        expect(sendClaudeSessionMessage).toHaveBeenCalledTimes(1);
+        expect(sendClaudeSessionMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'summary',
+                summary: 'happy codex name support',
+            }),
+        );
+    });
+
+    it('skips blank initial titles', () => {
+        const sendClaudeSessionMessage = vi.fn();
+
+        const applied = applyInitialCodexSessionTitle(
+            { sendClaudeSessionMessage },
+            '   ',
+        );
+
+        expect(applied).toBeNull();
+        expect(sendClaudeSessionMessage).not.toHaveBeenCalled();
+    });
+});
+
+describe('buildInitialCodexTurnPrompt', () => {
+    it('uses the default change-title instruction when no initial title is set', () => {
+        expect(buildInitialCodexTurnPrompt('fix the failing test')).toBe(
+            `fix the failing test\n\n${CHANGE_TITLE_INSTRUCTION}`,
+        );
+    });
+
+    it('pins the first title exactly when an initial title is provided', () => {
+        const prompt = buildInitialCodexTurnPrompt(
+            'review the codex flow',
+            'Codex PR Review',
+        );
+
+        expect(prompt).toContain('review the codex flow');
+        expect(prompt).toContain(
+            'set the chat session title exactly to "Codex PR Review"',
+        );
+        expect(prompt).toContain('Unless the task changes dramatically later, keep using this title.');
+    });
+});

--- a/packages/happy-cli/src/codex/initialTitle.ts
+++ b/packages/happy-cli/src/codex/initialTitle.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from 'node:crypto';
+
+import { CHANGE_TITLE_INSTRUCTION } from '@/gemini/constants';
+import { trimIdent } from '@/utils/trimIdent';
+
+function normalizeInitialName(initialName?: string | null): string | null {
+    const trimmed = initialName?.trim();
+    return trimmed ? trimmed : null;
+}
+
+export function applyInitialCodexSessionTitle(
+    session: {
+        sendClaudeSessionMessage: (body: {
+            type: 'summary';
+            summary: string;
+            leafUuid: string;
+        }) => void;
+    },
+    initialName?: string | null,
+): string | null {
+    const normalized = normalizeInitialName(initialName);
+    if (!normalized) {
+        return null;
+    }
+
+    session.sendClaudeSessionMessage({
+        type: 'summary',
+        summary: normalized,
+        leafUuid: randomUUID(),
+    });
+
+    return normalized;
+}
+
+export function buildInitialCodexTurnPrompt(
+    message: string,
+    initialName?: string | null,
+): string {
+    const normalized = normalizeInitialName(initialName);
+    const titleInstruction = normalized
+        ? trimIdent(
+            `Before continuing, call functions.happy__change_title and set the chat session title exactly to ${JSON.stringify(normalized)}. Unless the task changes dramatically later, keep using this title.`,
+        )
+        : CHANGE_TITLE_INSTRUCTION;
+
+    return `${message}\n\n${titleInstruction}`;
+}

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -20,8 +20,6 @@ import { createSessionMetadata } from '@/utils/createSessionMetadata';
 import { startHappyServer } from '@/claude/utils/startHappyServer';
 import { MessageBuffer } from "@/ui/ink/messageBuffer";
 import { CodexDisplay } from "@/ui/ink/CodexDisplay";
-import { trimIdent } from "@/utils/trimIdent";
-import { CHANGE_TITLE_INSTRUCTION } from '@/gemini/constants';
 import { notifyDaemonSessionStarted } from "@/daemon/controlClient";
 import { encodeBase64, decodeBase64 } from '@/api/encryption';
 import type { Session as ApiSession } from '@/api/types';
@@ -33,6 +31,7 @@ import { resolveCodexExecutionPolicy } from './executionPolicy';
 import { mapCodexMcpMessageToSessionEnvelopes, mapCodexProcessorMessageToSessionEnvelopes } from './utils/sessionProtocolMapper';
 import { resumeExistingThread } from './resumeExistingThread';
 import { emitReadyIfIdle } from './emitReadyIfIdle';
+import { applyInitialCodexSessionTitle, buildInitialCodexTurnPrompt } from './initialTitle';
 
 /**
  * Extracts a human-readable error from a codex task_complete/turn_aborted event.
@@ -57,6 +56,7 @@ export async function runCodex(opts: {
     startedBy?: 'daemon' | 'terminal';
     noSandbox?: boolean;
     resumeThreadId?: string;
+    initialName?: string;
 }): Promise<void> {
     // Early check: ensure Codex CLI is installed before proceeding
     try {
@@ -170,6 +170,8 @@ export async function runCodex(opts: {
         }
     });
     session = initialSession;
+
+    const initialName = applyInitialCodexSessionTitle(session, opts.initialName);
 
     // On reconnect, un-archive the session and skip replaying old messages.
     if (reconnectSessionId) {
@@ -695,7 +697,7 @@ export async function runCodex(opts: {
                 }
 
                 const turnPrompt = first
-                    ? message.message + '\n\n' + CHANGE_TITLE_INSTRUCTION
+                    ? buildInitialCodexTurnPrompt(message.message, initialName)
                     : message.message;
 
                 const result = await client.sendTurnAndWait(turnPrompt, {

--- a/packages/happy-cli/src/commands/codexCommand.test.ts
+++ b/packages/happy-cli/src/commands/codexCommand.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   mockAuthAndSetupMachineIfNeeded: vi.fn(),
   mockRunCodex: vi.fn(),
   mockExtractCodexResumeFlag: vi.fn(),
+  mockExtractCodexNameFlag: vi.fn(),
   mockExtractNoSandboxFlag: vi.fn(),
   mockEnsureDaemonRunning: vi.fn(),
 }))
@@ -18,6 +19,7 @@ vi.mock('@/codex/runCodex', () => ({
 
 vi.mock('@/codex/cliArgs', () => ({
   extractCodexResumeFlag: mocks.mockExtractCodexResumeFlag,
+  extractCodexNameFlag: mocks.mockExtractCodexNameFlag,
 }))
 
 vi.mock('@/utils/sandboxFlags', () => ({
@@ -44,6 +46,10 @@ describe('handleCodexCommand', () => {
       resumeThreadId: null,
       args,
     }))
+    mocks.mockExtractCodexNameFlag.mockImplementation((args: string[]) => ({
+      initialName: null,
+      args,
+    }))
     mocks.mockEnsureDaemonRunning.mockResolvedValue(undefined)
     mocks.mockRunCodex.mockResolvedValue(undefined)
   })
@@ -57,6 +63,7 @@ describe('handleCodexCommand', () => {
       startedBy: 'terminal',
       noSandbox: false,
       resumeThreadId: undefined,
+      initialName: undefined,
     })
     expect(
       mocks.mockEnsureDaemonRunning.mock.invocationCallOrder[0],
@@ -70,16 +77,21 @@ describe('handleCodexCommand', () => {
     })
     mocks.mockExtractCodexResumeFlag.mockReturnValue({
       resumeThreadId: 'thread-123',
+      args: ['--name', 'release prep', '--started-by', 'daemon'],
+    })
+    mocks.mockExtractCodexNameFlag.mockReturnValue({
+      initialName: 'release prep',
       args: ['--started-by', 'daemon'],
     })
 
-    await handleCodexCommand(['--no-sandbox', '--resume', 'thread-123', '--started-by', 'daemon'])
+    await handleCodexCommand(['--no-sandbox', '--resume', 'thread-123', '--name', 'release prep', '--started-by', 'daemon'])
 
     expect(mocks.mockRunCodex).toHaveBeenCalledWith({
       credentials: { token: 'token' },
       startedBy: 'daemon',
       noSandbox: true,
       resumeThreadId: 'thread-123',
+      initialName: 'release prep',
     })
   })
 })

--- a/packages/happy-cli/src/commands/codexCommand.ts
+++ b/packages/happy-cli/src/commands/codexCommand.ts
@@ -1,6 +1,6 @@
 import { authAndSetupMachineIfNeeded } from '@/ui/auth'
 import { runCodex } from '@/codex/runCodex'
-import { extractCodexResumeFlag } from '@/codex/cliArgs'
+import { extractCodexNameFlag, extractCodexResumeFlag } from '@/codex/cliArgs'
 import { extractNoSandboxFlag } from '@/utils/sandboxFlags'
 import { ensureDaemonRunning } from '@/daemon/ensureDaemonRunning'
 
@@ -8,10 +8,11 @@ export async function handleCodexCommand(args: string[]): Promise<void> {
   let startedBy: 'daemon' | 'terminal' | undefined = undefined
   const sandboxArgs = extractNoSandboxFlag(args)
   const codexArgs = extractCodexResumeFlag(sandboxArgs.args)
+  const nameArgs = extractCodexNameFlag(codexArgs.args)
 
-  for (let i = 0; i < codexArgs.args.length; i++) {
-    if (codexArgs.args[i] === '--started-by') {
-      startedBy = codexArgs.args[++i] as 'daemon' | 'terminal'
+  for (let i = 0; i < nameArgs.args.length; i++) {
+    if (nameArgs.args[i] === '--started-by') {
+      startedBy = nameArgs.args[++i] as 'daemon' | 'terminal'
     }
   }
 
@@ -23,5 +24,6 @@ export async function handleCodexCommand(args: string[]): Promise<void> {
     startedBy,
     noSandbox: sandboxArgs.noSandbox,
     resumeThreadId: codexArgs.resumeThreadId ?? undefined,
+    initialName: nameArgs.initialName ?? undefined,
   })
 }


### PR DESCRIPTION
This adds a focused `--name` flag to `happy codex` so terminal-started Codex sessions can start with a user-chosen title instead of waiting for the model to infer one from the first prompt. The CLI now parses `--name`, passes it into the Codex runner, writes the initial Happy session summary immediately on session creation, and pins the first-turn `change_title` instruction to that exact title so the session stays identifiable in the app.

## Proof It Works

Real CLI log output from running:

```bash
happy codex --name "pr-verify-codex-name"
```

From `/Users/chenqian/.happy/logs/2026-05-06-15-17-17-pid-89342.log`:

```text
[15:17:17.472] Starting happy CLI with args: [...,"codex","--name","pr-verify-codex-name"]
      "type": "summary",
      "summary": "pr-verify-codex-name",
[15:17:20.742] [Codex] Applied initial session title: "pr-verify-codex-name"
```

## Verification

Passed:

```bash
../../node_modules/.bin/vitest run src/codex/cliArgs.test.ts src/codex/initialTitle.test.ts src/commands/codexCommand.test.ts
npx pnpm@10.11.0 --filter @slopus/happy-wire build
npx pnpm@10.11.0 --filter happy build
```

Notes on full `npx pnpm@10.11.0 --filter happy test`:
- The new `--name` coverage passes.
- The suite still has unrelated baseline/environment failures in existing areas, including `src/modules/difftastic/index.test.ts`, `src/modules/ripgrep/index.test.ts`, `src/claude/claude.integration.test.ts`, `src/codex/codex.integration.test.ts`, and `src/claude/planMode.integration.test.ts`.

## Related

- Related to #804
- Related to #1127
