### PR TITLE
fix(acp): two-signal turn-complete state machine (response + updates)

### DIFF
--- a/packages/happy-cli/src/agent/acp/AcpBackend.race.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.race.test.ts
@@ -134,6 +134,28 @@ describe('AcpBackend turn-completion race conditions', () => {
     expect(idleCount()).toBe(1);
   });
 
+  it('content-only tool_call_update does not cancel the post-response grace window', async () => {
+    const backend = createBackend();
+    const response = defer<unknown>();
+    const { idleCount } = stubBackend(backend, response);
+
+    const sendPromise = backend.sendPrompt('test-session', 'hello');
+    await Promise.resolve();
+
+    response.resolve({ stopReason: 'end_turn' });
+    await sendPromise;
+    expect(idleCount()).toBe(0);
+
+    dispatchUpdate(backend, {
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't1',
+      content: [{ type: 'text', text: 'still streaming' }],
+    });
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleCount()).toBe(1);
+  });
+
   it('race: empty turn — response arrives, NO updates ever — grace timer still settles the turn', async () => {
     const backend = createBackend();
     const response = defer<unknown>();

--- a/packages/happy-cli/src/agent/acp/AcpBackend.race.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.race.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentMessage } from '@/agent/core';
+import { DEFAULT_IDLE_TIMEOUT_MS } from './sessionUpdateHandlers';
+import { AcpBackend } from './AcpBackend';
+
+interface DeferredPromise<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+}
+
+function defer<T>(): DeferredPromise<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createBackend(): AcpBackend {
+  return new AcpBackend({
+    agentName: 'test',
+    cwd: '/tmp',
+    command: '/bin/true',
+  });
+}
+
+function stubBackend(backend: AcpBackend, responseControl: DeferredPromise<unknown>) {
+  const messages: AgentMessage[] = [];
+  backend.onMessage((msg) => messages.push(msg));
+
+  // Pretend a session is already open.
+  (backend as unknown as { acpSessionId: string }).acpSessionId = 'test-session';
+  (backend as unknown as { connection: { prompt: (...args: unknown[]) => Promise<unknown>; cancel: () => Promise<void> } }).connection = {
+    prompt: vi.fn(() => responseControl.promise),
+    cancel: vi.fn(async () => {}),
+  };
+
+  return {
+    messages,
+    idleCount: () => messages.filter((m) => m.type === 'status' && (m as { status: string }).status === 'idle').length,
+  };
+}
+
+function dispatchUpdate(backend: AcpBackend, update: Record<string, unknown>): void {
+  (backend as unknown as { handleSessionUpdate(params: unknown): void }).handleSessionUpdate({
+    sessionId: 'test-session',
+    update,
+  });
+}
+
+describe('AcpBackend turn-completion race conditions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('normal order: updates first, response last — emits idle exactly once after the idle window', async () => {
+    const backend = createBackend();
+    const response = defer<unknown>();
+    const { idleCount } = stubBackend(backend, response);
+
+    const sendPromise = backend.sendPrompt('test-session', 'hello');
+    // Let `sendPrompt` reach `await this.connection.prompt(...)`.
+    await Promise.resolve();
+
+    // Updates first.
+    dispatchUpdate(backend, { sessionUpdate: 'agent_message_chunk', content: { text: 'hi' } });
+    dispatchUpdate(backend, { sessionUpdate: 'agent_message_chunk', content: { text: ' there' } });
+
+    // Without the response, even a long silence must not produce `idle`.
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS * 2);
+    expect(idleCount()).toBe(0);
+
+    // Response arrives last (spec-typical ordering).
+    response.resolve({ stopReason: 'end_turn' });
+    await sendPromise;
+    // The .then() callback runs as a microtask, then maybeCompleteTurn sees
+    // updatesSettled=true (set by the chunk idle timer that already fired
+    // during the silence advance above) and emits idle synchronously.
+    expect(idleCount()).toBe(1);
+  });
+
+  it('race: response arrives BEFORE the final update — defers idle for the grace window, then emits once', async () => {
+    const backend = createBackend();
+    const response = defer<unknown>();
+    const { idleCount } = stubBackend(backend, response);
+
+    const sendPromise = backend.sendPrompt('test-session', 'hello');
+    await Promise.resolve();
+
+    // Agent flushes the response immediately, before any chunk.
+    response.resolve({ stopReason: 'end_turn' });
+    await sendPromise;
+
+    // Response is in, updates haven't settled — grace timer should be armed.
+    expect(idleCount()).toBe(0);
+
+    // A late chunk arrives within the grace window.
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS / 2);
+    dispatchUpdate(backend, { sessionUpdate: 'agent_message_chunk', content: { text: 'late chunk' } });
+
+    // Chunk handler should have re-armed the chunk-idle timer; the grace
+    // path's eventual fire must not double-emit.
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS * 3);
+    expect(idleCount()).toBe(1);
+  });
+
+  it('race: empty turn — response arrives, NO updates ever — grace timer still settles the turn', async () => {
+    const backend = createBackend();
+    const response = defer<unknown>();
+    const { idleCount } = stubBackend(backend, response);
+
+    const sendPromise = backend.sendPrompt('test-session', 'hello');
+    await Promise.resolve();
+
+    response.resolve({ stopReason: 'end_turn' });
+    await sendPromise;
+
+    // Right after response: idle must NOT fire (grace timer protects against
+    // the chunk-first ordering above).
+    expect(idleCount()).toBe(0);
+
+    // After POST_RESPONSE_GRACE_MS the grace timer fires and we accept "no
+    // updates ever arrived" as the update stream settling.
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleCount()).toBe(1);
+  });
+
+  it('race: tool_call_update completes BEFORE response — turn does not finish until response arrives', async () => {
+    const backend = createBackend();
+    const response = defer<unknown>();
+    const { idleCount } = stubBackend(backend, response);
+
+    const sendPromise = backend.sendPrompt('test-session', 'use a tool');
+    await Promise.resolve();
+
+    // Tool starts then immediately completes — all before the RPC response.
+    dispatchUpdate(backend, {
+      sessionUpdate: 'tool_call',
+      toolCallId: 't1',
+      status: 'pending',
+      kind: 'read_file',
+    });
+    dispatchUpdate(backend, {
+      sessionUpdate: 'tool_call_update',
+      toolCallId: 't1',
+      status: 'completed',
+      kind: 'read_file',
+      content: [],
+    });
+
+    // The deferred-idle timer (introduced by the spinner-stuck fix) fires
+    // after 500 ms and marks updates settled. Without a response, no idle.
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS * 4);
+    expect(idleCount()).toBe(0);
+
+    // Response finally arrives.
+    response.resolve({ stopReason: 'end_turn' });
+    await sendPromise;
+    expect(idleCount()).toBe(1);
+  });
+
+  it('error path: response Promise rejects — no idle emitted, sendPrompt throws', async () => {
+    const backend = createBackend();
+    const response = defer<unknown>();
+    const { idleCount, messages } = stubBackend(backend, response);
+
+    const sendPromise = backend.sendPrompt('test-session', 'hello');
+    await Promise.resolve();
+
+    response.reject(new Error('boom'));
+
+    await expect(sendPromise).rejects.toThrow(/boom/);
+
+    // Even if a stale update sneaks in afterwards, we should not emit idle
+    // for a turn whose RPC errored out.
+    dispatchUpdate(backend, { sessionUpdate: 'agent_message_chunk', content: { text: 'stale' } });
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS * 4);
+    expect(idleCount()).toBe(0);
+
+    // The error path emits an `error` status instead.
+    expect(messages.some((m) => m.type === 'status' && (m as { status: string }).status === 'error')).toBe(true);
+  });
+
+  it('a fresh prompt while a previous one is still racing replaces the turnId — stale .then is ignored', async () => {
+    const backend = createBackend();
+    const response1 = defer<unknown>();
+    const { idleCount } = stubBackend(backend, response1);
+
+    // First prompt — won't be awaited from this test (kept "in flight").
+    const send1 = backend.sendPrompt('test-session', 'first');
+    await Promise.resolve();
+
+    // Before the first response comes back, the caller bumps a new prompt.
+    // Swap the deferred for the second response.
+    const response2 = defer<unknown>();
+    const conn = (backend as unknown as { connection: { prompt: ReturnType<typeof vi.fn> } }).connection;
+    conn.prompt.mockImplementation(() => response2.promise);
+
+    const send2 = backend.sendPrompt('test-session', 'second');
+    await Promise.resolve();
+
+    // Late resolution of the first response — must NOT mark the *current*
+    // turn as response-received.
+    response1.resolve({ stopReason: 'end_turn' });
+    // Bring stray microtasks forward.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // No idle yet — the current (second) turn still has no response.
+    expect(idleCount()).toBe(0);
+
+    // Now the second response actually arrives.
+    response2.resolve({ stopReason: 'end_turn' });
+    await send2;
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleCount()).toBe(1);
+
+    await send1; // tidy up: the first promise resolved with response1 above.
+  });
+});

