### PR TITLE
fix(acp): harden AcpBackend.dispose lifecycle and drop dead pendingPermissions

### DIFF
--- a/packages/happy-cli/src/agent/acp/AcpBackend.disposeSafety.test.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.disposeSafety.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentMessage } from '@/agent/core';
+import { AcpBackend } from './AcpBackend';
+
+function createBackend(extraOptions: Partial<ConstructorParameters<typeof AcpBackend>[0]> = {}): AcpBackend {
+  return new AcpBackend({
+    agentName: 'test',
+    cwd: '/tmp',
+    command: '/bin/true',
+    ...extraOptions,
+  });
+}
+
+function captureEvents(backend: AcpBackend): AgentMessage[] {
+  const events: AgentMessage[] = [];
+  backend.onMessage((msg) => events.push(msg));
+  return events;
+}
+
+describe('AcpBackend dispose safety', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('createHandlerContext.setIdleTimeout — callback does NOT fire after dispose', async () => {
+    const backend = createBackend();
+    const events = captureEvents(backend);
+    const ctx = (backend as unknown as { createHandlerContext(): { setIdleTimeout(cb: () => void, ms: number): void; emitIdleStatus(): void } }).createHandlerContext();
+
+    const callback = vi.fn();
+    ctx.setIdleTimeout(callback, 500);
+
+    // Dispose before the timer fires (don't await — dispose's process.kill
+    // paths take real time; we just need the synchronous `disposed = true`).
+    void backend.dispose();
+    expect((backend as unknown as { disposed: boolean }).disposed).toBe(true);
+
+    // Advance past the would-be fire moment.
+    vi.advanceTimersByTime(500);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(events.some((e) => e.type === 'status' && (e as { status: string }).status === 'idle')).toBe(false);
+  });
+
+  it('createHandlerContext.setIdleTimeout — scheduling AFTER dispose is a no-op', () => {
+    const backend = createBackend();
+    const ctx = (backend as unknown as { createHandlerContext(): { setIdleTimeout(cb: () => void, ms: number): void } }).createHandlerContext();
+
+    void backend.dispose();
+    const callback = vi.fn();
+    ctx.setIdleTimeout(callback, 100);
+
+    vi.advanceTimersByTime(1000);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('createHandlerContext.emitIdleStatus — gated on disposed', () => {
+    const backend = createBackend();
+    const events = captureEvents(backend);
+    const ctx = (backend as unknown as { createHandlerContext(): { emitIdleStatus(): void } }).createHandlerContext();
+
+    void backend.dispose();
+    ctx.emitIdleStatus();
+
+    expect(events.some((e) => e.type === 'status' && (e as { status: string }).status === 'idle')).toBe(false);
+  });
+
+  it('dispose() calls permissionHandler.reset() to unblock pending RPC awaits', async () => {
+    const reset = vi.fn();
+    const permissionHandler = {
+      handleToolCall: vi.fn(),
+      reset,
+      abortAll: vi.fn(),
+      updateSession: vi.fn(),
+    };
+
+    const backend = createBackend({
+      permissionHandler: permissionHandler as unknown as ConstructorParameters<typeof AcpBackend>[0]['permissionHandler'],
+    });
+
+    await backend.dispose();
+    expect(reset).toHaveBeenCalledOnce();
+    expect(reset.mock.calls[0][0]).toMatch(/dispose/i);
+  });
+
+  it('dispose() tolerates permissionHandler.reset() throwing (does not block subsequent cleanup)', async () => {
+    const permissionHandler = {
+      handleToolCall: vi.fn(),
+      reset: vi.fn(() => {
+        throw new Error('boom from reset');
+      }),
+      abortAll: vi.fn(),
+      updateSession: vi.fn(),
+    };
+
+    const backend = createBackend({
+      permissionHandler: permissionHandler as unknown as ConstructorParameters<typeof AcpBackend>[0]['permissionHandler'],
+    });
+
+    await expect(backend.dispose()).resolves.toBeUndefined();
+    expect((backend as unknown as { disposed: boolean }).disposed).toBe(true);
+  });
+});

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -171,6 +171,14 @@ export interface AcpPermissionHandler {
     toolName: string,
     input: unknown
   ): Promise<{ decision: 'approved' | 'approved_for_session' | 'denied' | 'abort' }>;
+
+  /**
+   * Optional reset hook called from `AcpBackend.dispose()` so any in-flight
+   * permission Promise (awaiting the user) can be rejected synchronously.
+   * Both `GeminiPermissionHandler` and `CodexPermissionHandler` inherit this
+   * from `BasePermissionHandler`.
+   */
+  reset?(reason?: string): void;
 }
 
 /**
@@ -325,8 +333,6 @@ export class AcpBackend implements AgentBackend {
   private toolCallTimeouts = new Map<string, NodeJS.Timeout>();
   /** Track tool call start times for performance monitoring */
   private toolCallStartTimes = new Map<string, number>();
