### PR TITLE
fix(acp): defer offline-reconnection session swap until current turn ends

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -482,6 +482,28 @@ export async function runAcp(opts: {
 
   let session: ApiSessionClient;
   let permissionHandler: GenericAcpPermissionHandler;
+
+  // Session-swap synchronization. `setupOfflineReconnection` can hand us a
+  // brand-new `ApiSessionClient` at any point — including mid-turn, while
+  // `onBackendMessage` is dispatching envelopes through `session.*`. If we
+  // swapped synchronously, half a turn's envelopes would land on the old
+  // (offline-stub) session and silently drop, while the other half landed
+  // on the new one. We mirror the queue-and-defer pattern already used by
+  // `runGemini.ts:144-181, 1001, 1291-1292`.
+  let isProcessingMessage = false;
+  let pendingSessionSwap: ApiSessionClient | null = null;
+
+  const applyPendingSessionSwap = () => {
+    if (pendingSessionSwap) {
+      logger.debug(`[${opts.agentName}] Applying deferred session swap`);
+      session = pendingSessionSwap;
+      if (permissionHandler) {
+        permissionHandler.updateSession(pendingSessionSwap);
+      }
+      pendingSessionSwap = null;
+    }
+  };
+
   const { session: initialSession, reconnectionHandle } = setupOfflineReconnection({
     api,
     sessionTag,
@@ -489,6 +511,13 @@ export async function runAcp(opts: {
     state,
     response,
     onSessionSwap: (newSession) => {
+      if (isProcessingMessage) {
+        // Defer until the in-flight turn finishes so envelopes don't get
+        // split across two ApiSessionClients.
+        logger.debug(`[${opts.agentName}] Session swap requested mid-turn — queueing`);
+        pendingSessionSwap = newSession;
+        return;
+      }
       session = newSession;
       if (permissionHandler) {
         permissionHandler.updateSession(newSession);
@@ -913,6 +942,9 @@ export async function runAcp(opts: {
       logAcp('incoming', `Incoming prompt: ${formatUnknownForConsole(batch.message, ACP_EVENT_PREVIEW_CHARS)}`);
       sendEnvelopes(sessionManager.startTurn());
       const turnEnded = waitForTurnEnd();
+      // Block session swaps for the duration of this turn — any swap
+      // requested while we're mid-flight is queued and applied below.
+      isProcessingMessage = true;
       try {
         if (typeof batch.mode.permissionMode === 'string' && batch.mode.permissionMode.length > 0) {
           await switchPermissionModeIfRequested(batch.mode.permissionMode);
@@ -933,6 +965,9 @@ export async function runAcp(opts: {
         logAcp('error', `Prompt error from ${opts.agentName}: ${error instanceof Error ? error.message : String(error)}`);
         clearPendingTurn(error instanceof Error ? error : new Error(String(error)));
         throw error;
+      } finally {
+        isProcessingMessage = false;
+        applyPendingSessionSwap();
       }
     }
   } finally {


### PR DESCRIPTION
## Summary
\`runAcp.ts\`'s \`onSessionSwap\` callback applied the new \`ApiSessionClient\` synchronously, including during an in-flight turn. \`onBackendMessage\` reads \`session.*\` on every envelope, so a network blip that triggers \`setupOfflineReconnection\` mid-turn caused envelopes to split across two sessions:

- Turn-start, model output, and tool-call envelopes landed on the OLD session (now an offline stub) and silently dropped.
- Tool-results, turn-end, and \`ready\` landed on the NEW session.

Net effect: a network blip during a long turn produced half-rendered messages in the mobile chat, and a stuck spinner if the swap landed near \`turn-end\`.

\`runGemini.ts:144-181, 1001, 1291-1292\` already solved this exact problem with a queue-and-defer pattern. This PR ports the same pattern to \`runAcp.ts\` so Gemini and the generic ACP runner behave identically.

## Diff in one paragraph

- New \`isProcessingMessage\` flag flipped to \`true\` right before each turn's \`try\` block and back to \`false\` in a \`finally\`.
- New \`pendingSessionSwap\` slot + \`applyPendingSessionSwap()\` helper.
- \`onSessionSwap\` queues the new session into \`pendingSessionSwap\` when \`isProcessingMessage\` is \`true\`, applies it immediately otherwise.
- The turn-loop's \`finally\` drains \`pendingSessionSwap\` before the next \`messageQueue.waitForMessagesAndGetAsString\` iteration.

## Scope
- Touches **only** \`packages/happy-cli/src/agent/acp/runAcp.ts\`.
- No new files, no API changes, no impact on the Codex / Claude paths.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/agent/acp/\` — all 48 ACP unit tests pass

The race is the same one that \`runGemini.ts\` has documentation for at lines 142-181; this PR doesn't add new tests because the test infra in \`runAcp.test.ts\` already exercises the \`onBackendMessage\` / \`session.*\` envelope path against a mock \`ApiSessionClient\`, and the new flags only kick in when an offline reconnect synthesizes a *new* session mid-turn — which is currently outside the unit-test fixture's surface area.

## Notes
The deferral is bounded by the per-turn \`TURN_TIMEOUT_MS\` (5 min by default), so a swap can never be queued indefinitely. If the turn times out via \`waitForTurnEnd\`, the \`catch\` path runs and the \`finally\` block still drains the pending swap before the next turn.