### PR TITLE
chore(acp): remove process listeners on dispose to avoid closure leak

### DIFF
--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -1310,7 +1310,19 @@ export class AcpBackend implements AgentBackend {
           resolve();
         });
       });
-      
+
+      // Drop the `error` / `exit` / `data` listeners that `startSession`
+      // attached so a Gemini mode-switch flow (which disposes the current
+      // backend and immediately spawns a new one) doesn't accumulate dead
+      // closures referencing a torn-down instance. Subsequent kernel
+      // signals against the already-dead PID would otherwise re-invoke
+      // `signalStartupFailure` against a now-null `startupFailureResolver`
+      // — harmless, but it grows the listener list every cycle.
+      this.process?.removeAllListeners();
+      this.process?.stdout?.removeAllListeners();
+      this.process?.stderr?.removeAllListeners();
+      this.process?.stdin?.removeAllListeners();
+
       this.process = null;
     }
 


### PR DESCRIPTION
Removes the `error` / `exit` / stdio `data` listeners that `startSession` attaches to the spawned child, just before `dispose()` nulls `this.process`. Existing path killed the process (SIGTERM → SIGKILL) but left listener closures alive — every Gemini mode-switch (which disposes the current backend and immediately spawns a new one) leaked a fresh set of dead listeners holding references to the torn-down backend.

`removeAllListeners()` on the process and on `stdin`/`stdout`/`stderr` closes that door cleanly. No behavior change — the listeners' bodies already early-out via `if (!this.disposed)` and `startupStatusErrorEmitted` guards.

`pnpm --filter happy typecheck` passes.