-  /** Pending permission requests that need response */
-  private pendingPermissions = new Map<string, (response: RequestPermissionResponse) => void>();
 
   /** Map from permission request ID to real tool call ID for tracking */
   private permissionToToolCallMap = new Map<string, string>();
@@ -879,7 +885,17 @@ export class AcpBackend implements AgentBackend {
       idleTimeout: this.idleTimeout,
       toolCallCountSincePrompt: this.toolCallCountSincePrompt,
       emit: (msg) => this.emit(msg),
-      emitIdleStatus: () => this.emitIdleStatus(),
+      // The four callbacks below all gate on `this.disposed` so that
+      // sessionUpdateHandlers' tool-call timeouts (which are bare Node
+      // setTimeouts, not tracked by `idleTimeout`) cannot mutate backend
+      // state after dispose. Without these guards, a tool-call timeout
+      // firing within milliseconds of `dispose()` would emit `idle` on a
+      // dead backend — that ghost emission could pollute a follow-up
+      // backend recreated by the Gemini mode-switch flow.
+      emitIdleStatus: () => {
+        if (this.disposed) return;
+        this.emitIdleStatus();
+      },
       clearIdleTimeout: () => {
         if (this.idleTimeout) {
           clearTimeout(this.idleTimeout);
@@ -887,9 +903,11 @@ export class AcpBackend implements AgentBackend {
         }
       },
       setIdleTimeout: (callback, ms) => {
+        if (this.disposed) return;
         this.idleTimeout = setTimeout(() => {
-          callback();
           this.idleTimeout = null;
+          if (this.disposed) return;
+          callback();
         }, ms);
       },
     };
@@ -1320,6 +1338,16 @@ export class AcpBackend implements AgentBackend {
       this.idleTimeout = null;
     }
 
+    // Reject any in-flight permission requests so the `requestPermission`
+    // RPC handler (which `await`s `options.permissionHandler.handleToolCall`)
+    // doesn't deadlock the ACP SDK's reader thread when the backend goes
+    // away while a permission dialog is still open on the mobile app.
+    try {
+      this.options.permissionHandler?.reset?.('AcpBackend disposed');
+    } catch (err) {
+      logger.debug('[AcpBackend] permissionHandler.reset threw during dispose:', err);
+    }
+
     // Clear state
     this.listeners = [];
     this.connection = null;
@@ -1331,6 +1359,5 @@ export class AcpBackend implements AgentBackend {
     }
     this.toolCallTimeouts.clear();
     this.toolCallStartTimes.clear();
-    this.pendingPermissions.clear();
   }
 }


