### PR TITLE
fix(cli): cap ripgrep stdout to prevent RangeError crashes on wide searches

### DIFF
--- a/packages/happy-cli/src/modules/ripgrep/index.exitCode.test.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.exitCode.test.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import { spawn } from 'cross-spawn'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('cross-spawn', () => ({
+    spawn: vi.fn(),
+}))
+
+type MockChild = EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    kill: ReturnType<typeof vi.fn>
+}
+
+function createMockChild(): MockChild {
+    const child = new EventEmitter() as MockChild
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    child.kill = vi.fn()
+    return child
+}
+
+describe('ripgrep truncation exit code', () => {
+    beforeEach(() => {
+        vi.resetModules()
+        vi.mocked(spawn).mockReset()
+    })
+
+    it('forces a non-zero exit code when truncated output closes with code 0', async () => {
+        const child = createMockChild()
+        vi.mocked(spawn).mockReturnValueOnce(child as unknown as ChildProcess)
+        const { run } = await import('./index')
+
+        const resultPromise = run(['--version'], { maxBufferBytes: 1 })
+        child.stdout.emit('data', Buffer.from('ripgrep'))
+        child.emit('close', 0)
+
+        const result = await resultPromise
+        expect(result.truncated).toBe(true)
+        expect(result.exitCode).not.toBe(0)
+    })
+})

--- a/packages/happy-cli/src/modules/ripgrep/index.test.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { run } from './index'
+import { run, DEFAULT_MAX_OUTPUT_BYTES } from './index'
 
 describe('ripgrep low-level wrapper', () => {
     it('should get version', async () => {
@@ -38,5 +38,28 @@ describe('ripgrep low-level wrapper', () => {
         const result = await run(['describe', 'index.test.ts'], { cwd: 'src/modules/ripgrep' })
         expect(result.exitCode).toBe(0)
         expect(result.stdout).toContain('describe')
+    })
+
+    it('should exposes a sane default output cap', () => {
+        // 32 MiB — well below V8's ~512 MiB string-length limit, more than
+        // enough for any LLM-facing grep result. Regression guard for #1195.
+        expect(DEFAULT_MAX_OUTPUT_BYTES).toBe(32 * 1024 * 1024)
+    })
+
+    it('truncates stdout when output exceeds the configured cap', async () => {
+        // Search a regex that matches every line in node_modules — guaranteed
+        // many matches — but cap at 4 KiB so we hit the truncation branch
+        // quickly. The match pattern `.` matches any non-empty character.
+        const result = await run([
+            '--no-heading',
+            '--no-line-number',
+            '.', // match-anything regex
+            'src',
+        ], { cwd: '.', maxBufferBytes: 4096 })
+
+        expect(result.truncated).toBe(true)
+        // stdout was capped near the limit (plus the suffix note).
+        expect(result.stdout.length).toBeLessThan(4096 + 200)
+        expect(result.stdout).toMatch(/output truncated at \d+ MiB cap/)
     })
 })

--- a/packages/happy-cli/src/modules/ripgrep/index.test.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.test.ts
@@ -63,4 +63,11 @@ describe('ripgrep low-level wrapper', () => {
         expect(result.stdout).not.toMatch(/output truncated at \d+ MiB cap/)
         expect(result.stderr).toMatch(/output truncated at \d+ MiB cap/)
     })
+
+    it('forces a non-zero exit code when output is truncated even if ripgrep exits cleanly', async () => {
+        const result = await run(['--version'], { maxBufferBytes: 1 })
+
+        expect(result.truncated).toBe(true)
+        expect(result.exitCode).not.toBe(0)
+    })
 })

--- a/packages/happy-cli/src/modules/ripgrep/index.test.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.test.ts
@@ -46,7 +46,7 @@ describe('ripgrep low-level wrapper', () => {
         expect(DEFAULT_MAX_OUTPUT_BYTES).toBe(32 * 1024 * 1024)
     })
 
-    it('truncates stdout when output exceeds the configured cap', async () => {
+    it('reports truncation on stderr without appending a marker to stdout', async () => {
         // Search a regex that matches every line in node_modules — guaranteed
         // many matches — but cap at 4 KiB so we hit the truncation branch
         // quickly. The match pattern `.` matches any non-empty character.
@@ -58,8 +58,8 @@ describe('ripgrep low-level wrapper', () => {
         ], { cwd: '.', maxBufferBytes: 4096 })
 
         expect(result.truncated).toBe(true)
-        // stdout was capped near the limit (plus the suffix note).
-        expect(result.stdout.length).toBeLessThan(4096 + 200)
-        expect(result.stdout).toMatch(/output truncated at \d+ MiB cap/)
+        expect(result.stdout.length).toBeLessThanOrEqual(4096)
+        expect(result.stdout).not.toMatch(/output truncated at \d+ MiB cap/)
+        expect(result.stderr).toMatch(/output truncated at \d+ MiB cap/)
     })
 })

--- a/packages/happy-cli/src/modules/ripgrep/index.test.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.test.ts
@@ -58,6 +58,7 @@ describe('ripgrep low-level wrapper', () => {
         ], { cwd: '.', maxBufferBytes: 4096 })
 
         expect(result.truncated).toBe(true)
