### PR TITLE
feat(cli): add Devin CLI integration via ACP

### DIFF
--- a/packages/happy-app/sources/app/(app)/dev/session-composer.tsx
+++ b/packages/happy-app/sources/app/(app)/dev/session-composer.tsx
@@ -41,14 +41,16 @@ const agentIcons = {
     codex: require('@/assets/images/icon-gpt.png'),
     openclaw: require('@/assets/images/icon-openclaw.png'),
     gemini: require('@/assets/images/icon-gemini.png'),
+    devin: require('@/assets/images/icon-gpt.png'),
 };
 
-type AgentKey = 'claude' | 'codex' | 'openclaw' | 'gemini';
+type AgentKey = 'claude' | 'codex' | 'openclaw' | 'gemini' | 'devin';
 const AGENTS: { key: AgentKey; label: string }[] = [
     { key: 'claude', label: 'claude code' },
     { key: 'codex', label: 'codex' },
     { key: 'openclaw', label: 'openclaw' },
     { key: 'gemini', label: 'gemini' },
+    { key: 'devin', label: 'devin' },
 ];
 
 // Sample data for pickers

--- a/packages/happy-app/sources/app/(app)/machine/[id].tsx
+++ b/packages/happy-app/sources/app/(app)/machine/[id].tsx
@@ -555,6 +555,15 @@ export default function MachineDetailScreen() {
                             }
                         />
                         <Item
+                            title="Devin"
+                            showChevron={false}
+                            rightElement={
+                                <Text style={{ color: metadata.cliAvailability.devin ? '#34C759' : theme.colors.textSecondary, fontSize: 14 }}>
+                                    {metadata.cliAvailability.devin ? t('machine.cliInstalled') : t('machine.cliNotFound')}
+                                </Text>
+                            }
+                        />
+                        <Item
                             title={t('machine.lastDetected')}
                             subtitle={new Date(metadata.cliAvailability.detectedAt).toLocaleString()}
                             showChevron={false}

--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -65,6 +65,7 @@ const agentIcons = {
     codex: require('@/assets/images/icon-gpt.png'),
     openclaw: require('@/assets/images/icon-openclaw.png'),
     gemini: require('@/assets/images/icon-gemini.png'),
+    devin: require('@/assets/images/icon-gpt.png'),
 };
 
 type AgentKey = NewSessionAgentType;
@@ -73,6 +74,7 @@ const ALL_AGENTS: { key: AgentKey; label: string }[] = [
     { key: 'codex', label: 'codex' },
     { key: 'openclaw', label: 'openclaw' },
     { key: 'gemini', label: 'gemini' },
+    { key: 'devin', label: 'devin' },
 ];
 
 type PickerItem = { key: string; label: string; subtitle?: string; dimmed?: boolean };

