### PR TITLE
fix(app): use Web Crypto UUID for reducer ID generation (silent message loss)

### DIFF
--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -1139,8 +1139,24 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
 // Helpers
 //
 
-function allocateId() {
-    return Math.random().toString(36).substring(2, 15);
+function allocateId(): string {
+    // Prefer Web Crypto's `randomUUID` (128-bit, cryptographically random):
+    //  - Node ≥ 19 exposes it on `globalThis.crypto.randomUUID`.
+    //  - React Native / Expo provide it via `expo-crypto`'s polyfill, which
+    //    happy-app already installs at startup.
+    // The old generator (`Math.random().toString(36).substring(2, 15)`)
+    // yields only ~67 bits of entropy — long sessions hit birthday-paradox
+    // collisions inside `state.messages` / `messageIds` / `toolIdToMessageId`,
+    // silently overwriting messages and routing tool-result events to the
+    // wrong message. Falling back to two `Math.random` chunks + a timestamp
+    // gives ~96+ bits (still strictly better than the original) so this
+    // file stays loadable in node-only test runners that may not have the
+    // RN polyfill registered.
+    const g = globalThis as { crypto?: { randomUUID?: () => string } };
+    if (typeof g.crypto?.randomUUID === 'function') {
+        return g.crypto.randomUUID();
+    }
+    return `${Math.random().toString(36).slice(2, 11)}-${Math.random().toString(36).slice(2, 11)}-${Date.now().toString(36)}`;
 }
 
 function processUsageData(state: ReducerState, usage: UsageData, timestamp: number) {


### PR DESCRIPTION
## Bug

\`allocateId()\` in \`packages/happy-app/sources/sync/reducer/reducer.ts:1142\` minted IDs via:

\`\`\`ts
Math.random().toString(36).substring(2, 15)
\`\`\`

That's ~13 base-36 chars ≈ **67 bits** of entropy, and \`Math.random\`'s distribution is non-uniform so the effective entropy is lower still.

Those IDs key three internal stores that MUST never collide:

- \`state.messages\` (Map<messageId, ReducerMessage>) — collision **silently overwrites** the existing message; it disappears from the chat.
- \`state.messageIds\` (sidechain owner lookup) — collision misroutes future sidechain replies.
- \`toolIdToMessageId\` — collision routes a later tool-result event to the **wrong** tool card.

In long sessions or after many short ones birthday-paradox collisions become realistic, and they manifest as messages just vanishing or tool results landing in the wrong tool card with no error.

## Fix

Switch \`allocateId()\` to \`globalThis.crypto.randomUUID\` (128-bit, cryptographically random):

- Node ≥ 19 exposes it on \`globalThis.crypto.randomUUID\`.
- React Native / Expo provide it through \`expo-crypto\`'s polyfill, which happy-app already initializes at startup (and \`expo-crypto\` is already a dep — see \`sync.ts:13\`, \`uploadFormFile.ts:10\` etc.).

A minimal \`Math.random\` + \`Date\` fallback (~96 bits) keeps the file loadable in node-only test runners that don't register the RN polyfill — still strictly better than the 67-bit original.

\`\`\`ts
function allocateId(): string {
  const g = globalThis as { crypto?: { randomUUID?: () => string } };
  if (typeof g.crypto?.randomUUID === 'function') {
    return g.crypto.randomUUID();
  }
  return \`\${Math.random().toString(36).slice(2, 11)}-\${Math.random().toString(36).slice(2, 11)}-\${Date.now().toString(36)}\`;
}
\`\`\`

## Scope

- Touches **only** \`packages/happy-app/sources/sync/reducer/reducer.ts\` (one function).
- No imports of \`expo-crypto\` added — keeps the reducer loadable in vitest without the RN polyfill.
- No API change.

## Test plan

- [x] \`pnpm --filter happy-app typecheck\` — passes
- [x] \`pnpm exec vitest run sources/sync/reducer\` — 82/82 pass (4 test files, including \`reducer.spec.ts\` which has the bulk of permission/sidechain coverage)

## Notes

The audit pass that flagged this also raised a separate concern about \`mergeToolInputs\` (line 187-192): when a permission is already stored, \`mergeToolInputs(permission.arguments, c.input)\` keeps the stored permission arguments and ignores the new tool-call input. On closer inspection the existing tests (e.g. \`reducer.spec.ts\` "should match completed permissions and tool calls by ID even with different arguments" at line 1636) make that **intentional** — once the user has approved a permission, the arguments are locked so a later tool-call can't silently mutate what was approved. So the \`mergeToolInputs\` behavior is **not** touched in this PR; flagging it here only for completeness in case a retry-after-deny code path wants a separate, narrower fix later.