### PR TITLE
feat(app): replace avatar with model icon

### DIFF
--- a/packages/happy-app/sources/app/(app)/settings/appearance.tsx
+++ b/packages/happy-app/sources/app/(app)/settings/appearance.tsx
@@ -31,6 +31,7 @@ export default function AppearanceSettingsScreen() {
     const [alwaysShowContextSize, setAlwaysShowContextSize] = useSettingMutable('alwaysShowContextSize');
     const [avatarStyle, setAvatarStyle] = useSettingMutable('avatarStyle');
     const [showFlavorIcons, setShowFlavorIcons] = useSettingMutable('showFlavorIcons');
+    const [replaceAvatarWithFlavorIcon, setReplaceAvatarWithFlavorIcon] = useSettingMutable('replaceAvatarWithFlavorIcon');
     const [themePreference, setThemePreference] = useLocalSettingMutable('themePreference');
     const [preferredLanguage] = useSettingMutable('preferredLanguage');
     
@@ -214,6 +215,17 @@ export default function AppearanceSettingsScreen() {
                         <Switch
                             value={showFlavorIcons}
                             onValueChange={setShowFlavorIcons}
+                        />
+                    }
+                />
+                <Item
+                    title={t('settingsAppearance.replaceAvatarWithFlavorIcon')}
+                    subtitle={t('settingsAppearance.replaceAvatarWithFlavorIconDescription')}
+                    icon={<Ionicons name="image-outline" size={29} color="#5856D6" />}
+                    rightElement={
+                        <Switch
+                            value={replaceAvatarWithFlavorIcon}
+                            onValueChange={setReplaceAvatarWithFlavorIcon}
                         />
                     }
                 />

--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -98,7 +98,7 @@ const SectionHeader = React.memo(({ session, displayPath }: { session: SessionRo
         >
             {/* Avatar — vertically centered */}
             <View style={styles.sectionHeaderAvatar}>
-                <Avatar id={session.avatarId} size={24} flavor={null} />
+                <Avatar id={session.avatarId} size={24} flavor={session.flavor} />
             </View>
 
             {/* Path + branch */}

--- a/packages/happy-app/sources/components/Avatar.tsx
+++ b/packages/happy-app/sources/components/Avatar.tsx
@@ -48,7 +48,43 @@ export const Avatar = React.memo((props: AvatarProps) => {
     const { flavor, size = 48, imageUrl, thumbhash, ...avatarProps } = props;
     const avatarStyle = useSetting('avatarStyle');
     const showFlavorIcons = useSetting('showFlavorIcons');
+    const replaceAvatarWithFlavorIcon = useSetting('replaceAvatarWithFlavorIcon');
     const { theme } = useUnistyles();
+
+    // Render flavor icon as main avatar when replacement is enabled
+    if (replaceAvatarWithFlavorIcon && flavor) {
+        const effectiveFlavor = flavor || 'claude';
+        const flavorIcon = flavorIcons[effectiveFlavor as keyof typeof flavorIcons] || flavorIcons.claude;
+        const bgColor = (monochrome?: boolean) => {
+            if (monochrome) return theme.colors.textSecondary + '20';
+            switch (effectiveFlavor) {
+                case 'claude': return '#E57035';
+                case 'codex': return theme.colors.surface;
+                case 'gemini': return '#4285F4';
+                case 'openclaw': return '#FF6B00';
+                default: return theme.colors.surface;
+            }
+        };
+        const iconTint = effectiveFlavor === 'codex' ? theme.colors.text : '#FFFFFF';
+
+        return (
+            <View style={{
+                width: size,
+                height: size,
+                borderRadius: avatarProps.square ? 0 : size / 2,
+                backgroundColor: bgColor(avatarProps.monochrome),
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}>
+                <Image
+                    source={flavorIcon}
+                    style={{ width: size * 0.55, height: size * 0.55 }}
+                    contentFit="contain"
+                    tintColor={avatarProps.monochrome ? theme.colors.textSecondary : iconTint}
+                />
+            </View>
+        );
+    }
 
     // Render custom image if provided
     if (imageUrl) {

--- a/packages/happy-app/sources/sync/settings.ts
+++ b/packages/happy-app/sources/sync/settings.ts
@@ -25,6 +25,7 @@ export const SettingsSchema = z.object({
     agentInputEnterToSend: z.boolean().describe('Whether pressing Enter submits/sends in the agent input (web)'),
     avatarStyle: z.string().describe('Avatar display style'),
     showFlavorIcons: z.boolean().describe('Whether to show AI provider icons in avatars'),
+    replaceAvatarWithFlavorIcon: z.boolean().describe('Whether to replace session avatars with AI provider icons'),
 
     hideInactiveSessions: z.boolean().describe('Hide inactive sessions in the main list'),
     expResumeSession: z.boolean().describe('Enable experimental session resume feature'),
@@ -96,6 +97,7 @@ export const settingsDefaults: Settings = {
     agentInputEnterToSend: true,
     avatarStyle: 'brutalist',
     showFlavorIcons: false,
+    replaceAvatarWithFlavorIcon: false,
 
     hideInactiveSessions: false,
     expResumeSession: false,

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -188,6 +188,8 @@ export const en = {
         },
         showFlavorIcons: 'Show AI Provider Icons',
         showFlavorIconsDescription: 'Display AI provider icons on session avatars',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -190,6 +190,8 @@ export const ca: TranslationStructure = {
         },
         showFlavorIcons: "Mostrar icones de proveïdors d'IA",
         showFlavorIconsDescription: "Mostrar icones del proveïdor d'IA als avatars de sessió",
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -204,6 +204,8 @@ export const en: TranslationStructure = {
         },
         showFlavorIcons: 'Show AI Provider Icons',
         showFlavorIconsDescription: 'Display AI provider icons on session avatars',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -190,6 +190,8 @@ export const es: TranslationStructure = {
         },
         showFlavorIcons: 'Mostrar íconos de proveedor de IA',
         showFlavorIconsDescription: 'Mostrar íconos del proveedor de IA en los avatares de sesión',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -188,6 +188,8 @@ export const it: TranslationStructure = {
         },
         showFlavorIcons: 'Mostra icone provider IA',
         showFlavorIconsDescription: 'Mostra le icone del provider IA sugli avatar di sessione',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -191,6 +191,8 @@ export const ja: TranslationStructure = {
         },
         showFlavorIcons: 'AIプロバイダーアイコンを表示',
         showFlavorIconsDescription: 'セッションアバターにAIプロバイダーアイコンを表示',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -207,6 +207,8 @@ export const pl: TranslationStructure = {
         },
         showFlavorIcons: 'Pokaż ikony dostawcy AI',
         showFlavorIconsDescription: 'Wyświetlaj ikony dostawcy AI na awatarach sesji',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -189,6 +189,8 @@ export const pt: TranslationStructure = {
         },
         showFlavorIcons: 'Mostrar ícones de provedores de IA',
         showFlavorIconsDescription: 'Exibir ícones do provedor de IA nos avatares de sessão',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -176,6 +176,8 @@ export const ru: TranslationStructure = {
         },
         showFlavorIcons: 'Показывать иконки провайдеров ИИ',
         showFlavorIconsDescription: 'Отображать иконки провайдеров ИИ на аватарах сессий',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -191,6 +191,8 @@ export const zhHans: TranslationStructure = {
         },
         showFlavorIcons: '显示 AI 提供商图标',
         showFlavorIconsDescription: '在会话头像上显示 AI 提供商图标',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -190,6 +190,8 @@ export const zhHant: TranslationStructure = {
         },
         showFlavorIcons: '顯示 AI 提供者圖示',
         showFlavorIconsDescription: '在工作階段頭像上顯示 AI 提供者圖示',
+        replaceAvatarWithFlavorIcon: 'Replace Avatar with Model Icon',
+        replaceAvatarWithFlavorIconDescription: 'Show AI provider icon instead of session avatar',
     },
 
     settingsFeatures: {


### PR DESCRIPTION
Adds a new setting `replaceAvatarWithFlavorIcon` that, when enabled, renders the AI provider icon (Claude, Codex, Gemini, OpenClaw) as the main session avatar instead of the generated gradient/pixelated avatar.

## Changes
- Adds `replaceAvatarWithFlavorIcon` to settings schema (default: `false`)
- Updates `Avatar.tsx` to render flavor icon with branded background colors
- Adds toggle in Appearance settings screen
- Adds translation keys for all supported languages
- Fixes `ActiveSessionsGroupCompact` section header to pass flavor

## Visual Behavior
- **Claude** → orange circle with white icon
- **Gemini** → blue circle with white icon
- **OpenClaw** → orange circle with white icon
- **Codex** → themed surface circle with text-colored icon
- **Monochrome/disconnected** → muted gray background with secondary text color

TypeScript typecheck passes with zero errors.