### PR TITLE
fix(app): tolerate JSON-stringified AskUserQuestion input (#936)

### DIFF
--- a/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
+++ b/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
@@ -23,6 +23,26 @@ interface AskUserQuestionInput {
     questions: Question[];
 }
 
+// Claude (the model) sometimes serializes the `questions` parameter — or the
+// whole input — as a JSON-encoded string rather than a native array/object.
+// Native Claude Code tolerates this; without this guard the view returns null
+// and ToolView falls back to the generic permission UI (slopus/happy#936,
+// also surfaces in slopus/happy#375 with multi-question forms).
+function normalizeAskUserQuestionInput(rawInput: unknown): AskUserQuestionInput | undefined {
+    let parsed: unknown = rawInput;
+    if (typeof parsed === 'string') {
+        try { parsed = JSON.parse(parsed); } catch { return undefined; }
+    }
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    const obj = parsed as Record<string, unknown>;
+    let questions: unknown = obj.questions;
+    if (typeof questions === 'string') {
+        try { questions = JSON.parse(questions); } catch { return undefined; }
+    }
+    if (!Array.isArray(questions)) return undefined;
+    return { ...obj, questions: questions as Question[] };
+}
+
 // Styles MUST be defined outside the component to prevent infinite re-renders
 // with react-native-unistyles. The theme is passed as a function parameter.
 const styles = StyleSheet.create((theme) => ({
@@ -170,11 +190,11 @@ export const AskUserQuestionView = React.memo<ToolViewProps>(({ tool, sessionId 
     const [isSubmitting, setIsSubmitting] = React.useState(false);
     const [isSubmitted, setIsSubmitted] = React.useState(false);
 
-    // Parse input
-    const input = tool.input as AskUserQuestionInput | undefined;
+    // Parse input — tolerate JSON-stringified shapes (see normalizeAskUserQuestionInput).
+    const input = normalizeAskUserQuestionInput(tool.input);
     const questions = input?.questions;
 
-    if (!questions || !Array.isArray(questions) || questions.length === 0) {
+    if (!questions || questions.length === 0) {
         return null;
     }
 

--- a/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
+++ b/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
@@ -17,8 +17,29 @@ interface AskUserQuestionInput {
     }>;
 }
 
+// Claude (the model) sometimes serializes the `questions` parameter — or the
+// whole input — as a JSON-encoded string rather than a native array/object.
+// Native Claude Code tolerates this; without this guard the view returns null
+// and ToolView falls back to the generic permission UI (slopus/happy#936,
+// also surfaces in slopus/happy#375 with multi-question forms).
+function normalizeAskUserQuestionInput(rawInput: unknown): AskUserQuestionInput | undefined {
+    let parsed: unknown = rawInput;
+    if (typeof parsed === 'string') {
+        try { parsed = JSON.parse(parsed); } catch { return undefined; }
+    }
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    const obj = parsed as Record<string, unknown>;
+    let questions: unknown = obj.questions;
+    if (typeof questions === 'string') {
+        try { questions = JSON.parse(questions); } catch { return undefined; }
+    }
+    if (!Array.isArray(questions)) return undefined;
+    return { ...obj, questions: questions as AskUserQuestionInput['questions'] };
+}
+
 export const AskUserQuestionView = React.memo<ToolViewProps>(({ tool, sessionId }) => {
-    const input = tool.input as AskUserQuestionInput | undefined;
+    // Tolerate JSON-stringified shapes (see normalizeAskUserQuestionInput).
+    const input = normalizeAskUserQuestionInput(tool.input);
     const questions = React.useMemo<InlineQuestion[]>(() => (
         (input?.questions ?? []).map((question, index) => ({
             ...question,


### PR DESCRIPTION
Ten people have hit this over eight months — #304, #375, #635, #654, #936 (two still open) plus five reports in Discord.

When the model serializes `AskUserQuestion`'s `questions` as a JSON string instead of an array, the view bails and `ToolView` falls through to the generic permission footer: you get raw JSON and Approve/Deny instead of the option buttons, and the turn proceeds on a default nobody picked. Fixes #936, and #375 looks like the same path.

Where it bails, in `AskUserQuestionView.tsx`:

```ts
const input = tool.input as AskUserQuestionInput | undefined;
const questions = input?.questions;
if (!questions || !Array.isArray(questions) || questions.length === 0) {
    return null;   // → ToolView renders PermissionFooter instead
}
```

`tool.input` can arrive as `'{"questions":[...]}'` or `{questions: "[...]"}`. The cast doesn't coerce, so the guard fails. Per #936, native Claude Code accepts both forms.

**Change** — one file, +23/-3: a `normalizeAskUserQuestionInput` helper that `JSON.parse`s the input, and the `questions` field, when they arrive as strings, in a try/catch. Well-formed input takes exactly the path it does today.

**Proof** — the same stringified `tool.input` fed through both paths: the old cast renders nothing, the new one renders the question card, its options and Submit. Before/after screenshots and the harness are in the comments below. `pnpm typecheck` clean.

> "happy could not render the choices to me, and basically took defaults and moved on without me doing anything."
> — omegaliterosmalakas, Discord, 2026-03-30, listing why he stopped using Happy

