### PR TITLE
fix(codex): update app-server protocol for codex-cli 0.130.0 compatibility

### DIFF
--- a/packages/happy-cli/src/codex/codexAppServerClient.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.ts
@@ -288,6 +288,30 @@ export class CodexAppServerClient {
             return method.startsWith('item/');
         }
 
+        if (method === 'item/reasoning/textDelta') {
+            const delta = typeof params.delta === 'string' ? params.delta : '';
+            if (delta.length > 0) {
+                this.eventHandler?.({
+                    type: 'agent_reasoning_delta',
+                    delta,
+                    item_id: params.itemId ?? '',
+                });
+            }
+            return true;
+        }
+
+        if (method === 'item/reasoning/summaryTextDelta') {
+            const delta = typeof params.delta === 'string' ? params.delta : '';
+            if (delta.length > 0) {
+                this.eventHandler?.({
+                    type: 'agent_reasoning_delta',
+                    delta,
+                    item_id: params.itemId ?? '',
+                });
+            }
+            return true;
+        }
+
         if (method === 'item/started' && item.type === 'commandExecution') {
             const callId = typeof item.id === 'string' ? item.id : '';
             this.eventHandler?.({
@@ -348,6 +372,20 @@ export class CodexAppServerClient {
                 }
                 return true;
             }
+        }
+
+        if (method === 'item/agentMessage/delta') {
+            // v2 streaming agent message delta — accumulate for live display
+            const text = typeof params.delta === 'string' ? params.delta : '';
+            const itemId = typeof params.itemId === 'string' ? params.itemId : '';
+            if (text.length > 0) {
+                this.eventHandler?.({
+                    type: 'agent_reasoning_delta',
+                    delta: text,
+                    item_id: itemId,
+                });
+            }
+            return true;
         }
 
         if (method === 'item/completed' && item.type === 'agentMessage') {
@@ -580,18 +618,12 @@ export class CodexAppServerClient {
     }): Promise<{ threadId: string; model: string }> {
         const params: NewConversationParams = {
             model: opts.model ?? null,
-            modelProvider: null,
-            profile: null,
             cwd: opts.cwd ?? process.cwd(),
             approvalPolicy: opts.approvalPolicy ?? null,
             sandbox: opts.sandbox ?? null,
             config: this.buildThreadConfig(opts.mcpServers),
             baseInstructions: null,
             developerInstructions: null,
-            compactPrompt: null,
-            includeApplyPatchTool: null,
-            experimentalRawEvents: false,
-            persistExtendedHistory: true,
         };
 
         const result = await this.request('thread/start', params) as NewConversationResponse;
@@ -619,14 +651,12 @@ export class CodexAppServerClient {
         const params: ResumeConversationParams = {
             threadId,
             model: opts?.model ?? defaults.model ?? null,
-            modelProvider: null,
             cwd: opts?.cwd ?? defaults.cwd ?? process.cwd(),
             approvalPolicy: opts?.approvalPolicy ?? defaults.approvalPolicy ?? null,
             sandbox: opts?.sandbox ?? defaults.sandbox ?? null,
             config: this.buildThreadConfig(opts?.mcpServers ?? defaults.mcpServers),
             baseInstructions: null,
             developerInstructions: null,
-            persistExtendedHistory: true,
         };
 
         const result = await this.request('thread/resume', params) as ResumeConversationResponse;
@@ -794,13 +824,13 @@ export class CodexAppServerClient {
         if (opts?.sandbox) {
             switch (opts.sandbox) {
                 case 'workspace-write':
-                    params.sandboxPolicy = { type: 'workspaceWrite' };
+                    params.sandboxPolicy = { type: 'workspaceWrite', writableRoots: [opts.cwd ?? process.cwd()], networkAccess: true, excludeTmpdirEnvVar: false, excludeSlashTmp: false };
                     break;
                 case 'danger-full-access':
                     params.sandboxPolicy = { type: 'dangerFullAccess' };
                     break;
                 case 'read-only':
-                    params.sandboxPolicy = { type: 'readOnly' };
+                    params.sandboxPolicy = { type: 'readOnly', networkAccess: true };
                     break;
             }
         }

--- a/packages/happy-cli/src/codex/codexAppServerTypes.ts
+++ b/packages/happy-cli/src/codex/codexAppServerTypes.ts
@@ -1,5 +1,5 @@
 /**
- * Cherry-picked types from `codex app-server generate-ts` (Codex 0.107.0).
+ * Cherry-picked types from `codex app-server generate-ts` (Codex 0.130.0).
  * Only the essential types needed for our integration.
  */
 
@@ -17,46 +17,40 @@ export type InitializeResponse = { userAgent: string };
 // --- Thread lifecycle ---
 
 export type NewConversationParams = {
-    model: string | null;
-    modelProvider: string | null;
-    profile: string | null;
-    cwd: string | null;
-    approvalPolicy: ApprovalPolicy | null;
-    sandbox: SandboxMode | null;
-    config: Record<string, unknown> | null;
-    baseInstructions: string | null;
-    developerInstructions: string | null;
-    compactPrompt: string | null;
-    includeApplyPatchTool: boolean | null;
-    experimentalRawEvents: boolean;
-    persistExtendedHistory: boolean;
+    model?: string | null;
+    modelProvider?: string | null;
+    cwd?: string | null;
+    approvalPolicy?: ApprovalPolicy | null;
+    sandbox?: SandboxMode | null;
+    config?: Record<string, unknown> | null;
+    baseInstructions?: string | null;
+    developerInstructions?: string | null;
 };
 
 export type NewConversationResponse = {
     thread: {
         id: ThreadId;
-        path: string;
+        path?: string;
         [key: string]: unknown;
     };
     model: string;
-    modelProvider: string;
-    cwd: string;
-    approvalPolicy: ApprovalPolicy;
-    sandbox: unknown;
-    reasoningEffort: ReasoningEffort | null;
+    modelProvider?: string;
+    cwd?: string;
+    approvalPolicy?: ApprovalPolicy;
+    sandbox?: unknown;
+    reasoningEffort?: ReasoningEffort | null;
 };
 
 export type ResumeConversationParams = {
     threadId: ThreadId;
-    model: string | null;
-    modelProvider: string | null;
-    cwd: string | null;
-    approvalPolicy: ApprovalPolicy | null;
-    sandbox: SandboxMode | null;
-    config: Record<string, unknown> | null;
-    baseInstructions: string | null;
-    developerInstructions: string | null;
-    persistExtendedHistory: boolean;
+    model?: string | null;
+    modelProvider?: string | null;
+    cwd?: string | null;
+    approvalPolicy?: ApprovalPolicy | null;
+    sandbox?: SandboxMode | null;
+    config?: Record<string, unknown> | null;
+    baseInstructions?: string | null;
+    developerInstructions?: string | null;
 };
 
 export type ResumeConversationResponse = NewConversationResponse;
@@ -131,10 +125,14 @@ export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "
 export type ReasoningSummary = "auto" | "concise" | "detailed" | "none";
 export type TurnAbortReason = "interrupted" | "replaced" | "review_ended";
 
+export type TurnStatus = "completed" | "interrupted" | "failed" | "inProgress";
+
 export type InputItem =
     | { type: "text"; text: string; text_elements?: unknown[] }
     | { type: "image"; url: string }
-    | { type: "localImage"; path: string };
+    | { type: "localImage"; path: string }
+    | { type: "skill"; name: string; path: string }
+    | { type: "mention"; name: string; path: string };
 
 export type SandboxPolicy =
     | { type: "dangerFullAccess" }


### PR DESCRIPTION
## Problem

When running `happy codex`, agent text output is not displayed — only in-progress tool calls are visible, then nothing.

## Root Cause

The Codex app-server protocol has evolved significantly since the integration was written (targeting codex-cli 0.107.0). The current codex-cli 0.130.0 uses the v2 protocol exclusively, which differs in several ways:

1. **Stale `thread/start` params**: `profile`, `compactPrompt`, `includeApplyPatchTool`, `experimentalRawEvents`, `persistExtendedHistory` are not part of the v2 `ThreadStartParams`. These unknown fields may cause the server to reject or misprocess the request.

2. **Missing streaming notification handlers**: The v2 protocol sends agent text via `item/agentMessage/delta` and reasoning via `item/reasoning/textDelta` / `item/reasoning/summaryTextDelta` notifications. None of these were handled, so streaming text was silently dropped.

3. **Incomplete `SandboxPolicy` objects**: `workspaceWrite` requires `writableRoots`, `networkAccess`, `excludeTmpdirEnvVar`, `excludeSlashTmp`; `readOnly` requires `networkAccess`. Sending `{ type: 'workspaceWrite' }` alone is invalid.

## Changes

### `codexAppServerTypes.ts`
- Remove stale fields from `NewConversationParams` and `ResumeConversationParams`
- Make all fields optional to match v2 `ThreadStartParams` / `ThreadResumeParams`
- Make `NewConversationResponse` fields optional (`path`, `modelProvider`, etc.)
- Add `TurnStatus` type
- Add `skill` and `mention` input types to `InputItem`
- Update version comment from 0.107.0 to 0.130.0

### `codexAppServerClient.ts`
- Remove stale params from `startThread()` and `resumeThread()` calls
- Handle `item/agentMessage/delta` notifications → emit `agent_reasoning_delta`
- Handle `item/reasoning/textDelta` notifications → emit `agent_reasoning_delta`
- Handle `item/reasoning/summaryTextDelta` notifications → emit `agent_reasoning_delta`
- Fix `sandboxPolicy` for `workspaceWrite` and `readOnly` with required fields

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- Existing unit tests remain compatible (types are wider, not narrower)
- Generated v2 protocol types from `codex app-server generate-ts` were used as reference