### PR TITLE
fix(acp): defer idle after tool completion (UI flicker / stuck spinner)

### DIFF
--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.idleDeferral.test.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.idleDeferral.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentMessage } from '../core';
+import {
+  DEFAULT_IDLE_TIMEOUT_MS,
+  completeToolCall,
+  failToolCall,
+  handleAgentMessageChunk,
+  scheduleDeferredIdle,
+  startToolCall,
+  type HandlerContext,
+  type SessionUpdate,
+} from './sessionUpdateHandlers';
+
+function makeCtx() {
+  const messages: AgentMessage[] = [];
+  let idleTimeoutHandle: NodeJS.Timeout | null = null;
+
+  const ctx: HandlerContext = {
+    transport: {
+      getIdleTimeout: () => DEFAULT_IDLE_TIMEOUT_MS,
+    } as HandlerContext['transport'],
+    activeToolCalls: new Set<string>(),
+    toolCallStartTimes: new Map<string, number>(),
+    toolCallTimeouts: new Map<string, NodeJS.Timeout>(),
+    toolCallIdToNameMap: new Map<string, string>(),
+    idleTimeout: null,
+    toolCallCountSincePrompt: 0,
+    emit: (msg) => {
+      messages.push(msg);
+    },
+    emitIdleStatus: () => {
+      messages.push({ type: 'status', status: 'idle' });
+    },
+    clearIdleTimeout: () => {
+      if (idleTimeoutHandle) {
+        clearTimeout(idleTimeoutHandle);
+        idleTimeoutHandle = null;
+      }
+    },
+    setIdleTimeout: (callback, ms) => {
+      idleTimeoutHandle = setTimeout(() => {
+        callback();
+        idleTimeoutHandle = null;
+      }, ms);
+    },
+  };
+
+  return {
+    ctx,
+    messages,
+    idleStatusCount: () => messages.filter((m) => m.type === 'status' && (m as { status: string }).status === 'idle').length,
+  };
+}
+
+describe('Spinner-stuck fix: deferred idle after tool completion', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does NOT emit idle synchronously when the last tool completes', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+
+    // Tool was the only active one, but idle must wait for the deferral window.
+    expect(idleStatusCount()).toBe(0);
+  });
+
+  it('emits idle after the standard idle window elapses', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+    expect(idleStatusCount()).toBe(0);
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+
+    expect(idleStatusCount()).toBe(1);
+  });
+
+  it('regression: a follow-up text chunk arriving before the window expires re-arms the timer (no flicker)', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    // Tool completes — schedules deferred idle.
+    completeToolCall('t1', 'read_file', [], ctx);
+
+    // Halfway through the window the agent streams a follow-up text chunk.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS / 2);
+    const chunk: SessionUpdate = {
+      sessionUpdate: 'agent_message_chunk',
+      content: { text: 'tool used: result is 42' },
+    };
+    handleAgentMessageChunk(chunk, ctx);
+
+    // The chunk handler should have re-armed the idle timer; idle must NOT
+    // have fired at the old tool-complete deadline.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS / 2);
+    expect(idleStatusCount()).toBe(0);
+
+    // After the new full window elapses, idle finally fires — exactly once.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(1);
+  });
+
+  it('a new tool starting before the window expires cancels the deferred idle', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+
+    // Before the window elapses, a second tool kicks off.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS / 2);
+    startToolCall(
+      't2',
+      'write_file',
+      { sessionUpdate: 'tool_call', toolCallId: 't2' } as SessionUpdate,
+      ctx,
+      'tool_call',
+    );
+
+    // Even if we ride through the originally-scheduled idle moment, no idle
+    // should be emitted while a tool is active.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(0);
+  });
+
+  it('failToolCall also defers idle (mirrors completeToolCall)', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    failToolCall('t1', 'failed', 'read_file', { error: 'nope' }, ctx);
+
+    expect(idleStatusCount()).toBe(0);
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(1);
+  });
+
+  it('scheduleDeferredIdle skips the emit if a tool became active during the wait', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+
+    scheduleDeferredIdle(ctx, 'unit test idle');
+
+    // Simulate a tool starting in-between.
+    ctx.activeToolCalls.add('t-late');
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+
+    // Active tool count > 0 at fire time → no idle should be emitted.
+    expect(idleStatusCount()).toBe(0);
+  });
+
+  it('multiple tool completions inside the deferral window collapse into a single idle emission', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.activeToolCalls.add('t2');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+    ctx.toolCallStartTimes.set('t2', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+    // First completion still has an active tool — must NOT schedule anything
+    // visible by waiting through the window:
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(0);
+
+    completeToolCall('t2', 'read_file', [], ctx);
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(1);
+  });
+});

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
@@ -84,6 +84,30 @@ export interface HandlerResult {
 }
 
 /**
+ * Schedule a deferred `idle` status emission after the standard idle timeout.
+ *
+ * We don't emit `idle` synchronously when a tool completes because the agent
+ * almost always streams follow-up text right after a tool result. Emitting
+ * `idle` immediately makes downstream UIs flicker (idle → busy → idle) — or
+ * in some clients, get stuck on a stale "idle" view while later chunks
+ * arrive. This mirrors the deferral that `handleAgentMessageChunk` already
+ * does after text chunks, so both event types converge on the same idle
+ * settling rule.
+ */
+export function scheduleDeferredIdle(ctx: HandlerContext, settledLogMessage: string): void {
+  ctx.clearIdleTimeout();
+  const idleTimeoutMs = ctx.transport.getIdleTimeout?.() ?? DEFAULT_IDLE_TIMEOUT_MS;
+  ctx.setIdleTimeout(() => {
+    if (ctx.activeToolCalls.size === 0) {
+      logger.debug(settledLogMessage);
+      ctx.emitIdleStatus();
+    } else {
+      logger.debug(`[AcpBackend] Deferred idle skipped — ${ctx.activeToolCalls.size} active tool calls`);
+    }
+  }, idleTimeoutMs);
+}
+
+/**
  * Parse args from update content (can be array or object)
  */
 export function parseArgsFromContent(content: unknown): Record<string, unknown> {
@@ -345,11 +369,11 @@ export function completeToolCall(
     callId: toolCallId,
   });
 
