### PR TITLE
fix(cli): clarify missing agent key recovery

### DIFF
--- a/packages/happy-cli/src/resume/resolveHappySession.test.ts
+++ b/packages/happy-cli/src/resume/resolveHappySession.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveSessionRecordByPrefix } from './resolveHappySession';
+import { missingAgentCredentialMessage, resolveSessionRecordByPrefix } from './resolveHappySession';
+
+describe('missingAgentCredentialMessage', () => {
+    it('distinguishes the Happy Agent credential from normal CLI auth', () => {
+        const message = missingAgentCredentialMessage('/home/me/.happy/agent.key');
+
+        expect(message).toContain('/home/me/.happy/agent.key');
+        expect(message).toContain('normal `happy auth login` only creates `access.key`');
+        expect(message).toContain('happy-agent auth login');
+    });
+});
 
 describe('resolveSessionRecordByPrefix', () => {
     const sessions = [

--- a/packages/happy-cli/src/resume/resolveHappySession.ts
+++ b/packages/happy-cli/src/resume/resolveHappySession.ts
@@ -77,13 +77,19 @@ function decryptBoxBundle(bundle: Uint8Array, recipientSecretKey: Uint8Array): U
     return decrypted ? new Uint8Array(decrypted) : null;
 }
 
+export function missingAgentCredentialMessage(credentialPath: string): string {
+    return [
+        `Cannot resume historical Happy sessions without ${credentialPath}.`,
+        'This is the Happy Agent credential file; normal `happy auth login` only creates `access.key`.',
+        'Restore the original `agent.key`, or authenticate the Happy Agent CLI with `happy-agent auth login` in this environment.',
+    ].join(' ');
+}
+
 function readAgentCredentials() {
     const credentialPath = getLocalHappyAgentCredentialPath();
     const credentials = readLocalHappyAgentCredentials();
     if (!credentials) {
-        throw new Error(
-            `Cannot resume historical Happy sessions without ${credentialPath}. Run \`happy-agent auth login\` in this environment first.`,
-        );
+        throw new Error(missingAgentCredentialMessage(credentialPath));
     }
     return credentials;
 }


### PR DESCRIPTION
## Summary
- clarify the historical session resume error when `agent.key` is missing
- distinguish Happy Agent credentials from normal `happy auth login` / `access.key`
- add a focused regression test for the recovery message

Fixes #1264

## Tests
- `git diff --check`
- `pnpm --filter happy typecheck`
- `pnpm --filter happy exec vitest run src/resume/resolveHappySession.test.ts`