### PR TITLE
Respect proxy env vars for socket.io clients

### DIFF
--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -95,6 +95,7 @@
     "fastify-type-provider-zod": "4.0.2",
     "http-proxy": "^1.18.1",
     "http-proxy-middleware": "^3.0.5",
+    "https-proxy-agent": "^7.0.6",
     "ink": "^6.5.1",
     "inquirer": "^13.2.2",
     "open": "^10.2.0",

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -22,6 +22,7 @@ import {
     ForkTruncateUuidNotFoundError,
     ForkSourceMissingError,
 } from '@/claude/utils/claudeSessionFork';
+import { socketProxyOptions } from './socketProxy';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -357,6 +358,7 @@ export class ApiMachineClient {
         logger.debug(`[API MACHINE] Connecting to ${serverUrl}`);
 
         this.socket = io(serverUrl, {
+            ...socketProxyOptions(serverUrl),
             transports: ['websocket'],
             auth: {
                 token: this.token,

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -21,6 +21,7 @@ import {
 } from '@/claude/utils/sessionProtocolMapper';
 import { InvalidateSync } from '@/utils/sync';
 import axios from 'axios';
+import { socketProxyOptions } from './socketProxy';
 
 /**
  * ACP (Agent Communication Protocol) message data types.
@@ -144,6 +145,7 @@ export class ApiSessionClient extends EventEmitter {
         //
 
         this.socket = io(configuration.serverUrl, {
+            ...socketProxyOptions(configuration.serverUrl),
             auth: {
                 token: this.token,
                 clientType: 'session-scoped' as const,

--- a/packages/happy-cli/src/api/socketProxy.test.ts
+++ b/packages/happy-cli/src/api/socketProxy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { noProxyMatches, proxyForSocketUrl, socketProxyOptions } from './socketProxy';
+
+describe('socket proxy options', () => {
+    it('uses HTTPS_PROXY for secure websocket URLs', () => {
+        const env = {
+            HTTPS_PROXY: 'http://127.0.0.1:7897',
+            HTTP_PROXY: 'http://127.0.0.1:8080',
+        };
+
+        expect(proxyForSocketUrl('wss://api.cluster-fluster.com', env)).toBe('http://127.0.0.1:7897');
+    });
+
+    it('falls back to HTTP_PROXY for secure websocket URLs', () => {
+        const env = {
+            HTTP_PROXY: 'http://127.0.0.1:8080',
+        };
+
+        expect(proxyForSocketUrl('wss://api.cluster-fluster.com', env)).toBe('http://127.0.0.1:8080');
+    });
+
+    it('skips proxy when NO_PROXY matches the host', () => {
+        const env = {
+            HTTPS_PROXY: 'http://127.0.0.1:7897',
+            NO_PROXY: 'localhost,api.cluster-fluster.com',
+        };
+
+        expect(proxyForSocketUrl('wss://api.cluster-fluster.com', env)).toBeNull();
+    });
+
+    it('matches common NO_PROXY wildcard forms', () => {
+        expect(noProxyMatches('api.cluster-fluster.com', '*.cluster-fluster.com')).toBe(true);
+        expect(noProxyMatches('api.cluster-fluster.com', '.cluster-fluster.com')).toBe(true);
+        expect(noProxyMatches('172.31.12.1', '172.31.*')).toBe(true);
+        expect(noProxyMatches('::1', '::1')).toBe(true);
+    });
+
+    it('returns socket.io transport options when a proxy is configured', () => {
+        const options = socketProxyOptions('wss://api.cluster-fluster.com', {
+            HTTPS_PROXY: 'http://127.0.0.1:7897',
+        });
+
+        expect(options).toHaveProperty('agent');
+        expect(options).toHaveProperty('transportOptions.websocket.agent');
+    });
+});

--- a/packages/happy-cli/src/api/socketProxy.ts
+++ b/packages/happy-cli/src/api/socketProxy.ts
@@ -1,0 +1,70 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { HttpsProxyAgent } = require('https-proxy-agent') as typeof import('https-proxy-agent');
+
+function normalizeHostname(hostname: string): string {
+    return hostname.replace(/^\[(.*)\]$/, '$1').toLowerCase();
+}
+
+function stripPort(pattern: string): string {
+    if (pattern.startsWith('[')) {
+        const end = pattern.indexOf(']');
+        return end > 0 ? pattern.slice(1, end) : pattern;
+    }
+
+    const colon = pattern.lastIndexOf(':');
+    if (colon > 0 && pattern.indexOf(':') === colon && /^\d+$/.test(pattern.slice(colon + 1))) {
+        return pattern.slice(0, colon);
+    }
+
+    return pattern;
+}
+
+export function noProxyMatches(hostname: string, noProxy = process.env.NO_PROXY ?? process.env.no_proxy ?? ''): boolean {
+    const host = normalizeHostname(hostname);
+
+    return noProxy
+        .split(',')
+        .map((entry) => entry.trim().toLowerCase())
+        .filter(Boolean)
+        .some((entry) => {
+            if (entry === '*') return true;
+
+            const pattern = stripPort(entry);
+            if (!pattern) return false;
+            if (pattern.endsWith('*')) return host.startsWith(pattern.slice(0, -1));
+            if (pattern.startsWith('*.')) return host === pattern.slice(2) || host.endsWith(pattern.slice(1));
+            if (pattern.startsWith('.')) return host.endsWith(pattern);
+
+            return host === pattern || host.endsWith(`.${pattern}`);
+        });
+}
+
+export function proxyForSocketUrl(serverUrl: string, env: NodeJS.ProcessEnv = process.env): string | null {
+    try {
+        const parsed = new URL(serverUrl);
+        if (noProxyMatches(parsed.hostname, env.NO_PROXY ?? env.no_proxy ?? '')) return null;
+
+        if (parsed.protocol === 'https:' || parsed.protocol === 'wss:') {
+            return env.HTTPS_PROXY ?? env.https_proxy ?? env.HTTP_PROXY ?? env.http_proxy ?? null;
+        }
+
+        return env.HTTP_PROXY ?? env.http_proxy ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export function socketProxyOptions(serverUrl: string, env: NodeJS.ProcessEnv = process.env): Record<string, unknown> {
+    const proxyUrl = proxyForSocketUrl(serverUrl, env);
+    if (!proxyUrl) return {};
+
+    const agent = new HttpsProxyAgent(proxyUrl);
+    return {
+        agent,
+        transportOptions: {
+            websocket: { agent },
+        },
+    };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -978,6 +978,9 @@ importers:
       http-proxy-middleware:
         specifier: ^3.0.5
         version: 3.0.5
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
       ink:
         specifier: ^6.5.1
         version: 6.6.0(@types/react@19.2.14)(react-devtools-core@6.1.5)(react@19.2.0)


### PR DESCRIPTION
## Summary

- add socket.io proxy options derived from `HTTPS_PROXY` / `HTTP_PROXY`
- apply the proxy agent to both session-scoped and machine-scoped WebSocket clients
- respect `NO_PROXY` / `no_proxy` for direct hosts, including wildcard-style entries
- add unit coverage for proxy selection and bypass matching

## Context

On networks where direct access to `api.cluster-fluster.com` hangs but HTTP(S) proxy env vars are configured, the REST calls can succeed while socket.io WebSocket connections time out. That leaves the daemon/session registered locally but unable to receive mobile-originated messages.

Locally I reproduced the failure as socket.io `Error: timeout` without an explicit WebSocket proxy agent, while `curl` succeeded through `HTTPS_PROXY=http://127.0.0.1:7897`. With the proxy options applied, an authless socket.io probe reached the server and failed with the expected `Missing authentication token` response instead of timing out.

## Validation

- `socketProxy` helper checks via Node import
- socket.io probe through `HTTPS_PROXY=http://127.0.0.1:7897` reached `/v1/updates` and returned expected auth error
