### PR TITLE
fix(app): scale MAX_CONTEXT_SIZE for 1M models + render alwaysShow before usage streams in

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -571,6 +571,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
             cacheCreation: source.cacheCreation,
             cacheRead: source.cacheRead,
             contextSize: source.contextSize,
+            model: source.model,
         };
     }, [sessionUsage, session.latestUsage]);
 

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -72,6 +72,7 @@ interface AgentInputProps {
         cacheCreation: number;
         cacheRead: number;
         contextSize: number;
+        model?: string;
     };
     alwaysShowContextSize?: boolean;
     onFileViewerPress?: () => void;
@@ -93,7 +94,18 @@ interface AgentInputProps {
     onAddImages?: (images: AttachmentPreview[]) => void;
 }
 
-const MAX_CONTEXT_SIZE = 190000;
+// Effective usable context per model. Anthropic 1M-context variants
+// expose ~950K usable tokens; everything else is treated as 200K (~190K usable).
+// See https://github.com/slopus/happy/issues/910
+const DEFAULT_MAX_CONTEXT_SIZE = 190000;
+const ONE_MILLION_MAX_CONTEXT_SIZE = 950000;
+
+function getMaxContextSize(model?: string): number {
+    if (model && /\[1m\]/i.test(model)) {
+        return ONE_MILLION_MAX_CONTEXT_SIZE;
+    }
+    return DEFAULT_MAX_CONTEXT_SIZE;
+}
 
 const stylesheet = StyleSheet.create((theme, runtime) => ({
     container: {
@@ -300,8 +312,9 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
     },
 }));
 
-const getContextWarning = (contextSize: number, alwaysShow: boolean = false, theme: Theme) => {
-    const percentageUsed = (contextSize / MAX_CONTEXT_SIZE) * 100;
+const getContextWarning = (contextSize: number, alwaysShow: boolean = false, theme: Theme, model?: string) => {
+    const maxContextSize = getMaxContextSize(model);
+    const percentageUsed = (contextSize / maxContextSize) * 100;
     const percentageRemaining = Math.max(0, Math.min(100, 100 - percentageUsed));
 
     if (percentageRemaining <= 5) {
@@ -598,7 +611,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
     // Calculate context warning
     const contextWarning = props.usageData?.contextSize
-        ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme)
+        ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme, props.usageData.model)
         : null;
 
     const agentInputEnterToSend = useSetting('agentInputEnterToSend');

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -609,9 +609,10 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
         return label;
     }, [isSandboxEnabled]);
 
-    // Calculate context warning
-    const contextWarning = props.usageData?.contextSize
-        ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme, props.usageData.model)
+    // Gate on `alwaysShow || contextSize` so the toggle still renders before usage streams in.
+    const alwaysShowContextSize = props.alwaysShowContextSize ?? false;
+    const contextWarning = alwaysShowContextSize || props.usageData?.contextSize
+        ? getContextWarning(props.usageData?.contextSize ?? 0, alwaysShowContextSize, theme, props.usageData?.model)
         : null;
 
     const agentInputEnterToSend = useSetting('agentInputEnterToSend');

--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -161,6 +161,7 @@ export type ReducerState = {
         cacheCreation: number;
         cacheRead: number;
         contextSize: number;
+        model?: string;
         timestamp: number;
     };
 };
@@ -239,6 +240,7 @@ export type ReducerResult = {
         cacheCreation: number;
         cacheRead: number;
         contextSize: number;
+        model?: string;
     };
     hasReadyEvent?: boolean;
 };
@@ -687,7 +689,7 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
 
             // Process usage data if present
             if (msg.usage) {
-                processUsageData(state, msg.usage, msg.createdAt);
+                processUsageData(state, msg.usage, msg.createdAt, msg.model);
             }
 
             // Process text and thinking content (tool calls handled in Phase 2)
@@ -1129,7 +1131,8 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
             outputTokens: state.latestUsage.outputTokens,
             cacheCreation: state.latestUsage.cacheCreation,
             cacheRead: state.latestUsage.cacheRead,
-            contextSize: state.latestUsage.contextSize
+            contextSize: state.latestUsage.contextSize,
+            model: state.latestUsage.model
         } : undefined,
         hasReadyEvent: hasReadyEvent || undefined
     };
@@ -1143,7 +1146,7 @@ function allocateId() {
     return Math.random().toString(36).substring(2, 15);
 }
 