--- a/packages/happy-app/sources/components/Avatar.tsx
+++ b/packages/happy-app/sources/components/Avatar.tsx
@@ -23,6 +23,7 @@ const flavorIcons = {
     codex: require('@/assets/images/icon-gpt.png'),
     gemini: require('@/assets/images/icon-gemini.png'),
     openclaw: require('@/assets/images/icon-openclaw.png'),
+    devin: require('@/assets/images/icon-gpt.png'),
 };
 
 const styles = StyleSheet.create((theme) => ({

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -139,7 +139,7 @@ export interface SpawnSessionOptions {
     directory: string;
     approvedNewDirectoryCreation?: boolean;
     token?: string;
-    agent?: 'codex' | 'claude' | 'gemini' | 'openclaw';
+    agent?: 'codex' | 'claude' | 'gemini' | 'openclaw' | 'devin';
     /**
      * If set, the daemon spawns the agent with `--resume <id>` so the new
      * Happy session attaches to a pre-existing on-disk Claude conversation
@@ -195,7 +195,7 @@ export async function machineSpawnNewSession(options: SpawnSessionOptions): Prom
             directory: string
             approvedNewDirectoryCreation?: boolean,
             token?: string,
-            agent?: 'codex' | 'claude' | 'gemini' | 'openclaw',
+            agent?: 'codex' | 'claude' | 'gemini' | 'openclaw' | 'devin',
             resumeClaudeSessionId?: string,
             parentSessionId?: string,
             forkedFromMessageId?: string,

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -12,7 +12,7 @@ const VOICE_SOFT_PAYWALL_SHOWN_KEY = 'voice-soft-paywall-shown';
 const VOICE_ONBOARDING_PROMPT_LOAD_COUNT_KEY = 'voice-onboarding-prompt-load-count';
 const VOICE_MESSAGE_COUNT_KEY = 'voice-message-count';
 
-export type NewSessionAgentType = 'claude' | 'codex' | 'gemini' | 'openclaw';
+export type NewSessionAgentType = 'claude' | 'codex' | 'gemini' | 'openclaw' | 'devin';
 export type NewSessionSessionType = 'simple' | 'worktree';
 
 export interface NewSessionDraft {

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -161,6 +161,7 @@ export const MachineMetadataSchema = z.object({
         codex: z.boolean(),
         gemini: z.boolean(),
         openclaw: z.boolean(),
+        devin: z.boolean(),
         detectedAt: z.number(),
     }).optional(),
     resumeSupport: z.object({

--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -32,6 +32,7 @@ This will:
 
 ```
 happy codex
+happy devin
 happy gemini
 happy openclaw
 
@@ -100,6 +101,7 @@ happy connect status
 | `happy` | Start Claude Code session (default) |
 | `happy codex` | Start Codex mode |
 | `happy gemini` | Start Gemini CLI session |
+| `happy devin` | Start Devin session |
 | `happy openclaw` | Start OpenClaw session |
 | `happy acp` | Start any ACP-compatible agent |
 | `happy resume <id>` | Resume a previous session |
@@ -144,6 +146,7 @@ yarn workspace happy cli --help
 - Node.js >= 20.0.0
 - For Claude: `claude` CLI installed & logged in
 - For Codex: `codex` CLI installed & logged in
+- For Devin: `devin` CLI installed & logged in
 - For Gemini: `npm install -g @google/gemini-cli` + `happy connect gemini`
 
 ## License

--- a/packages/happy-cli/src/agent/acp/AcpBackend.ts
+++ b/packages/happy-cli/src/agent/acp/AcpBackend.ts
@@ -334,6 +334,9 @@ export class AcpBackend implements AgentBackend {
   /** Map from real tool call ID to tool name for auto-approval */
   private toolCallIdToNameMap = new Map<string, string>();
 
+  /** Map from tool call ID to last streamed content (for agents that stream output in in_progress updates) */
+  private toolCallLastContent = new Map<string, unknown>();
+
   /** Track if we just sent a prompt with change_title instruction */
   private recentPromptHadChangeTitle = false;
 
@@ -563,6 +566,9 @@ export class AcpBackend implements AgentBackend {
       const client: Client = {
         sessionUpdate: async (params: SessionNotification) => {
           this.handleSessionUpdate(params);
+        },
+        extNotification: async (method: string, params: Record<string, unknown>) => {
+          logger.debug(`[AcpBackend] Received vendor notification: ${method}`, JSON.stringify(params));
         },
         requestPermission: async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
           
@@ -876,6 +882,7 @@ export class AcpBackend implements AgentBackend {
       toolCallStartTimes: this.toolCallStartTimes,
       toolCallTimeouts: this.toolCallTimeouts,
       toolCallIdToNameMap: this.toolCallIdToNameMap,
+      toolCallLastContent: this.toolCallLastContent,
       idleTimeout: this.idleTimeout,
       toolCallCountSincePrompt: this.toolCallCountSincePrompt,
       emit: (msg) => this.emit(msg),

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { KNOWN_ACP_AGENTS, resolveAcpAgentConfig } from './acpAgentConfig';
 
 describe('KNOWN_ACP_AGENTS', () => {
-  it('defines built-in Gemini and OpenCode command mappings', () => {
+  it('defines built-in Gemini, OpenCode, and Devin command mappings', () => {
     expect(KNOWN_ACP_AGENTS).toEqual({
       gemini: { command: 'gemini', args: ['--experimental-acp'] },
       opencode: { command: 'opencode', args: ['acp'] },
+      devin: { command: 'devin', args: ['acp'] },
     });
   });
 });

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
@@ -6,6 +6,7 @@ export type AcpAgentConfig = {
 export const KNOWN_ACP_AGENTS: Record<string, AcpAgentConfig> = {
   gemini: { command: 'gemini', args: ['--experimental-acp'] },
   opencode: { command: 'opencode', args: ['acp'] },
+  devin: { command: 'devin', args: ['acp'] },
 };
 
 export type ResolvedAcpAgentConfig = {

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -436,12 +436,15 @@ type PendingTurn = {
   timeout: NodeJS.Timeout;
 };
 
-function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'acp' {
+function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'devin' | 'acp' {
   if (agentName === 'gemini') {
     return 'gemini';
   }
   if (agentName === 'opencode') {
     return 'opencode';
+  }
+  if (agentName === 'devin') {
+    return 'devin';
   }
   return 'acp';
 }

--- a/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
+++ b/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts
@@ -59,6 +59,8 @@ export interface HandlerContext {
   toolCallTimeouts: Map<string, NodeJS.Timeout>;
   /** Map of tool call ID to tool name */
   toolCallIdToNameMap: Map<string, string>;
+  /** Map of tool call ID to last streamed content (for agents that stream output in in_progress updates) */
+  toolCallLastContent: Map<string, unknown>;
   /** Current idle timeout handle */
   idleTimeout: NodeJS.Timeout | null;
   /** Tool call counter since last prompt */
@@ -325,7 +327,7 @@ export function completeToolCall(
 ): void {
   const startTime = ctx.toolCallStartTimes.get(toolCallId);
   const duration = formatDuration(startTime);
-  const toolKindStr = typeof toolKind === 'string' ? toolKind : 'unknown';
+  const toolKindStr = typeof toolKind === 'string' ? toolKind : (ctx.toolCallIdToNameMap.get(toolCallId) ?? 'unknown');
 
   ctx.activeToolCalls.delete(toolCallId);
   ctx.toolCallStartTimes.delete(toolCallId);
@@ -365,7 +367,7 @@ export function failToolCall(
 ): void {
   const startTime = ctx.toolCallStartTimes.get(toolCallId);
   const duration = startTime ? Date.now() - startTime : null;
-  const toolKindStr = typeof toolKind === 'string' ? toolKind : 'unknown';
+  const toolKindStr = typeof toolKind === 'string' ? toolKind : (ctx.toolCallIdToNameMap.get(toolCallId) ?? 'unknown');
   const isInvestigation = ctx.transport.isInvestigationTool?.(toolCallId, toolKindStr) ?? false;
   const hadTimeout = ctx.toolCallTimeouts.has(toolCallId);
 
@@ -456,10 +458,18 @@ export function handleToolCallUpdate(
     } else {
       logger.debug(`[AcpBackend] Tool call ${toolCallId} already tracked, status: ${status}`);
     }
+    // Store latest content from streaming in_progress updates
+    if (update.content != null) {
+      ctx.toolCallLastContent.set(toolCallId, update.content);
+    }
   } else if (status === 'completed') {
-    completeToolCall(toolCallId, toolKind, update.content, ctx);
+    const content = update.content ?? ctx.toolCallLastContent.get(toolCallId);
+    ctx.toolCallLastContent.delete(toolCallId);
+    completeToolCall(toolCallId, update.kind, content, ctx);
   } else if (status === 'failed' || status === 'cancelled') {
-    failToolCall(toolCallId, status, toolKind, update.content, ctx);
+    const content = update.content ?? ctx.toolCallLastContent.get(toolCallId);
+    ctx.toolCallLastContent.delete(toolCallId);
+    failToolCall(toolCallId, status, update.kind, content, ctx);
   }
 
   return { handled: true, toolCallCountSincePrompt };

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -451,7 +451,7 @@ export class ApiMachineClient {
             const prev = this.lastKnownCLIAvailability;
             const newResumeSupport = detectResumeSupport();
             const prevResume = this.lastKnownResumeSupport;
-            const cliAvailabilityChanged = !prev || prev.claude !== newAvailability.claude || prev.codex !== newAvailability.codex || prev.gemini !== newAvailability.gemini || prev.openclaw !== newAvailability.openclaw;
+            const cliAvailabilityChanged = !prev || prev.claude !== newAvailability.claude || prev.codex !== newAvailability.codex || prev.gemini !== newAvailability.gemini || prev.openclaw !== newAvailability.openclaw || prev.devin !== newAvailability.devin;
             const resumeSupportChanged = !prevResume
                 || prevResume.rpcAvailable !== newResumeSupport.rpcAvailable
                 || prevResume.happyAgentAuthenticated !== newResumeSupport.happyAgentAuthenticated;

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -139,6 +139,7 @@ export const MachineMetadataSchema = z.object({
     codex: z.boolean(),
     gemini: z.boolean(),
     openclaw: z.boolean(),
+    devin: z.boolean(),
     detectedAt: z.number(),
   }).optional(),
   resumeSupport: z.object({

--- a/packages/happy-cli/src/commands/devinCommand.ts
+++ b/packages/happy-cli/src/commands/devinCommand.ts
@@ -1,0 +1,34 @@
+import { authAndSetupMachineIfNeeded } from '@/ui/auth'
+import { runAcp, resolveAcpAgentConfig } from '@/agent/acp'
+import { ensureDaemonRunning } from '@/daemon/ensureDaemonRunning'
+
+export async function handleDevinCommand(args: string[]): Promise<void> {
+  let startedBy: 'daemon' | 'terminal' | undefined = undefined
+  let verbose = false
+  const passthroughArgs: string[] = []
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--started-by') {
+      startedBy = args[++i] as 'daemon' | 'terminal'
+    } else if (args[i] === '--happy-starting-mode') {
+      i++ // skip value, consumed by daemon flow
+    } else if (args[i] === '--verbose') {
+      verbose = true
+    } else {
+      passthroughArgs.push(args[i])
+    }
+  }
+
+  const resolved = resolveAcpAgentConfig(['devin', ...passthroughArgs])
+  const { credentials } = await authAndSetupMachineIfNeeded()
+  await ensureDaemonRunning()
+
+  await runAcp({
+    credentials,
+    startedBy,
+    verbose,
+    agentName: resolved.agentName,
+    command: resolved.command,
+    args: resolved.args,
+  })
+}

--- a/packages/happy-cli/src/daemon/controlServer.ts
+++ b/packages/happy-cli/src/daemon/controlServer.ts
@@ -129,7 +129,7 @@ export function startDaemonControlServer({
         body: z.object({
           directory: z.string(),
           sessionId: z.string().optional(),
-          agent: z.enum(['claude', 'codex', 'gemini', 'openclaw']).optional(),
+          agent: z.enum(['claude', 'codex', 'gemini', 'openclaw', 'devin']).optional(),
           environmentVariables: z.record(z.string(), z.string()).optional(),
         }),
         response: {

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -398,8 +398,8 @@ export async function startDaemon(): Promise<void> {
 
           // Construct command for the CLI
           const cliPath = join(projectPath(), 'dist', 'index.mjs');
-          // Determine agent command - support claude, codex, and gemini
-          const agent = options.agent === 'gemini' ? 'gemini' : (options.agent === 'codex' ? 'codex' : (options.agent === 'openclaw' ? 'openclaw' : 'claude'));
+          // Determine agent command - support claude, codex, gemini, devin, and openclaw
+          const agent = options.agent === 'gemini' ? 'gemini' : (options.agent === 'codex' ? 'codex' : (options.agent === 'openclaw' ? 'openclaw' : (options.agent === 'devin' ? 'devin' : 'claude')));
           // Restrict resume to Claude — Codex/Gemini don't honour the
           // happy-pass-through `--resume <id>` argument the same way.
           const resumeFragment = options.resumeClaudeSessionId && agent === 'claude'
@@ -487,7 +487,7 @@ export async function startDaemon(): Promise<void> {
         if (!useTmux) {
           logger.debug(`[DAEMON RUN] Using regular process spawning`);
 
-          // Construct arguments for the CLI - support claude, codex, and gemini
+          // Construct arguments for the CLI - support claude, codex, gemini, and devin
           let agentCommand: string;
           switch (options.agent) {
             case 'claude':
@@ -502,6 +502,9 @@ export async function startDaemon(): Promise<void> {
               break;
             case 'openclaw':
               agentCommand = 'openclaw';
+              break;
+            case 'devin':
+              agentCommand = 'devin';
               break;
             default:
               return {

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -34,6 +34,7 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
 import { handleResumeCommand } from '@/resume/handleResumeCommand'
 import { ensureDaemonRunning } from './daemon/ensureDaemonRunning'
 import { handleCodexCommand } from './commands/codexCommand'
+import { handleDevinCommand } from './commands/devinCommand'
 
 
 (async () => {
@@ -140,6 +141,18 @@ Conversation history is preserved on the server, but in-flight tool calls are in
     try {
       await handleCodexCommand(args.slice(1));
       // Do not force exit here; allow instrumentation to show lingering handles
+    } catch (error) {
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
+      if (process.env.DEBUG) {
+        console.error(error)
+      }
+      process.exit(1)
+    }
+    return;
+  } else if (subcommand === 'devin') {
+    // Handle devin command
+    try {
+      await handleDevinCommand(args.slice(1));
     } catch (error) {
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
       if (process.env.DEBUG) {
@@ -678,6 +691,7 @@ ${chalk.bold('Usage:')}
   happy auth              Manage authentication
   happy resume            Resume a previous Happy session by Happy session ID
   happy codex             Start Codex mode
+  happy devin             Start Devin mode (ACP)
   happy gemini            Start Gemini mode (ACP)
   happy acp               Start a generic ACP-compatible agent
   happy connect           Connect AI vendor API keys

--- a/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
+++ b/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
@@ -120,7 +120,7 @@ export interface SpawnSessionOptions {
     directory: string;
     sessionId?: string;
     approvedNewDirectoryCreation?: boolean;
-    agent?: 'claude' | 'codex' | 'gemini' | 'openclaw';
+    agent?: 'claude' | 'codex' | 'gemini' | 'openclaw' | 'devin';
     environmentVariables?: Record<string, string>;
     token?: string;
     /**

--- a/packages/happy-cli/src/utils/createSessionMetadata.ts
+++ b/packages/happy-cli/src/utils/createSessionMetadata.ts
@@ -19,7 +19,7 @@ import packageJson from '../../package.json';
 /**
  * Backend flavor identifier for session metadata.
  */
-export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'acp';
+export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'devin' | 'acp';
 
 /**
  * Options for creating session metadata.

--- a/packages/happy-cli/src/utils/detectCLI.ts
+++ b/packages/happy-cli/src/utils/detectCLI.ts
@@ -8,6 +8,7 @@ export interface CLIAvailability {
   codex: boolean;
   gemini: boolean;
   openclaw: boolean;
+  devin: boolean;
   detectedAt: number;
 }
 
@@ -37,6 +38,7 @@ function detectPosix(): CLIAvailability {
   const claude = commandExists('claude');
   const codex = commandExists('codex');
   const gemini = commandExists('gemini');
+  const devin = commandExists('devin');
 
   // OpenClaw: check command, config file, or env var
   const openclawCommand = commandExists('openclaw');
@@ -44,7 +46,7 @@ function detectPosix(): CLIAvailability {
   const openclawEnv = !!process.env.OPENCLAW_GATEWAY_URL;
   const openclaw = openclawCommand || openclawConfig || openclawEnv;
 
-  return { claude, codex, gemini, openclaw, detectedAt: Date.now() };
+  return { claude, codex, gemini, openclaw, devin, detectedAt: Date.now() };
 }
 
 function detectWindows(): CLIAvailability {
@@ -60,6 +62,7 @@ function detectWindows(): CLIAvailability {
   const claude = checkCommand('claude');
   const codex = checkCommand('codex');
   const gemini = checkCommand('gemini');
+  const devin = checkCommand('devin');
 
   // OpenClaw: check command, config file, or env var
   const openclawCommand = checkCommand('openclaw');
@@ -67,5 +70,5 @@ function detectWindows(): CLIAvailability {
   const openclawEnv = !!process.env.OPENCLAW_GATEWAY_URL;
   const openclaw = openclawCommand || openclawConfig || openclawEnv;
 
-  return { claude, codex, gemini, openclaw, detectedAt: Date.now() };
+  return { claude, codex, gemini, openclaw, devin, detectedAt: Date.now() };
 }


### PR DESCRIPTION
## Summary

Add first-class Devin CLI support via the existing ACP framework — `happy devin` and `happy acp devin` now work out of the box.

## Motivation

The [Devin CLI](https://docs.devin.ai/cli/overview) supports the Agent Communication Protocol (ACP), but `happy acp devin` doesn't work today because Devin isn't registered in `KNOWN_ACP_AGENTS`. Without this registration, Happy invokes `devin` with no arguments instead of `devin acp`, so the ACP handshake never starts.

## Changes

**CLI integration (follows the existing codex/gemini/openclaw pattern):**
- Register `devin` in `KNOWN_ACP_AGENTS` → `{ command: 'devin', args: ['acp'] }`
- Add `happy devin` shortcut command via [devinCommand.ts](cci:7://file:///home/gt/code/happy/packages/happy-cli/src/commands/devinCommand.ts:0:0-0:0)
- Wire Devin through daemon spawn, CLI detection, session metadata, and control server enums

**App UI (minimal, follows existing pattern for each agent):**
- Add Devin to agent type unions, session composer, avatar icons, machine detail CLI status, and new-session picker

**ACP framework fixes (surfaced during Devin testing, benefits all ACP agents):**
- **Tool name resolution**: [completeToolCall](cci:1://file:///home/gt/code/happy/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts:316:0-353:1)/[failToolCall](cci:1://file:///home/gt/code/happy/packages/happy-cli/src/agent/acp/sessionUpdateHandlers.ts:355:0-431:1) now fall back to `toolCallIdToNameMap` when `update.kind` is missing on completion — fixes tools showing as "unknown"
- **Streaming content accumulation**: Content from `in_progress` updates is stored in `toolCallLastContent` and used as fallback when the `completed` event arrives without content — fixes lost tool output for agents that stream results incrementally
- **Vendor notification handler**: Added defensive [extNotification](cci:1://file:///home/gt/code/happy/packages/happy-cli/src/agent/acp/AcpBackend.ts:569:8-571:9) handler to [AcpBackend](cci:2://file:///home/gt/code/happy/packages/happy-cli/src/agent/acp/AcpBackend.ts:316:0-1342:1) to log rather than crash on vendor-specific notifications

**Docs:**
- Updated CLI README with Devin in usage examples, commands table, and requirements

## Testing

- All existing ACP unit tests pass (48/48)
- `acpAgentConfig.test.ts` updated for Devin entry
- Tested end-to-end with Devin CLI: sessions start, tool calls show correct names, streaming content is preserved through completion

## Notes

- happy-app is using icon-gpt for Devin for now - will need to include the official Devin CLI icon if this PR is considered for merging.
- Generated and tested using Claude Opus 4.6 Thinking.