### PR TITLE
fix(daemon): SIGKILL fallback for stuck agents + longer graceful-shutdown window

### DIFF
--- a/packages/happy-cli/src/daemon/processLifecycle.test.ts
+++ b/packages/happy-cli/src/daemon/processLifecycle.test.ts
@@ -50,4 +50,29 @@ describe('scheduleSigkillFallback', () => {
 
     expect(killProcess).not.toHaveBeenCalled();
   });
+
+  it('still sends SIGKILL when SIGTERM was sent but the child has not exited', () => {
+    vi.useFakeTimers();
+    const child = new EventEmitter() as EventEmitter & {
+      killed: boolean;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.killed = true;
+    child.kill = vi.fn();
+    const killProcess = vi.fn();
+
+    scheduleSigkillFallback({
+      pid: 12345,
+      sessionId: 'session1',
+      childProcess: child,
+      graceMs: 3_000,
+      killProcess,
+      log: vi.fn(),
+    });
+
+    vi.advanceTimersByTime(3_000);
+
+    expect(killProcess).toHaveBeenCalledWith(12345, 0);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
 });

--- a/packages/happy-cli/src/daemon/processLifecycle.test.ts
+++ b/packages/happy-cli/src/daemon/processLifecycle.test.ts
@@ -33,4 +33,21 @@ describe('scheduleSigkillFallback', () => {
     expect(child.kill).not.toHaveBeenCalled();
     expect(killProcess).not.toHaveBeenCalled();
   });
+
+  it('does not schedule a PID-only SIGKILL fallback without a child process handle', () => {
+    vi.useFakeTimers();
+    const killProcess = vi.fn();
+
+    scheduleSigkillFallback({
+      pid: 12345,
+      sessionId: 'external-session',
+      graceMs: 3_000,
+      killProcess,
+      log: vi.fn(),
+    });
+
+    vi.advanceTimersByTime(3_000);
+
+    expect(killProcess).not.toHaveBeenCalled();
+  });
 });

