### PR TITLE
fix(cli): detect Claude Code installed via pnpm global

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -33,6 +33,39 @@ function resolvePathSafe(filePath) {
 }
 
 /**
+ * Parse a shell script shim (e.g. created by pnpm) and extract the binary it
+ * invokes. Returns the resolved absolute path if the binary exists on disk,
+ * or null otherwise.
+ *
+ * @param {string} shimPath - Path to the shim file
+ * @returns {string|null} Resolved binary path or null
+ */
+function resolveShimTarget(shimPath) {
+    try {
+        if (!fs.existsSync(shimPath)) return null;
+
+        const content = fs.readFileSync(shimPath, 'utf8');
+        if (!content.startsWith('#!') || !(/\bsh\b/.test(content.split('\n')[0]))) {
+            return null;
+        }
+
+        const shimDir = path.dirname(shimPath);
+        for (const line of content.split('\n')) {
+            if (!line.includes('claude-code')) continue;
+
+            const match = line.match(/"\$basedir\/([^"]+)"/);
+            if (match) {
+                const resolved = path.join(shimDir, match[1]);
+                if (fs.existsSync(resolved)) return resolved;
+            }
+        }
+    } catch (e) {
+        // File read or parse failure
+    }
+    return null;
+}
+
+/**
  * Resolve the Claude Code entrypoint inside a package directory.
  *
  * Prior to @anthropic-ai/claude-code@2.1.113 the package shipped a JS
@@ -121,7 +154,12 @@ function findClaudeInPath() {
                 if (entrypoint) {
                     return { path: entrypoint, source: 'npm' };
                 }
-                // Shim found but no resolvable entrypoint — skip and let other finders handle it
+
+                const shimTarget = resolveShimTarget(claudePath);
+                if (shimTarget) {
+                    return { path: shimTarget, source: detectSourceFromPath(shimTarget) };
+                }
+
                 return null;
             }
 
@@ -170,6 +208,11 @@ function detectSourceFromPath(resolvedPath) {
     // Must check before general Homebrew paths to distinguish from npm-through-Homebrew
     if (normalizedPath.includes('@anthropic-ai') && normalizedPath.includes('.claude-code-')) {
         return 'Homebrew';
+    }
+
+    // pnpm: virtual store layout with .pnpm directory
+    if (normalizedPath.includes('.pnpm') && normalizedPath.includes('claude-code')) {
+        return 'pnpm';
     }
 
     // npm: clean claude-code directory (even through Homebrew's npm)
@@ -469,9 +512,15 @@ function findGlobalClaudeCliPath() {
  */
 function getVersion(cliPath) {
     try {
-        const pkgPath = path.join(path.dirname(cliPath), 'package.json');
+        let dir = path.dirname(cliPath);
+        const pkgPath = path.join(dir, 'package.json');
         if (fs.existsSync(pkgPath)) {
             const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            return pkg.version;
+        }
+        const parentPkgPath = path.join(path.dirname(dir), 'package.json');
+        if (fs.existsSync(parentPkgPath)) {
+            const pkg = JSON.parse(fs.readFileSync(parentPkgPath, 'utf8'));
             return pkg.version;
         }
     } catch (e) {}
@@ -609,6 +658,7 @@ module.exports = {
     findBunGlobalCliPath,
     findHomebrewCliPath,
     findNativeInstallerCliPath,
+    resolveShimTarget,
     getVersion,
     compareVersions,
     getClaudeCliPath,

--- a/packages/happy-cli/scripts/claude_version_utils.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import {
   findGlobalClaudeCliPath,
   findClaudeInPath,
@@ -9,7 +11,8 @@ import {
   findHomebrewCliPath,
   findNativeInstallerCliPath,
   getVersion,
-  compareVersions
+  compareVersions,
+  resolveShimTarget,
 } from '../scripts/claude_version_utils.cjs';
 
 describe('Claude Version Utils - Cross-Platform Detection', () => {
@@ -369,5 +372,157 @@ describe('HAPPY_CLAUDE_PATH env var', () => {
     process.env.HAPPY_CLAUDE_PATH = '/nonexistent/path/claude';
     const result = findGlobalClaudeCliPath();
     expect(result?.source).not.toBe('HAPPY_CLAUDE_PATH');
+  });
+});
+
+describe('resolveShimTarget', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'happy-shim-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should extract binary path from pnpm POSIX shim', () => {
+    const binDir = path.join(tmpDir, 'global', '5', '.pnpm',
+      '@anthropic-ai+claude-code@2.1.131', 'node_modules',
+      '@anthropic-ai', 'claude-code', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary-placeholder');
+
+    const shimContent = [
+      '#!/bin/sh',
+      'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
+      '',
+      'case `uname` in',
+      '    *CYGWIN*|*MINGW*|*MSYS*)',
+      '        if command -v cygpath > /dev/null 2>&1; then',
+      '            basedir=`cygpath -w "$basedir"`',
+      '        fi',
+      '    ;;',
+      'esac',
+      '',
+      '"$basedir/global/5/.pnpm/@anthropic-ai+claude-code@2.1.131/node_modules/@anthropic-ai/claude-code/bin/claude.exe"   "$@"',
+      'exit $?',
+    ].join('\n');
+
+    const shimPath = path.join(tmpDir, 'claude');
+    fs.writeFileSync(shimPath, shimContent);
+
+    const result = resolveShimTarget(shimPath);
+    expect(result).toBe(
+      path.join(binDir, 'claude.exe')
+    );
+  });
+
+  it('should return null for non-shell-script files', () => {
+    const filePath = path.join(tmpDir, 'claude');
+    fs.writeFileSync(filePath, 'not a shell script');
+    expect(resolveShimTarget(filePath)).toBeNull();
+  });
+
+  it('should return null when shim does not reference claude-code', () => {
+    const shimContent = [
+      '#!/bin/sh',
+      'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
+      '"$basedir/some-other-tool/bin/other"   "$@"',
+      'exit $?',
+    ].join('\n');
+
+    const shimPath = path.join(tmpDir, 'other');
+    fs.writeFileSync(shimPath, shimContent);
+    expect(resolveShimTarget(shimPath)).toBeNull();
+  });
+
+  it('should return null when resolved binary does not exist on disk', () => {
+    const shimContent = [
+      '#!/bin/sh',
+      'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
+      '"$basedir/global/5/.pnpm/@anthropic-ai+claude-code@9.9.9/node_modules/@anthropic-ai/claude-code/bin/claude.exe"   "$@"',
+      'exit $?',
+    ].join('\n');
+
+    const shimPath = path.join(tmpDir, 'claude');
+    fs.writeFileSync(shimPath, shimContent);
+    expect(resolveShimTarget(shimPath)).toBeNull();
+  });
+
+  it('should return null for non-existent file', () => {
+    expect(resolveShimTarget('/nonexistent/file')).toBeNull();
+  });
+
+  it('should handle shim with #!/usr/bin/env sh shebang', () => {
+    const binDir = path.join(tmpDir, 'store', '@anthropic-ai', 'claude-code', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary-placeholder');
+
+    const shimContent = [
+      '#!/usr/bin/env sh',
+      'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
+      '"$basedir/store/@anthropic-ai/claude-code/bin/claude.exe"   "$@"',
+      'exit $?',
+    ].join('\n');
+
+    const shimPath = path.join(tmpDir, 'claude');
+    fs.writeFileSync(shimPath, shimContent);
+
+    const result = resolveShimTarget(shimPath);
+    expect(result).toBe(path.join(binDir, 'claude.exe'));
+  });
+});
+
+describe('detectSourceFromPath - pnpm installations', () => {
+  it('should detect pnpm global installation with .pnpm store', () => {
+    const result = detectSourceFromPath(
+      '/Users/test/Library/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@2.1.131/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
+    );
+    expect(result).toBe('pnpm');
+  });
+
+  it('should detect pnpm on Linux', () => {
+    const result = detectSourceFromPath(
+      '/home/user/.local/share/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@2.1.131/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
+    );
+    expect(result).toBe('pnpm');
+  });
+
+  it('should detect pnpm on Windows', () => {
+    const result = detectSourceFromPath(
+      'C:\\Users\\test\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\@anthropic-ai+claude-code@2.1.131\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
+    );
+    expect(result).toBe('pnpm');
+  });
+});
+
+describe('getVersion - binary in bin/ subdirectory', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'happy-ver-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should find version when binary is in bin/ subdirectory', () => {
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '2.1.131' }));
+
+    const version = getVersion(path.join(binDir, 'claude.exe'));
+    expect(version).toBe('2.1.131');
+  });
+
+  it('should still find version when binary is at package root', () => {
+    fs.writeFileSync(path.join(tmpDir, 'cli.js'), '// cli');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '2.1.112' }));
+
+    const version = getVersion(path.join(tmpDir, 'cli.js'));
+    expect(version).toBe('2.1.112');
   });
 });