-function processUsageData(state: ReducerState, usage: UsageData, timestamp: number) {
+function processUsageData(state: ReducerState, usage: UsageData, timestamp: number, model?: string) {
     // Only update if this is newer than the current latest usage
     if (!state.latestUsage || timestamp > state.latestUsage.timestamp) {
         state.latestUsage = {
@@ -1152,6 +1155,7 @@ function processUsageData(state: ReducerState, usage: UsageData, timestamp: numb
             cacheCreation: usage.cache_creation_input_tokens || 0,
             cacheRead: usage.cache_read_input_tokens || 0,
             contextSize: (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0) + usage.input_tokens,
+            model,
             timestamp: timestamp
         };
     }

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -125,6 +125,7 @@ export interface Session {
         cacheCreation: number;
         cacheRead: number;
         contextSize: number;
+        model?: string;
         timestamp: number;
     } | null;
 }

--- a/packages/happy-app/sources/sync/typesRaw.ts
+++ b/packages/happy-app/sources/sync/typesRaw.ts
@@ -526,6 +526,7 @@ export type NormalizedMessage = ({
     isSidechain: boolean,
     meta?: MessageMeta,
     usage?: UsageData,
+    model?: string,
     /**
      * Underlying Claude `uuid` for this message — used as the rewind point
      * for the session fork / duplicate flow. Optional because some message
@@ -835,7 +836,8 @@ export function normalizeRawMessage(id: string, localId: string | null, createdA
                     isSidechain: raw.content.data.isSidechain ?? false,
                     content,
                     meta: raw.meta,
-                    usage: raw.content.data.message.usage
+                    usage: raw.content.data.message.usage,
+                    model: raw.content.data.message.model
                 };
             } else if (raw.content.data.type === 'user') {
                 if (!raw.content.data.uuid) {


### PR DESCRIPTION
## Summary

Two related fixes to the **Always Show Context Size** indicator in `AgentInput`. Originally only #910; on rebase I traced #1274 to the same render path and added a one-line gate fix that pairs naturally with the model plumbing.

### Commit 1 — Closes #910 (scale MAX_CONTEXT_SIZE for 1M-context models)
- Context-remaining indicator was hardcoded to **190K**, so any session on a 1M-context Anthropic model (e.g. `claude-opus-4-7[1m]`) clamped to 0% within minutes and the toggle appeared broken.
- Plumb the assistant `model` field from the raw Claude API event through `NormalizedMessage` → reducer `latestUsage` → `Session.latestUsage` → `AgentInput.usageData`.
- `AgentInput` now picks the limit dynamically via `getMaxContextSize(model)`: **950K** for model ids matching `[1m]`, **190K** otherwise.

### Commit 2 — Closes #1274 (render alwaysShow before usage streams in)
- The outer gate at the call site short-circuited to `null` whenever `usageData.contextSize` was `0` or `undefined`:
  ```ts
  const contextWarning = props.usageData?.contextSize
      ? getContextWarning(...)
      : null;
  ```
  …which swallowed the alwaysShow signal that `getContextWarning` itself honors (line 311). Two failure modes this addresses on Android (and silently on iOS/web — same render path):
  1. Fresh session with no agent reply yet — `latestUsage` is undefined, indicator never showed.
  2. Sessions where the reducer resets `contextSize` to 0 on session events (`reducer.ts:324, 338`) with no subsequent assistant message carrying usage.
- Gate is now `alwaysShow || contextSize`, and `getContextWarning` receives `contextSize ?? 0`. On fresh always-show sessions the indicator renders **"100% remaining"** until real usage arrives.

## Files changed
- `sources/sync/typesRaw.ts` — capture `message.model` when normalizing assistant messages; add `model?: string` to `NormalizedMessage`.
- `sources/sync/reducer/reducer.ts` — thread `model` through `processUsageData` / `ReducerState.latestUsage` / `ReducerResult.usage`.
- `sources/sync/storageTypes.ts` — add `model?: string` to persisted `Session.latestUsage`.
- `sources/-session/SessionView.tsx` — thread `model` into the memoized `usageData` source mapping.
- `sources/components/AgentInput.tsx` — `getMaxContextSize(model)` helper + rewrite the `contextWarning` gate to honor `alwaysShow` when usage is missing.

## Test plan
- [x] `pnpm typecheck` in `packages/happy-app` passes.
- [x] `pnpm test --run` in `packages/happy-app` — **identical** failure baseline to `main` (11 failed / 466 passed / 57 skipped on both branches; failures are pre-existing markdown, GitHub API, settings-defaults, and model-mode tests untouched by this PR).
- [ ] Manual: open a session on `claude-opus-4-7[1m]` with **Always Show Context Size** enabled; the percentage should reflect 1M-token usage rather than sticking at 0%.
- [ ] Manual: open a 200K-context session (Sonnet/Haiku); behavior unchanged.
- [ ] Manual: enable **Always Show Context Size** on a fresh session (no agent reply yet) — the indicator should render "100% remaining" immediately rather than waiting for usage.

## Notes
- `[1m]` detection is `/\[1m\]/i` against the model id returned by the Claude API stream. Happy to switch to an explicit lookup table if you'd prefer.
- `model` is optional throughout — pre-existing sessions and non-Claude flavors keep working with the 190K default.
- Rebased onto `main` (270+ commits since the original PR); `SessionView.tsx` was reconciled with the new memoized `usageData` introduced in main.

Closes #910
Closes #1274
