### PR TITLE
fix(cli): detect Claude Code installed via pnpm global

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -1,15 +1,18 @@
 /**
- * Shared utilities for finding and resolving Claude Code CLI path
- * Used by both local and remote launchers
+ * Shared utilities for finding and resolving Claude Code CLI path.
+ * Used by both local and remote launchers.
  *
- * Supports multiple installation methods:
- * 1. npm global: npm install -g @anthropic-ai/claude-code
- * 2. Homebrew: brew install claude-code
- * 3. Native installer:
+ * Supports multiple installation methods (checked in this order):
+ * 1. HAPPY_CLAUDE_PATH env var (explicit override)
+ * 2. PATH lookup: which/where claude
+ * 3. npm global:   npm install -g @anthropic-ai/claude-code
+ * 4. pnpm global:  pnpm add -g @anthropic-ai/claude-code
+ * 5. Bun global:   bun add -g @anthropic-ai/claude-code
+ * 6. Homebrew:     brew install claude-code
+ * 7. Native installer:
  *    - macOS/Linux: curl -fsSL https://claude.ai/install.sh | bash
  *    - PowerShell:  irm https://claude.ai/install.ps1 | iex
  *    - Windows CMD: curl -fsSL https://claude.ai/install.cmd | cmd
- * 4. PATH fallback: bun, pnpm, or any other package manager
  */
 
 const { execSync } = require('child_process');
@@ -30,6 +33,59 @@ function resolvePathSafe(filePath) {
         // Symlink resolution failed, return original path
         return filePath;
     }
