### PR TITLE
feat(cli): add Hermes Agent CLI integration via ACP

### DIFF
--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -33,6 +33,7 @@ This will:
 ```
 happy codex
 happy gemini
+happy hermes
 happy openclaw
 
 # or any ACP-compatible CLI
@@ -100,6 +101,7 @@ happy connect status
 | `happy` | Start Claude Code session (default) |
 | `happy codex` | Start Codex mode |
 | `happy gemini` | Start Gemini CLI session |
+| `happy hermes` | Start Hermes Agent CLI session |
 | `happy openclaw` | Start OpenClaw session |
 | `happy acp` | Start any ACP-compatible agent |
 | `happy resume <id>` | Resume a previous session |

--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -34,6 +34,7 @@ This will:
 happy codex
 happy agy        # Antigravity CLI (Gemini's successor)
 happy gemini     # deprecated — use `happy agy`
+happy hermes
 happy openclaw
 
 # or any ACP-compatible CLI
@@ -102,6 +103,7 @@ happy connect status
 | `happy codex` | Start Codex mode |
 | `happy agy` | Start agy (Antigravity CLI) session |
 | `happy gemini` | Start Gemini CLI session (**deprecated** — use `happy agy`) |
+| `happy hermes` | Start Hermes Agent CLI session |
 | `happy openclaw` | Start OpenClaw session |
 | `happy acp` | Start any ACP-compatible agent |
 | `happy resume <id>` | Resume a previous session |

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { KNOWN_ACP_AGENTS, resolveAcpAgentConfig } from './acpAgentConfig';
 
 describe('KNOWN_ACP_AGENTS', () => {
-  it('defines built-in Gemini and OpenCode command mappings', () => {
+  it('defines built-in Gemini, OpenCode, and Hermes command mappings', () => {
     expect(KNOWN_ACP_AGENTS).toEqual({
       gemini: { command: 'gemini', args: ['--experimental-acp'] },
       opencode: { command: 'opencode', args: ['acp'] },
+      hermes: { command: 'hermes', args: ['acp'] },
     });
   });
 });
@@ -16,6 +17,11 @@ describe('resolveAcpAgentConfig', () => {
       agentName: 'gemini',
       command: 'gemini',
       args: ['--experimental-acp'],
+    });
+    expect(resolveAcpAgentConfig(['hermes'])).toEqual({
+      agentName: 'hermes',
+      command: 'hermes',
+      args: ['acp'],
     });
   });
 

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
@@ -6,6 +6,7 @@ export type AcpAgentConfig = {
 export const KNOWN_ACP_AGENTS: Record<string, AcpAgentConfig> = {
   gemini: { command: 'gemini', args: ['--experimental-acp'] },
   opencode: { command: 'opencode', args: ['acp'] },
+  hermes: { command: 'hermes', args: ['acp'] },
 };
 
 export type ResolvedAcpAgentConfig = {

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -436,12 +436,15 @@ type PendingTurn = {
   timeout: NodeJS.Timeout;
 };
 
-function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'acp' {
+function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'hermes' | 'acp' {
   if (agentName === 'gemini') {
     return 'gemini';
   }
   if (agentName === 'opencode') {
     return 'opencode';
+  }
+  if (agentName === 'hermes') {
+    return 'hermes';
   }
   return 'acp';
 }

--- a/packages/happy-cli/src/agent/core/AgentBackend.ts
+++ b/packages/happy-cli/src/agent/core/AgentBackend.ts
@@ -48,7 +48,7 @@ export interface McpServerConfig {
 export type AgentTransport = 'native-claude' | 'mcp-codex' | 'acp';
 
 /** Agent identifier */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'claude-acp' | 'codex-acp';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'claude-acp' | 'codex-acp' | 'hermes';
 
 /**
  * Configuration for creating an agent backend

--- a/packages/happy-cli/src/agent/core/AgentBackend.ts
+++ b/packages/happy-cli/src/agent/core/AgentBackend.ts
@@ -48,7 +48,7 @@ export interface McpServerConfig {
 export type AgentTransport = 'native-claude' | 'mcp-codex' | 'acp';
 
 /** Agent identifier */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'claude-acp' | 'codex-acp';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'claude-acp' | 'codex-acp' | 'hermes';
 
 /**
  * Configuration for creating an agent backend

--- a/packages/happy-cli/src/agent/factories/hermes.test.ts
+++ b/packages/happy-cli/src/agent/factories/hermes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createHermesBackend, registerHermesAgent } from './hermes';
+import { agentRegistry } from '../core';
+
+describe('createHermesBackend', () => {
+  it('creates a backend with default options', () => {
+    const result = createHermesBackend({ cwd: '/tmp' });
+    expect(result.backend).toBeDefined();
+    expect(result.model).toBeNull();
+  });
+
+  it('passes through apiKey and model', () => {
+    const result = createHermesBackend({
+      cwd: '/tmp',
+      apiKey: 'test-key',
+      model: 'hermes-4',
+    });
+    expect(result.backend).toBeDefined();
+    expect(result.model).toBe('hermes-4');
+  });
+});
+
+describe('registerHermesAgent', () => {
+  it('registers hermes in the global agent registry', () => {
+    registerHermesAgent();
+    expect(agentRegistry.has('hermes')).toBe(true);
+    expect(agentRegistry.list()).toContain('hermes');
+  });
+});

--- a/packages/happy-cli/src/agent/factories/hermes.ts
+++ b/packages/happy-cli/src/agent/factories/hermes.ts
@@ -1,0 +1,96 @@
+/**
+ * Hermes ACP Backend - Hermes Agent CLI via ACP
+ *
+ * This module provides a factory function for creating a Hermes backend
+ * that communicates using the Agent Client Protocol (ACP).
+ *
+ * Hermes Agent (NousResearch/hermes-agent) ships ACP support via the
+ * `hermes acp` command, installed with `pip install 'hermes-agent[acp]'`.
+ */
+
+import { AcpBackend, type AcpBackendOptions, type AcpPermissionHandler } from '../acp/AcpBackend';
+import type { AgentBackend, McpServerConfig, AgentFactoryOptions } from '../core';
+import { agentRegistry } from '../core';
+import { DefaultTransport } from '../transport';
+import { logger } from '@/ui/logger';
+
+/**
+ * Options for creating a Hermes ACP backend
+ */
+export interface HermesBackendOptions extends AgentFactoryOptions {
+  /** API key passthrough for upstream Hermes providers (set via env if provided) */
+  apiKey?: string;
+
+  /** Model to use. If undefined, Hermes CLI will use its config default. */
+  model?: string | null;
+
+  /** MCP servers to make available to the agent */
+  mcpServers?: Record<string, McpServerConfig>;
+
+  /** Optional permission handler for tool approval */
+  permissionHandler?: AcpPermissionHandler;
+}
+
+/**
+ * Result of creating a Hermes backend
+ */
+export interface HermesBackendResult {
+  /** The created AgentBackend instance */
+  backend: AgentBackend;
+  /** The resolved model that will be used */
+  model: string | null;
+}
+
+/**
+ * Create a Hermes backend using ACP.
+ *
+ * The Hermes Agent CLI must be installed with the `acp` extra and available
+ * on PATH. Uses the `hermes acp` command to enable ACP mode.
+ *
+ * @param options - Configuration options
+ * @returns HermesBackendResult with backend and resolved model
+ */
+export function createHermesBackend(options: HermesBackendOptions): HermesBackendResult {
+  const apiKey = options.apiKey || undefined;
+  const model = options.model ?? null;
+
+  const backendOptions: AcpBackendOptions = {
+    agentName: 'hermes',
+    cwd: options.cwd,
+    command: 'hermes',
+    args: ['acp'],
+    env: {
+      ...options.env,
+      ...(apiKey ? { HERMES_API_KEY: apiKey } : {}),
+      ...(model ? { HERMES_MODEL: model } : {}),
+    },
+    mcpServers: options.mcpServers,
+    permissionHandler: options.permissionHandler,
+    transportHandler: new DefaultTransport('hermes'),
+  };
+
+  logger.debug('[Hermes] Creating ACP backend with options:', {
+    cwd: backendOptions.cwd,
+    command: backendOptions.command,
+    args: backendOptions.args,
+    hasApiKey: !!apiKey,
+    model: model,
+    mcpServerCount: options.mcpServers ? Object.keys(options.mcpServers).length : 0,
+  });
+
+  return {
+    backend: new AcpBackend(backendOptions),
+    model,
+  };
+}
+
+/**
+ * Register Hermes backend with the global agent registry.
+ *
+ * This function should be called during application initialization
+ * to make the Hermes agent available for use.
+ */
+export function registerHermesAgent(): void {
+  agentRegistry.register('hermes', (opts) => createHermesBackend(opts).backend);
+  logger.debug('[Hermes] Registered with agent registry');
+}

--- a/packages/happy-cli/src/agent/factories/index.ts
+++ b/packages/happy-cli/src/agent/factories/index.ts
@@ -15,6 +15,14 @@ export {
   type GeminiBackendResult,
 } from './gemini';
 
+// Hermes factory
+export {
+  createHermesBackend,
+  registerHermesAgent,
+  type HermesBackendOptions,
+  type HermesBackendResult,
+} from './hermes';
+
 // Future factories:
 // export { createCodexBackend, registerCodexAgent, type CodexBackendOptions } from './codex';
 // export { createClaudeBackend, registerClaudeAgent, type ClaudeBackendOptions } from './claude';

--- a/packages/happy-cli/src/agent/index.ts
+++ b/packages/happy-cli/src/agent/index.ts
@@ -40,5 +40,7 @@ export function initializeAgents(): void {
   // Import and register agents from factories
   const { registerGeminiAgent } = require('./factories/gemini');
   registerGeminiAgent();
+  const { registerHermesAgent } = require('./factories/hermes');
+  registerHermesAgent();
 }
 

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -522,7 +522,7 @@ export class ApiMachineClient {
         const prev = this.lastKnownCLIAvailability;
         const newResumeSupport = detectResumeSupport();
         const prevResume = this.lastKnownResumeSupport;
-        const cliAvailabilityChanged = !prev || prev.claude !== newAvailability.claude || prev.codex !== newAvailability.codex || prev.gemini !== newAvailability.gemini || prev.openclaw !== newAvailability.openclaw;
+        const cliAvailabilityChanged = !prev || prev.claude !== newAvailability.claude || prev.codex !== newAvailability.codex || prev.gemini !== newAvailability.gemini || prev.openclaw !== newAvailability.openclaw || prev.hermes !== newAvailability.hermes;
         const resumeSupportChanged = !prevResume
             || prevResume.rpcAvailable !== newResumeSupport.rpcAvailable
             || prevResume.happyAgentAuthenticated !== newResumeSupport.happyAgentAuthenticated;

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -139,6 +139,7 @@ export const MachineMetadataSchema = z.object({
     codex: z.boolean(),
     gemini: z.boolean(),
     openclaw: z.boolean(),
+    hermes: z.boolean().optional(),
     detectedAt: z.number(),
   }).optional(),
   resumeSupport: z.object({

--- a/packages/happy-cli/src/hermes/runHermes.ts
+++ b/packages/happy-cli/src/hermes/runHermes.ts
@@ -1,0 +1,85 @@
+/**
+ * Hermes CLI Entry Point
+ *
+ * This module provides the main entry point for running the Hermes Agent
+ * through Happy CLI. It is a thin wrapper around the generic ACP runner,
+ * since Hermes Agent natively supports the Agent Client Protocol via
+ * `hermes acp` (requires `pip install 'hermes-agent[acp]'`).
+ *
+ * Performs a pre-flight check that the `hermes` binary is on PATH and
+ * prints an install hint if missing — Hermes is a separate Python package
+ * that the user must install themselves.
+ */
+
+import { execSync } from 'node:child_process';
+import os from 'node:os';
+
+import chalk from 'chalk';
+
+import { runAcp } from '@/agent/acp';
+import type { Credentials } from '@/persistence';
+
+/**
+ * Check whether the `hermes` CLI is available on PATH.
+ *
+ * Exported so the `happy hermes` subcommand handler can pre-flight the check
+ * before triggering auth / daemon setup — first-time users without Hermes
+ * installed should NOT be dragged through the QR flow just to hit an
+ * install-hint error.
+ */
+export function hermesCliAvailable(): boolean {
+  const isWindows = os.platform() === 'win32';
+  try {
+    if (isWindows) {
+      execSync('powershell -NoProfile -Command "Get-Command hermes -ErrorAction SilentlyContinue"', {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+    } else {
+      execSync('command -v hermes >/dev/null 2>&1', { stdio: 'ignore' });
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Print the install hint for Hermes Agent and exit with code 1.
+ */
+export function printHermesMissingAndExit(): never {
+  console.error(chalk.red('Error:'), '`hermes` CLI not found on PATH.');
+  console.error('');
+  console.error('Hermes Agent is a Python package from Nous Research.');
+  console.error('Install with ACP support:');
+  console.error('');
+  console.error(chalk.cyan("  pip install 'hermes-agent[acp]'"));
+  console.error('');
+  console.error('Or use uv:');
+  console.error('');
+  console.error(chalk.cyan("  uvx --from 'hermes-agent[acp]' hermes-acp"));
+  console.error('');
+  console.error('See https://github.com/NousResearch/hermes-agent for setup.');
+  process.exit(1);
+}
+
+export async function runHermes(opts: {
+  credentials: Credentials;
+  startedBy?: 'daemon' | 'terminal';
+  verbose?: boolean;
+}): Promise<void> {
+  // Defense-in-depth: the subcommand handler also checks this before auth,
+  // but re-check here in case runHermes is invoked from another code path.
+  if (!hermesCliAvailable()) {
+    printHermesMissingAndExit();
+  }
+
+  await runAcp({
+    credentials: opts.credentials,
+    startedBy: opts.startedBy,
+    verbose: opts.verbose,
+    agentName: 'hermes',
+    command: 'hermes',
+    args: ['acp'],
+  });
+}

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -354,6 +354,39 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       process.exit(1)
     }
     return;
+  } else if (subcommand === 'hermes') {
+    // Handle hermes command (ACP-based agent)
+    try {
+      const { runHermes, hermesCliAvailable, printHermesMissingAndExit } = await import('@/hermes/runHermes');
+
+      // Pre-check binary BEFORE auth/daemon — don't drag first-time users
+      // without Hermes installed through the QR flow only to hit an error.
+      if (!hermesCliAvailable()) {
+        printHermesMissingAndExit();
+      }
+
+      let startedBy: 'daemon' | 'terminal' | undefined = undefined;
+      let verbose = false;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === '--started-by') {
+          startedBy = args[++i] as 'daemon' | 'terminal';
+        } else if (args[i] === '--verbose') {
+          verbose = true;
+        }
+      }
+
+      const { credentials } = await authAndSetupMachineIfNeeded();
+      await ensureDaemonRunning();
+
+      await runHermes({ credentials, startedBy, verbose });
+    } catch (error) {
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error');
+      if (process.env.DEBUG) {
+        console.error(error);
+      }
+      process.exit(1);
+    }
+    return;
   } else if (subcommand === 'acp') {
     try {
       const { runAcp, resolveAcpAgentConfig } = await import('@/agent/acp');
@@ -679,6 +712,7 @@ ${chalk.bold('Usage:')}
   happy resume            Resume a previous Happy session by Happy session ID
   happy codex             Start Codex mode
   happy gemini            Start Gemini mode (ACP)
+  happy hermes            Start Hermes Agent mode (ACP)
   happy acp               Start a generic ACP-compatible agent
   happy connect           Connect AI vendor API keys
   happy sandbox           Configure and manage OS-level sandboxing

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -357,6 +357,39 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       process.exit(1)
     }
     return;
+  } else if (subcommand === 'hermes') {
+    // Handle hermes command (ACP-based agent)
+    try {
+      const { runHermes, hermesCliAvailable, printHermesMissingAndExit } = await import('@/hermes/runHermes');
+
+      // Pre-check binary BEFORE auth/daemon — don't drag first-time users
+      // without Hermes installed through the QR flow only to hit an error.
+      if (!hermesCliAvailable()) {
+        printHermesMissingAndExit();
+      }
+
+      let startedBy: 'daemon' | 'terminal' | undefined = undefined;
+      let verbose = false;
+      for (let i = 1; i < args.length; i++) {
+        if (args[i] === '--started-by') {
+          startedBy = args[++i] as 'daemon' | 'terminal';
+        } else if (args[i] === '--verbose') {
+          verbose = true;
+        }
+      }
+
+      const { credentials } = await authAndSetupMachineIfNeeded();
+      await ensureDaemonRunning();
+
+      await runHermes({ credentials, startedBy, verbose });
+    } catch (error) {
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error');
+      if (process.env.DEBUG) {
+        console.error(error);
+      }
+      process.exit(1);
+    }
+    return;
   } else if (subcommand === 'acp') {
     try {
       const { runAcp, resolveAcpAgentConfig } = await import('@/agent/acp');
@@ -717,6 +750,7 @@ ${chalk.bold('Usage:')}
   happy codex             Start Codex mode
   happy gemini            Start Gemini mode (ACP) [deprecated — use agy]
   happy agy               Start agy (Antigravity CLI) mode
+  happy hermes            Start Hermes Agent mode (ACP)
   happy acp               Start a generic ACP-compatible agent
   happy connect           Connect AI vendor API keys
   happy sandbox           Configure and manage OS-level sandboxing

--- a/packages/happy-cli/src/utils/createSessionMetadata.ts
+++ b/packages/happy-cli/src/utils/createSessionMetadata.ts
@@ -19,7 +19,7 @@ import packageJson from '../../package.json';
 /**
  * Backend flavor identifier for session metadata.
  */
-export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'acp';
+export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'acp' | 'hermes';
 
 /**
  * Options for creating session metadata.

--- a/packages/happy-cli/src/utils/createSessionMetadata.ts
+++ b/packages/happy-cli/src/utils/createSessionMetadata.ts
@@ -20,7 +20,7 @@ import packageJson from '../../package.json';
 /**
  * Backend flavor identifier for session metadata.
  */
-export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'acp';
+export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'acp' | 'hermes';
 
 /**
  * Options for creating session metadata.

--- a/packages/happy-cli/src/utils/detectCLI.ts
+++ b/packages/happy-cli/src/utils/detectCLI.ts
@@ -9,6 +9,7 @@ export interface CLIAvailability {
   gemini: boolean;
   openclaw: boolean;
   agy: boolean;
+  hermes: boolean;
   detectedAt: number;
 }
 
@@ -39,6 +40,7 @@ function detectPosix(): CLIAvailability {
   const codex = commandExists('codex');
   const gemini = commandExists('gemini');
   const agy = commandExists('agy');
+  const hermes = commandExists('hermes');
 
   // OpenClaw: check command, config file, or env var
   const openclawCommand = commandExists('openclaw');
@@ -46,7 +48,7 @@ function detectPosix(): CLIAvailability {
   const openclawEnv = !!process.env.OPENCLAW_GATEWAY_URL;
   const openclaw = openclawCommand || openclawConfig || openclawEnv;
 
-  return { claude, codex, gemini, openclaw, agy, detectedAt: Date.now() };
+  return { claude, codex, gemini, openclaw, agy, hermes, detectedAt: Date.now() };
 }
 
 function detectWindows(): CLIAvailability {
@@ -63,6 +65,7 @@ function detectWindows(): CLIAvailability {
   const codex = checkCommand('codex');
   const gemini = checkCommand('gemini');
   const agy = checkCommand('agy');
+  const hermes = checkCommand('hermes');
 
   // OpenClaw: check command, config file, or env var
   const openclawCommand = checkCommand('openclaw');
@@ -70,5 +73,5 @@ function detectWindows(): CLIAvailability {
   const openclawEnv = !!process.env.OPENCLAW_GATEWAY_URL;
   const openclaw = openclawCommand || openclawConfig || openclawEnv;
 
-  return { claude, codex, gemini, openclaw, agy, detectedAt: Date.now() };
+  return { claude, codex, gemini, openclaw, agy, hermes, detectedAt: Date.now() };
 }


### PR DESCRIPTION
Adds first-class support for [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) via the Agent Client Protocol, mirroring the pattern in #1276 (Kimi CLI). Hermes ships ACP support out of the box through `hermes acp` (installed via `pip install 'hermes-agent[acp]'`), so this PR is a small factory + runner + subcommand wiring — no new ACP infrastructure needed.

Closes #1129.

## What this adds

- **Factory** `packages/happy-cli/src/agent/factories/hermes.ts` (+ unit tests) — builds an `AcpBackend` with `command='hermes'`, `args=['acp']`, optional `HERMES_API_KEY` / `HERMES_MODEL` env passthrough.
- **Entry wrapper** `packages/happy-cli/src/hermes/runHermes.ts` — thin wrapper around the generic ACP runner, plus a `hermesCliAvailable()` pre-flight that prints a `pip install` hint and exits with code 1 when the `hermes` binary is missing from PATH.
- **Subcommand** `happy hermes` runs the pre-check **before** `authAndSetupMachineIfNeeded()` and `ensureDaemonRunning()` so first-time users without Hermes installed are not dragged through the QR flow only to hit an install-hint error.
- **Wiring** `hermes` is added to `KNOWN_ACP_AGENTS`, `resolveSessionFlavor`, the `AgentId` union, the `BackendFlavor` union, the factories barrel, and `initializeAgents()`.
- **Docs** README's agents list and commands table, plus `happy --help`, now list `happy hermes` alongside the existing agents.

## Why mirror #1276 (Kimi) rather than #1317 (Devin)?

Hermes Agent is a self-hosted Python CLI with its own auth/config — no extra app- or daemon-side UI surface is needed beyond the existing ACP plumbing. The Kimi PR's factory + runner + one-subcommand shape is the smallest correct surface for that case. (Happy to expand if maintainers prefer the Devin-style integration.)

## Proof

CLI smoke test of the missing-binary path (default for anyone who hasn't installed Hermes yet):

\`\`\`
\$ PATH=/usr/bin:/bin ./bin/happy.mjs hermes
Error: \`hermes\` CLI not found on PATH.

Hermes Agent is a Python package from Nous Research.
Install with ACP support:

  pip install 'hermes-agent[acp]'

Or use uv:

  uvx --from 'hermes-agent[acp]' hermes-acp

See https://github.com/NousResearch/hermes-agent for setup.
\`\`\`

\`happy --help\` excerpt:

\`\`\`
happy gemini            Start Gemini mode (ACP)
happy hermes            Start Hermes Agent mode (ACP)
happy acp               Start a generic ACP-compatible agent
\`\`\`

Validation:
- \`pnpm --filter happy typecheck\` — clean.
- \`pnpm --filter happy test\` (vitest unit) — 58 files / 515 tests pass (incl. 3 new for the Hermes factory and 1 added assertion to \`acpAgentConfig.test.ts\`).

A live end-to-end video proof against a real Hermes install will follow once `hermes-agent[acp]` is installed on the test box — happy to attach in a comment, or hold the PR until then if maintainers prefer.