### PR TITLE
fix(app): RN Blob polyfill rejects ArrayBuffer in S3 POST attachment upload

### DIFF
--- a/packages/happy-app/sources/sync/apiAttachments.ts
+++ b/packages/happy-app/sources/sync/apiAttachments.ts
@@ -12,6 +12,7 @@
  */
 import { AuthCredentials } from '@/auth/tokenStorage';
 import { getServerUrl } from './serverConfig';
+import { appendFormFile } from './uploadFormFile';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -103,8 +104,10 @@ export async function uploadEncryptedBlob(
                 formData.append(k, v);
             }
         }
-        const blob = new Blob([encryptedData.buffer as ArrayBuffer], { type: 'application/octet-stream' });
-        formData.append('file', blob);
+        // S3's content-type rule on presigned POST is satisfied by the
+        // policy's Content-Type form field; the per-part type just needs
+        // to be something multipart-valid. Filename is cosmetic.
+        const cleanup = await appendFormFile(formData, encryptedData, 'file', 'blob', 'application/octet-stream');
         let response: Response;
         try {
             response = await fetch(upload.uploadUrl, {
@@ -112,9 +115,11 @@ export async function uploadEncryptedBlob(
                 body: formData,
             });
         } catch (err) {
+            await cleanup();
             const message = err instanceof Error ? err.message : String(err);
             throw new Error(`Blob upload (POST) network error to ${upload.uploadUrl}: ${message}`);
         }
+        await cleanup();
         if (!response.ok) {
             throw new Error(`Blob upload (POST) failed: ${response.status} ${response.statusText} at ${upload.uploadUrl}`);
         }

--- a/packages/happy-app/sources/sync/uploadFormFile.ts
+++ b/packages/happy-app/sources/sync/uploadFormFile.ts
@@ -1,0 +1,29 @@
+/**
+ * Native (iOS/Android) impl: append a Uint8Array to FormData for a multipart
+ * upload. RN's Blob polyfill rejects `new Blob([arrayBuffer])`, so we stage
+ * the bytes to a temp file in cacheDirectory and use RN FormData's
+ * `{ uri, type, name }` form, which the platform multipart writer streams
+ * directly off disk. Returns a cleanup that deletes the temp file.
+ */
+import { encodeBase64 } from '@/encryption/base64';
+import { writeAsStringAsync, deleteAsync, cacheDirectory, EncodingType } from 'expo-file-system/legacy';
+import { randomUUID } from 'expo-crypto';
+
+export async function appendFormFile(
+    formData: FormData,
+    bytes: Uint8Array,
+    field: string,
+    filename: string,
+    contentType: string,
+): Promise<() => Promise<void>> {
+    if (!cacheDirectory) {
+        throw new Error('cacheDirectory unavailable on this platform');
+    }
+    const tempUri = `${cacheDirectory}happy-upload-${randomUUID()}`;
+    await writeAsStringAsync(tempUri, encodeBase64(bytes), { encoding: EncodingType.Base64 });
+    // RN typings don't know about the {uri, type, name} form, but the runtime does.
+    formData.append(field, { uri: tempUri, type: contentType, name: filename } as unknown as Blob);
+    return async () => {
+        try { await deleteAsync(tempUri, { idempotent: true }); } catch { /* best effort */ }
+    };
+}

--- a/packages/happy-app/sources/sync/uploadFormFile.web.ts
+++ b/packages/happy-app/sources/sync/uploadFormFile.web.ts
@@ -1,0 +1,14 @@
+/**
+ * Web impl: real Blob constructor works, no temp file needed.
+ */
+export async function appendFormFile(
+    formData: FormData,
+    bytes: Uint8Array,
+    field: string,
+    filename: string,
+    contentType: string,
+): Promise<() => Promise<void>> {
+    const blob = new Blob([bytes.buffer as ArrayBuffer], { type: contentType });
+    formData.append(field, blob, filename);
+    return async () => { /* no-op */ };
+}


### PR DESCRIPTION
## Summary

Image upload to a server with S3 storage (presigned POST policy) fails on **both** Android and iOS with:

```
Creating blobs from 'ArrayBuffer' and 'ArrayBufferView' are not supported
```

The PUT path (local-storage mode) already documents and works around this at `apiAttachments.ts:134`, but the comment scopes the issue to iOS — it's actually the same on Android because RN's Blob polyfill rejects `new Blob([arrayBuffer])` on both platforms. The S3 POST path constructs a Blob from `encryptedData.buffer` and the FormData append throws before the request leaves the device. Surfaced as an opaque "Upload Failed" alert; in the absence of devtools the user has no way to know what went wrong.

This may explain a portion of what was observed when `expImageUpload` was hidden in `5cc918ca` ("broken, next release") — anyone whose self-host or prod backend uses S3 storage hits this on every send, regardless of platform.

## Root cause

`apiAttachments.ts` POST branch:

```ts
const blob = new Blob([encryptedData.buffer as ArrayBuffer], { type: 'application/octet-stream' });
formData.append('file', blob);
```

RN's Blob polyfill (`react-native/Libraries/Blob/Blob.js`) refuses ArrayBuffer/TypedArray construction on both iOS and Android. Web has a real Blob constructor, so it works there.

## Fix

Split a tiny `uploadFormFile` helper across `.ts` (native) and `.web.ts`, mirroring the existing `readFileBytes` / `aes` / `thumbhash` platform-split pattern:

- **Native** writes the encrypted bytes to a temp file in `cacheDirectory` (`expo-file-system/legacy`) and uses RN FormData's `{ uri, type, name }` form. The platform multipart writer streams the body straight off disk — no Blob in sight. A returned cleanup function deletes the temp file in both success and error paths.
- **Web** keeps the real `Blob` constructor.

The S3 presigned POST policy validates content-type via the policy's own form field, so the per-part type just needs to be multipart-valid. The filename is cosmetic. No protocol changes.

## Files

- `packages/happy-app/sources/sync/apiAttachments.ts` — POST branch now uses `appendFormFile` + cleanup
- `packages/happy-app/sources/sync/uploadFormFile.ts` — new (native)
- `packages/happy-app/sources/sync/uploadFormFile.web.ts` — new (web)

## Test plan

- [x] Android (Expo SDK 54, `expo-file-system` 55): picker → encrypt → S3 POST → CLI download/decrypt → image visible to Claude. Verified end-to-end against a backend with S3 storage configured.
- [ ] iOS — the same code path; not personally tested. Same Blob polyfill behavior as Android per RN source.
- [ ] Web — uses real Blob, identical to current behavior. No regression expected.
- [ ] Local-storage (PUT) mode — untouched, still uses the existing standalone-buffer trick.

## Notes

- The temp file is cleaned up before returning in both success and error paths; cleanup is `idempotent: true` and `try/catch`'d so a leaked file (e.g. process killed mid-upload) doesn't break later uploads.
- Web bundle size unchanged — Metro picks the `.web.ts` variant and doesn't pull in `expo-file-system/legacy`.