### PR TITLE
fix(acp): launch happy MCP bridge via node on Windows (gemini + generic ACP)

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -529,10 +529,17 @@ export async function runAcp(opts: {
   let sawModels = false;
 
   const happyServer = await startHappyServer(session);
+  // Launch the bridge via `node <path>` (rather than relying on the .mjs
+  // shebang) so it works on Windows, where the shell cannot execute shebang
+  // scripts directly. Mirrors the launcher pattern already used in
+  // `runCodex.ts`. Without this, the MCP server never connects on Windows,
+  // `change_title` is invisible to the model, and the agent improvises by
+  // echoing into the shell.
+  const bridgeEntrypoint = join(projectPath(), 'bin', 'happy-mcp.mjs');
   const mcpServers = {
     happy: {
-      command: join(projectPath(), 'bin', 'happy-mcp.mjs'),
-      args: ['--url', happyServer.url],
+      command: process.execPath,
+      args: ['--no-warnings', '--no-deprecation', bridgeEntrypoint, '--url', happyServer.url],
     },
   };
 

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -503,11 +503,17 @@ export async function runGemini(opts: {
   //
 
   const happyServer = await startHappyServer(session);
-  const bridgeCommand = join(projectPath(), 'bin', 'happy-mcp.mjs');
+  // Launch the bridge via `node <path>` (rather than relying on the .mjs
+  // shebang) so it works on Windows, where the shell cannot execute shebang
+  // scripts directly. Mirrors the launcher pattern already used in
+  // `runCodex.ts`. Without this, the MCP server never connects on Windows,
+  // `change_title` is invisible to the model, and Gemini improvises by
+  // echoing into the shell.
+  const bridgeEntrypoint = join(projectPath(), 'bin', 'happy-mcp.mjs');
   const mcpServers = {
     happy: {
-      command: bridgeCommand,
-      args: ['--url', happyServer.url]
+      command: process.execPath,
+      args: ['--no-warnings', '--no-deprecation', bridgeEntrypoint, '--url', happyServer.url]
     }
   };
 


### PR DESCRIPTION
## Summary

\`runCodex.ts\` already worked around Windows' inability to execute \`.mjs\` shebang scripts by launching the happy MCP bridge as \`process.execPath bin/happy-mcp.mjs --url <url>\` rather than the bare shebang path. The same fix was never back-ported to:

- \`packages/happy-cli/src/gemini/runGemini.ts:506-512\`
- \`packages/happy-cli/src/agent/acp/runAcp.ts:531-537\` (used by all other ACP-routed agents)

so on Windows:

- \`happy gemini\`: the bridge spawn fails inside Gemini CLI, the \`mcp__happy__change_title\` tool never registers with the model, the LLM can't rename the chat and tends to improvise by echoing into the shell.
- \`happy <generic-acp-agent>\`: same symptom for any agent that goes through \`runAcp.ts\`.

POSIX users were unaffected (the shebang resolves to the same node).

## Diff

Both call sites now use the same launcher pattern as \`runCodex.ts:648-658\`:

\`\`\`ts
const bridgeEntrypoint = join(projectPath(), 'bin', 'happy-mcp.mjs');
const mcpServers = {
  happy: {
    command: process.execPath,
    args: ['--no-warnings', '--no-deprecation', bridgeEntrypoint, '--url', happyServer.url],
  },
};
\`\`\`

\`process.execPath\` resolves to the same node binary the parent CLI is running under — the same one the shebang would have selected on POSIX. POSIX behavior is unchanged.

Inline comments at both sites explain the *why* so the next person who touches this code doesn't need to re-derive it from \`runCodex.ts\`.

## Scope
- Touches **only** \`packages/happy-cli/src/agent/acp/runAcp.ts\` and \`packages/happy-cli/src/gemini/runGemini.ts\`.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/agent/acp/\` — 48 tests pass, no regressions
- [ ] Manual Windows smoke (don't have a Windows box handy — would appreciate Windows reviewer running \`happy gemini\` once)

## Notes
A nicer next step would be hoisting the launcher snippet into a shared helper (\`agent/util/happyMcpBridge.ts\`) so \`runCodex.ts\` and the two new sites all import the same factory, but that's a follow-up refactor — this PR is intentionally minimal to keep the Windows fix unblocked.