### PR TITLE
fix(acp): route turn-end timeout through unified clearPendingTurn path

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -569,8 +569,24 @@ export async function runAcp(opts: {
 
   const waitForTurnEnd = () => new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      pendingTurn = null;
-      reject(new Error(`Timed out waiting for ${opts.agentName} to finish the turn`));
+      // Route the timeout through the unified `clearPendingTurn` path so
+      // the surrounding catch handler in the prompt-batch loop always
+      // sees a consistent state machine (pendingTurn nulled, timer
+      // cleared, reject delivered exactly once). Previously the timer cb
+      // nulled pendingTurn itself, which left a window where a late
+      // `idle` from the backend (firing within the same tick) hit the
+      // now-no-op `clearPendingTurn` at the idle-status handler — and
+      // the eventual catch path could be mis-ordered with respect to
+      // the turn's envelope flush.
+      //
+      // Guard with reference equality so an out-of-band `clearPendingTurn`
+      // racing the timer doesn't get clobbered.
+      if (pendingTurn?.timeout !== timeout) return;
+      clearPendingTurn(
+        new Error(
+          `Timed out waiting for ${opts.agentName} to finish the turn after ${TURN_TIMEOUT_MS / 60_000} minutes`,
+        ),
+      );
     }, TURN_TIMEOUT_MS);
     pendingTurn = { resolve, reject, timeout };
   });


### PR DESCRIPTION
## Summary

\`packages/happy-cli/src/agent/acp/runAcp.ts\` has two cleanup paths for the per-turn pending promise:

1. The unified \`clearPendingTurn(err?)\` helper at line 556 — used by the backend's idle-status handler (line 815-816), the abort path, and the runner shutdown.
2. The \`waitForTurnEnd\` setTimeout callback at line 570-576 — which until now skipped \`clearPendingTurn\` and directly did \`pendingTurn = null; reject(...)\`.

The two diverged, and when a backend \`idle\` event fires within the **same tick** as the 5-minute timeout — entirely possible if the agent's last update lands right at the boundary — the ordering of:

- timer cb sees \`pendingTurn\` and nulls it
- idle-status handler then calls \`clearPendingTurn()\` and finds nothing to do
- microtask: catch-block in the prompt-batch loop fires \`endTurn('failed')\` + \`ready\`

...becomes load-bearing. Any future change to either side has to keep the two state-machine paths in lockstep.

## Diagnosis & fix

This PR routes the timer cb through \`clearPendingTurn(err)\` so there is exactly **one** teardown path. The change adds a reference-equality guard so an out-of-band \`clearPendingTurn\` racing the timer cannot get clobbered:

\`\`\`ts
const timeout = setTimeout(() => {
  if (pendingTurn?.timeout !== timeout) return;
  clearPendingTurn(new Error(
    `Timed out waiting for ${opts.agentName} to finish the turn after ${TURN_TIMEOUT_MS / 60_000} minutes`,
  ));
}, TURN_TIMEOUT_MS);
\`\`\`

The error message now also reports the configured timeout window — useful when reading mobile-side spinner-stuck reports.

## Scope
- Touches **only** \`packages/happy-cli/src/agent/acp/runAcp.ts\` (single function, 16-line diff).
- No behavior change on the non-race happy path.
- No API surface change.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/agent/acp/runAcp.test.ts\` — 9 tests pass, no regressions

Note on test coverage: \`runAcp\` is a long top-level closure (~1000 lines) that captures dozens of mocks for any meaningful unit test, and the race is between same-tick microtask ordering — fragile in vitest with real timers, error-prone with fake. The PR's diff is small enough that close reading is the better safety net here; reviewer should focus on the unified-cleanup-site invariant (\`clearPendingTurn\` is the only path that touches \`pendingTurn\`).