+}
+
+/**
+ * Find path to pnpm globally installed Claude Code CLI.
+ *
+ * Strategy (two-layer, mirrors findNpmGlobalCliPath):
+ *
+ * 1. Primary — `pnpm root -g`:
+ *    Returns the global node_modules path (e.g. ~/Library/pnpm/global/5/node_modules).
+ *    Inside that directory, @anthropic-ai/claude-code is a symlink into pnpm's
+ *    .pnpm virtual store. resolveClaudeEntrypoint() handles both legacy cli.js
+ *    and modern bin/claude.exe entrypoints.
+ *
+ * 2. Fallback — PNPM_HOME env var:
+ *    When pnpm is not in PATH (e.g. shell profile not sourced in daemon context),
+ *    PNPM_HOME (set by `pnpm setup`) points to the pnpm home directory.
+ *    Global packages live under PNPM_HOME/global/<lockfileVersion>/node_modules/.
+ *    The lockfile version number (e.g. "5" for pnpm v8-v10, "6" for v11) varies
+ *    across pnpm major releases, so we scan all subdirectories.
+ *
+ * @returns {string|null} Path to the Claude Code entrypoint, or null if not found
+ */
+function findPnpmGlobalCliPath() {
+    // Primary: ask pnpm directly — same pattern as findNpmGlobalCliPath().
+    try {
+        const globalRoot = execSync('pnpm root -g', { encoding: 'utf8' }).trim();
+        const pkgDir = path.join(globalRoot, '@anthropic-ai', 'claude-code');
+        const entrypoint = resolveClaudeEntrypoint(pkgDir);
+        if (entrypoint) return entrypoint;
+    } catch (e) {
+        // pnpm not in PATH or command failed
+    }
+
+    // Fallback: derive the path from PNPM_HOME env var.
+    const pnpmHome = process.env.PNPM_HOME;
+    if (pnpmHome) {
+        const globalDir = path.join(pnpmHome, 'global');
+        if (fs.existsSync(globalDir)) {
+            try {
+                // Scan all version subdirectories (e.g. "5", "6") to handle
+                // different pnpm lockfile format versions across major releases.
+                for (const version of fs.readdirSync(globalDir)) {
+                    const pkgDir = path.join(globalDir, version, 'node_modules', '@anthropic-ai', 'claude-code');
+                    const entrypoint = resolveClaudeEntrypoint(pkgDir);
+                    if (entrypoint) return entrypoint;
+                }
+            } catch (e) {
+                // Directory read failed
+            }
+        }
+    }
+
+    return null;
 }
 
 /**
@@ -121,7 +177,11 @@ function findClaudeInPath() {
                 if (entrypoint) {
                     return { path: entrypoint, source: 'npm' };
                 }
-                // Shim found but no resolvable entrypoint — skip and let other finders handle it
+
+                // Non-executable shim without adjacent node_modules (e.g. pnpm shim).
+                // Dedicated finders (findPnpmGlobalCliPath, etc.) handle these cases,
+                // so we return null and let the priority chain in findGlobalClaudeCliPath
+                // try them.
                 return null;
             }
 
@@ -170,6 +230,14 @@ function detectSourceFromPath(resolvedPath) {
     // Must check before general Homebrew paths to distinguish from npm-through-Homebrew
     if (normalizedPath.includes('@anthropic-ai') && normalizedPath.includes('.claude-code-')) {
         return 'Homebrew';
+    }
+
+    // pnpm: content-addressable virtual store uses .pnpm/ directory.
+    // The resolved real path (after following symlinks from node_modules)
+    // looks like: .../.pnpm/@anthropic-ai+claude-code@x.y.z/node_modules/@anthropic-ai/claude-code/bin/claude.exe
+    // Must check before npm because pnpm paths also contain node_modules.
+    if (normalizedPath.includes('.pnpm') && normalizedPath.includes('claude-code')) {
+        return 'pnpm';
     }
 
     // npm: clean claude-code directory (even through Homebrew's npm)
@@ -430,32 +498,39 @@ function findLatestVersionBinary(versionsDir, binaryName = null) {
 }
 
 /**
- * Find path to globally installed Claude Code CLI
- * Priority: HAPPY_CLAUDE_PATH env var > PATH > npm > Bun > Homebrew > Native
+ * Find path to globally installed Claude Code CLI.
+ * Priority: HAPPY_CLAUDE_PATH > PATH > npm > pnpm > Bun > Homebrew > Native
  * @returns {{path: string, source: string}|null} Path and source, or null if not found
  */
 function findGlobalClaudeCliPath() {
-    // 1. Environment variable (explicit override)
+    // 1. Environment variable (explicit override, highest priority)
     const envPath = process.env.HAPPY_CLAUDE_PATH;
     if (envPath && fs.existsSync(envPath)) {
         const resolved = resolvePathSafe(envPath) || envPath;
         return { path: resolved, source: 'HAPPY_CLAUDE_PATH' };
     }
 
-    // 2. Check PATH (respects user's shell config)
+    // 2. PATH lookup (respects user's shell config — covers all managers)
     const pathResult = findClaudeInPath();
     if (pathResult) return pathResult;
 
-    // 3. Fall back to package manager detection
+    // 3. npm global: `npm root -g` → node_modules/@anthropic-ai/claude-code
     const npmPath = findNpmGlobalCliPath();
     if (npmPath) return { path: npmPath, source: 'npm' };
 
+    // 4. pnpm global: `pnpm root -g` or PNPM_HOME env var
+    const pnpmPath = findPnpmGlobalCliPath();
+    if (pnpmPath) return { path: pnpmPath, source: 'pnpm' };
+
+    // 5. Bun global: ~/.bun/bin/claude symlink
     const bunPath = findBunGlobalCliPath();
     if (bunPath) return { path: bunPath, source: 'Bun' };
 
+    // 6. Homebrew: /opt/homebrew, /usr/local, ~/.linuxbrew
     const homebrewPath = findHomebrewCliPath();
     if (homebrewPath) return { path: homebrewPath, source: 'Homebrew' };
 
+    // 7. Native installer: ~/.local/bin, %LOCALAPPDATA%\Claude, etc.
     const nativePath = findNativeInstallerCliPath();
     if (nativePath) return { path: nativePath, source: 'native installer' };
 
@@ -469,9 +544,15 @@ function findGlobalClaudeCliPath() {
  */
 function getVersion(cliPath) {
     try {
-        const pkgPath = path.join(path.dirname(cliPath), 'package.json');
+        let dir = path.dirname(cliPath);
+        const pkgPath = path.join(dir, 'package.json');
         if (fs.existsSync(pkgPath)) {
             const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            return pkg.version;
+        }
+        const parentPkgPath = path.join(path.dirname(dir), 'package.json');
+        if (fs.existsSync(parentPkgPath)) {
+            const pkg = JSON.parse(fs.readFileSync(parentPkgPath, 'utf8'));
             return pkg.version;
         }
     } catch (e) {}
@@ -606,6 +687,7 @@ module.exports = {
     findClaudeInPath,
     detectSourceFromPath,
     findNpmGlobalCliPath,
+    findPnpmGlobalCliPath,
     findBunGlobalCliPath,
     findHomebrewCliPath,
     findNativeInstallerCliPath,

--- a/packages/happy-cli/scripts/claude_version_utils.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.test.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import {
   findGlobalClaudeCliPath,
   findClaudeInPath,
   detectSourceFromPath,
   findNpmGlobalCliPath,
+  findPnpmGlobalCliPath,
   findBunGlobalCliPath,
   findHomebrewCliPath,
   findNativeInstallerCliPath,
   getVersion,
-  compareVersions
+  compareVersions,
 } from '../scripts/claude_version_utils.cjs';
 
 describe('Claude Version Utils - Cross-Platform Detection', () => {
@@ -369,5 +372,131 @@ describe('HAPPY_CLAUDE_PATH env var', () => {
     process.env.HAPPY_CLAUDE_PATH = '/nonexistent/path/claude';
     const result = findGlobalClaudeCliPath();
     expect(result?.source).not.toBe('HAPPY_CLAUDE_PATH');
+  });
+});
+
+describe('findPnpmGlobalCliPath - PNPM_HOME fallback', () => {
+  let tmpDir: string;
+  let originalPnpmHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'happy-pnpm-test-'));
+    originalPnpmHome = process.env.PNPM_HOME;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalPnpmHome !== undefined) {
+      process.env.PNPM_HOME = originalPnpmHome;
+    } else {
+      delete process.env.PNPM_HOME;
+    }
+  });
+
+  it('should find claude-code with modern bin/claude.exe entrypoint', () => {
+    const pkgDir = path.join(tmpDir, 'global', '5', 'node_modules', '@anthropic-ai', 'claude-code');
+    const binDir = path.join(pkgDir, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary');
+    fs.writeFileSync(path.join(pkgDir, 'package.json'),
+      JSON.stringify({ bin: { claude: 'bin/claude.exe' }, version: '1.0.0' }));
+
+    process.env.PNPM_HOME = tmpDir;
+    const result = findPnpmGlobalCliPath();
+    expect(result).toBe(path.join(binDir, 'claude.exe'));
+  });
+
+  it('should find claude-code with legacy cli.js entrypoint', () => {
+    const pkgDir = path.join(tmpDir, 'global', '5', 'node_modules', '@anthropic-ai', 'claude-code');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'cli.js'), '// legacy');
+
+    process.env.PNPM_HOME = tmpDir;
+    const result = findPnpmGlobalCliPath();
+    expect(result).toBe(path.join(pkgDir, 'cli.js'));
+  });
+
+  it('should scan multiple global version directories', () => {
+    // global/3/ exists but has no claude-code
+    fs.mkdirSync(path.join(tmpDir, 'global', '3', 'node_modules'), { recursive: true });
+
+    // global/6/ has claude-code
+    const pkgDir = path.join(tmpDir, 'global', '6', 'node_modules', '@anthropic-ai', 'claude-code');
+    const binDir = path.join(pkgDir, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary');
+    fs.writeFileSync(path.join(pkgDir, 'package.json'),
+      JSON.stringify({ bin: { claude: 'bin/claude.exe' } }));
+
+    process.env.PNPM_HOME = tmpDir;
+    const result = findPnpmGlobalCliPath();
+    expect(result).toBe(path.join(binDir, 'claude.exe'));
+  });
+
+  it('should return null when PNPM_HOME has no claude-code', () => {
+    fs.mkdirSync(path.join(tmpDir, 'global', '5', 'node_modules'), { recursive: true });
+
+    process.env.PNPM_HOME = tmpDir;
+    const result = findPnpmGlobalCliPath();
+    // pnpm root -g may succeed on this machine, so we only assert type
+    expect(result === null || typeof result === 'string').toBe(true);
+  });
+
+  it('should not throw when PNPM_HOME is not set', () => {
+    delete process.env.PNPM_HOME;
+    expect(() => findPnpmGlobalCliPath()).not.toThrow();
+  });
+});
+
+describe('detectSourceFromPath - pnpm installations', () => {
+  it('should detect pnpm global installation with .pnpm store', () => {
+    const result = detectSourceFromPath(
+      '/Users/test/Library/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@1.0.0/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
+    );
+    expect(result).toBe('pnpm');
+  });
+
+  it('should detect pnpm on Linux', () => {
+    const result = detectSourceFromPath(
+      '/home/user/.local/share/pnpm/global/5/.pnpm/@anthropic-ai+claude-code@1.0.0/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
+    );
+    expect(result).toBe('pnpm');
+  });
+
+  it('should detect pnpm on Windows', () => {
+    const result = detectSourceFromPath(
+      'C:\\Users\\test\\AppData\\Local\\pnpm\\global\\5\\.pnpm\\@anthropic-ai+claude-code@1.0.0\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe'
+    );
+    expect(result).toBe('pnpm');
+  });
+});
+
+describe('getVersion - binary in bin/ subdirectory', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'happy-ver-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should find version when binary is in bin/ subdirectory', () => {
+    const binDir = path.join(tmpDir, 'bin');
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(path.join(binDir, 'claude.exe'), 'binary');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '1.0.0' }));
+
+    const version = getVersion(path.join(binDir, 'claude.exe'));
+    expect(version).toBe('1.0.0');
+  });
+
+  it('should still find version when binary is at package root', () => {
+    fs.writeFileSync(path.join(tmpDir, 'cli.js'), '// cli');
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ version: '0.9.0' }));
+
+    const version = getVersion(path.join(tmpDir, 'cli.js'));
+    expect(version).toBe('0.9.0');
   });
 });

