### PR TITLE
chore(api): clear apiSession.flush() ping timeout once the ack arrives

### DIFF
--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -748,12 +748,24 @@ export class ApiSessionClient extends EventEmitter {
             return;
         }
         return new Promise((resolve) => {
-            this.socket.emit('ping', () => {
-                resolve();
-            });
-            setTimeout(() => {
+            // Track which side resolved so we never resolve twice and we
+            // always clear the unbacked timer. The old code left a bare
+            // 10s setTimeout running after the ping ack came back, which
+            // held the event loop open for the rest of the 10s window —
+            // that's the "why does `happy claude` take 10 seconds to quit
+            // after Ctrl-C" complaint.
+            let settled = false;
+            const timeout = setTimeout(() => {
+                if (settled) return;
+                settled = true;
                 resolve();
             }, 10000);
+            this.socket.emit('ping', () => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeout);
+                resolve();
+            });
         });
     }
 


### PR DESCRIPTION
`flush()`'s final step races a 10-second `setTimeout` against the `'ping'` ack callback to bound how long shutdown waits for the socket to drain. The old code never cleared the timer when the ack came back, so even on a successful ping the bare `setTimeout` held the event loop open for the rest of the 10s window — this is the "why does `happy claude` take 10 seconds to exit after Ctrl-C" complaint.

Wrap both resolution paths in a `settled` guard, capture the timer handle, and `clearTimeout` it from the ack callback. Net: a healthy socket flushes and the process exits as soon as the ping round-trips; the 10s cap only kicks in for a genuinely stuck socket.

`pnpm --filter happy typecheck` passes.