--- a/packages/happy-cli/scripts/claude_version_utils.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.test.ts
@@ -376,6 +376,10 @@ describe('HAPPY_CLAUDE_PATH env var', () => {
 });
 
 describe('resolveShimTarget', () => {
+  const FIXTURE_VERSION = '1.0.0';
+  const FIXTURE_PKG_SLUG = `@anthropic-ai+claude-code@${FIXTURE_VERSION}`;
+  const FIXTURE_PNPM_REL = `global/5/.pnpm/${FIXTURE_PKG_SLUG}/node_modules/@anthropic-ai/claude-code`;
+
   let tmpDir: string;
 
   beforeEach(() => {
@@ -387,9 +391,7 @@ describe('resolveShimTarget', () => {
   });
 
   it('should extract binary path from pnpm POSIX shim', () => {
-    const binDir = path.join(tmpDir, 'global', '5', '.pnpm',
-      '@anthropic-ai+claude-code@2.1.131', 'node_modules',
-      '@anthropic-ai', 'claude-code', 'bin');
+    const binDir = path.join(tmpDir, FIXTURE_PNPM_REL, 'bin');
     fs.mkdirSync(binDir, { recursive: true });
     fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary-placeholder');
 
@@ -405,7 +407,7 @@ describe('resolveShimTarget', () => {
       '    ;;',
       'esac',
       '',
-      '"$basedir/global/5/.pnpm/@anthropic-ai+claude-code@2.1.131/node_modules/@anthropic-ai/claude-code/bin/claude.exe"   "$@"',
+      `"$basedir/${FIXTURE_PNPM_REL}/bin/claude.exe"   "$@"`,
       'exit $?',
     ].join('\n');
 
@@ -413,9 +415,7 @@ describe('resolveShimTarget', () => {
     fs.writeFileSync(shimPath, shimContent);
 
     const result = resolveShimTarget(shimPath);
-    expect(result).toBe(
-      path.join(binDir, 'claude.exe')
-    );
+    expect(result).toBe(path.join(binDir, 'claude.exe'));
   });
 
   it('should return null for non-shell-script files', () => {
@@ -441,7 +441,7 @@ describe('resolveShimTarget', () => {
     const shimContent = [
       '#!/bin/sh',
       'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
-      '"$basedir/global/5/.pnpm/@anthropic-ai+claude-code@9.9.9/node_modules/@anthropic-ai/claude-code/bin/claude.exe"   "$@"',
+      `"$basedir/${FIXTURE_PNPM_REL}/bin/claude.exe"   "$@"`,
       'exit $?',
     ].join('\n');
 
@@ -477,21 +477,21 @@ describe('resolveShimTarget', () => {
 describe('detectSourceFromPath - pnpm installations', () => {
   it('should detect pnpm global installation with .pnpm store', () => {
     const result = detectSourceFromPath(
-      '/Users/test/Library/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@2.1.131/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
+      '/Users/test/Library/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@1.0.0/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
     );
     expect(result).toBe('pnpm');
   });
 
   it('should detect pnpm on Linux', () => {
     const result = detectSourceFromPath(
-      '/home/user/.local/share/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@2.1.131/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
+      '/home/user/.local/share/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@1.0.0/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
     );
     expect(result).toBe('pnpm');
   });
 
   it('should detect pnpm on Windows', () => {
     const result = detectSourceFromPath(
-      'C:\\Users\\test\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\@anthropic-ai+claude-code@2.1.131\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
+      'C:\\Users\\test\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\@anthropic-ai+claude-code@1.0.0\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
     );
     expect(result).toBe('pnpm');
   });
@@ -512,17 +512,17 @@ describe('getVersion - binary in bin/ subdirectory', () => {
     const binDir = path.join(tmpDir, 'bin');
     fs.mkdirSync(binDir);
     fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary');
-    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '2.1.131' }));
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '1.0.0' }));
 
     const version = getVersion(path.join(binDir, 'claude.exe'));
-    expect(version).toBe('2.1.131');
+    expect(version).toBe('1.0.0');
   });
 
   it('should still find version when binary is at package root', () => {
     fs.writeFileSync(path.join(tmpDir, 'cli.js'), '// cli');
-    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '2.1.112' }));
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '0.9.0' }));
 
     const version = getVersion(path.join(tmpDir, 'cli.js'));
-    expect(version).toBe('2.1.112');
+    expect(version).toBe('0.9.0');
   });
 });

--- a/packages/happy-cli/vitest.config.ts
+++ b/packages/happy-cli/vitest.config.ts
@@ -10,6 +10,16 @@ export default defineConfig({
             {
                 extends: true,
                 test: {
+                    name: 'scripts',
+                    include: ['scripts/**/*.test.ts'],
+                    sequence: {
+                        groupOrder: 0,
+                    },
+                },
+            },
+            {
+                extends: true,
+                test: {
                     name: 'unit',
                     include: ['src/**/*.test.ts'],
                     exclude: ['src/**/*.integration.test.ts'],


### PR DESCRIPTION
## Summary

- Add `resolveShimTarget()` to parse pnpm shell script shims and extract the actual binary path from the `.pnpm` virtual store
- Add pnpm source detection in `detectSourceFromPath()` — paths containing `.pnpm` + `claude-code` are identified as `'pnpm'`
- Fix `getVersion()` to walk up one directory when `package.json` is not in the same directory as the binary (e.g., `bin/claude.exe` → parent has `package.json`)
- Add `scripts` vitest project to `vitest.config.ts` so `scripts/**/*.test.ts` files are included in test runs

## Root cause

pnpm creates shell script shims (e.g., `~/.local/share/pnpm/claude`) that invoke binaries from its virtual store at `.pnpm/@anthropic-ai+claude-code@x.y.z/node_modules/...`. The existing `findClaudeInPath()` found the shim via `which claude`, but since it's not a `.js`/`.cjs`/`.exe` file, the code tried to resolve `node_modules/@anthropic-ai/claude-code/` adjacent to the shim — which doesn't exist in pnpm's layout. All other detection methods (npm, bun, homebrew, native) also don't match pnpm's path structure, so detection returned `null`.

## How it works

When `findClaudeInPath()` finds a non-executable shim and the npm `node_modules` fallback fails, it now calls `resolveShimTarget(shimPath)` which:
1. Reads the shim file and verifies it's a shell script (`#!` shebang with `sh`)
2. Scans for lines containing `claude-code`
3. Extracts the `$basedir/...` path pattern and resolves it relative to the shim's directory
4. Verifies the resolved binary exists on disk

## Test plan

- [x] 11 new tests added (6 for `resolveShimTarget`, 3 for pnpm `detectSourceFromPath`, 2 for `getVersion` with `bin/` subdirectory)
- [x] All 59 scripts tests pass (`vitest run --project scripts`)
- [x] No regressions in existing 42 tests
- [x] End-to-end verification on macOS with pnpm-installed Claude Code v2.1.131:
  ```
  Detection result: { path: ".../.pnpm/@anthropic-ai+claude-code@2.1.131/.../bin/claude.exe", source: "pnpm" }
  Version: 2.1.131
  ```

Closes #1182, relates to #724