### PR TITLE
fix(daemon): kill child process on webhook timeout to prevent zombie sessions

### DIFF
--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -437,7 +437,13 @@ export async function startDaemon(): Promise<void> {
               // Set timeout for webhook (same as regular flow)
               const timeout = setTimeout(() => {
                 pidToAwaiter.delete(tmuxResult.pid!);
-                logger.debug(`[DAEMON RUN] Session webhook timeout for PID ${tmuxResult.pid} (tmux)`);
+                logger.debug(`[DAEMON RUN] Session webhook timeout for PID ${tmuxResult.pid} (tmux), killing child`);
+                // Kill the child process to prevent zombie sessions that register after timeout
+                try {
+                  process.kill(tmuxResult.pid!, 'SIGTERM');
+                } catch (e) {
+                  logger.debug(`[DAEMON RUN] Failed to kill timed-out tmux child PID ${tmuxResult.pid}:`, e);
+                }
                 resolve({
                   type: 'error',
                   errorMessage: `Session webhook timeout for PID ${tmuxResult.pid} (tmux)`
@@ -580,7 +586,13 @@ export async function startDaemon(): Promise<void> {
       return new Promise((resolve) => {
         const timeout = setTimeout(() => {
           pidToAwaiter.delete(happyProcess.pid!);
-          logger.debug(`[DAEMON RUN] Session webhook timeout for PID ${happyProcess.pid}`);
+          logger.debug(`[DAEMON RUN] Session webhook timeout for PID ${happyProcess.pid}, killing child`);
+          // Kill the child process to prevent zombie sessions that register after timeout
+          try {
+            happyProcess.kill('SIGTERM');
+          } catch (e) {
+            logger.debug(`[DAEMON RUN] Failed to kill timed-out child PID ${happyProcess.pid}:`, e);
+          }
           resolve({
             type: 'error',
             errorMessage: `Session webhook timeout for PID ${happyProcess.pid}`


### PR DESCRIPTION
## Summary

When the daemon spawns a Happy session and the child doesn't send its \`/session-started\` webhook within 15s, the daemon resolves the spawn promise with an error but leaves the child process running. The child often eventually finishes registering — creating a zombie session that's invisible to the caller. Meanwhile the caller (mobile app, integration test) retries the spawn, producing duplicate sessions for the same intent. This PR sends SIGTERM to the child on webhook timeout in both the regular and tmux spawn paths, so a timed-out spawn never leaves a half-registered session behind.

## Reproduction

1. Have the daemon spawn a session through the mobile app or \`/spawn-session\` HTTP endpoint
2. Cause the child to be slow to register (heavy machine load, slow disk, slow npm cold start)
3. Observe in \`~/.happy/logs/*-daemon.log\`:
   \`\`\`
   [DAEMON RUN] Session webhook timeout for PID 12345
   \`\`\`
4. Check \`happy doctor\` — the supposedly-failed PID is still alive
5. Mobile app shows two sessions instead of one (caller retried after timeout)

## Fix

Both timeout handlers now \`process.kill(pid, 'SIGTERM')\` (or \`childProcess.kill('SIGTERM')\` for the regular path) before resolving with the error. Wrapped in try/catch since the child may have already exited.

## Test plan

- [x] \`pnpm --filter happy build\` passes (\`tsc --noEmit\`)
- [ ] Manual: simulate slow webhook (insert artificial \`setTimeout\` delay before \`notifyDaemonSessionStarted\`), confirm daemon log shows \"killing child\" and the PID is no longer running

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>