### PR TITLE
fix(cli): reset terminal state when switching from remote to local mode

### DIFF
--- a/packages/happy-cli/src/claude/loop.ts
+++ b/packages/happy-cli/src/claude/loop.ts
@@ -101,6 +101,10 @@ export async function loop(opts: LoopOptions): Promise<number> {
                     case 'switch':
                         mode = 'local';
                         opts.onModeChange?.(mode);
+                        // Reset terminal state left behind by the remote client (phone/web).
+                        // Without this, cursor position, raw-mode flags and window-size residue
+                        // from the remote session corrupt the local Claude Code TUI on re-entry.
+                        process.stdout.write('\x1bc');
                         break;
                     default:
                         const _: never = reason satisfies never;


### PR DESCRIPTION
## Problem

After switching from mobile/web (remote mode) back to desktop CLI (local mode) via double-space, the terminal shows display corruption: double cursors, garbled rendering, broken status line. The workaround is to press Ctrl-C twice to exit and re-enter.

**Root cause**: The `remote → local` switch in `loop.ts` carries over the remote client's terminal state (cursor position, raw-mode flags, window-size residue) directly into local Claude Code with no reset.

```ts
case 'switch':
    mode = 'local';
    opts.onModeChange?.(mode);
    // ← nothing here; terminal state from phone/web session persists
    break;
```

## Fix

Write `ESC c` (RIS — Reset to Initial State) before entering local mode. This is the standard VT100/xterm sequence for a full terminal reset, equivalent to `tput reset`.

```ts
case 'switch':
    mode = 'local';
    opts.onModeChange?.(mode);
    process.stdout.write('\x1bc');  // clear remote terminal state
    break;
```

## Testing

1. Start `happy` on desktop CLI
2. Send a message from mobile → switches to remote mode
3. Press double-space on desktop to switch back to local mode
4. **Before**: double cursors / garbled display
5. **After**: clean terminal, Claude Code renders correctly

## Notes

- Regression of #301 / #613, confirmed on happy 1.1.8 + macOS + tmux
- `\x1bc` may cause a brief screen flash on some terminals — acceptable trade-off vs. broken display

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via [Happy](https://happy.engineering)