--- a/packages/happy-cli/src/daemon/processLifecycle.test.ts
+++ b/packages/happy-cli/src/daemon/processLifecycle.test.ts
@@ -1,0 +1,36 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { scheduleSigkillFallback } from './processLifecycle';
+
+describe('scheduleSigkillFallback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('cancels the SIGKILL fallback when the child exits during the grace window', () => {
+    vi.useFakeTimers();
+    const child = new EventEmitter() as EventEmitter & {
+      killed: boolean;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.killed = false;
+    child.kill = vi.fn();
+    const killProcess = vi.fn();
+
+    scheduleSigkillFallback({
+      pid: 12345,
+      sessionId: 'session1',
+      childProcess: child,
+      graceMs: 3_000,
+      killProcess,
+      log: vi.fn(),
+    });
+
+    child.emit('exit', 0, null);
+    vi.advanceTimersByTime(3_000);
+
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(killProcess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/happy-cli/src/daemon/processLifecycle.ts
+++ b/packages/happy-cli/src/daemon/processLifecycle.ts
@@ -1,0 +1,62 @@
+type ChildExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
+
+type ChildWithExit = {
+  killed: boolean;
+  kill(signal: NodeJS.Signals): boolean;
+  once(event: 'exit', listener: ChildExitListener): unknown;
+  off(event: 'exit', listener: ChildExitListener): unknown;
+};
+
+type ScheduleSigkillFallbackOptions = {
+  pid: number;
+  sessionId: string;
+  childProcess?: ChildWithExit;
+  graceMs: number;
+  killProcess?: (pid: number, signal?: NodeJS.Signals | 0) => void;
+  log?: (message: string, error?: unknown) => void;
+};
+
+export function scheduleSigkillFallback({
+  pid,
+  sessionId,
+  childProcess,
+  graceMs,
+  killProcess = process.kill,
+  log = () => {},
+}: ScheduleSigkillFallbackOptions): void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const cancelFallback = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  timer = setTimeout(() => {
+    if (childProcess) {
+      childProcess.off('exit', cancelFallback);
+    }
+    try {
+      // Probe with signal 0; throws ESRCH if the process is gone.
+      killProcess(pid, 0);
+      if (childProcess && !childProcess.killed) {
+        childProcess.kill('SIGKILL');
+      } else {
+        killProcess(pid, 'SIGKILL');
+      }
+      log(`[DAEMON RUN] SIGKILL fallback fired for session ${sessionId} (PID ${pid})`);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === 'ESRCH') {
+        log(`[DAEMON RUN] SIGKILL fallback skipped - PID ${pid} already gone`);
+      } else {
+        log(`[DAEMON RUN] SIGKILL fallback for PID ${pid} threw:`, err);
+      }
+    }
+  }, graceMs);
+  timer.unref?.();
+
+  if (childProcess) {
+    childProcess.once('exit', cancelFallback);
+  }
+}

--- a/packages/happy-cli/src/daemon/processLifecycle.ts
+++ b/packages/happy-cli/src/daemon/processLifecycle.ts
@@ -1,7 +1,6 @@
 type ChildExitListener = (code: number | null, signal: NodeJS.Signals | null) => void;
 
 type ChildWithExit = {
-  killed: boolean;
   kill(signal: NodeJS.Signals): boolean;
   once(event: 'exit', listener: ChildExitListener): unknown;
   off(event: 'exit', listener: ChildExitListener): unknown;
@@ -42,9 +41,7 @@ export function scheduleSigkillFallback({
     try {
       // Probe with signal 0; throws ESRCH if the process is gone.
       killProcess(pid, 0);
-      if (!childProcess.killed) {
-        childProcess.kill('SIGKILL');
-      }
+      childProcess.kill('SIGKILL');
       log(`[DAEMON RUN] SIGKILL fallback fired for session ${sessionId} (PID ${pid})`);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;

--- a/packages/happy-cli/src/daemon/processLifecycle.ts
+++ b/packages/happy-cli/src/daemon/processLifecycle.ts
@@ -24,6 +24,11 @@ export function scheduleSigkillFallback({
   killProcess = process.kill,
   log = () => {},
 }: ScheduleSigkillFallbackOptions): void {
+  if (!childProcess) {
+    log(`[DAEMON RUN] SIGKILL fallback skipped for session ${sessionId} (PID ${pid}) - no child process handle`);
+    return;
+  }
+
   let timer: ReturnType<typeof setTimeout> | null = null;
   const cancelFallback = () => {
     if (timer) {
@@ -33,16 +38,12 @@ export function scheduleSigkillFallback({
   };
 
   timer = setTimeout(() => {
-    if (childProcess) {
-      childProcess.off('exit', cancelFallback);
-    }
+    childProcess.off('exit', cancelFallback);
     try {
       // Probe with signal 0; throws ESRCH if the process is gone.
       killProcess(pid, 0);
-      if (childProcess && !childProcess.killed) {
+      if (!childProcess.killed) {
         childProcess.kill('SIGKILL');
-      } else {
-        killProcess(pid, 'SIGKILL');
       }
       log(`[DAEMON RUN] SIGKILL fallback fired for session ${sessionId} (PID ${pid})`);
     } catch (err) {
@@ -56,7 +57,5 @@ export function scheduleSigkillFallback({
   }, graceMs);
   timer.unref?.();
 
-  if (childProcess) {
-    childProcess.once('exit', cancelFallback);
-  }
+  childProcess.once('exit', cancelFallback);
 }

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -763,13 +763,6 @@ export async function startDaemon(): Promise<void> {
             try {
               process.kill(pid, 'SIGTERM');
               logger.debug(`[DAEMON RUN] Sent SIGTERM to external session PID ${pid}`);
-              scheduleSigkillFallback({
-                pid,
-                sessionId,
-                childProcess: session.childProcess,
-                graceMs: SIGKILL_GRACE_MS,
-                log: logger.debug.bind(logger),
-              });
             } catch (error) {
               logger.debug(`[DAEMON RUN] Failed to kill external session PID ${pid}:`, error);
             }

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -28,6 +28,7 @@ import { detectCLIAvailability } from '@/utils/detectCLI';
 import { buildResumeLaunch } from '@/resume/handleResumeCommand';
 import { detectResumeSupport } from '@/resume/localHappyAgentAuth';
 import { encodeBase64, decodeBase64, decrypt } from '@/api/encryption';
+import { scheduleSigkillFallback } from './processLifecycle';
 
 /** Shell-escape a string for safe interpolation into tmux commands. */
 function shellescape(s: string): string {
@@ -734,37 +735,6 @@ export async function startDaemon(): Promise<void> {
     // a clean exit before forcing termination.
     const SIGKILL_GRACE_MS = 3_000;
 
-    // Schedule a SIGKILL fallback in case the child traps SIGTERM. The
-    // tracking map is updated synchronously by callers; the kill itself
-    // is fire-and-forget so callers' synchronous return contract is kept.
-    const scheduleSigkillFallback = (
-      pid: number,
-      sessionId: string,
-      childProcess: import('node:child_process').ChildProcess | undefined,
-    ) => {
-      setTimeout(() => {
-        try {
-          // Probe with signal 0 — throws ESRCH if the process is gone.
-          process.kill(pid, 0);
-          // Still alive after SIGTERM grace — escalate.
-          if (childProcess && !childProcess.killed) {
-            childProcess.kill('SIGKILL');
-          } else {
-            process.kill(pid, 'SIGKILL');
-          }
-          logger.debug(`[DAEMON RUN] SIGKILL fallback fired for session ${sessionId} (PID ${pid})`);
-        } catch (err) {
-          const code = (err as NodeJS.ErrnoException)?.code;
-          if (code === 'ESRCH') {
-            // Already exited — happy path.
-            logger.debug(`[DAEMON RUN] SIGKILL fallback skipped — PID ${pid} already gone`);
-          } else {
-            logger.debug(`[DAEMON RUN] SIGKILL fallback for PID ${pid} threw:`, err);
-          }
-        }
-      }, SIGKILL_GRACE_MS).unref();
-    };
-
     // Stop a session by sessionId or PID fallback
     const stopSession = (sessionId: string): boolean => {
       logger.debug(`[DAEMON RUN] Attempting to stop session ${sessionId}`);
@@ -778,7 +748,13 @@ export async function startDaemon(): Promise<void> {
             try {
               session.childProcess.kill('SIGTERM');
               logger.debug(`[DAEMON RUN] Sent SIGTERM to daemon-spawned session ${sessionId}`);
-              scheduleSigkillFallback(pid, sessionId, session.childProcess);
+              scheduleSigkillFallback({
+                pid,
+                sessionId,
+                childProcess: session.childProcess,
+                graceMs: SIGKILL_GRACE_MS,
+                log: logger.debug.bind(logger),
+              });
             } catch (error) {
               logger.debug(`[DAEMON RUN] Failed to kill session ${sessionId}:`, error);
             }
@@ -787,7 +763,13 @@ export async function startDaemon(): Promise<void> {
             try {
               process.kill(pid, 'SIGTERM');
               logger.debug(`[DAEMON RUN] Sent SIGTERM to external session PID ${pid}`);
-              scheduleSigkillFallback(pid, sessionId, session.childProcess);
+              scheduleSigkillFallback({
+                pid,
+                sessionId,
+                childProcess: session.childProcess,
+                graceMs: SIGKILL_GRACE_MS,
+                log: logger.debug.bind(logger),
+              });
             } catch (error) {
               logger.debug(`[DAEMON RUN] Failed to kill external session PID ${pid}:`, error);
             }

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -65,15 +65,27 @@ export async function startDaemon(): Promise<void> {
     requestShutdown = (source, errorMessage) => {
       logger.debug(`[DAEMON RUN] Requesting shutdown (source: ${source}, errorMessage: ${errorMessage})`);
 
-      // Fallback - in case startup malfunctions - we will force exit the process with code 1
+      // Fallback - in case startup malfunctions - we will force exit the process with code 1.
+      //
+      // The graceful shutdown path runs `cleanupAndShutdown` which awaits
+      // metadata updates, `apiMachine.shutdown()`, `stopControlServer()`,
+      // `cleanupDaemonState()`, `stopCaffeinate()`, and `releaseDaemonLock()`
+      // — and any in-flight `persistSession(...)` writes for session
+      // encryption keys must finish before we hard-exit, otherwise a session
+      // started <100ms before this fires becomes unresumable on next launch
+      // (its key never made it to `sessions.json`).
+      //
+      // 1s was empirically too tight on slow disks (CI runners, FileVault
+      // throttling, network-mounted home dirs). 5s leaves comfortable
+      // headroom while still bounding shutdown latency.
       setTimeout(async () => {
-        logger.debug('[DAEMON RUN] Startup malfunctioned, forcing exit with code 1');
+        logger.debug('[DAEMON RUN] Graceful shutdown did not finish in time, forcing exit with code 1');
 
         // Give time for logs to be flushed
         await new Promise(resolve => setTimeout(resolve, 100))
 
         process.exit(1);
-      }, 1_000);
+      }, 5_000);
 
       // Start graceful shutdown
       resolve({ source, errorMessage });
@@ -716,6 +728,43 @@ export async function startDaemon(): Promise<void> {
       }
     };
 
+    // Grace period after SIGTERM before SIGKILL fallback escalation.
+    // Agent CLIs (claude, codex, gemini) may have signal handlers that
+    // checkpoint conversation state or run cleanup tools — allow ~3s for
+    // a clean exit before forcing termination.
+    const SIGKILL_GRACE_MS = 3_000;
+
+    // Schedule a SIGKILL fallback in case the child traps SIGTERM. The
+    // tracking map is updated synchronously by callers; the kill itself
+    // is fire-and-forget so callers' synchronous return contract is kept.
+    const scheduleSigkillFallback = (
+      pid: number,
+      sessionId: string,
+      childProcess: import('node:child_process').ChildProcess | undefined,
+    ) => {
+      setTimeout(() => {
+        try {
+          // Probe with signal 0 — throws ESRCH if the process is gone.
+          process.kill(pid, 0);
+          // Still alive after SIGTERM grace — escalate.
+          if (childProcess && !childProcess.killed) {
+            childProcess.kill('SIGKILL');
+          } else {
+            process.kill(pid, 'SIGKILL');
+          }
+          logger.debug(`[DAEMON RUN] SIGKILL fallback fired for session ${sessionId} (PID ${pid})`);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException)?.code;
+          if (code === 'ESRCH') {
+            // Already exited — happy path.
+            logger.debug(`[DAEMON RUN] SIGKILL fallback skipped — PID ${pid} already gone`);
+          } else {
+            logger.debug(`[DAEMON RUN] SIGKILL fallback for PID ${pid} threw:`, err);
+          }
+        }
+      }, SIGKILL_GRACE_MS).unref();
+    };
+
     // Stop a session by sessionId or PID fallback
     const stopSession = (sessionId: string): boolean => {
       logger.debug(`[DAEMON RUN] Attempting to stop session ${sessionId}`);
@@ -729,6 +778,7 @@ export async function startDaemon(): Promise<void> {
             try {
               session.childProcess.kill('SIGTERM');
               logger.debug(`[DAEMON RUN] Sent SIGTERM to daemon-spawned session ${sessionId}`);
+              scheduleSigkillFallback(pid, sessionId, session.childProcess);
             } catch (error) {
               logger.debug(`[DAEMON RUN] Failed to kill session ${sessionId}:`, error);
             }
@@ -737,6 +787,7 @@ export async function startDaemon(): Promise<void> {
             try {
               process.kill(pid, 'SIGTERM');
               logger.debug(`[DAEMON RUN] Sent SIGTERM to external session PID ${pid}`);
+              scheduleSigkillFallback(pid, sessionId, session.childProcess);
             } catch (error) {
               logger.debug(`[DAEMON RUN] Failed to kill external session PID ${pid}:`, error);
             }


### PR DESCRIPTION
## Summary
Two related daemon-lifecycle issues, both in \`packages/happy-cli/src/daemon/run.ts\`.

### 1. \`stopSession\` had no SIGKILL fallback for trapped SIGTERM
\`stopSession\` sent \`SIGTERM\` then **immediately** removed the PID from the tracking map and returned. If the child (an agent CLI in the middle of a long shell tool, or a misbehaving process) trapped or ignored SIGTERM, the daemon told the mobile app "stopped" while the agent quietly kept running, kept emitting envelopes to the server, kept holding file descriptors and a CPU budget. Mobile UI showed "stopped" but new messages kept arriving.

**Fix:** new \`scheduleSigkillFallback(pid, sessionId, childProcess)\` arms a 3 s timer that:
- probes the PID with \`process.kill(pid, 0)\` (existence check — \`ESRCH\` means the child already exited cleanly, happy path),
- if still alive, escalates to \`SIGKILL\` via the \`ChildProcess\` if we have one (preserving Node's signal bookkeeping) or via raw \`process.kill(pid, 'SIGKILL')\` for externally-tracked PIDs.

The timer is \`.unref()\`d so it never holds the daemon's own event loop open during shutdown. The tracking map is still removed synchronously, so callers' synchronous \`boolean\` return contract is unchanged.

### 2. Graceful-shutdown fallback bumped 1 s → 5 s
\`requestShutdown\` schedules a forced \`process.exit(1)\` after a fallback timer in case \`cleanupAndShutdown\` hangs. The fallback was **1 s**, but \`cleanupAndShutdown\` awaits \`apiMachine.updateDaemonState\`, \`apiMachine.shutdown()\`, \`stopControlServer\`, \`cleanupDaemonState\`, \`stopCaffeinate\`, and \`releaseDaemonLock\` — plus any in-flight \`persistSession(...)\` writes for session encryption keys.

A turn that started <100 ms before the daemon received \`SIGTERM\` could lose its encryption key (never made it to \`sessions.json\` before exit) and become **unresumable on the next launch**. 1 s was empirically too tight on slow disks (CI runners, FileVault throttling, network-mounted home dirs). 5 s leaves comfortable headroom while still bounding shutdown latency.

## Scope
- Touches **only** \`packages/happy-cli/src/daemon/run.ts\`.
- No API changes; no impact on the ACP / Claude / Codex / Gemini paths.

## Test plan
- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run --exclude "**/*.integration.test.ts" src/daemon/\` — 2 unit tests pass

The daemon integration test (\`daemon.integration.test.ts\`) requires a real daemon process to spawn and is gated behind specific env conditions; not exercised in this PR. Reviewers running it locally should still see the existing SIGKILL test at line 292 pass — the new fallback path does **not** change behavior when the child is already exiting.

## Notes
The 3 s SIGKILL grace and 5 s shutdown grace are both tunable constants if the reviewer prefers different defaults. Both are intentionally not exposed as env vars to keep the daemon's exit semantics predictable from the user side.