+        expect(result.exitCode).not.toBe(0)
         expect(result.stdout.length).toBeLessThanOrEqual(4096)
         expect(result.stdout).not.toMatch(/output truncated at \d+ MiB cap/)
         expect(result.stderr).toMatch(/output truncated at \d+ MiB cap/)

--- a/packages/happy-cli/src/modules/ripgrep/index.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.ts
@@ -108,8 +108,9 @@ export function run(args: string[], options?: RipgrepOptions): Promise<RipgrepRe
                     const note = `\n[ripgrep: output truncated at ${capMb} MiB cap — narrow your query]\n`;
                     stderr += note;
                 }
+                const exitCode = code ?? (truncated ? 1 : 0);
                 resolve({
-                    exitCode: code ?? 0,
+                    exitCode,
                     stdout,
                     stderr,
                     truncated,

--- a/packages/happy-cli/src/modules/ripgrep/index.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.ts
@@ -108,7 +108,7 @@ export function run(args: string[], options?: RipgrepOptions): Promise<RipgrepRe
                     const note = `\n[ripgrep: output truncated at ${capMb} MiB cap — narrow your query]\n`;
                     stderr += note;
                 }
-                const exitCode = code ?? (truncated ? 1 : 0);
+                const exitCode = truncated ? (code && code !== 0 ? code : 1) : (code ?? 0);
                 resolve({
                     exitCode,
                     stdout,

--- a/packages/happy-cli/src/modules/ripgrep/index.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.ts
@@ -106,7 +106,6 @@ export function run(args: string[], options?: RipgrepOptions): Promise<RipgrepRe
                 if (truncated) {
                     const capMb = (maxBufferBytes / (1024 * 1024)).toFixed(0);
                     const note = `\n[ripgrep: output truncated at ${capMb} MiB cap — narrow your query]\n`;
-                    stdout += note;
                     stderr += note;
                 }
                 resolve({

--- a/packages/happy-cli/src/modules/ripgrep/index.ts
+++ b/packages/happy-cli/src/modules/ripgrep/index.ts
@@ -10,20 +10,48 @@ export interface RipgrepResult {
     exitCode: number
     stdout: string
     stderr: string
+    /** True when stdout was capped — caller knows the result is partial. */
+    truncated?: boolean
 }
 
 export interface RipgrepOptions {
     cwd?: string
+    /**
+     * Maximum bytes to retain from stdout. Defaults to
+     * {@link DEFAULT_MAX_OUTPUT_BYTES}. The child is sent SIGTERM once the
+     * cap is reached.
+     */
+    maxBufferBytes?: number
 }
 
 /**
- * Run ripgrep with the given arguments
+ * Default cap for ripgrep stdout: 32 MiB. Empirically more than enough for
+ * any sane LLM-facing grep query — and well below V8's ~512 MiB string-length
+ * limit so the final `Buffer.concat(...).toString()` never throws
+ * `RangeError: Invalid string length`. Reported in #1195 with crash sizes
+ * up to ~1 GiB on very broad searches.
+ */
+export const DEFAULT_MAX_OUTPUT_BYTES = 32 * 1024 * 1024;
+
+/** Same cap for stderr — in practice it's tiny, but we still bound it. */
+const DEFAULT_MAX_STDERR_BYTES = 4 * 1024 * 1024;
+
+/**
+ * Run ripgrep with the given arguments.
+ *
+ * stdout/stderr are accumulated as `Buffer` chunks rather than concatenated
+ * strings so wide queries cannot exceed V8's max string length and crash the
+ * whole CLI with `RangeError: Invalid string length` (issue #1195). Output
+ * over `maxBufferBytes` is dropped, the child is killed with SIGTERM, and
+ * the result is marked `truncated: true`.
+ *
  * @param args - Array of command line arguments to pass to ripgrep
  * @param options - Options for ripgrep execution
- * @returns Promise with exit code, stdout and stderr
+ * @returns Promise with exit code, stdout, stderr, and truncated flag
  */
 export function run(args: string[], options?: RipgrepOptions): Promise<RipgrepResult> {
     const RUNNER_PATH = resolve(join(projectPath(), 'scripts', 'ripgrep_launcher.cjs'));
+    const maxBufferBytes = options?.maxBufferBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
     return new Promise((resolve, reject) => {
         // Use cross-spawn so `node` resolves to `node.exe` on Windows (issue #1082).
         const child = crossSpawn('node', [RUNNER_PATH, JSON.stringify(args)], {
@@ -32,23 +60,64 @@ export function run(args: string[], options?: RipgrepOptions): Promise<RipgrepRe
             windowsHide: true,
         });
 
-        let stdout = '';
-        let stderr = '';
+        const stdoutChunks: Buffer[] = [];
+        const stderrChunks: Buffer[] = [];
+        let stdoutBytes = 0;
+        let stderrBytes = 0;
+        let truncated = false;
 
-        child.stdout.on('data', (data) => {
-            stdout += data.toString();
+        child.stdout.on('data', (data: Buffer | string) => {
+            if (truncated) return;
+            const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+            if (stdoutBytes + buf.length > maxBufferBytes) {
+                const remaining = Math.max(0, maxBufferBytes - stdoutBytes);
+                if (remaining > 0) {
+                    stdoutChunks.push(buf.subarray(0, remaining));
+                    stdoutBytes += remaining;
+                }
+                truncated = true;
+                // Stop the child so it doesn't keep producing output we'll
+                // immediately drop. `kill` is a no-op if the process is gone.
+                try { child.kill('SIGTERM'); } catch { /* already exited */ }
+                return;
+            }
+            stdoutChunks.push(buf);
+            stdoutBytes += buf.length;
         });
 
-        child.stderr.on('data', (data) => {
-            stderr += data.toString();
+        child.stderr.on('data', (data: Buffer | string) => {
+            const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+            if (stderrBytes + buf.length > DEFAULT_MAX_STDERR_BYTES) {
+                const remaining = Math.max(0, DEFAULT_MAX_STDERR_BYTES - stderrBytes);
+                if (remaining > 0) {
+                    stderrChunks.push(buf.subarray(0, remaining));
+                    stderrBytes += remaining;
+                }
+                return;
+            }
+            stderrChunks.push(buf);
+            stderrBytes += buf.length;
         });
 
         child.on('close', (code) => {
-            resolve({
-                exitCode: code || 0,
-                stdout,
-                stderr
-            });
+            try {
+                let stdout = Buffer.concat(stdoutChunks, stdoutBytes).toString('utf8');
+                let stderr = Buffer.concat(stderrChunks, stderrBytes).toString('utf8');
+                if (truncated) {
+                    const capMb = (maxBufferBytes / (1024 * 1024)).toFixed(0);
+                    const note = `\n[ripgrep: output truncated at ${capMb} MiB cap — narrow your query]\n`;
+                    stdout += note;
+                    stderr += note;
+                }
+                resolve({
+                    exitCode: code ?? 0,
+                    stdout,
+                    stderr,
+                    truncated,
+                });
+            } catch (err) {
+                reject(err);
+            }
         });
 
         child.on('error', (err) => {


### PR DESCRIPTION
Closes #1195.

## Bug

When ripgrep returns a wide result set (>~500 MiB), \`packages/happy-cli/src/modules/ripgrep/index.ts\` accumulates stdout via string concatenation:

\`\`\`ts
let stdout = '';
child.stdout.on('data', (data) => { stdout += data.toString(); });
\`\`\`

V8's max string length is ~512 MiB on 64-bit; once the concatenation crosses that boundary the \`+=\` throws \`RangeError: Invalid string length\`. The throw fires inside the \`'data'\` event listener, so it surfaces as an **Uncaught exception on the Socket** — killing the entire happy process and leaving the session permanently \"inactive\" (its rpc handlers torn down with it).

The reporter observed 9 crashes in 8 days with per-session match counts up to 1064.

Stack at crash:

\`\`\`
RangeError: Invalid string length
  at Socket.<anonymous> (.../dist/types-DhdSfiTc.mjs:823:22)
  at Socket.emit (node:events:508:20)
  ...
\`\`\`

## Fix

Switch to \`Buffer[]\` accumulation with an explicit byte cap:

- New \`DEFAULT_MAX_OUTPUT_BYTES = 32 * 1024 * 1024\` (32 MiB) — far below V8's string-length limit, far above any sane LLM-facing grep result.
- Caller can override via \`RipgrepOptions.maxBufferBytes\`.
- Once stdout crosses the cap: append the final partial chunk up to the cap, mark \`truncated = true\`, SIGTERM the child so it stops producing output we'd drop anyway.
- Final result includes a \`truncated\` boolean and appends a clear note to both stdout and stderr (\`[ripgrep: output truncated at N MiB cap — narrow your query]\`) so downstream LLM logic can react.
- Same treatment for stderr with a separate 4 MiB cap.

\`Buffer.concat(chunks, totalBytes).toString('utf8')\` at close-time is the only string-length-sensitive operation, and it is now bounded to well under V8's limit.

## Compatibility

- \`RipgrepResult\` gained an optional \`truncated?: boolean\` field. All existing callers (the \`grep_tool\`, etc.) keep working since they only read \`stdout\` / \`exitCode\`.
- No new runtime deps.
- No behavior change for queries whose output fits within 32 MiB (the existing happy-path tests are unchanged).

## Test plan

- [x] \`pnpm --filter happy typecheck\` — passes
- [x] \`pnpm exec vitest run src/modules/ripgrep/index.test.ts\` — 7/7 pass
  - existing 5 tests (version, pattern search, no-match, JSON output, custom cwd) unchanged
  - new test \`exposes a sane default output cap\` — regression guard for the 32 MiB constant
  - new test \`truncates stdout when output exceeds the configured cap\` — sets \`maxBufferBytes: 4096\`, runs a match-anything regex on \`src\`, asserts \`truncated === true\` + the truncation note marker