### PR TITLE
chore(acp): hoist change_title constant + redact prompt debug log

### DIFF
--- a/packages/happy-cli/src/agent/acp/AcpBackend.prompt-redaction.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.prompt-redaction.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { logger } from '@/ui/logger';
+import { AcpBackend } from './AcpBackend';
+
+function createBackend(): AcpBackend {
+  return new AcpBackend({
+    agentName: 'test',
+    cwd: '/tmp',
+    command: '/bin/true',
+  });
+}
+
+function stubConnection(backend: AcpBackend): void {
+  // `sendPrompt` short-circuits when these aren't set; stub them so the
+  // happy-path log calls fire without spawning a real ACP agent.
+  (backend as unknown as { acpSessionId: string }).acpSessionId = 'test-session';
+  (backend as unknown as { connection: { prompt: (...args: unknown[]) => Promise<unknown> } }).connection = {
+    prompt: vi.fn(async () => ({})),
+  };
+}
+
+function joinDebugMessages(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls
+    .map((call) =>
+      call
+        .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+        .join(' '),
+    )
+    .join('\n');
+}
+
+describe('AcpBackend.sendPrompt — prompt log redaction', () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {
+      // Suppress noise in test output.
+    });
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  it('never logs the prompt body verbatim', async () => {
+    const backend = createBackend();
+    stubConnection(backend);
+    const secret = 'API_KEY=sk-leak-via-debug-log';
+
+    await backend.sendPrompt('test-session', secret);
+
+    const allDebugMessages = joinDebugMessages(debugSpy);
+    expect(allDebugMessages).not.toContain(secret);
+  });
+
+  it('logs the prompt length so debugging context is still available', async () => {
+    const backend = createBackend();
+    stubConnection(backend);
+    const prompt = 'hello world'; // length 11
+
+    await backend.sendPrompt('test-session', prompt);
+
+    const allDebugMessages = joinDebugMessages(debugSpy);
+    expect(allDebugMessages).toContain('length: 11');
+  });
+
+  it('logs the sessionId and block count without dumping the request body', async () => {
+    const backend = createBackend();
+    stubConnection(backend);
+
+    await backend.sendPrompt('test-session', 'whatever');
+
+    const allDebugMessages = joinDebugMessages(debugSpy);
+    expect(allDebugMessages).toContain('sessionId=test-session');
+    expect(allDebugMessages).toContain('blocks=1');
+    // The pre-redaction code path dumped `JSON.stringify(promptRequest, null, 2)`
+    // which embedded the prompt text inside a `text` field — guard against
+    // accidentally reintroducing that.
+    expect(allDebugMessages).not.toMatch(/"text":\s*"whatever"/);
+  });
+});

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -1060,9 +1060,10 @@ export class AcpBackend implements AgentBackend {
     this.waitingForResponse = true;
 
     try {
-      logger.debug(`[AcpBackend] Sending prompt (length: ${prompt.length}): ${prompt.substring(0, 100)}...`);
-      logger.debug(`[AcpBackend] Full prompt: ${prompt}`);
-      
+      // Log only the prompt length, never the contents, to avoid leaking
+      // user/system prompts (secrets, PII, internal instructions) into log files.
+      logger.debug(`[AcpBackend] Sending prompt (length: ${prompt.length})`);
+
       const contentBlock: ContentBlock = {
         type: 'text',
         text: prompt,
@@ -1073,7 +1074,9 @@ export class AcpBackend implements AgentBackend {
         prompt: [contentBlock],
       };
 
-      logger.debug(`[AcpBackend] Prompt request:`, JSON.stringify(promptRequest, null, 2));
+      logger.debug(
+        `[AcpBackend] Prompt request sessionId=${promptRequest.sessionId} blocks=${promptRequest.prompt.length}`,
+      );
       await this.connection.prompt(promptRequest);
       logger.debug('[AcpBackend] Prompt request sent to ACP connection');
       

--- a/packages/happy-cli/src/agent/constants/happyChangeTitleTool.ts
+++ b/packages/happy-cli/src/agent/constants/happyChangeTitleTool.ts
@@ -1,0 +1,9 @@
+/**
+ * The fully-qualified MCP tool name for Happy's `change_title` tool, which lets
+ * agents rename the current session. Each agent (Claude, Gemini, Codex) exposes
+ * this MCP tool, plus a few legacy variants (`change_title`, `change-title`,
+ * `happy__change_title`); the constant below de-duplicates the spec-correct
+ * form across permission whitelists, transport pattern lists, and prompt
+ * heuristics so the canonical string lives in one place.
+ */
+export const HAPPY_CHANGE_TITLE_TOOL_NAME = 'mcp__happy__change_title' as const;

--- a/packages/happy-cli/src/agent/factories/gemini.ts
+++ b/packages/happy-cli/src/agent/factories/gemini.ts
@@ -9,6 +9,7 @@
  */
 
 import { AcpBackend, type AcpBackendOptions, type AcpPermissionHandler } from '../acp/AcpBackend';
+import { HAPPY_CHANGE_TITLE_TOOL_NAME } from '../constants/happyChangeTitleTool';
 import type { AgentBackend, McpServerConfig, AgentFactoryOptions } from '../core';
 import { agentRegistry } from '../core';
 import { geminiTransport } from '../transport';
@@ -150,7 +151,7 @@ export function createGeminiBackend(options: GeminiBackendOptions): GeminiBacken
       return lower.includes('change_title') ||
              lower.includes('change title') ||
              lower.includes('set title') ||
-             lower.includes('mcp__happy__change_title');
+             lower.includes(HAPPY_CHANGE_TITLE_TOOL_NAME);
     },
   };
 

--- a/packages/happy-cli/src/agent/transport/handlers/GeminiTransport.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/GeminiTransport.ts
@@ -20,6 +20,7 @@ import type {
   ToolNameContext,
 } from '../TransportHandler';
 import type { AgentMessage } from '../../core';
+import { HAPPY_CHANGE_TITLE_TOOL_NAME } from '../../constants/happyChangeTitleTool';
 import { logger } from '@/ui/logger';
 
 /**
@@ -58,7 +59,7 @@ interface ExtendedToolPattern extends ToolPattern {
 const GEMINI_TOOL_PATTERNS: ExtendedToolPattern[] = [
   {
     name: 'change_title',
-    patterns: ['change_title', 'change-title', 'happy__change_title', 'mcp__happy__change_title'],
+    patterns: ['change_title', 'change-title', 'happy__change_title', HAPPY_CHANGE_TITLE_TOOL_NAME],
     inputFields: ['title'],
     emptyInputDefault: true, // change_title often has empty input (title extracted from context)
   },

--- a/packages/happy-cli/src/codex/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/codex/utils/permissionHandler.ts
@@ -8,6 +8,7 @@
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
 import type { AgentState } from "@/api/types";
+import { HAPPY_CHANGE_TITLE_TOOL_NAME } from '@/agent/constants/happyChangeTitleTool';
 import {
     BasePermissionHandler,
     PermissionResult,
@@ -26,7 +27,7 @@ export class CodexPermissionHandler extends BasePermissionHandler {
     // and the MCP-qualified form for defense in depth.
     private static readonly ALWAYS_AUTO_APPROVE_NAMES: ReadonlySet<string> = new Set([
         'change_title',
-        'mcp__happy__change_title',
+        HAPPY_CHANGE_TITLE_TOOL_NAME,
     ]);
 
     // Tool-call IDs that should auto-approve when they exactly match one of

--- a/packages/happy-cli/src/gemini/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/gemini/utils/permissionHandler.ts
@@ -8,6 +8,7 @@
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
 import type { PermissionMode } from '@/api/types';
+import { HAPPY_CHANGE_TITLE_TOOL_NAME } from '@/agent/constants/happyChangeTitleTool';
 import {
     BasePermissionHandler,
     PermissionResult,
@@ -62,7 +63,7 @@ export class GeminiPermissionHandler extends BasePermissionHandler {
         const alwaysAutoApproveNames: ReadonlySet<string> = new Set([
             'change_title',
             'happy__change_title',
-            'mcp__happy__change_title',
+            HAPPY_CHANGE_TITLE_TOOL_NAME,
             'GeminiReasoning',
             'CodexReasoning',
             'think',


### PR DESCRIPTION
## Summary
Two related hygiene fixes around the ACP backend code path.

### 1. Hoist `mcp__happy__change_title` into a single constant
The fully-qualified MCP tool name for Happy's session-rename tool was hard-coded as a string literal in four sites:
- \`packages/happy-cli/src/codex/utils/permissionHandler.ts\` — auto-approval whitelist
- \`packages/happy-cli/src/gemini/utils/permissionHandler.ts\` — auto-approval whitelist
- \`packages/happy-cli/src/agent/transport/handlers/GeminiTransport.ts\` — tool name pattern matcher
- \`packages/happy-cli/src/agent/factories/gemini.ts\` — \`hasChangeTitleInstruction\` prompt heuristic

This PR introduces \`HAPPY_CHANGE_TITLE_TOOL_NAME\` in a new \`packages/happy-cli/src/agent/constants/happyChangeTitleTool.ts\` and references it from each site. No behavioral change — the legacy short variants (\`change_title\`, \`change-title\`, \`happy__change_title\`) stay inline where they were, since each site uses a different subset.

### 2. Stop logging the prompt body in \`AcpBackend.sendPrompt\`
Previously \`sendPrompt\` emitted three \`logger.debug\` lines per prompt that all dumped the prompt verbatim:
- \`Sending prompt (length: N): \${prompt.substring(0, 100)}...\` — first 100 chars
- \`Full prompt: \${prompt}\` — the entire prompt
- \`Prompt request: \${JSON.stringify(promptRequest, null, 2)}\` — re-embedded as a \`text\` field inside the JSON dump

User and system prompts can contain secrets (API keys, tokens, credentials), PII, or internal instructions. Debug log files are routinely rotated, shared, or attached to bug reports, so verbatim logging is a privacy hole. After this PR \`sendPrompt\` logs only:
- \`Sending prompt (length: N)\`
- \`Prompt request sessionId=… blocks=N\`

The new \`AcpBackend.prompt-redaction.test.ts\` locks the behavior in.

## Scope
- Touches \`packages/happy-cli/\` only.
- New file: \`src/agent/constants/happyChangeTitleTool.ts\`.
- New test: \`src/agent/acp/AcpBackend.prompt-redaction.test.ts\`.
- Existing files modified: \`AcpBackend.ts\`, \`factories/gemini.ts\`, \`transport/handlers/GeminiTransport.ts\`, \`codex/utils/permissionHandler.ts\`, \`gemini/utils/permissionHandler.ts\`.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/agent/acp/\` — 51 tests pass (incl. 3 new redaction tests)
- [x] \`pnpm exec vitest run src/codex/__tests__/permissionHandler.test.ts\` — 5 tests pass (codex auto-approval whitelist still works after const refactor)

New redaction tests cover:
- \`sendPrompt\` never logs the prompt body verbatim, even with sensitive content.
- \`length: N\` is still logged so debugging context is preserved.
- \`sessionId\` and \`blocks=N\` are logged without dumping the request body.
- Regression guard against re-introducing a JSON-embedded \`text\` field.

## Notes
The fully-qualified name \`mcp__happy__change_title\` still appears in two non-runtime places intentionally:
- \`packages/happy-cli/src/claude/utils/systemPrompt.ts\` — a static instruction string for the agent, where a \`const\` would couple the prompt template to the constant.
- \`packages/happy-cli/src/claude/claude.integration.test.ts\` — integration test fixtures; left as literals so the test reads like an end-to-end scenario.