### PR TITLE
fix(cli): redact secret-shaped values in startup args log and apiMachine debug log

### DIFF
--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -6,6 +6,7 @@
 import { io, Socket } from 'socket.io-client';
 import { logger } from '@/ui/logger';
 import { configuration } from '@/configuration';
+import { redactObjectForLog } from '@/utils/redactSecrets';
 import { MachineMetadata, DaemonState, Machine, Update, UpdateMachineBody } from './types';
 import { registerCommonHandlers, SpawnSessionOptions, SpawnSessionResult } from '../modules/common/registerCommonHandlers';
 import { encodeBase64, decodeBase64, encrypt, decrypt } from './encryption';
@@ -124,7 +125,12 @@ export class ApiMachineClient {
         // Register spawn session handler
         this.rpcHandlerManager.registerHandler('spawn-happy-session', async (params: any) => {
             const { directory, sessionId, machineId, approvedNewDirectoryCreation, agent, environmentVariables, token, resumeClaudeSessionId, parentSessionId, forkedFromMessageId } = params || {};
-            logger.debug(`[API MACHINE] Spawning session with params: ${JSON.stringify(params)}`);
+            // `params` can include `token`, `encryptionKey`, `environmentVariables`
+            // and other secret-bearing fields forwarded from the mobile app —
+            // redact before logging so they don't land in `~/.happy/logs/*-daemon.log`
+            // (default 0o644) and don't get forwarded if a user has enabled the
+            // dangerous-logging flag.
+            logger.debug(`[API MACHINE] Spawning session with params: ${JSON.stringify(redactObjectForLog(params))}`);
 
             if (!directory) {
                 throw new Error('Directory is required');

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -34,6 +34,7 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
 import { handleResumeCommand } from '@/resume/handleResumeCommand'
 import { ensureDaemonRunning } from './daemon/ensureDaemonRunning'
 import { handleCodexCommand } from './commands/codexCommand'
+import { redactArgvForLog } from './utils/redactSecrets'
 
 
 (async () => {
@@ -41,7 +42,12 @@ import { handleCodexCommand } from './commands/codexCommand'
 
   // If --version is passed - do not log, its likely daemon inquiring about our version
   if (!args.includes('--version')) {
-    logger.debug('Starting happy CLI with args: ', process.argv)
+    // `--claude-env ANTHROPIC_TOKEN=...` and similar `KEY=VAL` arg values
+    // can carry OAuth tokens, API keys, etc. The log file lives in
+    // `~/.happy/logs/` (default 0o644) and may be forwarded over plain
+    // HTTP if `DANGEROUSLY_LOG_TO_SERVER_FOR_AI_AUTO_DEBUGGING` is set,
+    // so we redact before logging.
+    logger.debug('Starting happy CLI with args: ', redactArgvForLog(process.argv))
   }
 
   // Check if first argument is a subcommand

--- a/packages/happy-cli/src/utils/redactSecrets.test.ts
+++ b/packages/happy-cli/src/utils/redactSecrets.test.ts
@@ -22,6 +22,21 @@ describe('redactArgvForLog', () => {
     ]);
   });
 
+  it('redacts secret values passed as the next argv token after a secret-named flag', () => {
+    expect(redactArgvForLog(['happy', 'openclaw', '--gateway-token', 'token-leak-12345'])).toEqual([
+      'happy',
+      'openclaw',
+      '--gateway-token',
+      REDACTED,
+    ]);
+    expect(redactArgvForLog(['happy', 'openclaw', '--gateway-password', 'password-leak-12345'])).toEqual([
+      'happy',
+      'openclaw',
+      '--gateway-password',
+      REDACTED,
+    ]);
+  });
+
   it('redacts case-insensitively (lower, mixed)', () => {
     expect(redactArgvForLog(['accessToken=value-1', 'API_KEY=value-2', 'oauth_secret=value-3'])).toEqual([
       `accessToken=${REDACTED}`,

--- a/packages/happy-cli/src/utils/redactSecrets.test.ts
+++ b/packages/happy-cli/src/utils/redactSecrets.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  REDACTED,
+  redactArgvForLog,
+  redactObjectForLog,
+} from './redactSecrets';
+
+describe('redactArgvForLog', () => {
+  it('redacts the value of a KEY=VAL arg when KEY contains a secret-name substring', () => {
+    expect(redactArgvForLog(['happy', '--claude-env', 'ANTHROPIC_TOKEN=sk-leak-12345'])).toEqual([
+      'happy',
+      '--claude-env',
+      `ANTHROPIC_TOKEN=${REDACTED}`,
+    ]);
+  });
+
+  it('redacts case-insensitively (lower, mixed)', () => {
+    expect(redactArgvForLog(['accessToken=value-1', 'API_KEY=value-2', 'oauth_secret=value-3'])).toEqual([
+      `accessToken=${REDACTED}`,
+      `API_KEY=${REDACTED}`,
+      `oauth_secret=${REDACTED}`,
+    ]);
+  });
+
+  it('passes through args without `=`', () => {
+    expect(redactArgvForLog(['happy', '--yolo', 'codex'])).toEqual(['happy', '--yolo', 'codex']);
+  });
+
+  it('passes through KEY=VAL when KEY is not secret-named', () => {
+    expect(redactArgvForLog(['LOG_LEVEL=debug', 'NODE_ENV=production'])).toEqual([
+      'LOG_LEVEL=debug',
+      'NODE_ENV=production',
+    ]);
+  });
+
+  it('does not crash on empty or odd inputs', () => {
+    expect(redactArgvForLog([])).toEqual([]);
+    expect(redactArgvForLog(['='])).toEqual(['=']); // key empty → eqIdx <= 0
+    expect(redactArgvForLog(['TOKEN='])).toEqual([`TOKEN=${REDACTED}`]); // empty value still redacted
+  });
+
+  it('does not double-redact a value that already contains `=`', () => {
+    // The first `=` is the boundary; the rest is the value (redacted whole).
+    expect(redactArgvForLog(['SECRET_KEY=val=with=equals'])).toEqual([`SECRET_KEY=${REDACTED}`]);
+  });
+});
+
+describe('redactObjectForLog', () => {
+  it('redacts top-level token / encryptionKey / password / auth keys', () => {
+    expect(
+      redactObjectForLog({
+        sessionId: 'sid-1',
+        token: 'oauth-secret',
+        encryptionKey: 'base64-key',
+        password: 'p',
+        unrelated: 42,
+      }),
+    ).toEqual({
+      sessionId: 'sid-1',
+      token: REDACTED,
+      encryptionKey: REDACTED,
+      password: REDACTED,
+      unrelated: 42,
+    });
+  });
+
+  it('force-redacts environmentVariables wholesale (free-form user values)', () => {
+    expect(
+      redactObjectForLog({
+        environmentVariables: { ANYTHING: 'could be a secret' },
+      }),
+    ).toEqual({ environmentVariables: REDACTED });
+  });
+
+  it('redacts inside nested objects and arrays', () => {
+    expect(
+      redactObjectForLog({
+        config: { apiKey: 'leak', name: 'ok' },
+        history: [{ accessToken: 'also leak' }, { kind: 'log' }],
+      }),
+    ).toEqual({
+      config: { apiKey: REDACTED, name: 'ok' },
+      history: [{ accessToken: REDACTED }, { kind: 'log' }],
+    });
+  });
+
+  it('leaves primitives / null / undefined untouched', () => {
+    expect(redactObjectForLog(null)).toBeNull();
+    expect(redactObjectForLog(undefined)).toBeUndefined();
+    expect(redactObjectForLog(42)).toBe(42);
+    expect(redactObjectForLog('hello')).toBe('hello');
+    expect(redactObjectForLog(true)).toBe(true);
+  });
+
+  it('preserves Date / RegExp / typed-array values without descending into them', () => {
+    const now = new Date();
+    const re = /foo/i;
+    const buf = new Uint8Array([1, 2, 3]);
+    expect(redactObjectForLog(now)).toBe(now);
+    expect(redactObjectForLog(re)).toBe(re);
+    expect(redactObjectForLog(buf)).toBe(buf);
+  });
+});

--- a/packages/happy-cli/src/utils/redactSecrets.test.ts
+++ b/packages/happy-cli/src/utils/redactSecrets.test.ts
@@ -15,6 +15,13 @@ describe('redactArgvForLog', () => {
     ]);
   });
 
+  it('redacts the env value when --claude-env is passed as --flag=KEY=VAL', () => {
+    expect(redactArgvForLog(['happy', '--claude-env=ANTHROPIC_TOKEN=sk-leak-12345'])).toEqual([
+      'happy',
+      `--claude-env=ANTHROPIC_TOKEN=${REDACTED}`,
+    ]);
+  });
+
   it('redacts case-insensitively (lower, mixed)', () => {
     expect(redactArgvForLog(['accessToken=value-1', 'API_KEY=value-2', 'oauth_secret=value-3'])).toEqual([
       `accessToken=${REDACTED}`,

--- a/packages/happy-cli/src/utils/redactSecrets.ts
+++ b/packages/happy-cli/src/utils/redactSecrets.ts
@@ -37,24 +37,52 @@ export const FORCE_REDACT_KEYS: ReadonlySet<string> = new Set([
  * Redact `KEY=VALUE` entries in a `process.argv`-shaped list when KEY looks
  * like a secret. `--claude-env ANTHROPIC_TOKEN=secret-xxx` is the canonical
  * case: the second arg arrives here as `ANTHROPIC_TOKEN=secret-xxx` and
- * gets rewritten to `ANTHROPIC_TOKEN=[REDACTED]`. Pure flags / positional
- * args without an `=` are passed through unchanged.
+ * gets rewritten to `ANTHROPIC_TOKEN=[REDACTED]`. Secret-named flags such as
+ * `--gateway-token secret` keep the flag name and redact the following token.
  */
 export function redactArgvForLog(argv: readonly string[]): string[] {
-  return argv.map((arg) => {
+  const redacted: string[] = [];
+  let redactNext = false;
+
+  for (const arg of argv) {
+    if (redactNext) {
+      redacted.push(REDACTED);
+      redactNext = false;
+      continue;
+    }
+
     const eqIdx = arg.indexOf('=');
-    if (eqIdx <= 0) return arg;
+    if (eqIdx <= 0) {
+      redacted.push(arg);
+      if (arg.startsWith('-') && SECRET_NAME_PATTERN.test(arg)) {
+        redactNext = true;
+      }
+      continue;
+    }
+
     const key = arg.slice(0, eqIdx);
     if (SECRET_NAME_PATTERN.test(key)) {
-      return `${key}=${REDACTED}`;
+      redacted.push(`${key}=${REDACTED}`);
+      continue;
     }
+
     const value = arg.slice(eqIdx + 1);
     const innerEqIdx = value.indexOf('=');
-    if (innerEqIdx <= 0) return arg;
+    if (innerEqIdx <= 0) {
+      redacted.push(arg);
+      continue;
+    }
+
     const innerKey = value.slice(0, innerEqIdx);
-    if (!SECRET_NAME_PATTERN.test(innerKey)) return arg;
-    return `${key}=${innerKey}=${REDACTED}`;
-  });
+    if (!SECRET_NAME_PATTERN.test(innerKey)) {
+      redacted.push(arg);
+      continue;
+    }
+
+    redacted.push(`${key}=${innerKey}=${REDACTED}`);
+  }
+
+  return redacted;
 }
 
 /**

--- a/packages/happy-cli/src/utils/redactSecrets.ts
+++ b/packages/happy-cli/src/utils/redactSecrets.ts
@@ -45,8 +45,15 @@ export function redactArgvForLog(argv: readonly string[]): string[] {
     const eqIdx = arg.indexOf('=');
     if (eqIdx <= 0) return arg;
     const key = arg.slice(0, eqIdx);
-    if (!SECRET_NAME_PATTERN.test(key)) return arg;
-    return `${key}=${REDACTED}`;
+    if (SECRET_NAME_PATTERN.test(key)) {
+      return `${key}=${REDACTED}`;
+    }
+    const value = arg.slice(eqIdx + 1);
+    const innerEqIdx = value.indexOf('=');
+    if (innerEqIdx <= 0) return arg;
+    const innerKey = value.slice(0, innerEqIdx);
+    if (!SECRET_NAME_PATTERN.test(innerKey)) return arg;
+    return `${key}=${innerKey}=${REDACTED}`;
   });
 }
 

--- a/packages/happy-cli/src/utils/redactSecrets.ts
+++ b/packages/happy-cli/src/utils/redactSecrets.ts
@@ -1,0 +1,75 @@
+/**
+ * Helpers for redacting secret-shaped fields out of log lines.
+ *
+ * Happy CLI writes debug logs to `~/.happy/logs/<timestamp>-pid-*.log` and
+ * may forward the same lines over HTTP if a user has opted into
+ * `DANGEROUSLY_LOG_TO_SERVER_FOR_AI_AUTO_DEBUGGING`. Any path that
+ * serializes either `process.argv` (which can hold things like
+ * `--claude-env ANTHROPIC_TOKEN=...`) or a user-supplied param object
+ * (which can hold OAuth tokens, encryption keys, environment variables)
+ * MUST go through one of these helpers first.
+ */
+
+/**
+ * Case-insensitive: an env-var name or property name is treated as secret
+ * if it contains any of these substrings.
+ *
+ * Trailing word boundaries are intentionally loose so `ANTHROPIC_TOKEN`,
+ * `AUTH_HEADER`, `SECRET_KEY`, `OAUTH_TOKEN`, `accessToken`, `apiKey`,
+ * `encryptionKey` all match.
+ */
+const SECRET_NAME_TOKENS = ['token', 'key', 'secret', 'auth', 'password', 'credential'];
+export const SECRET_NAME_PATTERN = new RegExp(`(?:${SECRET_NAME_TOKENS.join('|')})`, 'i');
+
+export const REDACTED = '[REDACTED]';
+
+/**
+ * Keys that should always be redacted regardless of whether they match
+ * `SECRET_NAME_PATTERN` — e.g. `environmentVariables` contains free-form
+ * user values that may themselves be secret.
+ */
+export const FORCE_REDACT_KEYS: ReadonlySet<string> = new Set([
+  'encryptionKey',
+  'environmentVariables',
+]);
+
+/**
+ * Redact `KEY=VALUE` entries in a `process.argv`-shaped list when KEY looks
+ * like a secret. `--claude-env ANTHROPIC_TOKEN=secret-xxx` is the canonical
+ * case: the second arg arrives here as `ANTHROPIC_TOKEN=secret-xxx` and
+ * gets rewritten to `ANTHROPIC_TOKEN=[REDACTED]`. Pure flags / positional
+ * args without an `=` are passed through unchanged.
+ */
+export function redactArgvForLog(argv: readonly string[]): string[] {
+  return argv.map((arg) => {
+    const eqIdx = arg.indexOf('=');
+    if (eqIdx <= 0) return arg;
+    const key = arg.slice(0, eqIdx);
+    if (!SECRET_NAME_PATTERN.test(key)) return arg;
+    return `${key}=${REDACTED}`;
+  });
+}
+
+/**
+ * Recursively redact secret-named properties in an object so it can be
+ * safely `JSON.stringify`'d for logging. The structure (keys, nesting,
+ * array order) is preserved so debug logs stay useful; only the values of
+ * secret-named keys are replaced with `[REDACTED]`. Non-plain values
+ * (Date, Buffer, etc.) are returned unchanged.
+ */
+export function redactObjectForLog(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (value instanceof Date || value instanceof RegExp) return value;
+  if (Array.isArray(value)) return value.map(redactObjectForLog);
+  // Avoid descending into typed arrays / Buffers — leave them as-is.
+  if (ArrayBuffer.isView(value)) return value;
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (FORCE_REDACT_KEYS.has(k) || SECRET_NAME_PATTERN.test(k)) {
+      result[k] = REDACTED;
+    } else {
+      result[k] = redactObjectForLog(v);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Closes #1279.

## Bug

\`happy --claude-env ANTHROPIC_TOKEN=sk-…\` (or any \`--claude-env KEY=VAL\` where KEY names a token / API key / secret / auth header) writes the VALUE verbatim into \`~/.happy/logs/<timestamp>-pid-*.log\`, because the CLI entry point logs \`process.argv\` unfiltered:

\`\`\`ts
// packages/happy-cli/src/index.ts:44
logger.debug('Starting happy CLI with args: ', process.argv)
\`\`\`

The log file is created with the default Node file mode (0o644 in practice), so any local UID can read it. If a user has opted into \`DANGEROUSLY_LOG_TO_SERVER_FOR_AI_AUTO_DEBUGGING\`, the same line is forwarded over HTTP to a remote endpoint, exfiltrating the token off the host. This affects any wrapper that injects bearer credentials — proxies, custom Anthropic-compatible endpoints, internal gateways.

The same shape also reaches \`apiMachine.ts:127\`, where the entire \`spawn-happy-session\` RPC params object — including \`token\`, \`encryptionKey\`, \`environmentVariables\` — is \`JSON.stringify\`'d into a debug log line. This PR fixes both call sites.

## Fix

New \`packages/happy-cli/src/utils/redactSecrets.ts\`:

- \`SECRET_NAME_PATTERN\` — case-insensitive substring match for \`token / key / secret / auth / password / credential\`.
- \`redactArgvForLog(argv)\` — replaces the VALUE half of any \`KEY=VAL\` arg when KEY matches the pattern. Non-\`=\`-shaped args pass through unchanged.
- \`redactObjectForLog(value)\` — recursively rewrites the VALUE of any property whose name matches the pattern OR is in the force-redact set (\`encryptionKey\`, \`environmentVariables\`). Plain objects + arrays are descended into; \`Date\` / \`RegExp\` / typed-array values are returned as-is.

Applied at two call sites:
- \`index.ts:44\` — wraps the \`process.argv\` startup log.
- \`apiMachine.ts:128\` — wraps the spawn-session params log.

## Scope

- **New file**: \`packages/happy-cli/src/utils/redactSecrets.ts\` (~80 LOC, no runtime deps).
- **New test**: \`redactSecrets.test.ts\` — 11 unit tests covering argv redaction (KEY=VAL detection, case-insensitive, empty inputs, values containing \`=\`) + object redaction (top-level, nested, arrays, force-redact list, primitives passthrough, Date/RegExp/typed-array passthrough).
- Two existing files modified to call the helpers.
- No API change; no behavior change for users not passing secrets via \`--claude-env\`.

## Test plan

- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/utils/redactSecrets.test.ts\` — 11/11 pass
- [x] Manual: \`happy --claude-env ANTHROPIC_TOKEN=secret-test-123 codex\` → \`grep secret-test-123 ~/.happy/logs/*.log\` → 0 matches; previous unredacted line is now \`ANTHROPIC_TOKEN=[REDACTED]\`.

## Notes

The redaction pattern is intentionally substring-based, not whole-word — so it catches \`ANTHROPIC_TOKEN\`, \`OAUTH_TOKEN\`, \`accessToken\`, \`apiKey\`, \`SECRET_KEY\`, \`x-auth-header\`, etc. False positives (legitimately non-secret args whose key happens to contain "token" / "key" / etc.) can be added to a future allow-list constant; none observed in the current CLI surface.

Related: there is a class of secret-shaped values that still reach logs from other call sites (e.g. \`runCodex.ts\`'s token-file write path, various \`JSON.stringify\` of session metadata). This PR fixes the two highest-impact paths reported in #1279; the same helpers can be applied to the rest in a follow-up audit pass.