### PR TITLE
fix: relay usage data to app via session protocol

### DIFF
--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -89,6 +89,14 @@ const sessionStopEventSchema = z.object({
     t: z.literal('stop'),
 });
 
+const sessionUsageEventSchema = z.object({
+    t: z.literal('usage'),
+    input_tokens: z.number(),
+    output_tokens: z.number(),
+    cache_creation_input_tokens: z.number().optional(),
+    cache_read_input_tokens: z.number().optional(),
+});
+
 const sessionEventSchema = z.discriminatedUnion('t', [
     sessionTextEventSchema,
     sessionServiceMessageEventSchema,
@@ -99,6 +107,7 @@ const sessionEventSchema = z.discriminatedUnion('t', [
     sessionStartEventSchema,
     sessionTurnEndEventSchema,
     sessionStopEventSchema,
+    sessionUsageEventSchema,
 ]);
 
 const sessionEnvelopeSchema = z.object({
@@ -559,6 +568,25 @@ function normalizeSessionEnvelope(
     if (envelope.ev.t === 'start' || envelope.ev.t === 'stop') {
         // Lifecycle marker for subagent boundaries; currently not rendered as chat content.
         return null;
+    }
+
+    if (envelope.ev.t === 'usage') {
+        // Usage data from assistant messages — not rendered but feeds the reducer's processUsageData
+        return {
+            id: messageId,
+            localId,
+            createdAt: messageCreatedAt,
+            role: 'agent',
+            isSidechain: false,
+            content: [],
+            meta,
+            usage: {
+                input_tokens: envelope.ev.input_tokens,
+                output_tokens: envelope.ev.output_tokens,
+                cache_creation_input_tokens: envelope.ev.cache_creation_input_tokens,
+                cache_read_input_tokens: envelope.ev.cache_read_input_tokens,
+            }
+        } satisfies NormalizedMessage;
     }
 
     if (envelope.ev.t === 'turn-end') {

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -13,7 +13,7 @@ import { RpcHandlerManager } from './rpc/RpcHandlerManager';
 import { registerCommonHandlers } from '../modules/common/registerCommonHandlers';
 import { calculateCost } from '@/utils/pricing';
 import { shouldReconnect } from '@/utils/lidState';
-import { type SessionEnvelope, type SessionTurnEndStatus } from '@slopus/happy-wire';
+import { createEnvelope, type SessionEnvelope, type SessionTurnEndStatus } from '@slopus/happy-wire';
 import {
     closeClaudeTurnWithStatus,
     mapClaudeLogMessageToSessionEnvelopes,
@@ -509,6 +509,17 @@ export class ApiSessionClient extends EventEmitter {
             } catch (error) {
                 logger.debug('[SOCKET] Failed to send usage data:', error);
             }
+
+            // Send usage as a session protocol envelope so the app can display context size
+            const usage = body.message.usage;
+            const usageEnvelope = createEnvelope('agent', {
+                t: 'usage',
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_creation_input_tokens: usage.cache_creation_input_tokens,
+                cache_read_input_tokens: usage.cache_read_input_tokens,
+            }, { turn: this.claudeSessionProtocolState.currentTurnId ?? undefined });
+            this.sendSessionProtocolMessage(usageEnvelope);
         }
 
         // Update metadata with summary if this is a summary message

--- a/packages/happy-wire/src/sessionProtocol.ts
+++ b/packages/happy-wire/src/sessionProtocol.ts
@@ -79,6 +79,14 @@ export const sessionStopEventSchema = z.object({
   t: z.literal('stop'),
 });
 
+export const sessionUsageEventSchema = z.object({
+  t: z.literal('usage'),
+  input_tokens: z.number(),
+  output_tokens: z.number(),
+  cache_creation_input_tokens: z.number().optional(),
+  cache_read_input_tokens: z.number().optional(),
+});
+
 export const sessionEventSchema = z.discriminatedUnion('t', [
   sessionTextEventSchema,
   sessionServiceMessageEventSchema,
@@ -89,6 +97,7 @@ export const sessionEventSchema = z.discriminatedUnion('t', [
   sessionStartEventSchema,
   sessionTurnEndEventSchema,
   sessionStopEventSchema,
+  sessionUsageEventSchema,
 ]);
 
 export type SessionEvent = z.infer<typeof sessionEventSchema>;


### PR DESCRIPTION
The UI for displaying context window usage already exists — `AgentInput`'s `getContextWarning()`, `processUsageData()` in the reducer, the `alwaysShowContextSize` setting, and all the translations were added in 3095a2b9, 9908e992, and 80035e24 (Aug–Sep 2025). But the data never reaches them: usage token counts are sent to the server via `usage-report` socket events for billing, but are not relayed back to the app through the session protocol. The result is that `latestUsage` is always empty and the context percentage display never appears.

This commit adds the missing plumbing:
- **Wire schema**: new `usage` event type in the session protocol discriminated union (`happy-wire`)
- **CLI**: emit a usage envelope after each assistant message, alongside the existing `usage-report` (`happy-cli`)
- **App**: handle the usage envelope in the message normalizer so the reducer's `processUsageData()` actually receives data (`happy-app`)

No new UI, no database changes, no server changes.

Closes #1126
Refs #652