--- a/packages/happy-cli/src/agent/acp/AcpBackend.race.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.race.test.ts
@@ -112,6 +112,28 @@ describe('AcpBackend turn-completion race conditions', () => {
     expect(idleCount()).toBe(1);
   });
 
+  it('late update after a settled window resets the update gate before response completes', async () => {
+    const backend = createBackend();
+    const response = defer<unknown>();
+    const { idleCount } = stubBackend(backend, response);
+
+    const sendPromise = backend.sendPrompt('test-session', 'hello');
+    await Promise.resolve();
+
+    dispatchUpdate(backend, { sessionUpdate: 'agent_message_chunk', content: { text: 'first' } });
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleCount()).toBe(0);
+
+    dispatchUpdate(backend, { sessionUpdate: 'agent_message_chunk', content: { text: 'late' } });
+    response.resolve({ stopReason: 'end_turn' });
+    await sendPromise;
+
+    expect(idleCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleCount()).toBe(1);
+  });
+
   it('race: empty turn — response arrives, NO updates ever — grace timer still settles the turn', async () => {
     const backend = createBackend();
     const response = defer<unknown>();

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -949,7 +949,8 @@ export class AcpBackend implements AgentBackend {
 
     // Dispatch to appropriate handler based on update type
     if (sessionUpdateType === 'agent_message_chunk') {
-      handleAgentMessageChunk(update as SessionUpdate, ctx);
+      const result = handleAgentMessageChunk(update as SessionUpdate, ctx);
+      if (result.handled) this.markUpdatesActive();
       return;
     }
 
@@ -958,6 +959,7 @@ export class AcpBackend implements AgentBackend {
       if (result.toolCallCountSincePrompt !== undefined) {
         this.toolCallCountSincePrompt = result.toolCallCountSincePrompt;
       }
+      if (result.handled) this.markUpdatesActive();
       return;
     }
 
@@ -967,7 +969,8 @@ export class AcpBackend implements AgentBackend {
     }
 
     if (sessionUpdateType === 'tool_call') {
-      handleToolCall(update as SessionUpdate, ctx);
+      const result = handleToolCall(update as SessionUpdate, ctx);
+      if (result.handled) this.markUpdatesActive();
       return;
     }
 
@@ -1288,6 +1291,16 @@ export class AcpBackend implements AgentBackend {
   private markUpdatesSettled(): void {
     this.updatesSettled = true;
     this.maybeCompleteTurn();
+  }
+
+  /**
+   * Called when a new session update proves the update stream was not truly
+   * settled. This prevents a stale idle/grace window from completing the turn
+   * before the newly-arrived update has had its own quiet period.
+   */
+  private markUpdatesActive(): void {
+    this.updatesSettled = false;
+    this.clearPostResponseGrace();
   }
 
   /**

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -959,7 +959,7 @@ export class AcpBackend implements AgentBackend {
       if (result.toolCallCountSincePrompt !== undefined) {
         this.toolCallCountSincePrompt = result.toolCallCountSincePrompt;
       }
-      if (result.handled) this.markUpdatesActive();
+      if (result.updatesActive) this.markUpdatesActive();
       return;
     }
 

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -879,7 +879,7 @@ export class AcpBackend implements AgentBackend {
       idleTimeout: this.idleTimeout,
       toolCallCountSincePrompt: this.toolCallCountSincePrompt,
       emit: (msg) => this.emit(msg),
-      emitIdleStatus: () => this.emitIdleStatus(),
+      markUpdatesSettled: () => this.markUpdatesSettled(),
       clearIdleTimeout: () => {
         if (this.idleTimeout) {
           clearTimeout(this.idleTimeout);
@@ -1037,6 +1037,23 @@ export class AcpBackend implements AgentBackend {
   private idleResolver: (() => void) | null = null;
   private waitingForResponse = false;
 
+  // Two-signal turn-complete state machine. A turn is "complete" only when
+  // BOTH the RPC `prompt` response is back AND the session-update stream has
+  // settled (no chunks for the idle window, no active tool calls). Per ACP
+  // spec these two streams can interleave in any order; we used to assume
+  // updates arrived last, which races with agents that flush their response
+  // before the final update.
+  private responseReceived = false;
+  private updatesSettled = false;
+  /** Monotonic turn counter so stale Promise resolutions can be ignored. */
+  private currentTurnId = 0;
+  /**
+   * Grace timer armed when the RPC response arrives before the update stream
+   * has settled. If no further update fires within this window we treat the
+   * update stream as drained and emit `idle`.
+   */
+  private postResponseGraceTimer: NodeJS.Timeout | null = null;
+
   async sendPrompt(sessionId: SessionId, prompt: string): Promise<void> {
     // Check if prompt contains change_title instruction (via optional callback)
     const promptHasChangeTitle = this.options.hasChangeTitleInstruction?.(prompt) ?? false;
@@ -1074,7 +1091,24 @@ export class AcpBackend implements AgentBackend {
       };
 
       logger.debug(`[AcpBackend] Prompt request:`, JSON.stringify(promptRequest, null, 2));
-      await this.connection.prompt(promptRequest);
+
+      // Reset turn-complete state machine for this prompt. We bump turnId so
+      // that the `.then(...)` callback below can detect when its turn has
+      // been superseded (e.g. by an immediate follow-up prompt) and skip
+      // touching the wrong turn's state.
+      const turnId = ++this.currentTurnId;
+      this.responseReceived = false;
+      this.updatesSettled = false;
+      this.clearPostResponseGrace();
+
+      const responsePromise = this.connection.prompt(promptRequest).then((result) => {
+        if (turnId === this.currentTurnId) {
+          this.responseReceived = true;
+          this.maybeCompleteTurn();
+        }
+        return result;
+      });
+      await responsePromise;
       logger.debug('[AcpBackend] Prompt request sent to ACP connection');
       
       // Don't emit 'idle' here - it will be emitted after all message chunks are received
@@ -1226,14 +1260,67 @@ export class AcpBackend implements AgentBackend {
   }
 
   /**
-   * Helper to emit idle status and resolve any waiting promises
+   * Helper to emit idle status and resolve any waiting promises.
+   *
+   * Always also clears the turn-complete state machine so that a subsequent
+   * stray `markUpdatesSettled` or RPC `.then` callback can't accidentally
+   * fire a second `idle` event for the same turn.
    */
   private emitIdleStatus(): void {
     this.emit({ type: 'status', status: 'idle' });
+    this.waitingForResponse = false;
+    this.responseReceived = false;
+    this.updatesSettled = false;
+    this.clearPostResponseGrace();
     // Resolve any waiting promises
     if (this.idleResolver) {
       logger.debug('[AcpBackend] Resolving idle waiter');
       this.idleResolver();
+    }
+  }
+
+  /**
+   * Called from `HandlerContext.markUpdatesSettled` when the update stream
+   * goes silent (last chunk's idle timer fires, last tool completes, or a
+   * tool-call timeout cleans up). Records the "updates side" of the
+   * two-signal completion gate and tries to finish the turn.
+   */
+  private markUpdatesSettled(): void {
+    this.updatesSettled = true;
+    this.maybeCompleteTurn();
+  }
+
+  /**
+   * Try to emit the final `idle` status if BOTH the RPC response is back AND
+   * the update stream has settled. If only the response is back we arm a
+   * `POST_RESPONSE_GRACE_MS` timer so an `idle` is still produced when the
+   * agent's prompt response arrives before its last `session/update`.
+   */
+  private maybeCompleteTurn(): void {
+    if (!this.waitingForResponse) return;
+    if (this.activeToolCalls.size > 0) return;
+    if (!this.responseReceived) return;
+    if (!this.updatesSettled) {
+      this.armPostResponseGrace();
+      return;
+    }
+    this.emitIdleStatus();
+  }
+
+  private armPostResponseGrace(): void {
+    if (this.postResponseGraceTimer) return;
+    this.postResponseGraceTimer = setTimeout(() => {
+      this.postResponseGraceTimer = null;
+      // Treat the absence of further updates as "stream settled".
+      this.updatesSettled = true;
+      this.maybeCompleteTurn();
+    }, DEFAULT_IDLE_TIMEOUT_MS);
+  }
+
+  private clearPostResponseGrace(): void {
+    if (this.postResponseGraceTimer) {
+      clearTimeout(this.postResponseGraceTimer);
+      this.postResponseGraceTimer = null;
     }
   }
 
@@ -1273,9 +1360,12 @@ export class AcpBackend implements AgentBackend {
 
   async dispose(): Promise<void> {
     if (this.disposed) return;
-    
+
     logger.debug('[AcpBackend] Disposing backend');
     this.disposed = true;
+
+    // Cancel any pending turn-complete grace timer so it doesn't fire after dispose.
+    this.clearPostResponseGrace();
 
     // Try graceful shutdown first
     if (this.connection && this.acpSessionId) {

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.idleDeferral.test.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.idleDeferral.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentMessage } from '../core';
+import {
+  DEFAULT_IDLE_TIMEOUT_MS,
+  completeToolCall,
+  failToolCall,
+  handleAgentMessageChunk,
+  scheduleDeferredIdle,
+  startToolCall,
+  type HandlerContext,
+  type SessionUpdate,
+} from './sessionUpdateHandlers';
+
+function makeCtx() {
+  const messages: AgentMessage[] = [];
+  let idleTimeoutHandle: NodeJS.Timeout | null = null;
+
+  const ctx: HandlerContext = {
+    transport: {
+      getIdleTimeout: () => DEFAULT_IDLE_TIMEOUT_MS,
+    } as HandlerContext['transport'],
+    activeToolCalls: new Set<string>(),
+    toolCallStartTimes: new Map<string, number>(),
+    toolCallTimeouts: new Map<string, NodeJS.Timeout>(),
+    toolCallIdToNameMap: new Map<string, string>(),
+    idleTimeout: null,
+    toolCallCountSincePrompt: 0,
+    emit: (msg) => {
+      messages.push(msg);
+    },
+    emitIdleStatus: () => {
+      messages.push({ type: 'status', status: 'idle' });
+    },
+    clearIdleTimeout: () => {
+      if (idleTimeoutHandle) {
+        clearTimeout(idleTimeoutHandle);
+        idleTimeoutHandle = null;
+      }
+    },
+    setIdleTimeout: (callback, ms) => {
+      idleTimeoutHandle = setTimeout(() => {
+        callback();
+        idleTimeoutHandle = null;
+      }, ms);
+    },
+  };
+
+  return {
+    ctx,
+    messages,
+    idleStatusCount: () => messages.filter((m) => m.type === 'status' && (m as { status: string }).status === 'idle').length,
+  };
+}
+
+describe('Spinner-stuck fix: deferred idle after tool completion', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does NOT emit idle synchronously when the last tool completes', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+
+    // Tool was the only active one, but idle must wait for the deferral window.
+    expect(idleStatusCount()).toBe(0);
+  });
+
+  it('emits idle after the standard idle window elapses', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+    expect(idleStatusCount()).toBe(0);
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+
+    expect(idleStatusCount()).toBe(1);
+  });
+
+  it('regression: a follow-up text chunk arriving before the window expires re-arms the timer (no flicker)', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    // Tool completes — schedules deferred idle.
+    completeToolCall('t1', 'read_file', [], ctx);
+
+    // Halfway through the window the agent streams a follow-up text chunk.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS / 2);
+    const chunk: SessionUpdate = {
+      sessionUpdate: 'agent_message_chunk',
+      content: { text: 'tool used: result is 42' },
+    };
+    handleAgentMessageChunk(chunk, ctx);
+
+    // The chunk handler should have re-armed the idle timer; idle must NOT
+    // have fired at the old tool-complete deadline.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS / 2);
+    expect(idleStatusCount()).toBe(0);
+
+    // After the new full window elapses, idle finally fires — exactly once.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(1);
+  });
+
+  it('a new tool starting before the window expires cancels the deferred idle', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+
+    // Before the window elapses, a second tool kicks off.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS / 2);
+    startToolCall(
+      't2',
+      'write_file',
+      { sessionUpdate: 'tool_call', toolCallId: 't2' } as SessionUpdate,
+      ctx,
+      'tool_call',
+    );
+
+    // Even if we ride through the originally-scheduled idle moment, no idle
+    // should be emitted while a tool is active.
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(0);
+  });
+
+  it('failToolCall also defers idle (mirrors completeToolCall)', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+
+    failToolCall('t1', 'failed', 'read_file', { error: 'nope' }, ctx);
+
+    expect(idleStatusCount()).toBe(0);
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(1);
+  });
+
+  it('scheduleDeferredIdle skips the emit if a tool became active during the wait', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+
+    scheduleDeferredIdle(ctx, 'unit test idle');
+
+    // Simulate a tool starting in-between.
+    ctx.activeToolCalls.add('t-late');
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+
+    // Active tool count > 0 at fire time → no idle should be emitted.
+    expect(idleStatusCount()).toBe(0);
+  });
+
+  it('multiple tool completions inside the deferral window collapse into a single idle emission', () => {
+    const { ctx, idleStatusCount } = makeCtx();
+    ctx.activeToolCalls.add('t1');
+    ctx.activeToolCalls.add('t2');
+    ctx.toolCallStartTimes.set('t1', Date.now());
+    ctx.toolCallStartTimes.set('t2', Date.now());
+
+    completeToolCall('t1', 'read_file', [], ctx);
+    // First completion still has an active tool — must NOT schedule anything
+    // visible by waiting through the window:
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(0);
+
+    completeToolCall('t2', 'read_file', [], ctx);
+    vi.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT_MS);
+    expect(idleStatusCount()).toBe(1);
+  });
+});

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.idleDeferral.test.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.idleDeferral.test.ts
@@ -29,7 +29,12 @@ function makeCtx() {
     emit: (msg) => {
       messages.push(msg);
     },
-    emitIdleStatus: () => {
+    // In production this signals the backend that the update stream has
+    // settled; the backend then waits for the RPC response before actually
+    // emitting `idle`. For these handler-level tests we model that as a
+    // direct `idle` push so the assertions in this file continue to verify
+    // the 500ms deferral timing exposed by sessionUpdateHandlers itself.
+    markUpdatesSettled: () => {
       messages.push({ type: 'status', status: 'idle' });
     },
     clearIdleTimeout: () => {

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
@@ -84,6 +84,8 @@ export interface HandlerContext {
 export interface HandlerResult {
   /** Whether the update was handled */
   handled: boolean;
+  /** Whether this update starts or advances turn activity that will later settle */
+  updatesActive?: boolean;
   /** Updated tool call counter */
   toolCallCountSincePrompt?: number;
 }
@@ -476,8 +478,10 @@ export function handleToolCallUpdate(
 
   const toolKind = update.kind || 'unknown';
   let toolCallCountSincePrompt = ctx.toolCallCountSincePrompt;
+  let updatesActive = false;
 
   if (status === 'in_progress' || status === 'pending') {
+    updatesActive = true;
     if (!ctx.activeToolCalls.has(toolCallId)) {
       toolCallCountSincePrompt++;
       startToolCall(toolCallId, toolKind, update, ctx, 'tool_call_update');
@@ -485,12 +489,14 @@ export function handleToolCallUpdate(
       logger.debug(`[AcpBackend] Tool call ${toolCallId} already tracked, status: ${status}`);
     }
   } else if (status === 'completed') {
+    updatesActive = true;
     completeToolCall(toolCallId, toolKind, update.content, ctx);
   } else if (status === 'failed' || status === 'cancelled') {
+    updatesActive = true;
     failToolCall(toolCallId, status, toolKind, update.content, ctx);
   }
 
-  return { handled: true, toolCallCountSincePrompt };
+  return { handled: true, updatesActive, toolCallCountSincePrompt };
 }
 
 /**

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
@@ -84,6 +84,30 @@ export interface HandlerResult {
 }
 
 /**
+ * Schedule a deferred `idle` status emission after the standard idle timeout.
+ *
+ * We don't emit `idle` synchronously when a tool completes because the agent
+ * almost always streams follow-up text right after a tool result. Emitting
+ * `idle` immediately makes downstream UIs flicker (idle → busy → idle) — or
+ * in some clients, get stuck on a stale "idle" view while later chunks
+ * arrive. This mirrors the deferral that `handleAgentMessageChunk` already
+ * does after text chunks, so both event types converge on the same idle
+ * settling rule.
+ */
+export function scheduleDeferredIdle(ctx: HandlerContext, settledLogMessage: string): void {
+  ctx.clearIdleTimeout();
+  const idleTimeoutMs = ctx.transport.getIdleTimeout?.() ?? DEFAULT_IDLE_TIMEOUT_MS;
+  ctx.setIdleTimeout(() => {
+    if (ctx.activeToolCalls.size === 0) {
+      logger.debug(settledLogMessage);
+      ctx.emitIdleStatus();
+    } else {
+      logger.debug(`[AcpBackend] Deferred idle skipped — ${ctx.activeToolCalls.size} active tool calls`);
+    }
+  }, idleTimeoutMs);
+}
+
+/**
  * Parse args from update content (can be array or object)
  */
 export function parseArgsFromContent(content: unknown): Record<string, unknown> {
@@ -345,11 +369,11 @@ export function completeToolCall(
     callId: toolCallId,
   });
 
-  // If no more active tool calls, emit idle
+  // If no more active tool calls, defer the idle status so a follow-up
+  // text chunk has a chance to re-arm the idle timer first. See
+  // `scheduleDeferredIdle` for the full rationale.
   if (ctx.activeToolCalls.size === 0) {
-    ctx.clearIdleTimeout();
-    logger.debug('[AcpBackend] All tool calls completed, emitting idle status');
-    ctx.emitIdleStatus();
+    scheduleDeferredIdle(ctx, '[AcpBackend] All tool calls completed (deferred), emitting idle status');
   }
 }
 
@@ -423,11 +447,10 @@ export function failToolCall(
     callId: toolCallId,
   });
 
-  // If no more active tool calls, emit idle
+  // If no more active tool calls, defer the idle status so a follow-up
+  // text chunk has a chance to re-arm the idle timer first.
   if (ctx.activeToolCalls.size === 0) {
-    ctx.clearIdleTimeout();
-    logger.debug('[AcpBackend] All tool calls completed/failed, emitting idle status');
-    ctx.emitIdleStatus();
+    scheduleDeferredIdle(ctx, '[AcpBackend] All tool calls completed/failed (deferred), emitting idle status');
   }
 }
 

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
@@ -65,8 +65,13 @@ export interface HandlerContext {
   toolCallCountSincePrompt: number;
   /** Emit function to send agent messages */
   emit: (msg: AgentMessage) => void;
-  /** Emit idle status helper */
-  emitIdleStatus: () => void;
+  /**
+   * Signal that the session-update stream has settled (no chunks for the
+   * idle window, no active tool calls). The backend decides whether this
+   * means the turn is complete — it must also see the RPC response before
+   * actually emitting an `idle` status. See AcpBackend.maybeCompleteTurn.
+   */
+  markUpdatesSettled: () => void;
   /** Clear idle timeout helper */
   clearIdleTimeout: () => void;
   /** Set idle timeout helper */
@@ -100,7 +105,7 @@ export function scheduleDeferredIdle(ctx: HandlerContext, settledLogMessage: str
   ctx.setIdleTimeout(() => {
     if (ctx.activeToolCalls.size === 0) {
       logger.debug(settledLogMessage);
-      ctx.emitIdleStatus();
+      ctx.markUpdatesSettled();
     } else {
       logger.debug(`[AcpBackend] Deferred idle skipped — ${ctx.activeToolCalls.size} active tool calls`);
     }
@@ -213,7 +218,7 @@ export function handleAgentMessageChunk(
     ctx.setIdleTimeout(() => {
       if (ctx.activeToolCalls.size === 0) {
         logger.debug('[AcpBackend] No more chunks received, emitting idle status');
-        ctx.emitIdleStatus();
+        ctx.markUpdatesSettled();
       } else {
         logger.debug(`[AcpBackend] Delaying idle status - ${ctx.activeToolCalls.size} active tool calls`);
       }
@@ -301,7 +306,7 @@ export function startToolCall(
 
       if (ctx.activeToolCalls.size === 0) {
         logger.debug('[AcpBackend] No more active tool calls after timeout, emitting idle status');
-        ctx.emitIdleStatus();
+        ctx.markUpdatesSettled();
       }
     }, timeoutMs);
 


### PR DESCRIPTION
## Summary

\`AcpBackend.sendPrompt\` previously relied on a **single** completion signal — the update-side \`idleResolver\` — to detect when an ACP turn was done. The RPC response from \`connection.prompt(...)\` was simply awaited for error propagation but did **not** participate in turn-complete detection.

Per ACP spec, agents are free to send the \`prompt\` response **before, during, or after** their final \`session/update\`, so the single-signal design races. This PR introduces a two-signal state machine so the response and the update stream are tracked independently and the turn finishes only when **both** have settled.

> **Stacking note:** this PR is built on top of #1286 (defer idle after tool completion). If #1286 has not yet merged, the diff here will look larger than just the state-machine changes; rebasing on \`main\` post-#1286 leaves only this PR's changes. The two PRs touch the same idle code path, so the recommended merge order is **#1286 first**, then this one.

## Diagnosed races

| Scenario | Old behavior | After this PR |
|---|---|---|
| Updates first, response last (spec-typical Gemini) | Works by luck — \`idleResolver\` fires from the chunk idle timer | Same observable outcome, but now also gated on \`responseReceived\` |
| Response first, then late chunks (Codex-ish) | Synchronous \`idle\` while chunks are still streaming — UI sees a closed turn that keeps writing | Grace window holds back \`idle\` until updates settle |
| Empty turn (response with no updates ever) | Deadlocks on \`waitForResponseComplete\` (120s timeout) | \`armPostResponseGrace()\` settles the turn after \`DEFAULT_IDLE_TIMEOUT_MS\` (500 ms) |
| \`tool_call_update\` completes before response | Deferred idle fires before response is back, turn flips to \`idle\` pending response | Update side settles, but \`idle\` waits for response |
| Two prompts overlap (stale resolution) | First prompt's late \`.then\` mutates current turn state | \`currentTurnId\` discriminator drops stale resolutions |

## What changed

### \`packages/happy-cli/src/agent/acp/AcpBackend.ts\`
Adds four private fields to track the new state machine:

\`\`\`ts
private responseReceived = false;
private updatesSettled = false;
private currentTurnId = 0;
private postResponseGraceTimer: NodeJS.Timeout | null = null;
\`\`\`

\`sendPrompt\` now bumps \`currentTurnId\`, resets the two booleans, then attaches a \`.then(...)\` to the RPC promise instead of bare-\`await\`ing it. That \`.then\` ignores stale resolutions (where \`turnId !== this.currentTurnId\`).

\`emitIdleStatus()\` is the single internal sink that actually emits \`{ type: 'status', status: 'idle' }\` and resolves \`idleResolver\`. It also clears all turn-complete state so a stale Promise or grace fire can't double-emit. Three new helpers (\`markUpdatesSettled\`, \`maybeCompleteTurn\`, \`armPostResponseGrace\`, \`clearPostResponseGrace\`) sit beside it; \`dispose()\` clears the grace timer.

### \`packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts\`
\`HandlerContext.emitIdleStatus\` is renamed to \`markUpdatesSettled\`. Its job is now reporting the update-stream's state, not deciding whether to emit \`idle\` — that decision moved to \`AcpBackend.maybeCompleteTurn\`. The three call sites (chunk idle timer, deferred-idle helper, tool-call timeout cleanup) are renamed accordingly.

### Tests
- **New** \`AcpBackend.race.test.ts\` (6 \`vi.useFakeTimers\` scenarios) covering: spec ordering, response-first race, empty turn, tool-complete-before-response, error rejection path, stale-turn ignoring.
- **Adjusted** \`sessionUpdateHandlers.idleDeferral.test.ts\` mock to track \`markUpdatesSettled\` (semantically the right hook for that file's deferral assertions).

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/agent/acp/\` — 61 tests pass (incl. 6 new race tests, no regressions)

## Risk

- \`status: idle\` event **schema** is unchanged. \`waitForResponseComplete\` keeps its existing contract (resolves on idle, rejects on its own timeout, configurable).
- Event **timing** changes when the agent sends response-first or empty-turn: idle is delayed up to \`DEFAULT_IDLE_TIMEOUT_MS\` (500 ms) — strictly never longer than the existing \`waitForResponseComplete\` 120s ceiling.
- No socket-schema, no mobile-app-side changes.
- Easy rollback: \`maybeCompleteTurn()\` can be reduced to an unconditional \`emitIdleStatus()\` call to restore the old behavior.

## Spec references
- \`session/prompt\` request/response: ACP spec, [Prompt Turn](https://agentclientprotocol.com/protocol/prompt-turn).
- \`session/update\` ordering with the \`prompt\` response is not constrained — both directions are valid per the JSON-RPC interleave rules used by \`@agentclientprotocol/sdk\`.