### PR TITLE
fix(acp): forward usage_update + warn on unhandled session updates

### DIFF
--- a/packages/happy-cli/src/agent/acp/AcpBackend.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentMessage } from '@/agent/core';
+import { logger } from '@/ui/logger';
+import { AcpBackend } from './AcpBackend';
+
+function createBackend(): AcpBackend {
+  return new AcpBackend({
+    agentName: 'test',
+    cwd: '/tmp',
+    command: '/bin/true',
+  });
+}
+
+function captureEvents(backend: AcpBackend): AgentMessage[] {
+  const events: AgentMessage[] = [];
+  backend.onMessage((msg) => events.push(msg));
+  return events;
+}
+
+// `handleSessionUpdate` is a private method on AcpBackend; cast to access for unit tests.
+function dispatchUpdate(backend: AcpBackend, update: Record<string, unknown>): void {
+  (backend as unknown as { handleSessionUpdate(params: unknown): void }).handleSessionUpdate({
+    sessionId: 'test',
+    update,
+  });
+}
+
+describe('AcpBackend.handleSessionUpdate', () => {
+  describe('usage_update routing', () => {
+    it('forwards usage_update with size/used as event AgentMessage', () => {
+      const backend = createBackend();
+      const events = captureEvents(backend);
+
+      dispatchUpdate(backend, {
+        sessionUpdate: 'usage_update',
+        size: 100000,
+        used: 5000,
+      });
+
+      expect(events).toEqual([
+        {
+          type: 'event',
+          name: 'usage_update',
+          payload: { size: 100000, used: 5000 },
+        },
+      ]);
+    });
+
+    it('includes optional cost when present', () => {
+      const backend = createBackend();
+      const events = captureEvents(backend);
+
+      dispatchUpdate(backend, {
+        sessionUpdate: 'usage_update',
+        size: 100000,
+        used: 12345,
+        cost: { amount: 0.42, currency: 'USD' },
+      });
+
+      expect(events[0]).toEqual({
+        type: 'event',
+        name: 'usage_update',
+        payload: {
+          size: 100000,
+          used: 12345,
+          cost: { amount: 0.42, currency: 'USD' },
+        },
+      });
+    });
+
+    it('ignores usage_update with non-numeric size or used', () => {
+      const backend = createBackend();
+      const events = captureEvents(backend);
+
+      dispatchUpdate(backend, {
+        sessionUpdate: 'usage_update',
+        size: 'oops',
+        used: 5000,
+      });
+
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe('unhandled session update warning', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {
+        // Suppress test output noise.
+      });
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns on unknown sessionUpdate type so missing routes surface', () => {
+      const backend = createBackend();
+
+      dispatchUpdate(backend, {
+        sessionUpdate: 'some_future_type',
+        someField: 'value',
+      });
+
+      expect(warnSpy).toHaveBeenCalledOnce();
+      const message = String(warnSpy.mock.calls[0][0] ?? '');
+      expect(message).toContain('Unhandled session update type: some_future_type');
+    });
+
+    it('does NOT warn on known types', () => {
+      const backend = createBackend();
+
+      dispatchUpdate(backend, {
+        sessionUpdate: 'usage_update',
+        size: 1,
+        used: 1,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/happy-cli/src/agent/acp/AcpBackend.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.test.ts
@@ -69,6 +69,28 @@ describe('AcpBackend.handleSessionUpdate', () => {
       });
     });
 
+    it('preserves explicit null cost when present', () => {
+      const backend = createBackend();
+      const events = captureEvents(backend);
+
+      dispatchUpdate(backend, {
+        sessionUpdate: 'usage_update',
+        size: 100000,
+        used: 12345,
+        cost: null,
+      });
+
+      expect(events[0]).toEqual({
+        type: 'event',
+        name: 'usage_update',
+        payload: {
+          size: 100000,
+          used: 12345,
+          cost: null,
+        },
+      });
+    });
+
     it('ignores usage_update with non-numeric size or used', () => {
       const backend = createBackend();
       const events = captureEvents(backend);

--- a/packages/happy-cli/src/agent/acp/AcpBackend.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.test.ts
@@ -120,5 +120,16 @@ describe('AcpBackend.handleSessionUpdate', () => {
 
       expect(warnSpy).not.toHaveBeenCalled();
     });
+
+    it('does NOT warn on standard session_info_update metadata updates', () => {
+      const backend = createBackend();
+
+      dispatchUpdate(backend, {
+        sessionUpdate: 'session_info_update',
+        title: 'Updated title',
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -1007,13 +1007,31 @@ export class AcpBackend implements AgentBackend {
       return;
     }
 
+    // ACP spec: `UsageUpdate { size: number, used: number, cost?: { amount, currency } }`.
+    // Forwarded as an `event` AgentMessage; downstream socket/UI forwarding is a follow-up.
+    if (updateType === 'usage_update') {
+      const usage = update as { size?: unknown; used?: unknown; cost?: unknown };
+      if (typeof usage.size === 'number' && typeof usage.used === 'number') {
+        this.emit({
+          type: 'event',
+          name: 'usage_update',
+          payload: {
+            size: usage.size,
+            used: usage.used,
+            ...(usage.cost && typeof usage.cost === 'object' ? { cost: usage.cost } : {}),
+          },
+        });
+      }
+      return;
+    }
+
     // Handle legacy and auxiliary update types
     handleLegacyMessageChunk(update as SessionUpdate, ctx);
     handlePlanUpdate(update as SessionUpdate, ctx);
     handleThinkingUpdate(update as SessionUpdate, ctx);
 
-    // Log unhandled session update types for debugging
-    // Cast to string to avoid TypeScript errors (SDK types don't include all Gemini-specific update types)
+    // Log unhandled session update types so missing routes surface to maintainers.
+    // Cast to string because SDK types don't include all Gemini-specific update types.
     const handledTypes = [
       'agent_message_chunk',
       'tool_call_update',
@@ -1023,13 +1041,14 @@ export class AcpBackend implements AgentBackend {
       'config_option_update',
       'config_options_update',
       'current_mode_update',
+      'usage_update',
     ];
     if (updateType &&
         !handledTypes.includes(updateType) &&
         !update.messageChunk &&
         !update.plan &&
         !update.thinking) {
-      logger.debug(`[AcpBackend] Unhandled session update type: ${updateType}`, JSON.stringify(update, null, 2));
+      logger.warn(`[AcpBackend] Unhandled session update type: ${updateType}`, JSON.stringify(update, null, 2));
     }
   }
 

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -1042,6 +1042,7 @@ export class AcpBackend implements AgentBackend {
       'config_options_update',
       'current_mode_update',
       'usage_update',
+      'session_info_update',
     ];
     if (updateType &&
         !handledTypes.includes(updateType) &&

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -1012,14 +1012,20 @@ export class AcpBackend implements AgentBackend {
     if (updateType === 'usage_update') {
       const usage = update as { size?: unknown; used?: unknown; cost?: unknown };
       if (typeof usage.size === 'number' && typeof usage.used === 'number') {
+        const payload: { size: number; used: number; cost?: unknown } = {
+          size: usage.size,
+          used: usage.used,
+        };
+        if (
+          Object.prototype.hasOwnProperty.call(usage, 'cost') &&
+          (usage.cost === null || typeof usage.cost === 'object')
+        ) {
+          payload.cost = usage.cost;
+        }
         this.emit({
           type: 'event',
           name: 'usage_update',
-          payload: {
-            size: usage.size,
-            used: usage.used,
-            ...(usage.cost && typeof usage.cost === 'object' ? { cost: usage.cost } : {}),
-          },
+          payload,
         });
       }
       return;


### PR DESCRIPTION
## Summary
- Dispatch `usage_update` session updates in `AcpBackend.handleSessionUpdate`, emitting an `event` AgentMessage with `{ size, used, cost? }` per ACP spec (`UsageUpdate { size, used, cost? }` in `@agentclientprotocol/sdk@0.14.1`).
- Add `'usage_update'` to the `handledTypes` whitelist.
- Promote the unhandled-type log from `logger.debug` to `logger.warn` so missing routes surface to maintainers instead of being silently absorbed.

## Why
Spec-compliant ACP agents emit `usage_update` to report context window usage (`size` / `used`) and cumulative session cost. Today these updates fall through to the silent `logger.debug` line in `handleSessionUpdate`, so context-usage progress never reaches downstream consumers (socket / mobile UI).

This PR builds the in-process signal. Downstream forwarding (e.g. mapping the new `event` AgentMessage to the existing `'usage-report'` socket.io event in `apiSession.ts`, or rendering it in the mobile app) is intentionally left as a follow-up to keep this diff focused on protocol routing.

The unhandled-type log at `logger.debug` was effectively invisible — when a new ACP `SessionUpdate` variant lands upstream we had no signal that it needs to be wired up. `logger.warn` makes the gap visible to maintainers without disrupting users; it still only fires on truly unrecognized types (not the legacy `messageChunk` / `plan` / `thinking` shapes that already have explicit fallback handlers).

## Scope
- Touches **only** `packages/happy-cli/src/agent/acp/AcpBackend.ts` plus a new colocated `AcpBackend.test.ts`.
- Does NOT change `runAcp.ts`, `apiSession.ts`, the mobile app, the socket schema, or `AcpSessionManager.ts`.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes, no new TypeScript errors
- [x] \`pnpm exec vitest run src/agent/acp/AcpBackend.test.ts\` — 5 new tests pass
- [x] \`pnpm exec vitest run src/agent/acp/\` — all 53 ACP unit tests pass (no regressions)

New tests cover:
- \`usage_update\` with numeric \`size\`/\`used\` is forwarded as \`{ type: 'event', name: 'usage_update', payload: { size, used } }\`.
- Optional \`cost\` is included in the payload when present.
- Non-numeric \`size\` / \`used\` is rejected (no emit).
- Unknown session update types trigger \`logger.warn\` with the type name.
- Known types do NOT trigger \`logger.warn\`.

## Spec references
- ACP SDK v0.14.1 / protocol v1: \`UsageUpdate { size: number, used: number, cost?: Cost | null }\` and \`Cost { amount, currency }\` (\`@agentclientprotocol/sdk@0.14.1\`, \`dist/schema/types.gen.d.ts\` lines 418–431 and 2757–2780).
- \`SessionUpdate\` discriminator: \`sessionUpdate: 'usage_update'\`.