--- a/packages/happy-cli/vitest.config.ts
+++ b/packages/happy-cli/vitest.config.ts
@@ -10,6 +10,16 @@ export default defineConfig({
             {
                 extends: true,
                 test: {
+                    name: 'scripts',
+                    include: ['scripts/**/*.test.ts'],
+                    sequence: {
+                        groupOrder: 0,
+                    },
+                },
+            },
+            {
+                extends: true,
+                test: {
                     name: 'unit',
                     include: ['src/**/*.test.ts'],
                     exclude: ['src/**/*.integration.test.ts'],


### PR DESCRIPTION
## Summary

- Add `findPnpmGlobalCliPath()` using `pnpm root -g` + `PNPM_HOME` env var fallback, mirroring `findNpmGlobalCliPath()` pattern
- Add pnpm source detection in `detectSourceFromPath()` — paths containing `.pnpm` + `claude-code` are identified as `'pnpm'`
- Fix `getVersion()` to walk up one directory when `package.json` is not in the same directory as the binary (e.g., `bin/claude.exe` → parent has `package.json`)
- Add `scripts` vitest project to `vitest.config.ts` so `scripts/**/*.test.ts` files are included in test runs

## Root cause

pnpm creates shell script shims (e.g., `~/Library/pnpm/claude`) that delegate to binaries in its `.pnpm` virtual store. The existing `findClaudeInPath()` found the shim via `which claude`, but since it's not a `.js`/`.cjs`/`.exe` file, the code tried to resolve `node_modules/@anthropic-ai/claude-code/` adjacent to the shim — which doesn't exist in pnpm's layout. All other detection methods (npm, bun, homebrew, native) also don't match pnpm's path structure, so detection returned `null`.

## How it works

New dedicated `findPnpmGlobalCliPath()` with two-layer strategy:

1. **Primary** — `pnpm root -g`: returns the global `node_modules` path (e.g., `~/Library/pnpm/global/5/node_modules`), where `@anthropic-ai/claude-code` is a symlink. Reuses `resolveClaudeEntrypoint()` to handle both legacy `cli.js` and modern `bin/claude.exe`.
2. **Fallback** — `PNPM_HOME` env var: when `pnpm` is not in PATH (e.g., daemon context), scans `PNPM_HOME/global/*/node_modules/` to cover different pnpm lockfile format versions across major releases.

Inserted into the detection priority chain: `HAPPY_CLAUDE_PATH > PATH > npm > pnpm > Bun > Homebrew > Native`.

## Test plan

- [x] 10 new tests (5 for `findPnpmGlobalCliPath` PNPM_HOME fallback, 3 for pnpm `detectSourceFromPath`, 2 for `getVersion` bin/ subdirectory)
- [x] All 58 scripts tests pass (`vitest run --project scripts`)
- [x] No regressions in existing 42 tests
- [x] End-to-end verification on macOS with pnpm-installed Claude Code v2.1.131:
  ```
  Detection: { path: ".../global/5/node_modules/@anthropic-ai/claude-code/bin/claude.exe", source: "pnpm" }
  Version: 2.1.131
  ```

Closes #1182, relates to #724