### PR TITLE
Refresh visible session messages on foreground

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -129,6 +129,7 @@ class Sync {
     private activityAccumulator: ActivityUpdateAccumulator;
     private pendingSettings: Partial<Settings> = loadPendingSettings();
     private appState: AppStateStatus = AppState.currentState;
+    private visibleSessionId: string | null = null;
     private backgroundSendTimeout: ReturnType<typeof setTimeout> | null = null;
     private backgroundSendNotificationId: string | null = null;
     private backgroundSendStartedAt: number | null = null;
@@ -183,6 +184,9 @@ class Sync {
                 this.machinesSync.invalidate();
                 this.pushTokenSync.invalidate();
                 this.sessionsSync.invalidate();
+                if (this.visibleSessionId) {
+                    this.getMessagesSync(this.visibleSessionId).invalidate();
+                }
                 this.nativeUpdateSync.invalidate();
                 log.log('📱 App became active: Invalidating artifacts sync');
                 this.artifactsSync.invalidate();
@@ -280,6 +284,7 @@ class Sync {
 
 
     onSessionVisible = (sessionId: string) => {
+        this.visibleSessionId = sessionId;
         this.getMessagesSync(sessionId).invalidate();
 
         // Also invalidate git status sync for this session

--- a/packages/happy-cli/src/agent/acp/runAcp.test.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.test.ts
@@ -44,6 +44,9 @@ const mocks = vi.hoisted(() => {
     mockApiCreate: vi.fn(),
     mockGetOrCreateMachine: vi.fn(async () => ({})),
     mockGetOrCreateSession: vi.fn(async () => ({ id: 'session-1' })),
+    mockPush: vi.fn(() => ({
+      sendSessionNotification: vi.fn(),
+    })),
     mockSetupOfflineReconnection: vi.fn(),
     mockNotifyDaemonSessionStarted: vi.fn(async () => ({ error: null })),
     mockStartHappyServer: vi.fn(),
@@ -209,6 +212,7 @@ describe('runAcp', () => {
     mocks.mockApiCreate.mockResolvedValue({
       getOrCreateMachine: mocks.mockGetOrCreateMachine,
       getOrCreateSession: mocks.mockGetOrCreateSession,
+      push: mocks.mockPush,
     });
     mocks.mockSetupOfflineReconnection.mockImplementation(() => ({
       session: mocks.mockSession,

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { ApiClient } from '@/api/api';
 import type { ApiSessionClient } from '@/api/apiSession';
+import type { PushNotificationClient } from '@/api/pushNotifications';
 import type { AgentMessage } from '@/agent/core';
 import { AcpBackend, type AcpPermissionHandler } from './AcpBackend';
 import { DefaultTransport } from '@/agent/transport';
@@ -407,8 +408,8 @@ function resolveRequestedLegacyModelCode(models: SessionModelState, requested: s
 class GenericAcpPermissionHandler extends BasePermissionHandler implements AcpPermissionHandler {
   private readonly logPrefix: string;
 
-  constructor(session: ApiSessionClient, agentName: string) {
-    super(session);
+  constructor(session: ApiSessionClient, agentName: string, pushClient?: PushNotificationClient) {
+    super(session, pushClient);
     this.logPrefix = `[${agentName}]`;
   }
 
@@ -511,7 +512,7 @@ export async function runAcp(opts: {
     }
   }
 
-  permissionHandler = new GenericAcpPermissionHandler(session, opts.agentName);
+  permissionHandler = new GenericAcpPermissionHandler(session, opts.agentName, api.push());
   // Drop any permission requests left in agent state from a previous CLI
   // process that died while a tool prompt was open — see the matching
   // call in claudeRemoteLauncher for the full rationale.
@@ -924,6 +925,19 @@ export async function runAcp(opts: {
         await turnEnded;
         sendEnvelopes(sessionManager.endTurn('completed'));
         session.sendSessionEvent({ type: 'ready' });
+        try {
+          api.push().sendSessionNotification({
+            kind: 'done',
+            metadata: session.getMetadata(),
+            data: {
+              sessionId: session.sessionId,
+              type: 'ready',
+              provider: opts.agentName,
+            }
+          });
+        } catch (pushError) {
+          logger.debug(`[${opts.agentName}] Failed to send ready push`, pushError);
+        }
         if (verbose) {
           logAcp('muted', `Outgoing prompt completion from ${opts.agentName}`);
         }

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -494,7 +494,7 @@ export async function runCodex(opts: {
 
     client = new CodexAppServerClient(sandboxConfig);
 
-    permissionHandler = new CodexPermissionHandler(session);
+    permissionHandler = new CodexPermissionHandler(session, api.push());
     // Drop any permission requests left in agent state from a previous CLI
     // process that died while a tool prompt was open — see the matching
     // call in claudeRemoteLauncher for the full rationale.

--- a/packages/happy-cli/src/codex/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/codex/utils/permissionHandler.ts
@@ -7,6 +7,7 @@
 
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
+import type { PushNotificationClient } from "@/api/pushNotifications";
 import type { AgentState } from "@/api/types";
 import {
     BasePermissionHandler,
@@ -37,8 +38,8 @@ export class CodexPermissionHandler extends BasePermissionHandler {
         'change_title',
     ];
 
-    constructor(session: ApiSessionClient) {
-        super(session);
+    constructor(session: ApiSessionClient, pushClient?: PushNotificationClient) {
+        super(session, pushClient);
     }
 
     protected getLogPrefix(): string {

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -512,7 +512,7 @@ export async function runGemini(opts: {
   };
 
   // Create permission handler for tool approval (variable declared earlier for onSessionSwap)
-  permissionHandler = new GeminiPermissionHandler(session);
+  permissionHandler = new GeminiPermissionHandler(session, api.push());
   
   // Create reasoning processor for handling thinking/reasoning chunks
   const reasoningProcessor = new GeminiReasoningProcessor((message) => {

--- a/packages/happy-cli/src/gemini/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/gemini/utils/permissionHandler.ts
@@ -7,6 +7,7 @@
 
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
+import type { PushNotificationClient } from "@/api/pushNotifications";
 import type { PermissionMode } from '@/api/types';
 import {
     BasePermissionHandler,
@@ -23,8 +24,8 @@ export type { PermissionResult, PendingRequest };
 export class GeminiPermissionHandler extends BasePermissionHandler {
     private currentPermissionMode: PermissionMode = 'default';
 
-    constructor(session: ApiSessionClient) {
-        super(session);
+    constructor(session: ApiSessionClient, pushClient?: PushNotificationClient) {
+        super(session, pushClient);
     }
 
     protected getLogPrefix(): string {
@@ -158,4 +159,3 @@ export class GeminiPermissionHandler extends BasePermissionHandler {
         });
     }
 }
-

--- a/packages/happy-cli/src/utils/BasePermissionHandler.ts
+++ b/packages/happy-cli/src/utils/BasePermissionHandler.ts
@@ -10,6 +10,7 @@
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
 import { AgentState } from "@/api/types";
+import type { PushNotificationClient } from "@/api/pushNotifications";
 
 /**
  * Permission response from the mobile app.
@@ -46,6 +47,7 @@ export interface PermissionResult {
 export abstract class BasePermissionHandler {
     protected pendingRequests = new Map<string, PendingRequest>();
     protected session: ApiSessionClient;
+    private pushClient?: PushNotificationClient;
     private isResetting = false;
 
     /**
@@ -53,8 +55,9 @@ export abstract class BasePermissionHandler {
      */
     protected abstract getLogPrefix(): string;
 
-    constructor(session: ApiSessionClient) {
+    constructor(session: ApiSessionClient, pushClient?: PushNotificationClient) {
         this.session = session;
+        this.pushClient = pushClient;
         this.setupRpcHandler();
     }
 
@@ -135,6 +138,20 @@ export abstract class BasePermissionHandler {
                 }
             }
         }));
+        try {
+            this.pushClient?.sendSessionNotification({
+                kind: 'permission',
+                metadata: this.session.getMetadata(),
+                data: {
+                    sessionId: this.session.sessionId,
+                    requestId: toolCallId,
+                    tool: toolName,
+                    type: 'permission_request',
+                }
+            });
+        } catch (error) {
+            logger.debug(`${this.getLogPrefix()} Failed to send permission push`, error);
+        }
     }
 
     /**

--- a/packages/happy-server/sources/app/events/eventRouter.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.ts
@@ -281,16 +281,20 @@ class EventRouter {
     // === PRESENCE QUERIES ===
 
     /**
-     * Returns true if the user has any non-machine socket that hasn't
-     * reported `app-state: background`.  Old clients that never send
-     * `app-state` are treated as active (connected = present).
+     * Returns true if the user has any UI socket that hasn't reported
+     * `app-state: background`. Session-scoped and machine-scoped sockets are
+     * agent/daemon connections, not a foreground user surface, so they must not
+     * suppress mobile push notifications.
+     *
+     * Old user-scoped clients that never send `app-state` are treated as active
+     * (connected = present).
      *
      * Uses fetchSockets() which works cross-replica via Redis streams adapter.
      */
     async hasActiveNonMachineSocket(userId: string): Promise<boolean> {
         const sockets = await this.io.in(`user:${userId}`).fetchSockets();
         return sockets.some(s => {
-            if (s.data.clientType === 'machine-scoped') return false;
+            if (s.data.clientType && s.data.clientType !== 'user-scoped') return false;
             // No app-state yet → old client or just connected; assume active
             const appState = s.data.appState as string | undefined;
             return appState !== 'background';


### PR DESCRIPTION
## Summary

- track the currently visible session in mobile sync state
- refresh that session's messages when the app returns to foreground
- stop treating CLI agent/session sockets as foreground user clients for push suppression
- send permission-request push notifications from shared Codex/Gemini/ACP permission handling
- send ACP task-complete push notifications when a prompt finishes
- keep per-message push notifications disabled, but allow `done`, `permission`, and `question` pushes to reach iPhone when no actual UI client is active

Fixes #1308

## Test plan

- `pnpm --filter happy typecheck`
- `pnpm --filter happy exec vitest run src/codex/__tests__/permissionHandler.test.ts src/agent/acp/runAcp.test.ts`
- `pnpm --filter happy-app typecheck`
- `pnpm --filter happy-server build`