-  // If no more active tool calls, emit idle
+  // If no more active tool calls, defer the idle status so a follow-up
+  // text chunk has a chance to re-arm the idle timer first. See
+  // `scheduleDeferredIdle` for the full rationale.
   if (ctx.activeToolCalls.size === 0) {
-    ctx.clearIdleTimeout();
-    logger.debug('[AcpBackend] All tool calls completed, emitting idle status');
-    ctx.emitIdleStatus();
+    scheduleDeferredIdle(ctx, '[AcpBackend] All tool calls completed (deferred), emitting idle status');
   }
 }
 
@@ -423,11 +447,10 @@ export function failToolCall(
     callId: toolCallId,
   });
 
-  // If no more active tool calls, emit idle
+  // If no more active tool calls, defer the idle status so a follow-up
+  // text chunk has a chance to re-arm the idle timer first.
   if (ctx.activeToolCalls.size === 0) {
-    ctx.clearIdleTimeout();
-    logger.debug('[AcpBackend] All tool calls completed/failed, emitting idle status');
-    ctx.emitIdleStatus();
+    scheduleDeferredIdle(ctx, '[AcpBackend] All tool calls completed/failed (deferred), emitting idle status');
   }
 }
 


### PR DESCRIPTION
## Summary
When the last tool in a turn completes (or fails), \`completeToolCall\` and \`failToolCall\` previously emitted \`{ type: 'status', status: 'idle' }\` **synchronously**. But agents almost always stream a short follow-up text chunk right after a tool result (e.g. \"tool used: result is 42\"), and that chunk arrives in the *next* tick.

The synchronous \`idle\` emit causes downstream UIs to see \`idle → busy → idle\` flicker — or, in some third-party clients (e.g. atomcode), get stuck on a stale idle view while later chunks arrive on what looks like a closed turn.

\`handleAgentMessageChunk\` already deferred \`idle\` through a \`setIdleTimeout(DEFAULT_IDLE_TIMEOUT_MS)\` (500 ms) window so a streaming chunk wouldn't trip the same flicker. Tool completion / failure now goes through the same deferral via a new \`scheduleDeferredIdle\` helper, so both event types converge on **one** idle-settling rule.

## Diagnosis
| Path | Before | After |
|---|---|---|
| \`handleAgentMessageChunk\` | \`setIdleTimeout(callback, 500ms)\` | unchanged |
| \`completeToolCall\` (last active) | \`emitIdleStatus()\` **immediately** | \`scheduleDeferredIdle()\` (defers 500 ms) |
| \`failToolCall\` (last active) | \`emitIdleStatus()\` **immediately** | \`scheduleDeferredIdle()\` (defers 500 ms) |
| \`startToolCall\`'s 120 s safety net | \`emitIdleStatus()\` **immediately** | unchanged — already waited the full timeout |

The discrepancy between chunks (deferred) and tool completions (synchronous) was the race that downstream UIs were tripping over.

## Behavior after this PR
- Tool completes (last active) → schedule deferred idle in \`DEFAULT_IDLE_TIMEOUT_MS\`.
- Follow-up text chunk arrives within the window → chunk handler clears and re-arms the timer; no extra \`idle\` is emitted.
- New tool starts within the window → \`scheduleDeferredIdle\` skips the emit because \`activeToolCalls.size > 0\` at fire time.
- Multiple tools finish back-to-back → only the last completion fires the deferred timer; one final \`idle\`.

## Scope
- Touches **only** \`packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts\` and adds a colocated test file.
- Does NOT change \`AcpBackend.ts\`, \`runAcp.ts\`, \`AcpSessionManager.ts\`, the mobile app, or any socket schema.
- The tool-call-timeout safety net path is left as immediate-emit because it has already waited the full 120 s timeout.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/agent/acp/\` — all 55 ACP tests pass (incl. 7 new fake-timer tests)

The new tests use \`vi.useFakeTimers()\` to deterministically reproduce the original race and pin the new behavior:
1. \`completeToolCall\` does NOT emit \`idle\` synchronously.
2. \`idle\` fires exactly when \`DEFAULT_IDLE_TIMEOUT_MS\` elapses.
3. **Race fix:** a follow-up text chunk inside the deferral window re-arms the timer; only the chunk-handler's later deadline emits, never the original tool-deadline.
4. A new tool starting inside the window cancels the deferred idle (still busy).
5. \`failToolCall\` defers idle the same way (mirrors \`completeToolCall\`).
6. \`scheduleDeferredIdle\` skips emit if a tool became active during the wait.
7. Multiple back-to-back completions collapse into a single \`idle\`.

## Downstream impact
Third-party ACP clients (e.g. atomcode) previously worked around this by sending an empty text chunk after every tool result, just to re-arm happy-cli's idle timer. That workaround can be removed once this lands.