### PR DESCRIPTION
## Summary
Two related dispose-path issues in \`packages/happy-cli/src/agent/acp/AcpBackend.ts\`:

### 1. Dead \`pendingPermissions\` Map masquerading as a cleanup hook
\`AcpBackend.pendingPermissions\` was declared at line 329 but **never** \`.set()\` anywhere in the codebase — only declared, then \`.clear()\`'d in \`dispose()\`. The actual pending-permission state lives in \`BasePermissionHandler.pendingRequests\` (\`packages/happy-cli/src/utils/BasePermissionHandler.ts:47\`), owned by \`GeminiPermissionHandler\` / \`CodexPermissionHandler\` and used by the synchronous \`requestPermission\` RPC handler at \`AcpBackend.ts:567-720\`.

Because \`dispose()\` never reached into the real pending map, disposing the backend while a permission dialog is open on the mobile app left the \`requestPermission\` SDK handler \`await\`ing a Promise nobody would ever resolve — blocking the ACP SDK's RPC reader thread for the full SIGTERM + SIGKILL grace period (~3 s + 1 s).

**Fix:**
- Delete the unused \`pendingPermissions\` Map and its \`.clear()\` call.
- Call \`this.options.permissionHandler?.reset?.('AcpBackend disposed')\` from \`dispose()\`. \`BasePermissionHandler.reset()\` (lines 189-235) already rejects every pending Promise with \`Error('Session reset')\` — same semantics that \`runAcp.ts:518, 864, 944\` already rely on.
- Surface \`reset?\` on the public \`AcpPermissionHandler\` interface as an **optional** method so both Gemini and Codex handlers wire up automatically; injected custom handlers don't need to change.
- Wrap the \`reset()\` call in try/catch so a misbehaving custom handler can't block the rest of \`dispose()\`.

### 2. \`HandlerContext\` callbacks fire on disposed backends
\`createHandlerContext()\` produced \`emitIdleStatus\`, \`setIdleTimeout\`, and \`clearIdleTimeout\` closures that captured \`this\` (the AcpBackend) but didn't gate on \`this.disposed\`. Tool-call timeouts in \`sessionUpdateHandlers.ts\` use bare \`setTimeout\` (not tracked by \`idleTimeout\`), so a timeout firing within milliseconds of \`dispose()\` — exactly what happens in the Gemini mode-switch flow that disposes the old backend while a tool is in-flight — would call \`emitIdleStatus\` on a dead instance and emit a ghost \`idle\` status that could pollute a freshly-recreated backend.

**Fix:** add \`if (this.disposed) return\` guards to:
- \`emitIdleStatus\` (before delegating to the instance method)
- \`setIdleTimeout\` (both at scheduling time and inside the inner \`setTimeout\` callback before invoking the caller's callback)

\`emit\` already had the disposed guard at line 364, so no change needed there.

## Scope
- Touches **only** \`packages/happy-cli/src/agent/acp/AcpBackend.ts\` plus a new colocated test file.
- No change to \`runAcp.ts\`, \`sessionUpdateHandlers.ts\`, or the permission handlers themselves.
- The \`AcpPermissionHandler\` interface gets a new optional method — fully backwards-compatible with any existing custom implementations.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/agent/acp/\` — 53 tests pass (incl. 5 new dispose-safety tests, no regressions)

### New tests cover:
1. \`setIdleTimeout\` scheduled **before** dispose: callback does not fire after \`vi.advanceTimersByTime(500)\`.
2. \`setIdleTimeout\` scheduled **after** dispose: no timer is even armed.
3. \`emitIdleStatus\` after dispose: no \`idle\` AgentMessage is pushed.
4. \`dispose()\` invokes \`permissionHandler.reset()\` exactly once with a disposed-context reason string.
5. \`dispose()\` tolerates \`permissionHandler.reset()\` throwing — \`disposed\` is still set to \`true\`.

## Notes
The Gemini mode-switch flow (\`runGemini.ts:947-979\`) is the most reliable way to hit this race in real usage: it tears down a backend with a tool-call in-flight and immediately spins up a new one. Before this fix, a ghost \`idle\` from the dead backend could land on the new one's listeners and trip turn-state assertions downstream.