### PR TITLE
fix(app): guard MermaidRenderer onMessage JSON.parse to avoid chat crash

### DIFF
--- a/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
+++ b/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
@@ -170,11 +170,31 @@ export const MermaidRenderer = React.memo((props: {
                     style={{ flex: 1 }}
                     scrollEnabled={false}
                     onMessage={(event) => {
-                        const data = JSON.parse(event.nativeEvent.data);
-                        if (data.type === 'dimensions') {
+                        // WebView's `onMessage` fires for ANY `window.ReactNativeWebView.postMessage`
+                        // call inside the embedded HTML — including future
+                        // diagnostic / console / error messages that may not
+                        // be JSON, or a malformed mermaid render that posts
+                        // a non-JSON payload before the dimensions one.
+                        // An uncaught `JSON.parse` here used to bubble up as
+                        // a synchronous throw on the RN bridge and crash the
+                        // surrounding chat view; guard it and validate the
+                        // payload shape before reading `.height`.
+                        let data: unknown;
+                        try {
+                            data = JSON.parse(event.nativeEvent.data);
+                        } catch {
+                            return;
+                        }
+                        if (
+                            data !== null &&
+                            typeof data === 'object' &&
+                            (data as { type?: unknown }).type === 'dimensions' &&
+                            typeof (data as { height?: unknown }).height === 'number'
+                        ) {
+                            const newHeight = (data as { height: number }).height;
                             setDimensions(prev => ({
                                 ...prev,
-                                height: Math.max(prev.height, data.height)
+                                height: Math.max(prev.height, newHeight)
                             }));
                         }
                     }}


### PR DESCRIPTION
`MermaidRenderer.tsx` passed `event.nativeEvent.data` straight into `JSON.parse` inside the WebView's `onMessage` handler. `onMessage` fires for ANY `window.ReactNativeWebView.postMessage` from the embedded HTML — including future diagnostic / console / error payloads, or a malformed mermaid render that posts a non-JSON payload before the dimensions message. A synchronous throw inside `onMessage` bubbles up on the React Native bridge and crashes the surrounding chat view; in release builds the chat list unmounts.

Wrap `JSON.parse` in try/catch and validate the parsed shape (object, `type === 'dimensions'`, numeric `height`) before applying it. Unknown payloads are silently ignored — same effect as today's happy path, without the crash risk.

No new dependency; no behavior change for the canonical `{type:'dimensions', height: ...}` payload that the inline HTML emits.

`pnpm --filter happy-app typecheck` passes.