### PR TITLE
feat(acp): decode tool_call.content subtypes and read args from rawInput

### DIFF
--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.toolContent.test.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.toolContent.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AgentMessage } from '../core';
+import {
+  emitToolContentItems,
+  formatToolCallDiff,
+  parseToolArgs,
+  type HandlerContext,
+  type SessionUpdate,
+} from './sessionUpdateHandlers';
+
+function makeCtx(): { ctx: HandlerContext; messages: AgentMessage[] } {
+  const messages: AgentMessage[] = [];
+  const ctx: HandlerContext = {
+    transport: {} as HandlerContext['transport'],
+    activeToolCalls: new Set<string>(),
+    toolCallStartTimes: new Map<string, number>(),
+    toolCallTimeouts: new Map<string, NodeJS.Timeout>(),
+    toolCallIdToNameMap: new Map<string, string>(),
+    idleTimeout: null,
+    toolCallCountSincePrompt: 0,
+    emit: (msg) => {
+      messages.push(msg);
+    },
+    emitIdleStatus: vi.fn(),
+    clearIdleTimeout: vi.fn(),
+    setIdleTimeout: vi.fn(),
+  };
+  return { ctx, messages };
+}
+
+describe('parseToolArgs', () => {
+  it('uses rawInput when present (object form)', () => {
+    const update: SessionUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      rawInput: { path: '/tmp/foo', limit: 5 },
+    } as SessionUpdate;
+
+    expect(parseToolArgs(update)).toEqual({ path: '/tmp/foo', limit: 5 });
+  });
+
+  it('wraps a non-object rawInput in { value }', () => {
+    const update: SessionUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      rawInput: 'just a string',
+    } as SessionUpdate;
+
+    expect(parseToolArgs(update)).toEqual({ value: 'just a string' });
+  });
+
+  it('falls back to content when rawInput is absent (legacy agents)', () => {
+    const update: SessionUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      content: { path: '/legacy', mode: 'read' },
+    };
+
+    expect(parseToolArgs(update)).toEqual({ path: '/legacy', mode: 'read' });
+  });
+
+  it('wraps a content array into { items } via the legacy fallback', () => {
+    const update: SessionUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      content: [{ type: 'content', content: { type: 'text', text: 'hi' } }],
+    };
+
+    const args = parseToolArgs(update);
+    expect(Array.isArray((args as { items?: unknown }).items)).toBe(true);
+  });
+
+  it('returns empty object when neither rawInput nor content is usable', () => {
+    const update: SessionUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+    };
+
+    expect(parseToolArgs(update)).toEqual({});
+  });
+
+  it('prefers rawInput even when content is also present', () => {
+    const update: SessionUpdate = {
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      rawInput: { from: 'rawInput' },
+      content: { from: 'content' },
+    } as SessionUpdate;
+
+    expect(parseToolArgs(update)).toEqual({ from: 'rawInput' });
+  });
+});
+
+describe('formatToolCallDiff', () => {
+  it('renders an empty header when both texts are empty', () => {
+    expect(formatToolCallDiff('/a/b.txt', '', '')).toBe('--- /a/b.txt\n+++ /a/b.txt\n');
+  });
+
+  it('prefixes old and new lines with - / + and includes the file header', () => {
+    const out = formatToolCallDiff('/x.txt', 'foo\nbar', 'foo\nBAZ');
+    expect(out).toContain('--- /x.txt');
+    expect(out).toContain('+++ /x.txt');
+    expect(out).toContain('-foo');
+    expect(out).toContain('-bar');
+    expect(out).toContain('+foo');
+    expect(out).toContain('+BAZ');
+  });
+
+  it('omits the header when path is empty', () => {
+    const out = formatToolCallDiff('', 'old', 'new');
+    expect(out.startsWith('---')).toBe(false);
+    expect(out).toContain('-old');
+    expect(out).toContain('+new');
+  });
+});
+
+describe('emitToolContentItems', () => {
+  it('emits an fs-edit for each diff entry', () => {
+    const { ctx, messages } = makeCtx();
+
+    emitToolContentItems(
+      'call-1',
+      'edit_file',
+      [
+        { type: 'diff', path: '/src/a.ts', oldText: 'old', newText: 'new' },
+        { type: 'diff', path: '/src/b.ts', oldText: '', newText: 'created' },
+      ],
+      ctx,
+    );
+
+    const edits = messages.filter((m) => m.type === 'fs-edit');
+    expect(edits).toHaveLength(2);
+    expect(edits[0]).toMatchObject({
+      type: 'fs-edit',
+      description: 'Edit /src/a.ts',
+      path: '/src/a.ts',
+    });
+    expect(typeof (edits[0] as { diff?: string }).diff).toBe('string');
+    expect(edits[1]).toMatchObject({
+      type: 'fs-edit',
+      description: 'Edit /src/b.ts',
+      path: '/src/b.ts',
+    });
+  });
+
+  it('emits a tool_terminal_ref event for each terminal entry', () => {
+    const { ctx, messages } = makeCtx();
+
+    emitToolContentItems(
+      'call-2',
+      'run_command',
+      [{ type: 'terminal', terminalId: 'term-42' }],
+      ctx,
+    );
+
+    expect(messages).toEqual([
+      {
+        type: 'event',
+        name: 'tool_terminal_ref',
+        payload: { toolCallId: 'call-2', toolName: 'run_command', terminalId: 'term-42' },
+      },
+    ]);
+  });
+
+  it('does not emit anything extra for plain content blocks', () => {
+    const { ctx, messages } = makeCtx();
+
+    emitToolContentItems(
+      'call-3',
+      'read_file',
+      [
+        { type: 'content', content: { type: 'text', text: 'hello' } },
+        { type: 'content', content: { type: 'image', data: '...' } },
+      ],
+      ctx,
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it('mixes diff / terminal / content correctly within one tool result', () => {
+    const { ctx, messages } = makeCtx();
+
+    emitToolContentItems(
+      'call-4',
+      'multi_tool',
+      [
+        { type: 'content', content: { type: 'text', text: 'log line' } },
+        { type: 'diff', path: '/x.ts', oldText: 'a', newText: 'b' },
+        { type: 'terminal', terminalId: 'term-1' },
+      ],
+      ctx,
+    );
+
+    const types = messages.map((m) => m.type);
+    expect(types).toEqual(['fs-edit', 'event']);
+  });
+
+  it('is a no-op when content is not an array (no throw)', () => {
+    const { ctx, messages } = makeCtx();
+
+    emitToolContentItems('call-5', 'tool', undefined, ctx);
+    emitToolContentItems('call-5', 'tool', 'string instead of array', ctx);
+    emitToolContentItems('call-5', 'tool', { type: 'diff' }, ctx);
+
+    expect(messages).toEqual([]);
+  });
+
+  it('skips diff entries with no string path/newText/oldText gracefully', () => {
+    const { ctx, messages } = makeCtx();
+
+    emitToolContentItems(
+      'call-6',
+      'edit_file',
+      [{ type: 'diff', path: 42, oldText: null, newText: undefined }],
+      ctx,
+    );
+
+    expect(messages).toHaveLength(1);
+    const edit = messages[0] as { type: 'fs-edit'; description: string; diff?: string; path?: string };
+    expect(edit.type).toBe('fs-edit');
+    expect(edit.path).toBeUndefined();
+    expect(edit.description).toBe('File edit');
+  });
+});

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
@@ -97,6 +97,97 @@ export function parseArgsFromContent(content: unknown): Record<string, unknown> 
 }
 
 /**
+ * Parse tool-call args from a `tool_call` / `tool_call_update` SessionUpdate.
+ *
+ * Per ACP spec (`ToolCall.rawInput` / `ToolCallUpdate.rawInput`), the tool's
+ * invocation parameters live on `rawInput`. The `content` field holds the
+ * tool's *output*. Older agents pre-dating the `rawInput` field sometimes
+ * stashed args inside `content`, so we keep that fallback for backwards
+ * compatibility.
+ */
+export function parseToolArgs(update: SessionUpdate): Record<string, unknown> {
+  const rawInput = (update as { rawInput?: unknown }).rawInput;
+  if (rawInput !== undefined && rawInput !== null) {
+    if (typeof rawInput === 'object' && !Array.isArray(rawInput)) {
+      return rawInput as Record<string, unknown>;
+    }
+    return { value: rawInput };
+  }
+  return parseArgsFromContent(update.content);
+}
+
+/**
+ * Render a minimal unified-diff-style string from an ACP `Diff` content item.
+ *
+ * Downstream consumers (e.g. `GeminiDiffProcessor`) treat `fs-edit.diff` as
+ * an opaque string and compare it across edits; we only need a stable
+ * textual representation, not a real `diff(1)` patch.
+ */
+export function formatToolCallDiff(path: string, oldText: string, newText: string): string {
+  const header = path ? `--- ${path}\n+++ ${path}\n` : '';
+  if (!oldText && !newText) {
+    return header;
+  }
+  const oldLines = oldText.split('\n').map((line) => `-${line}`).join('\n');
+  const newLines = newText.split('\n').map((line) => `+${line}`).join('\n');
+  return `${header}${oldLines}\n${newLines}`;
+}
+
+/**
+ * Emit structured AgentMessages for the subtyped items inside a
+ * `ToolCall.content` / `ToolCallUpdate.content` array.
+ *
+ * Per ACP spec, `content` is `Array<ToolCallContent>` where each item is
+ * tagged with `type: 'content' | 'diff' | 'terminal'`:
+ * - `diff`   → emit `fs-edit { path, diff }` so the existing fs-edit pipeline
+ *               (e.g. `GeminiDiffProcessor`) renders it as a real edit.
+ * - `terminal` → emit `event { name: 'tool_terminal_ref' }` carrying the
+ *                 referenced terminalId for downstream consumers.
+ * - `content` → no extra emit; the `ContentBlock` stays inside the
+ *                transparent `tool-result.result` passthrough.
+ *
+ * The original `tool-result` AgentMessage is left untouched, so any existing
+ * consumer that reads `result` verbatim keeps working.
+ */
+export function emitToolContentItems(
+  toolCallId: string,
+  toolName: string,
+  content: unknown,
+  ctx: HandlerContext,
+): void {
+  if (!Array.isArray(content)) return;
+
+  for (const item of content) {
+    if (!item || typeof item !== 'object') continue;
+    const tagged = item as { type?: unknown };
+
+    if (tagged.type === 'diff') {
+      const diff = item as { path?: unknown; oldText?: unknown; newText?: unknown };
+      const path = typeof diff.path === 'string' ? diff.path : '';
+      const newText = typeof diff.newText === 'string' ? diff.newText : '';
+      const oldText = typeof diff.oldText === 'string' ? diff.oldText : '';
+      ctx.emit({
+        type: 'fs-edit',
+        description: path ? `Edit ${path}` : 'File edit',
+        diff: formatToolCallDiff(path, oldText, newText),
+        path: path || undefined,
+      });
+    } else if (tagged.type === 'terminal') {
+      const terminal = item as { terminalId?: unknown };
+      const terminalId = typeof terminal.terminalId === 'string' ? terminal.terminalId : undefined;
+      if (terminalId) {
+        ctx.emit({
+          type: 'event',
+          name: 'tool_terminal_ref',
+          payload: { toolCallId, toolName, terminalId },
+        });
+      }
+    }
+    // type === 'content': the ContentBlock stays inside tool-result.result.
+  }
+}
+
+/**
  * Extract error detail from update content
  */
 export function extractErrorDetail(content: unknown): string | undefined {
@@ -293,8 +384,9 @@ export function startToolCall(
   // Emit running status
   ctx.emit({ type: 'status', status: 'running' });
 
-  // Parse args and emit tool-call event
-  const args = parseArgsFromContent(update.content);
+  // Parse args from the spec-correct `rawInput` field with a content-based
+  // fallback for older agents — see parseToolArgs for details.
+  const args = parseToolArgs(update);
 
   // Extract locations if present
   if (update.locations && Array.isArray(update.locations)) {
@@ -344,6 +436,10 @@ export function completeToolCall(
     result: content,
     callId: toolCallId,
   });
+
+  // Surface subtyped items (diff / terminal) from `content` as structured
+  // AgentMessages on top of the raw passthrough above.
+  emitToolContentItems(toolCallId, toolKindStr, content, ctx);
 
   // If no more active tool calls, emit idle
   if (ctx.activeToolCalls.size === 0) {


### PR DESCRIPTION
## Summary
Two related ACP tool-call improvements inside \`packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts\`, both grounded in the ACP spec (SDK v0.14.1).

### 1. Read tool args from \`rawInput\` (spec-correct), fall back to \`content\` (legacy)
Per ACP spec (\`ToolCall\` and \`ToolCallUpdate\`):
- \`rawInput?: unknown\` — Raw input parameters sent to the tool.
- \`content?: Array<ToolCallContent>\` — Content **produced by** the tool call.

The previous code in \`startToolCall\` read args from \`update.content\`, which mistakes the output collection for the input parameters. \`startToolCall\` now goes through a new \`parseToolArgs\` helper:

\`\`\`ts
export function parseToolArgs(update: SessionUpdate): Record<string, unknown> {
  const rawInput = (update as { rawInput?: unknown }).rawInput;
  if (rawInput !== undefined && rawInput !== null) {
    if (typeof rawInput === 'object' && !Array.isArray(rawInput)) {
      return rawInput as Record<string, unknown>;
    }
    return { value: rawInput };
  }
  return parseArgsFromContent(update.content);
}
\`\`\`

\`rawInput\` wins when present; otherwise we fall back to the existing \`parseArgsFromContent\` shape so agents that pre-date \`rawInput\` keep working — fully backwards-compatible.

### 2. Decode \`ToolCallContent\` subtypes into structured AgentMessages
Per ACP spec, each entry in \`ToolCall.content\` is tagged:

\`\`\`ts
type ToolCallContent =
  | (Content  & { type: 'content' })   // text / image / audio / resource_link / resource
  | (Diff     & { type: 'diff' })       // { path, oldText?, newText }
  | (Terminal & { type: 'terminal' });  // { terminalId }
\`\`\`

The previous code passed the entire array through verbatim as \`tool-result.result\`, so diffs and terminal references reached downstream as opaque objects. \`completeToolCall\` now keeps emitting the original \`tool-result\` (consumers reading \`result\` keep working) and **additionally** walks the array via a new \`emitToolContentItems\`:

| ACP subtype | Extra AgentMessage emitted |
|---|---|
| \`diff\` | \`{ type: 'fs-edit', description, diff, path }\` — picked up by \`runAcp.ts\`'s fs-edit switch case and \`GeminiDiffProcessor\` |
| \`terminal\` | \`{ type: 'event', name: 'tool_terminal_ref', payload: { toolCallId, toolName, terminalId } }\` |
| \`content\` | (no extra emit; the \`ContentBlock\` stays inside the \`tool-result.result\` passthrough) |

The new \`formatToolCallDiff\` helper renders a minimal unified-diff-style string for the \`fs-edit.diff\` field. \`GeminiDiffProcessor\` treats this as an opaque blob and only compares it across edits, so a real \`diff(1)\` patch is not needed.

## Scope
- Touches **only** \`packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts\` and adds a colocated test file.
- Does NOT change \`AcpBackend.ts\`, \`runAcp.ts\`, \`AcpSessionManager.ts\`, \`apiSession.ts\`, the mobile app, or any socket schema. The \`fs-edit\` AgentMessage already has a downstream consumer (\`runAcp.ts:162\` + \`GeminiDiffProcessor\`); the \`tool_terminal_ref\` event is new and is a signal-only addition — downstream UI rendering can follow up.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes, no new TypeScript errors
- [x] \`pnpm exec vitest run src/agent/acp/\` — 63 tests pass (incl. 15 new tests in \`sessionUpdateHandlers.toolContent.test.ts\`)

The 15 new tests cover:
- \`parseToolArgs\`: \`rawInput\` priority (object form), value-wrapping for non-object \`rawInput\`, content fallback for legacy agents, array-wrapped \`{ items }\` fallback, empty-update case.
- \`formatToolCallDiff\`: header presence, line prefixes, empty-text handling, no-path branch.
- \`emitToolContentItems\`: one \`fs-edit\` per \`diff\` entry, \`tool_terminal_ref\` per terminal, no-op for plain \`content\`, mixed scenarios, no-throw for non-array input, defensive parsing for missing string fields.

## Spec references
- \`ToolCall\` and \`ToolCallUpdate\` field semantics: \`@agentclientprotocol/sdk@0.14.1\` \`dist/schema/types.gen.d.ts\` lines 2532–2577 and 2641–2700.
- \`ToolCallContent\` union: same file, lines 2578–2592.
- \`Diff\` / \`Terminal\` shapes: lines 525–548 and 2403–2415.