### PR TITLE
fix(cli): use cross-spawn in runClaudeCli for Windows shim support

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -530,7 +530,12 @@ function getClaudeCliPath() {
  */
 function runClaudeCli(cliPath) {
     const { pathToFileURL } = require('url');
-    const { spawn } = require('child_process');
+    // Use cross-spawn (already a dependency, used everywhere else in this repo
+    // for the same reason) so Windows handles `.cmd`/`.bat`/extensionless npm
+    // shims correctly instead of failing with `spawn UNKNOWN` / errno -4094.
+    // For a plain `.exe` path it behaves identically to child_process.spawn.
+    // See issue #551 and the CVE-2024-27980 hardening notes elsewhere.
+    const spawn = require('cross-spawn');
 
     // Check if it's a JavaScript file (.js or .cjs) or a binary file
     const isJsFile = cliPath.endsWith('.js') || cliPath.endsWith('.cjs');


### PR DESCRIPTION
## Problem

`runClaudeCli()` in `packages/happy-cli/scripts/claude_version_utils.cjs` launches the resolved Claude Code binary with raw `child_process.spawn()`. On Windows this throws `Error: spawn UNKNOWN` / `errno -4094` when the resolved path is an npm-generated shim (`claude.cmd`, or the extensionless `claude` shim under `%APPDATA%\npm`) instead of a real PE executable — reported in #551 (and a likely contributor to #1144's silent exit, since the `child.on('error')` handler's output can get swallowed by the Ink TUI).

## Fix

Use `cross-spawn` instead of `child_process.spawn` in this function.

Every other process-spawn site in the repo already does this for the same reason:
- `scripts/ripgrep_launcher.cjs` / `src/modules/ripgrep/index.ts` (#1082)
- `src/utils/spawnHappyCLI.ts` (CVE-2024-27980 hardening)
- `src/codex/codexAppServerClient.ts`
- `src/daemon/doctor.ts`
- `src/claude/claudeLocal.ts`

`runClaudeCli` was the one launcher still on raw `spawn`. For a plain `.exe` path `cross-spawn` behaves identically, so this is a safe drop-in. `cross-spawn` and `@types/cross-spawn` are already direct dependencies of `happy-cli` — no new deps.

## Testing

- Verified on Windows 11 (Node 25): with the patch, `runClaudeCli(getClaudeCliPath())` spawns the native-installer `claude.exe` and exits 0 as before; `happy --version`, `happy --help`, `happy doctor` all work after `pnpm build`.
- Could not reproduce the original `-4094` locally (my `claude` resolves to a real `.exe`), so I can't 100% confirm it closes #551 — but the change is the documented standard pattern in this codebase and is strictly safer for the npm-shim case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)