### PR TITLE
feat: Add first-class support for Kimi CLI via ACP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ happy-workspaces/
 
 # third party tools
 .supervibe/
+node-compile-cache/

--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -33,6 +33,7 @@ This will:
 ```
 happy codex
 happy gemini
+happy kimi
 happy openclaw
 
 # or any ACP-compatible CLI
@@ -100,6 +101,7 @@ happy connect status
 | `happy` | Start Claude Code session (default) |
 | `happy codex` | Start Codex mode |
 | `happy gemini` | Start Gemini CLI session |
+| `happy kimi` | Start Kimi CLI session |
 | `happy openclaw` | Start OpenClaw session |
 | `happy acp` | Start any ACP-compatible agent |
 | `happy resume <id>` | Resume a previous session |

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { KNOWN_ACP_AGENTS, resolveAcpAgentConfig } from './acpAgentConfig';
 
 describe('KNOWN_ACP_AGENTS', () => {
-  it('defines built-in Gemini and OpenCode command mappings', () => {
+  it('defines built-in Gemini, OpenCode, and Kimi command mappings', () => {
     expect(KNOWN_ACP_AGENTS).toEqual({
       gemini: { command: 'gemini', args: ['--experimental-acp'] },
       opencode: { command: 'opencode', args: ['acp'] },
+      kimi: { command: 'kimi', args: ['acp'] },
     });
   });
 });
@@ -16,6 +17,11 @@ describe('resolveAcpAgentConfig', () => {
       agentName: 'gemini',
       command: 'gemini',
       args: ['--experimental-acp'],
+    });
+    expect(resolveAcpAgentConfig(['kimi'])).toEqual({
+      agentName: 'kimi',
+      command: 'kimi',
+      args: ['acp'],
     });
   });
 

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
@@ -6,6 +6,7 @@ export type AcpAgentConfig = {
 export const KNOWN_ACP_AGENTS: Record<string, AcpAgentConfig> = {
   gemini: { command: 'gemini', args: ['--experimental-acp'] },
   opencode: { command: 'opencode', args: ['acp'] },
+  kimi: { command: 'kimi', args: ['acp'] },
 };
 
 export type ResolvedAcpAgentConfig = {

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -436,12 +436,15 @@ type PendingTurn = {
   timeout: NodeJS.Timeout;
 };
 
-function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'acp' {
+function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'kimi' | 'acp' {
   if (agentName === 'gemini') {
     return 'gemini';
   }
   if (agentName === 'opencode') {
     return 'opencode';
+  }
+  if (agentName === 'kimi') {
+    return 'kimi';
   }
   return 'acp';
 }

--- a/packages/happy-cli/src/agent/core/AgentBackend.ts
+++ b/packages/happy-cli/src/agent/core/AgentBackend.ts
@@ -48,7 +48,7 @@ export interface McpServerConfig {
 export type AgentTransport = 'native-claude' | 'mcp-codex' | 'acp';
 
 /** Agent identifier */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'claude-acp' | 'codex-acp';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'claude-acp' | 'codex-acp' | 'kimi';
 
 /**
  * Configuration for creating an agent backend

--- a/packages/happy-cli/src/agent/factories/index.ts
+++ b/packages/happy-cli/src/agent/factories/index.ts
@@ -15,6 +15,14 @@ export {
   type GeminiBackendResult,
 } from './gemini';
 
+// Kimi factory
+export {
+  createKimiBackend,
+  registerKimiAgent,
+  type KimiBackendOptions,
+  type KimiBackendResult,
+} from './kimi';
+
 // Future factories:
 // export { createCodexBackend, registerCodexAgent, type CodexBackendOptions } from './codex';
 // export { createClaudeBackend, registerClaudeAgent, type ClaudeBackendOptions } from './claude';

--- a/packages/happy-cli/src/agent/factories/kimi.test.ts
+++ b/packages/happy-cli/src/agent/factories/kimi.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createKimiBackend, registerKimiAgent } from './kimi';
+import { agentRegistry } from '../core';
+
+describe('createKimiBackend', () => {
+  it('creates a backend with default options', () => {
+    const result = createKimiBackend({ cwd: '/tmp' });
+    expect(result.backend).toBeDefined();
+    expect(result.model).toBeNull();
+  });
+
+  it('passes through apiKey and model', () => {
+    const result = createKimiBackend({
+      cwd: '/tmp',
+      apiKey: 'test-key',
+      model: 'kimi-k2.6',
+    });
+    expect(result.backend).toBeDefined();
+    expect(result.model).toBe('kimi-k2.6');
+  });
+});
+
+describe('registerKimiAgent', () => {
+  it('registers kimi in the global agent registry', () => {
+    registerKimiAgent();
+    expect(agentRegistry.has('kimi')).toBe(true);
+    expect(agentRegistry.list()).toContain('kimi');
+  });
+});

--- a/packages/happy-cli/src/agent/factories/kimi.ts
+++ b/packages/happy-cli/src/agent/factories/kimi.ts
@@ -1,0 +1,95 @@
+/**
+ * Kimi ACP Backend - Kimi CLI agent via ACP
+ *
+ * This module provides a factory function for creating a Kimi backend
+ * that communicates using the Agent Client Protocol (ACP).
+ *
+ * Kimi CLI supports ACP mode via the `kimi acp` command.
+ */
+
+import { AcpBackend, type AcpBackendOptions, type AcpPermissionHandler } from '../acp/AcpBackend';
+import type { AgentBackend, McpServerConfig, AgentFactoryOptions } from '../core';
+import { agentRegistry } from '../core';
+import { DefaultTransport } from '../transport';
+import { logger } from '@/ui/logger';
+
+/**
+ * Options for creating a Kimi ACP backend
+ */
+export interface KimiBackendOptions extends AgentFactoryOptions {
+  /** API key for Kimi (defaults to KIMI_API_KEY env var) */
+  apiKey?: string;
+
+  /** Model to use. If undefined, Kimi CLI will use its config default. */
+  model?: string | null;
+
+  /** MCP servers to make available to the agent */
+  mcpServers?: Record<string, McpServerConfig>;
+
+  /** Optional permission handler for tool approval */
+  permissionHandler?: AcpPermissionHandler;
+}
+
+/**
+ * Result of creating a Kimi backend
+ */
+export interface KimiBackendResult {
+  /** The created AgentBackend instance */
+  backend: AgentBackend;
+  /** The resolved model that will be used */
+  model: string | null;
+}
+
+/**
+ * Create a Kimi backend using ACP.
+ *
+ * The Kimi CLI must be installed and available in PATH.
+ * Uses the `kimi acp` command to enable ACP mode.
+ *
+ * @param options - Configuration options
+ * @returns KimiBackendResult with backend and resolved model
+ */
+export function createKimiBackend(options: KimiBackendOptions): KimiBackendResult {
+  const apiKey = options.apiKey || process.env.KIMI_API_KEY || undefined;
+  const model = options.model ?? null;
+
+  const backendOptions: AcpBackendOptions = {
+    agentName: 'kimi',
+    cwd: options.cwd,
+    command: 'kimi',
+    args: ['acp'],
+    env: {
+      ...options.env,
+      ...(apiKey ? { KIMI_API_KEY: apiKey } : {}),
+      ...(model ? { KIMI_MODEL: model } : {}),
+    },
+    mcpServers: options.mcpServers,
+    permissionHandler: options.permissionHandler,
+    transportHandler: new DefaultTransport('kimi'),
+  };
+
+  logger.debug('[Kimi] Creating ACP backend with options:', {
+    cwd: backendOptions.cwd,
+    command: backendOptions.command,
+    args: backendOptions.args,
+    hasApiKey: !!apiKey,
+    model: model,
+    mcpServerCount: options.mcpServers ? Object.keys(options.mcpServers).length : 0,
+  });
+
+  return {
+    backend: new AcpBackend(backendOptions),
+    model,
+  };
+}
+
+/**
+ * Register Kimi backend with the global agent registry.
+ *
+ * This function should be called during application initialization
+ * to make the Kimi agent available for use.
+ */
+export function registerKimiAgent(): void {
+  agentRegistry.register('kimi', (opts) => createKimiBackend(opts).backend);
+  logger.debug('[Kimi] Registered with agent registry');
+}

--- a/packages/happy-cli/src/agent/index.ts
+++ b/packages/happy-cli/src/agent/index.ts
@@ -40,5 +40,7 @@ export function initializeAgents(): void {
   // Import and register agents from factories
   const { registerGeminiAgent } = require('./factories/gemini');
   registerGeminiAgent();
+  const { registerKimiAgent } = require('./factories/kimi');
+  registerKimiAgent();
 }
 

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -354,6 +354,33 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       process.exit(1)
     }
     return;
+  } else if (subcommand === 'kimi') {
+    // Handle kimi command (ACP-based agent)
+    try {
+      const { runKimi } = await import('@/kimi/runKimi');
+
+      let startedBy: 'daemon' | 'terminal' | undefined = undefined;
+      let verbose = false;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === '--started-by') {
+          startedBy = args[++i] as 'daemon' | 'terminal';
+        } else if (args[i] === '--verbose') {
+          verbose = true;
+        }
+      }
+
+      const { credentials } = await authAndSetupMachineIfNeeded();
+      await ensureDaemonRunning();
+
+      await runKimi({ credentials, startedBy, verbose });
+    } catch (error) {
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error');
+      if (process.env.DEBUG) {
+        console.error(error);
+      }
+      process.exit(1);
+    }
+    return;
   } else if (subcommand === 'acp') {
     try {
       const { runAcp, resolveAcpAgentConfig } = await import('@/agent/acp');
@@ -679,6 +706,7 @@ ${chalk.bold('Usage:')}
   happy resume            Resume a previous Happy session by Happy session ID
   happy codex             Start Codex mode
   happy gemini            Start Gemini mode (ACP)
+  happy kimi              Start Kimi mode (ACP)
   happy acp               Start a generic ACP-compatible agent
   happy connect           Connect AI vendor API keys
   happy sandbox           Configure and manage OS-level sandboxing

--- a/packages/happy-cli/src/kimi/runKimi.ts
+++ b/packages/happy-cli/src/kimi/runKimi.ts
@@ -1,0 +1,25 @@
+/**
+ * Kimi CLI Entry Point
+ *
+ * This module provides the main entry point for running the Kimi agent
+ * through Happy CLI. It is a thin wrapper around the generic ACP runner,
+ * since Kimi CLI natively supports the Agent Client Protocol via `kimi acp`.
+ */
+
+import { runAcp } from '@/agent/acp';
+import type { Credentials } from '@/persistence';
+
+export async function runKimi(opts: {
+  credentials: Credentials;
+  startedBy?: 'daemon' | 'terminal';
+  verbose?: boolean;
+}): Promise<void> {
+  await runAcp({
+    credentials: opts.credentials,
+    startedBy: opts.startedBy,
+    verbose: opts.verbose,
+    agentName: 'kimi',
+    command: 'kimi',
+    args: ['acp'],
+  });
+}

--- a/packages/happy-cli/src/utils/createSessionMetadata.ts
+++ b/packages/happy-cli/src/utils/createSessionMetadata.ts
@@ -19,7 +19,7 @@ import packageJson from '../../package.json';
 /**
  * Backend flavor identifier for session metadata.
  */
-export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'acp';
+export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'acp' | 'kimi';
 
 /**
  * Options for creating session metadata.


### PR DESCRIPTION
## Summary
  Add first-class support for [Kimi CLI](https://github.com/MoonshotAI/Kimi-cli) as a new agent provider in Happy.

  ## Changes
  - New `happy kimi` CLI command
  - Registers Kimi as a known ACP agent (`kimi acp`)
  - Reuses existing `AcpBackend` and `runAcp` infrastructure
  - Adds `kimi` to `AgentId`, `BackendFlavor`, and `KNOWN_ACP_AGENTS`
  - Adds tests for Kimi backend factory and ACP agent config
  - Updates README with `happy kimi` usage

  ## Why
  Kimi CLI natively supports the Agent Client Protocol (ACP) via `kimi acp`. Since Happy already has a generic ACP runner and first-class Gemini support via the s
  ame protocol, adding Kimi requires minimal code while giving users a seamless experience.

  ## Testing
  - [x] `happy kimi` starts successfully
  - [x] ACP handshake completes (initialize → newSession)
  - [x] Prompts flow correctly (user → Kimi → user)
  - [x] Thinking and message chunks render correctly
  - [x] Remote sync to Happy App works
  - [x] TypeScript compiles with zero errors
  - [x] Unit tests pass (16/16)

  ## Screenshot / Log
  [10:32] Happy Session ID: cmp7qdocn8nknwk0ui9ac73wk [10:32] Status: idle [10:32] Incoming prompt: 你好 [10:32] Status: running [10:32] Outgoing message: "你好！
  我是 Kimi Code CLI，很高兴为你服务..." [10:32] Status: idle