### PR TITLE
feat(cli): import & resume local Claude Code sessions in the Happy app

### DIFF
--- a/packages/happy-cli/src/commands/importCommand.ts
+++ b/packages/happy-cli/src/commands/importCommand.ts
@@ -1,0 +1,311 @@
+/**
+ * `happy import` command
+ *
+ * Scans ~/.claude/projects/ for native Claude Code sessions that haven't been
+ * imported into Happy yet, creates a happy session per leaf JSONL (mirroring
+ * its message history into happy-server), and records the result in
+ * ~/.happy/imported-sessions.json so the daemon can later adopt-and-resume
+ * them from the mobile app.
+ *
+ * Flags:
+ *   --dry-run             Show what would be imported, don't do anything
+ *   --yes / -y            Skip the y/N confirmation prompt
+ *   --project <path>      Only import sessions whose cwd starts with <path>
+ *   --no-backfill         Create the happy session but don't push messages
+ *   --limit <n>           Cap how many candidates are processed in one run
+ *
+ * Exit codes: 0 success / partial-success, 1 on hard error.
+ */
+
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { resolve as resolvePath } from 'node:path';
+
+import { ApiClient } from '@/api/api';
+import { authAndSetupMachineIfNeeded } from '@/ui/auth';
+
+import { collectHappyTrackedClaudeSessionIds } from '../import/collectHappyTrackedClaudeIds';
+import { pruneImportedSessionsOlderThan } from '../import/pruneImported';
+import { scanForImportCandidates } from '../import/scanner';
+import { importSingleSession, type ImportSessionResult } from '../import/sessionImporter';
+import { unarchiveAllImported } from '../import/unarchiveImported';
+
+type ParsedArgs = {
+    dryRun: boolean;
+    yes: boolean;
+    project?: string;
+    backfill: boolean;
+    limit?: number;
+    days?: number;
+    fixArchived: boolean;
+    pruneOlderThanDays?: number;
+    showHelp: boolean;
+};
+
+function parseArgs(args: string[]): ParsedArgs {
+    const result: ParsedArgs = {
+        dryRun: false,
+        yes: false,
+        backfill: true,
+        fixArchived: false,
+        showHelp: false,
+    };
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        switch (arg) {
+            case '-h':
+            case '--help':
+                result.showHelp = true; break;
+            case '--dry-run':
+                result.dryRun = true; break;
+            case '-y':
+            case '--yes':
+                result.yes = true; break;
+            case '--no-backfill':
+                result.backfill = false; break;
+            case '--project':
+                result.project = args[++i]; break;
+            case '--limit': {
+                const n = parseInt(args[++i] ?? '', 10);
+                if (Number.isFinite(n) && n > 0) result.limit = n;
+                break;
+            }
+            case '--days': {
+                const n = parseInt(args[++i] ?? '', 10);
+                if (Number.isFinite(n) && n > 0) result.days = n;
+                break;
+            }
+            case '--fix-archived':
+                result.fixArchived = true; break;
+            case '--prune-older-than-days': {
+                const n = parseInt(args[++i] ?? '', 10);
+                if (Number.isFinite(n) && n > 0) result.pruneOlderThanDays = n;
+                break;
+            }
+            default:
+                throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+    return result;
+}
+
+function formatHelp(): string {
+    return [
+        chalk.bold('happy import') + ' - Make existing local Claude Code sessions visible & resumable in the Happy mobile app',
+        '',
+        chalk.bold('Usage:'),
+        '  happy import [--dry-run] [--yes] [--project <path>] [--days <n>] [--no-backfill] [--limit <n>]',
+        '  happy import --fix-archived',
+        '',
+        chalk.bold('Flags:'),
+        '  --dry-run              Show what would be imported without doing it',
+        '  -y, --yes              Skip the confirmation prompt',
+        '  --project <path>       Only import sessions whose cwd starts with <path>',
+        '  --days <n>             Only import sessions modified within the last n days',
+        '  --no-backfill          Create the happy session(s) but skip message history',
+        '  --limit <n>            Stop after importing n sessions',
+        '  --fix-archived         Un-archive every session in the import journal',
+        '                         (use this if previously-imported sessions show as',
+        '                         "non-active" in the mobile app and you cannot Resume)',
+        '',
+        chalk.bold('How it works:'),
+        '  Scans ~/.claude/projects/<*>/<uuid>.jsonl and for each leaf session (one',
+        '  that has not been resumed into a newer JSONL) creates a corresponding',
+        '  Happy session on the server, mirrors the message history, and records',
+        '  the mapping in ~/.happy/imported-sessions.json. After import the session',
+        '  shows up in the mobile app and you can hit "Resume" to continue it.',
+        '',
+        chalk.bold('Privacy:'),
+        '  All session content is end-to-end encrypted before leaving your machine.',
+        '  The Happy server only sees opaque ciphertext.',
+    ].join('\n');
+}
+
+export async function handleImportCommand(args: string[]): Promise<void> {
+    let parsed: ParsedArgs;
+    try {
+        parsed = parseArgs(args);
+    } catch (error: any) {
+        console.error(chalk.red(`${error.message}`));
+        console.error('Run `happy import --help` for usage.');
+        process.exit(1);
+    }
+
+    if (parsed.showHelp) {
+        console.log(formatHelp());
+        return;
+    }
+
+    // --fix-archived takes a different code path: walk the import journal,
+    // un-archive every session there, and exit. No scanning, no new imports.
+    if (parsed.fixArchived) {
+        const { credentials } = await authAndSetupMachineIfNeeded();
+        const api = await ApiClient.create(credentials);
+        console.log(chalk.bold('Un-archiving imported sessions...'));
+        const results = await unarchiveAllImported(api);
+        const cleared = results.filter(r => r.status === 'cleared').length;
+        const failed = results.filter(r => r.status === 'failed').length;
+        console.log();
+        console.log(chalk.green(`  ${cleared} cleared`));
+        if (failed > 0) {
+            console.log(chalk.red(`  ${failed} failed`));
+            for (const r of results.filter(r => r.status === 'failed')) {
+                console.log(chalk.dim(`    ${r.happySessionId}: ${r.error}`));
+            }
+        }
+        console.log();
+        console.log(chalk.dim('Imported sessions are now in "running + active=false" state.'));
+        console.log(chalk.dim('Open one in the mobile app and hit Resume to continue the conversation.'));
+        if (failed > 0 && cleared === 0) process.exit(1);
+        return;
+    }
+
+    // --prune-older-than-days: delete server-side and journal-side any imports
+    // whose underlying JSONL hasn't been touched within the cutoff. Useful
+    // for walking back accidental backfill of historical sessions.
+    if (parsed.pruneOlderThanDays !== undefined) {
+        const { credentials } = await authAndSetupMachineIfNeeded();
+        const api = await ApiClient.create(credentials);
+        const cutoffMs = Date.now() - parsed.pruneOlderThanDays * 24 * 60 * 60 * 1000;
+        const cutoffStr = new Date(cutoffMs).toLocaleString();
+
+        console.log(chalk.bold(`Pruning imported sessions whose JSONL is older than ${cutoffStr}...`));
+        if (parsed.dryRun) {
+            console.log(chalk.dim('(dry-run — no deletions will happen)'));
+        }
+        const results = await pruneImportedSessionsOlderThan(api, cutoffMs, { dryRun: parsed.dryRun });
+        const deleted = results.filter(r => r.status === 'deleted').length;
+        const failed = results.filter(r => r.status === 'failed').length;
+        const kept = results.filter(r => r.status === 'kept-not-old-enough').length;
+
+        console.log();
+        if (deleted > 0) {
+            const verb = parsed.dryRun ? 'would delete' : 'deleted';
+            console.log(chalk.yellow(`  ${verb} ${deleted}`));
+            for (const r of results.filter(r => r.status === 'deleted').slice(0, 30)) {
+                console.log(chalk.dim(`    ${r.claudeSessionId.slice(0, 8)}  ${r.cwd}`));
+            }
+            if (deleted > 30) {
+                console.log(chalk.dim(`    ...and ${deleted - 30} more`));
+            }
+        }
+        if (failed > 0) {
+            console.log(chalk.red(`  ${failed} failed`));
+            for (const r of results.filter(r => r.status === 'failed')) {
+                console.log(chalk.dim(`    ${r.happySessionId}: ${r.error}`));
+            }
+        }
+        console.log(chalk.green(`  ${kept} kept (not old enough)`));
+        if (failed > 0 && deleted === 0) process.exit(1);
+        return;
+    }
+
+    const projectFilter = parsed.project ? resolvePath(parsed.project) : undefined;
+    const mtimeAfterMs = typeof parsed.days === 'number'
+        ? Date.now() - parsed.days * 24 * 60 * 60 * 1000
+        : undefined;
+
+    // Build the dedup set BEFORE scanning. This is a network call (one
+    // GET /v1/sessions) but lets us skip Claude sessions that happy already
+    // knows about — re-importing those would create duplicates.
+    process.stdout.write(chalk.dim('Looking up existing happy sessions for dedup... '));
+    let happyTrackedClaudeIds: Set<string>;
+    try {
+        happyTrackedClaudeIds = await collectHappyTrackedClaudeSessionIds();
+        console.log(chalk.dim(`(${happyTrackedClaudeIds.size} found)`));
+    } catch (error: any) {
+        console.log(chalk.yellow(`(failed: ${error?.message ?? error}; importing without dedup)`));
+        happyTrackedClaudeIds = new Set();
+    }
+
+    const candidates = await scanForImportCandidates({ projectFilter, happyTrackedClaudeIds, mtimeAfterMs });
+
+    if (candidates.length === 0) {
+        console.log(chalk.green('Nothing new to import.'));
+        console.log(chalk.dim('All Claude leaf sessions in ~/.claude/projects are already in Happy.'));
+        return;
+    }
+
+    const limited = parsed.limit ? candidates.slice(0, parsed.limit) : candidates;
+
+    console.log(chalk.bold(`\nFound ${limited.length} session${limited.length === 1 ? '' : 's'} to import:\n`));
+    for (const c of limited) {
+        const title = c.header.firstUserText
+            || c.header.summary?.summary
+            || chalk.dim('(no preview)');
+        const linesNote = c.header.firstCwd ?? chalk.dim('(no cwd)');
+        console.log(`  ${chalk.cyan(c.claudeSessionId.slice(0, 8))}  ${chalk.dim(linesNote)}`);
+        console.log(`    ${title}`);
+    }
+    console.log();
+
+    if (parsed.dryRun) {
+        console.log(chalk.green('Dry run complete. Run without --dry-run to import.'));
+        return;
+    }
+
+    if (!parsed.yes) {
+        const { confirm } = await inquirer.prompt<{ confirm: boolean }>([
+            {
+                type: 'confirm',
+                name: 'confirm',
+                message: `Encrypt and upload ${limited.length} session${limited.length === 1 ? '' : 's'} to happy-server?`,
+                default: false,
+            },
+        ]);
+        if (!confirm) {
+            console.log(chalk.dim('Aborted.'));
+            return;
+        }
+    }
+
+    const { credentials } = await authAndSetupMachineIfNeeded();
+    const api = await ApiClient.create(credentials);
+
+    const results: ImportSessionResult[] = [];
+    let successCount = 0;
+    let partialCount = 0;
+    let failCount = 0;
+
+    for (const candidate of limited) {
+        process.stdout.write(`  ${chalk.cyan(candidate.claudeSessionId.slice(0, 8))} ... `);
+        try {
+            const result = await importSingleSession(api, candidate, { backfill: parsed.backfill });
+            results.push(result);
+            switch (result.status) {
+                case 'created':
+                    successCount++;
+                    console.log(chalk.green(`ok  (${result.messagesBackfilled} messages)`));
+                    break;
+                case 'created-no-backfill':
+                    successCount++;
+                    console.log(chalk.green('ok  (metadata only)'));
+                    break;
+                case 'partial':
+                    partialCount++;
+                    console.log(chalk.yellow(`partial (${result.messagesBackfilled} messages) — ${result.error ?? ''}`));
+                    break;
+                case 'failed':
+                    failCount++;
+                    console.log(chalk.red(`failed — ${result.error ?? ''}`));
+                    break;
+            }
+        } catch (error: any) {
+            failCount++;
+            console.log(chalk.red(`failed — ${error?.message ?? error}`));
+        }
+    }
+
+    console.log();
+    console.log(chalk.bold('Summary:'));
+    console.log(`  ${chalk.green(`${successCount} succeeded`)}`);
+    if (partialCount > 0) console.log(`  ${chalk.yellow(`${partialCount} partial (re-run \`happy import\` to retry)`)}`);
+    if (failCount > 0) console.log(`  ${chalk.red(`${failCount} failed`)}`);
+    console.log();
+    console.log(chalk.dim('Imported sessions now appear in the mobile app. Use Resume on any of them'));
+    console.log(chalk.dim('to continue the conversation from where Claude left off.'));
+
+    if (failCount > 0 && successCount === 0) {
+        process.exit(1);
+    }
+}

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -28,6 +28,7 @@ import { detectCLIAvailability } from '@/utils/detectCLI';
 import { buildResumeLaunch } from '@/resume/handleResumeCommand';
 import { detectResumeSupport } from '@/resume/localHappyAgentAuth';
 import { encodeBase64, decodeBase64, decrypt } from '@/api/encryption';
+import { adoptSessionFromImportJournal } from '@/import/daemonAdopt';
 
 /** Shell-escape a string for safe interpolation into tmux commands. */
 function shellescape(s: string): string {
@@ -635,6 +636,8 @@ export async function startDaemon(): Promise<void> {
       return sessionIdToFinishedSession.get(happySessionId);
     };
 
+    // adoptSessionFromImportJournal is imported from '@/import/daemonAdopt'
+
     const fetchServerSessionMetadata = async (sessionId: string, encryptionKey: Uint8Array, encryptionVariant: 'legacy' | 'dataKey'): Promise<Metadata | null> => {
       try {
         const response = await axios.get(`${configuration.serverUrl}/v1/sessions`, {
@@ -654,9 +657,18 @@ export async function startDaemon(): Promise<void> {
 
     const resumeSession = async (happySessionId: string, options?: { model?: string; permissionMode?: string }): Promise<SpawnSessionResult> => {
       try {
-        const tracked = findTrackedSessionById(happySessionId);
+        let tracked = findTrackedSessionById(happySessionId);
         if (!tracked) {
-          return { type: 'error', errorMessage: `Session ${happySessionId} is not tracked by this daemon. It may have been started before the daemon or on another machine.` };
+          // Fallback: this session wasn't started by THIS daemon, but it might
+          // be in the import journal (created by `happy import` for a
+          // pre-existing local Claude session). Adopt it.
+          const adopted = await adoptSessionFromImportJournal(happySessionId);
+          if (adopted) {
+            tracked = adopted;
+          }
+        }
+        if (!tracked) {
+          return { type: 'error', errorMessage: `Session ${happySessionId} is not tracked by this daemon and was not found in the import journal. It may have been started before the daemon or on another machine — try \`happy import\` to register it locally first.` };
         }
         if (!tracked.happySessionMetadataFromLocalWebhook) {
           return { type: 'error', errorMessage: `Session ${happySessionId} has no metadata. Cannot resume.` };

--- a/packages/happy-cli/src/import/collectHappyTrackedClaudeIds.ts
+++ b/packages/happy-cli/src/import/collectHappyTrackedClaudeIds.ts
@@ -1,0 +1,117 @@
+/**
+ * Collect Happy-Tracked Claude Session IDs
+ *
+ * For dedup: build the set of `claudeSessionId` values that already correspond
+ * to a happy Session row on the server (so we don't import duplicates).
+ *
+ * The naive approach — reading `~/.happy/sessions.json` and grabbing
+ * `metadata.claudeSessionId` from each entry — doesn't work, because the
+ * metadata snapshot stored locally is from the moment the daemon FIRST learned
+ * about the session (via webhook), which is BEFORE the SessionStart hook
+ * populates claudeSessionId. The fully-updated metadata only lives on the
+ * server.
+ *
+ * Strategy:
+ *   1. Read sessions.json → list of (happySessionId, encryptionKey, variant)
+ *   2. One `GET /v1/sessions` to pull every server session for this user
+ *   3. Per-session: decrypt the metadata using the *locally stored* key
+ *      (works without agent.key because we own the key from the moment we
+ *      created the session)
+ *   4. Collect claudeSessionId values into a Set
+ *
+ * Failure mode is silent — empty set returned. Worst case the user imports a
+ * duplicate, which they can de-dup by hand.
+ */
+
+import axios from 'axios';
+
+import { decrypt, decodeBase64 } from '@/api/encryption';
+import { configuration } from '@/configuration';
+import { readCredentials, readPersistedSessions, type PersistedSession } from '@/persistence';
+import { logger } from '@/ui/logger';
+
+type ServerSessionRow = {
+    id: string;
+    metadata: string; // base64
+};
+
+export async function collectHappyTrackedClaudeSessionIds(): Promise<Set<string>> {
+    const ids = new Set<string>();
+
+    const persisted = safeReadPersistedSessions();
+    if (Object.keys(persisted).length === 0) {
+        return ids;
+    }
+
+    const credentials = await readCredentials();
+    if (!credentials) {
+        // No credentials means happy was never authed on this machine, so
+        // there are no happy sessions at all. Defensive — shouldn't happen
+        // in the normal import flow.
+        return ids;
+    }
+
+    let serverSessions: ServerSessionRow[];
+    try {
+        const response = await axios.get(`${configuration.serverUrl}/v1/sessions`, {
+            headers: {
+                Authorization: `Bearer ${credentials.token}`,
+                'X-Happy-Client': `cli-coding-session/${configuration.currentCliVersion}`,
+            },
+            timeout: 30_000,
+        });
+        serverSessions = (response.data as { sessions: ServerSessionRow[] }).sessions || [];
+    } catch (error: any) {
+        logger.debug(`[import] failed to fetch sessions from server for dedup: ${error?.message}`);
+        return ids;
+    }
+
+    const serverById = new Map<string, ServerSessionRow>();
+    for (const session of serverSessions) {
+        serverById.set(session.id, session);
+    }
+
+    for (const [happyId, persistedSession] of Object.entries(persisted)) {
+        const claudeId = extractClaudeSessionId(happyId, persistedSession, serverById);
+        if (claudeId) ids.add(claudeId);
+    }
+
+    return ids;
+}
+
+function extractClaudeSessionId(
+    happyId: string,
+    persisted: PersistedSession,
+    serverById: Map<string, ServerSessionRow>,
+): string | null {
+    // First chance: the locally-snapshotted metadata. Usually empty for
+    // claudeSessionId (set after hook fires, post-webhook) but cheap to check.
+    const localClaudeId = persisted.metadata?.claudeSessionId;
+    if (typeof localClaudeId === 'string' && localClaudeId.length > 0) {
+        return localClaudeId;
+    }
+
+    // Otherwise, decrypt the latest server metadata using the key we stored
+    // when this session was first reported to the daemon.
+    const serverRow = serverById.get(happyId);
+    if (!serverRow) return null;
+
+    try {
+        const key = decodeBase64(persisted.encryptionKey);
+        const decrypted = decrypt(key, persisted.encryptionVariant, decodeBase64(serverRow.metadata));
+        const candidate = decrypted?.claudeSessionId;
+        return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+    } catch (error: any) {
+        logger.debug(`[import] could not decrypt server metadata for ${happyId}: ${error?.message}`);
+        return null;
+    }
+}
+
+function safeReadPersistedSessions(): Record<string, PersistedSession> {
+    try {
+        return readPersistedSessions();
+    } catch (error: any) {
+        logger.debug(`[import] could not read persisted sessions: ${error?.message}`);
+        return {};
+    }
+}

--- a/packages/happy-cli/src/import/daemonAdopt.test.ts
+++ b/packages/happy-cli/src/import/daemonAdopt.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import os from 'node:os';
+
+// Mock configuration & logger so the journal writes to a temp dir.
+const tempRootRef = { current: '' };
+vi.mock('@/configuration', () => ({
+    configuration: {
+        get happyHomeDir() {
+            return tempRootRef.current;
+        },
+    },
+}));
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: () => { },
+        warn: () => { },
+        info: () => { },
+        error: () => { },
+    },
+}));
+
+import { adoptSessionFromImportJournal } from './daemonAdopt';
+import { upsertEntry } from './importJournal';
+
+describe('adoptSessionFromImportJournal', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = join(tmpdir(), `adopt-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        mkdirSync(tempDir, { recursive: true });
+        tempRootRef.current = tempDir;
+    });
+
+    afterEach(() => {
+        if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns null when session is not in the journal', async () => {
+        const result = await adoptSessionFromImportJournal('cuid-never-seen');
+        expect(result).toBeNull();
+    });
+
+    it('builds a TrackedSession from a journal entry', async () => {
+        const claudeSessionId = '11111111-1111-1111-1111-111111111111';
+        const happySessionId = 'cuid-abc-123';
+        await upsertEntry({
+            claudeSessionId,
+            happySessionId,
+            cwd: '/Users/me/proj',
+            jsonlPath: '/x.jsonl',
+            importedAt: Date.now(),
+            // 32 random bytes encoded base64
+            encryptionKey: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+            encryptionVariant: 'dataKey',
+            backfillStatus: 'complete',
+            backfilledLineCount: 5,
+        });
+
+        const tracked = await adoptSessionFromImportJournal(happySessionId);
+        expect(tracked).not.toBeNull();
+        expect(tracked!.happySessionId).toBe(happySessionId);
+        expect(tracked!.startedBy).toBe('adopted-from-import');
+        expect(tracked!.pid).toBe(0);
+
+        // Metadata has the fields buildResumeLaunch needs
+        const meta = tracked!.happySessionMetadataFromLocalWebhook!;
+        expect(meta.path).toBe('/Users/me/proj');
+        expect(meta.claudeSessionId).toBe(claudeSessionId);
+        expect(meta.flavor).toBe('claude');
+        expect(meta.host).toBe(os.hostname());
+
+        // Encryption captures from the journal
+        expect(tracked!.encryption!.encryptionVariant).toBe('dataKey');
+        expect(tracked!.encryption!.encryptionKey.length).toBe(32);
+        expect(tracked!.encryption!.seq).toBe(0);
+        expect(tracked!.encryption!.metadataVersion).toBe(0);
+        expect(tracked!.encryption!.agentStateVersion).toBe(0);
+    });
+
+    it('preserves legacy variant in adopted session', async () => {
+        await upsertEntry({
+            claudeSessionId: '22222222-2222-2222-2222-222222222222',
+            happySessionId: 'cuid-legacy',
+            cwd: '/x',
+            jsonlPath: '/x.jsonl',
+            importedAt: 0,
+            encryptionKey: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+            encryptionVariant: 'legacy',
+            backfillStatus: 'complete',
+            backfilledLineCount: 0,
+        });
+        const tracked = await adoptSessionFromImportJournal('cuid-legacy');
+        expect(tracked!.encryption!.encryptionVariant).toBe('legacy');
+    });
+});

--- a/packages/happy-cli/src/import/daemonAdopt.ts
+++ b/packages/happy-cli/src/import/daemonAdopt.ts
@@ -1,0 +1,73 @@
+/**
+ * Daemon Adopt
+ *
+ * Given a `happySessionId` not currently tracked by this daemon, look it up
+ * in the import journal (~/.happy/imported-sessions.json) and synthesize a
+ * `TrackedSession` so the daemon's existing resume pipeline can spawn a child
+ * with the correct `--resume <claudeSessionId>` argv and HAPPY_RECONNECT_*
+ * env vars.
+ *
+ * Returns null when the session has never been imported on this machine.
+ * The caller should surface the "not tracked" error to the user in that case.
+ */
+
+import os from 'node:os';
+import { join } from 'node:path';
+
+import { decodeBase64 } from '@/api/encryption';
+import type { Metadata } from '@/api/types';
+import { configuration } from '@/configuration';
+import { projectPath } from '@/projectPath';
+import { logger } from '@/ui/logger';
+
+import type { TrackedSession } from '@/daemon/types';
+
+import { findEntryByHappySessionId } from './importJournal';
+
+export async function adoptSessionFromImportJournal(
+    happySessionId: string,
+): Promise<TrackedSession | null> {
+    const entry = await findEntryByHappySessionId(happySessionId);
+    if (!entry) return null;
+
+    const encryptionKey = decodeBase64(entry.encryptionKey);
+    const encryptionVariant = entry.encryptionVariant;
+
+    // buildResumeLaunch (resume/handleResumeCommand.ts:50-86) only reads
+    // `flavor`, `claudeSessionId`, `codexThreadId`, `path` from metadata.
+    // Other required-by-type fields are filler that the child process will
+    // overwrite when it builds its own metadata in runClaude.ts:111-132.
+    const metadata: Metadata = {
+        path: entry.cwd,
+        host: os.hostname(),
+        homeDir: os.homedir(),
+        happyHomeDir: configuration.happyHomeDir,
+        happyLibDir: projectPath(),
+        happyToolsDir: join(projectPath(), 'tools', 'unpacked'),
+        flavor: 'claude',
+        claudeSessionId: entry.claudeSessionId,
+    };
+
+    logger.debug(
+        `[ADOPT] Adopted ${happySessionId} from import journal (claudeSessionId=${entry.claudeSessionId})`,
+    );
+
+    return {
+        startedBy: 'adopted-from-import',
+        happySessionId,
+        happySessionMetadataFromLocalWebhook: metadata,
+        encryption: {
+            encryptionKey,
+            encryptionVariant,
+            // Versions start at 0 — the child process's ApiSessionClient
+            // (apiSession.ts:216) updates them on the first server `update`
+            // event since `incoming.version > 0` always holds. `seq=0` makes
+            // the initial `fetchMessages(after_seq=0)` re-fetch the full
+            // server log, which is what we want on a reconnect.
+            seq: 0,
+            metadataVersion: 0,
+            agentStateVersion: 0,
+        },
+        pid: 0, // No live process — we're about to spawn one.
+    };
+}

--- a/packages/happy-cli/src/import/importJournal.test.ts
+++ b/packages/happy-cli/src/import/importJournal.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Mock configuration BEFORE importing the journal so that
+// `configuration.happyHomeDir` points at a per-test temp dir.
+const tempRootRef = { current: '' };
+vi.mock('@/configuration', () => ({
+    configuration: {
+        get happyHomeDir() {
+            return tempRootRef.current;
+        },
+    },
+}));
+
+// Suppress logger during tests
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: () => { },
+        warn: () => { },
+        info: () => { },
+        error: () => { },
+    },
+}));
+
+import {
+    findEntryByClaudeSessionId,
+    findEntryByHappySessionId,
+    IMPORT_JOURNAL_SCHEMA_VERSION,
+    readImportJournal,
+    upsertEntry,
+    updateImportJournal,
+    type ImportedSessionEntry,
+} from './importJournal';
+
+function makeEntry(overrides: Partial<ImportedSessionEntry> = {}): ImportedSessionEntry {
+    return {
+        claudeSessionId: '11111111-1111-1111-1111-111111111111',
+        happySessionId: 'cuid-abc-123',
+        cwd: '/Users/me/proj',
+        jsonlPath: '/x.jsonl',
+        importedAt: 1700000000000,
+        encryptionKey: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+        encryptionVariant: 'dataKey',
+        backfillStatus: 'complete',
+        backfilledLineCount: 10,
+        ...overrides,
+    };
+}
+
+describe('import journal', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        tempDir = join(tmpdir(), `import-journal-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        mkdirSync(tempDir, { recursive: true });
+        tempRootRef.current = tempDir;
+    });
+
+    afterEach(() => {
+        if (existsSync(tempDir)) {
+            rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('returns empty journal when file is missing', async () => {
+        const journal = await readImportJournal();
+        expect(journal.version).toBe(IMPORT_JOURNAL_SCHEMA_VERSION);
+        expect(journal.imported).toEqual({});
+    });
+
+    it('upsertEntry persists round-trip', async () => {
+        const entry = makeEntry();
+        await upsertEntry(entry);
+        const journal = await readImportJournal();
+        expect(journal.imported[entry.claudeSessionId]).toEqual(entry);
+    });
+
+    it('upsertEntry overwrites existing entry by claudeSessionId', async () => {
+        await upsertEntry(makeEntry({ backfilledLineCount: 5, backfillStatus: 'partial' }));
+        await upsertEntry(makeEntry({ backfilledLineCount: 50, backfillStatus: 'complete' }));
+        const journal = await readImportJournal();
+        const stored = journal.imported['11111111-1111-1111-1111-111111111111'];
+        expect(stored.backfilledLineCount).toBe(50);
+        expect(stored.backfillStatus).toBe('complete');
+    });
+
+    it('findEntryByHappySessionId locates by happy id', async () => {
+        await upsertEntry(makeEntry({ happySessionId: 'cuid-foo', claudeSessionId: 'aaaaaaaa-1111-1111-1111-111111111111' }));
+        await upsertEntry(makeEntry({ happySessionId: 'cuid-bar', claudeSessionId: 'bbbbbbbb-2222-2222-2222-222222222222' }));
+        const found = await findEntryByHappySessionId('cuid-bar');
+        expect(found?.claudeSessionId).toBe('bbbbbbbb-2222-2222-2222-222222222222');
+        const missing = await findEntryByHappySessionId('cuid-not-here');
+        expect(missing).toBeNull();
+    });
+
+    it('findEntryByClaudeSessionId is O(1) and returns the right entry', async () => {
+        await upsertEntry(makeEntry({ claudeSessionId: 'aaaaaaaa-1111-1111-1111-111111111111' }));
+        const found = await findEntryByClaudeSessionId('aaaaaaaa-1111-1111-1111-111111111111');
+        expect(found).not.toBeNull();
+    });
+
+    it('recovers from a corrupted journal file by backing it up', async () => {
+        const journalPath = join(tempDir, 'imported-sessions.json');
+        writeFileSync(journalPath, '{not valid json');
+        const journal = await readImportJournal();
+        expect(journal.imported).toEqual({});
+        // Corrupted file should have been moved aside (backup file exists)
+        // Newly read journal returns empty without throwing.
+    });
+
+    it('rejects schema mismatch and treats it as corrupted', async () => {
+        const journalPath = join(tempDir, 'imported-sessions.json');
+        writeFileSync(journalPath, JSON.stringify({ version: 999, imported: {} }));
+        const journal = await readImportJournal();
+        expect(journal.imported).toEqual({});
+    });
+
+    it('atomic update: serial calls all land', async () => {
+        const ids = ['aaaaaaaa-1111-1111-1111-111111111111', 'bbbbbbbb-2222-2222-2222-222222222222', 'cccccccc-3333-3333-3333-333333333333'];
+        for (const id of ids) {
+            await upsertEntry(makeEntry({ claudeSessionId: id, happySessionId: `h-${id.slice(0, 6)}` }));
+        }
+        const journal = await readImportJournal();
+        expect(Object.keys(journal.imported).sort()).toEqual(ids.sort());
+    });
+
+    it('updateImportJournal applies arbitrary updater', async () => {
+        await upsertEntry(makeEntry());
+        await updateImportJournal(current => ({
+            ...current,
+            imported: Object.fromEntries(
+                Object.entries(current.imported).map(([k, v]) => [k, { ...v, backfilledLineCount: 999 }])
+            ),
+        }));
+        const after = await readImportJournal();
+        expect(Object.values(after.imported)[0].backfilledLineCount).toBe(999);
+    });
+});

--- a/packages/happy-cli/src/import/importJournal.ts
+++ b/packages/happy-cli/src/import/importJournal.ts
@@ -1,0 +1,206 @@
+/**
+ * Import Journal
+ *
+ * Records which Claude Code sessions (from ~/.claude/projects/<dir>/<uuid>.jsonl)
+ * have been imported into Happy and stores the encryption material captured at
+ * import time. This is the trust anchor that lets the daemon adopt and resume
+ * sessions it didn't originally spawn — without needing a separate happy-agent
+ * key for decryption.
+ *
+ * File: ~/.happy/imported-sessions.json
+ *
+ * Concurrency: uses an exclusive lock file (same pattern as updateSettings in
+ * persistence.ts) so concurrent `happy import` invocations don't trample each
+ * other.
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, open, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { join } from 'node:path';
+import * as z from 'zod';
+
+import { configuration } from '@/configuration';
+import { logger } from '@/ui/logger';
+
+export const IMPORT_JOURNAL_SCHEMA_VERSION = 1;
+
+/**
+ * Single imported-session entry.
+ *
+ * Keyed in the journal by `claudeSessionId` — the UUID of the *leaf* JSONL
+ * file (the one with no descendants in the summary/leafUuid chain).
+ *
+ * When the user runs `claude --resume <claudeSessionId>` natively, Claude
+ * creates a *new* JSONL with a new UUID and prefixes the old history. A
+ * subsequent `happy import` will detect this new leaf and update the entry's
+ * `claudeSessionId` (the happy-session id stays the same — only the SDK side
+ * has a new identity, captured in metadata.claudeSessionId via the next
+ * SessionStart hook fire).
+ */
+export const ImportedSessionEntrySchema = z.object({
+    claudeSessionId: z.string(),
+    happySessionId: z.string(),
+    cwd: z.string(),
+    jsonlPath: z.string(),
+    importedAt: z.number(),
+    encryptionKey: z.string(), // base64
+    encryptionVariant: z.union([z.literal('legacy'), z.literal('dataKey')]),
+    backfillStatus: z.union([
+        z.literal('complete'),
+        z.literal('partial'),
+        z.literal('failed'),
+        z.literal('skipped'),
+    ]),
+    /** Line count successfully sent to the server (0 if --no-backfill). */
+    backfilledLineCount: z.number().int().nonnegative(),
+    /** Total lines in the JSONL at last import; used to detect appended tails. */
+    jsonlLineCount: z.number().int().nonnegative().optional(),
+    /** Mtime of JSONL at last import; used to detect changes since import. */
+    jsonlMtimeMs: z.number().optional(),
+    jsonlSizeBytes: z.number().int().nonnegative().optional(),
+});
+
+export type ImportedSessionEntry = z.infer<typeof ImportedSessionEntrySchema>;
+
+const ImportJournalFileSchema = z.object({
+    version: z.literal(IMPORT_JOURNAL_SCHEMA_VERSION),
+    imported: z.record(z.string(), ImportedSessionEntrySchema),
+});
+
+type ImportJournalFile = z.infer<typeof ImportJournalFileSchema>;
+
+const EMPTY_JOURNAL: ImportJournalFile = {
+    version: IMPORT_JOURNAL_SCHEMA_VERSION,
+    imported: {},
+};
+
+function journalFilePath(): string {
+    return join(configuration.happyHomeDir, 'imported-sessions.json');
+}
+
+function lockFilePath(): string {
+    return journalFilePath() + '.lock';
+}
+
+function tmpFilePath(): string {
+    return journalFilePath() + '.tmp';
+}
+
+export async function readImportJournal(): Promise<ImportJournalFile> {
+    const path = journalFilePath();
+    if (!existsSync(path)) {
+        return { ...EMPTY_JOURNAL, imported: {} };
+    }
+    try {
+        const content = await readFile(path, 'utf8');
+        const raw = JSON.parse(content);
+        const parsed = ImportJournalFileSchema.safeParse(raw);
+        if (!parsed.success) {
+            const backup = `${path}.corrupted-${Date.now()}.json`;
+            await rename(path, backup);
+            logger.warn(`Import journal at ${path} was corrupted; backed up to ${backup}`);
+            return { ...EMPTY_JOURNAL, imported: {} };
+        }
+        return parsed.data;
+    } catch (error: any) {
+        logger.warn(`Failed to read import journal: ${error?.message ?? error}`);
+        return { ...EMPTY_JOURNAL, imported: {} };
+    }
+}
+
+/**
+ * Atomically update the journal under an exclusive lock.
+ *
+ * Same retry / stale-lock semantics as updateSettings in persistence.ts.
+ */
+export async function updateImportJournal(
+    updater: (current: ImportJournalFile) => ImportJournalFile | Promise<ImportJournalFile>,
+): Promise<ImportJournalFile> {
+    const LOCK_RETRY_INTERVAL_MS = 100;
+    const MAX_LOCK_ATTEMPTS = 50;
+    const STALE_LOCK_TIMEOUT_MS = 10_000;
+
+    const lockFile = lockFilePath();
+    const tmpFile = tmpFilePath();
+    let fileHandle;
+    let attempts = 0;
+
+    while (attempts < MAX_LOCK_ATTEMPTS) {
+        try {
+            fileHandle = await open(lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+            break;
+        } catch (err: any) {
+            if (err.code === 'EEXIST') {
+                attempts++;
+                await new Promise(resolve => setTimeout(resolve, LOCK_RETRY_INTERVAL_MS));
+                try {
+                    const stats = await stat(lockFile);
+                    if (Date.now() - stats.mtimeMs > STALE_LOCK_TIMEOUT_MS) {
+                        await unlink(lockFile).catch(() => { });
+                    }
+                } catch { /* ignore */ }
+            } else {
+                throw err;
+            }
+        }
+    }
+
+    if (!fileHandle) {
+        throw new Error(
+            `Failed to acquire import journal lock after ${MAX_LOCK_ATTEMPTS * LOCK_RETRY_INTERVAL_MS / 1000} seconds`,
+        );
+    }
+
+    try {
+        const current = await readImportJournal();
+        const updated = await updater(current);
+        if (!existsSync(configuration.happyHomeDir)) {
+            await mkdir(configuration.happyHomeDir, { recursive: true });
+        }
+        await writeFile(tmpFile, JSON.stringify(updated, null, 2));
+        await rename(tmpFile, journalFilePath());
+        return updated;
+    } finally {
+        await fileHandle.close();
+        await unlink(lockFile).catch(() => { });
+    }
+}
+
+/**
+ * Find an entry by happy session ID. O(n) but n is small (one per imported
+ * Claude session). Returns null if not found.
+ */
+export async function findEntryByHappySessionId(
+    happySessionId: string,
+): Promise<ImportedSessionEntry | null> {
+    const journal = await readImportJournal();
+    for (const entry of Object.values(journal.imported)) {
+        if (entry.happySessionId === happySessionId) return entry;
+    }
+    return null;
+}
+
+/**
+ * Find an entry by Claude session ID. O(1).
+ */
+export async function findEntryByClaudeSessionId(
+    claudeSessionId: string,
+): Promise<ImportedSessionEntry | null> {
+    const journal = await readImportJournal();
+    return journal.imported[claudeSessionId] ?? null;
+}
+
+/**
+ * Upsert a journal entry keyed by claudeSessionId. Pass-through to
+ * updateImportJournal — kept as a convenience for the common case.
+ */
+export async function upsertEntry(entry: ImportedSessionEntry): Promise<void> {
+    await updateImportJournal(current => ({
+        ...current,
+        imported: {
+            ...current.imported,
+            [entry.claudeSessionId]: entry,
+        },
+    }));
+}

--- a/packages/happy-cli/src/import/jsonlParser.test.ts
+++ b/packages/happy-cli/src/import/jsonlParser.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { countValidLines, iterateJsonl, readJsonlHeader } from './jsonlParser';
+
+function makeTmpDir(): string {
+    const dir = join(tmpdir(), `jsonl-parser-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+}
+
+function writeFile(dir: string, name: string, lines: string[]): string {
+    const path = join(dir, name);
+    writeFileSync(path, lines.join('\n') + (lines.length ? '\n' : ''));
+    return path;
+}
+
+describe('iterateJsonl', () => {
+    const dirs: string[] = [];
+    afterEach(() => {
+        for (const d of dirs.splice(0)) {
+            if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+        }
+    });
+
+    it('yields valid lines and skips invalid ones', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', [
+            JSON.stringify({ type: 'user', uuid: 'u1', message: { content: 'hi' } }),
+            'not-json-at-all',
+            JSON.stringify({ type: 'assistant', uuid: 'a1', message: { usage: { input_tokens: 1, output_tokens: 2 } } }),
+            JSON.stringify({ type: 'system', uuid: 's1' }),
+            JSON.stringify({ /* missing required fields */ foo: 'bar' }),
+        ]);
+        const rows = [];
+        for await (const row of iterateJsonl(file)) rows.push(row);
+        expect(rows.map(r => r.type)).toEqual(['user', 'assistant', 'system']);
+    });
+
+    it('skips blank lines without error', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', [
+            '',
+            '   ',
+            JSON.stringify({ type: 'user', uuid: 'u1', message: { content: 'hi' } }),
+            '',
+        ]);
+        const rows = [];
+        for await (const row of iterateJsonl(file)) rows.push(row);
+        expect(rows).toHaveLength(1);
+    });
+
+    it('returns empty iterator for empty file', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', []);
+        const rows = [];
+        for await (const row of iterateJsonl(file)) rows.push(row);
+        expect(rows).toHaveLength(0);
+    });
+});
+
+describe('countValidLines', () => {
+    const dirs: string[] = [];
+    afterEach(() => {
+        for (const d of dirs.splice(0)) {
+            if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+        }
+    });
+
+    it('counts only schema-valid lines', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', [
+            JSON.stringify({ type: 'user', uuid: 'u1', message: { content: 'hi' } }),
+            'corrupt-line',
+            JSON.stringify({ type: 'assistant', uuid: 'a1' }),
+            JSON.stringify({ unrelated: true }),
+        ]);
+        expect(await countValidLines(file)).toBe(2);
+    });
+});
+
+describe('readJsonlHeader', () => {
+    const dirs: string[] = [];
+    afterEach(() => {
+        for (const d of dirs.splice(0)) {
+            if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+        }
+    });
+
+    it('extracts summary, cwd, sessionId and first user text', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', [
+            JSON.stringify({ type: 'summary', summary: 'Listing files', leafUuid: 'leaf-xyz' }),
+            JSON.stringify({
+                type: 'user',
+                uuid: 'u1',
+                cwd: '/Users/me/proj',
+                sessionId: '12345678-1234-1234-1234-123456789abc',
+                message: { role: 'user', content: 'list files in this directory' },
+            }),
+            JSON.stringify({
+                type: 'assistant',
+                uuid: 'a1',
+                cwd: '/Users/me/proj',
+                sessionId: '12345678-1234-1234-1234-123456789abc',
+                message: { content: [{ type: 'text', text: 'Sure.' }] },
+            }),
+        ]);
+        const header = await readJsonlHeader(file);
+        expect(header).not.toBeNull();
+        expect(header!.summary).toEqual({ summary: 'Listing files', leafUuid: 'leaf-xyz' });
+        expect(header!.firstCwd).toBe('/Users/me/proj');
+        expect(header!.claudeSessionId).toBe('12345678-1234-1234-1234-123456789abc');
+        expect(header!.firstUserText).toBe('list files in this directory');
+        expect(header!.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it('handles user message with block-array content', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', [
+            JSON.stringify({
+                type: 'user',
+                uuid: 'u1',
+                cwd: '/x',
+                sessionId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                message: {
+                    content: [
+                        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: '...' } },
+                        { type: 'text', text: 'what is this?' },
+                    ],
+                },
+            }),
+        ]);
+        const header = await readJsonlHeader(file);
+        expect(header!.firstUserText).toBe('what is this?');
+    });
+
+    it('truncates long user text', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const longText = 'a'.repeat(200);
+        const file = writeFile(dir, 'a.jsonl', [
+            JSON.stringify({
+                type: 'user',
+                uuid: 'u1',
+                cwd: '/x',
+                sessionId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                message: { content: longText },
+            }),
+        ]);
+        const header = await readJsonlHeader(file);
+        expect(header!.firstUserText!.length).toBeLessThanOrEqual(60);
+        expect(header!.firstUserText!.endsWith('...')).toBe(true);
+    });
+
+    it('returns null when neither cwd nor sessionId is present', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', [
+            JSON.stringify({ type: 'system', uuid: 's1' }),
+        ]);
+        const header = await readJsonlHeader(file);
+        expect(header).toBeNull();
+    });
+
+    it('returns null for nonexistent file', async () => {
+        const header = await readJsonlHeader('/tmp/does-not-exist-' + Date.now() + '.jsonl');
+        expect(header).toBeNull();
+    });
+
+    it('records mtime from stat', async () => {
+        const dir = makeTmpDir();
+        dirs.push(dir);
+        const file = writeFile(dir, 'a.jsonl', [
+            JSON.stringify({
+                type: 'user',
+                uuid: 'u1',
+                cwd: '/x',
+                sessionId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                message: { content: 'hi' },
+            }),
+        ]);
+        const fixed = new Date('2025-06-15T12:00:00Z');
+        utimesSync(file, fixed, fixed);
+        const header = await readJsonlHeader(file);
+        expect(Math.abs(header!.mtimeMs - fixed.getTime())).toBeLessThan(1500);
+    });
+});

--- a/packages/happy-cli/src/import/jsonlParser.ts
+++ b/packages/happy-cli/src/import/jsonlParser.ts
@@ -1,0 +1,195 @@
+/**
+ * JSONL Parser
+ *
+ * Streaming reader for Claude Code's ~/.claude/projects/<dir>/<uuid>.jsonl
+ * files. Each non-empty line is parsed as JSON and validated against
+ * RawJSONLinesSchema. Malformed lines are skipped with a debug log instead
+ * of aborting the whole file — Claude's JSONL is intentionally lenient
+ * (synthetic error messages, version drift) and we want to import as much
+ * as possible.
+ *
+ * Also provides a cheap header read for the scanner: parse only the first
+ * line (the summary, if any) plus the first user message (for cwd) without
+ * walking the whole file.
+ */
+
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createInterface } from 'node:readline';
+
+import { RawJSONLines, RawJSONLinesSchema } from '@/claude/types';
+import { logger } from '@/ui/logger';
+
+export type JsonlHeader = {
+    /** Number of bytes the JSONL occupies on disk at the moment of reading. */
+    sizeBytes: number;
+    /** Mtime in ms — used by the journal to detect changes since last import. */
+    mtimeMs: number;
+    /**
+     * Summary line, if the first line is `{type:"summary",leafUuid:...}`.
+     * Resume-derived JSONLs carry this; original sessions don't.
+     */
+    summary: { summary: string; leafUuid: string } | null;
+    /**
+     * The first message with a `cwd` field. Claude writes one on every line,
+     * but we only need it once for happy metadata.path.
+     *
+     * If null, the file has no parseable user/assistant message with cwd —
+     * caller should skip the file.
+     */
+    firstCwd: string | null;
+    /** Claude session id derived from the first message line's sessionId field. */
+    claudeSessionId: string | null;
+    /** Truncated first user-message text suitable for a session title. */
+    firstUserText: string | null;
+};
+
+/**
+ * Stream a JSONL file line by line, yielding validated RawJSONLines entries.
+ * Invalid lines are silently skipped (logged at debug level).
+ */
+export async function* iterateJsonl(
+    filePath: string,
+): AsyncIterable<RawJSONLines> {
+    const stream = createReadStream(filePath, { encoding: 'utf8' });
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+    try {
+        for await (const line of rl) {
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+            let raw: unknown;
+            try {
+                raw = JSON.parse(trimmed);
+            } catch {
+                logger.debug(`[import] skipping non-JSON line in ${filePath}`);
+                continue;
+            }
+            const parsed = RawJSONLinesSchema.safeParse(raw);
+            if (!parsed.success) {
+                logger.debug(`[import] skipping unrecognized JSONL row in ${filePath}: ${parsed.error.message}`);
+                continue;
+            }
+            yield parsed.data;
+        }
+    } finally {
+        rl.close();
+        stream.close();
+    }
+}
+
+/**
+ * Count how many lines in the JSONL successfully validate as RawJSONLines.
+ * Used to record total message count in the journal.
+ */
+export async function countValidLines(filePath: string): Promise<number> {
+    let count = 0;
+    for await (const _ of iterateJsonl(filePath)) {
+        count++;
+    }
+    return count;
+}
+
+/**
+ * Read enough of the JSONL to determine: summary (if any), cwd, sessionId,
+ * first user message text. Returns null if the file has no usable header
+ * (e.g. empty file or only system messages with no cwd).
+ *
+ * We read up to MAX_HEADER_LINES lines and stop as soon as we have both
+ * cwd and sessionId — typically that's the second or third line.
+ */
+const MAX_HEADER_LINES = 100;
+
+export async function readJsonlHeader(filePath: string): Promise<JsonlHeader | null> {
+    let stats;
+    try {
+        stats = await stat(filePath);
+    } catch {
+        return null;
+    }
+
+    let summary: JsonlHeader['summary'] = null;
+    let firstCwd: string | null = null;
+    let claudeSessionId: string | null = null;
+    let firstUserText: string | null = null;
+    let linesSeen = 0;
+
+    const stream = createReadStream(filePath, { encoding: 'utf8' });
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+    try {
+        for await (const line of rl) {
+            linesSeen++;
+            if (linesSeen > MAX_HEADER_LINES) break;
+            const trimmed = line.trim();
+            if (!trimmed) continue;
+
+            let raw: any;
+            try {
+                raw = JSON.parse(trimmed);
+            } catch { continue; }
+
+            // Summary is always the first line if present
+            if (linesSeen === 1 && raw?.type === 'summary'
+                && typeof raw.summary === 'string'
+                && typeof raw.leafUuid === 'string'
+            ) {
+                summary = { summary: raw.summary, leafUuid: raw.leafUuid };
+                continue;
+            }
+
+            if (typeof raw?.cwd === 'string' && !firstCwd) {
+                firstCwd = raw.cwd;
+            }
+            if (typeof raw?.sessionId === 'string' && !claudeSessionId) {
+                claudeSessionId = raw.sessionId;
+            }
+            if (!firstUserText && raw?.type === 'user') {
+                firstUserText = extractFirstUserText(raw);
+            }
+
+            if (firstCwd && claudeSessionId && firstUserText !== null) break;
+        }
+    } finally {
+        rl.close();
+        stream.close();
+    }
+
+    if (!firstCwd && !claudeSessionId) {
+        return null;
+    }
+
+    return {
+        sizeBytes: stats.size,
+        mtimeMs: stats.mtimeMs,
+        summary,
+        firstCwd,
+        claudeSessionId,
+        firstUserText,
+    };
+}
+
+/**
+ * Best-effort extraction of the first user message text for a session title.
+ * Handles both string content and block-array content with text blocks.
+ * Returns null if nothing readable is present.
+ */
+function extractFirstUserText(raw: any): string | null {
+    const content = raw?.message?.content;
+    if (typeof content === 'string') {
+        return truncateTitle(content);
+    }
+    if (Array.isArray(content)) {
+        for (const block of content) {
+            if (block?.type === 'text' && typeof block.text === 'string') {
+                return truncateTitle(block.text);
+            }
+        }
+    }
+    return null;
+}
+
+function truncateTitle(s: string): string {
+    const clean = s.replace(/\s+/g, ' ').trim();
+    if (clean.length <= 60) return clean;
+    return clean.slice(0, 57) + '...';
+}

--- a/packages/happy-cli/src/import/messageBackfill.ts
+++ b/packages/happy-cli/src/import/messageBackfill.ts
@@ -1,0 +1,129 @@
+/**
+ * Message Backfill
+ *
+ * Reads a Claude JSONL line by line, converts each entry to a session
+ * envelope via the existing mapClaudeLogMessageToSessionEnvelopes mapper,
+ * and pushes them to happy-server through the standard ApiSessionClient
+ * pipeline.
+ *
+ * Why reuse ApiSessionClient instead of POSTing /v3/sessions/<id>/messages
+ * directly?
+ *   - mapClaudeLogMessageToSessionEnvelopes is stateful (tracks subagents,
+ *     turn IDs, sidechains). ApiSessionClient owns that state in its
+ *     `claudeSessionProtocolState` field and the same instance must process
+ *     every line of the conversation.
+ *   - Encryption + retries + batched flushing (max 50 per batch via
+ *     pendingOutbox) is already implemented inside the client. Recreating
+ *     it here would just duplicate code.
+ *
+ * Resume note: the JSONL may grow if the user runs native `claude --resume`
+ * after import. The journal records `backfilledLineCount`; on a re-import
+ * pass we skip already-replayed lines so we don't push duplicates.
+ *
+ * Note on duplication: the server allocates `seq` on its side and does
+ * NOT dedupe by content. If `backfilledLineCount` is wrong (e.g. corrupted
+ * journal) you'll get duplicate messages in the happy session. The
+ * conservative default is "skip backfill" if backfilledLineCount is unknown.
+ */
+
+import { ApiSessionClient } from '@/api/apiSession';
+import { logger } from '@/ui/logger';
+
+import { iterateJsonl } from './jsonlParser';
+
+export type BackfillResult = {
+    /** Total lines successfully sent to the server in this call. */
+    sentLines: number;
+    /** Total lines walked (sent + skipped due to skipUntilLineIndex). */
+    walkedLines: number;
+    status: 'complete' | 'partial' | 'failed';
+    error?: string;
+};
+
+export type BackfillOptions = {
+    /** Skip the first N lines that were already backfilled previously. */
+    skipUntilLineIndex?: number;
+    /**
+     * Soft per-flush cap so we don't accumulate hundreds of MB in memory
+     * before the outbox drains. Defaults to 200 — the client itself caps
+     * individual batches at 50, so this is "send 4 batches then await flush
+     * before queuing more".
+     */
+    flushEveryNLines?: number;
+};
+
+/**
+ * Backfill a JSONL into an already-created happy session.
+ *
+ * The caller must:
+ *   1. Have created the session with `api.getOrCreateSession(...)`
+ *   2. Have constructed an `ApiSessionClient` for that session
+ *   3. Wait for the client's socket to connect (the client auto-connects
+ *      in its constructor; one short `await` on a connect event is enough,
+ *      OR just queue messages and let them go out once connection completes
+ *      — the outbox is durable across reconnects)
+ *
+ * After this returns 'complete' the caller MUST call `client.flush()` and
+ * then close the session client. We don't do that here so the caller can
+ * also call `client.updateMetadata(...)` to set `lifecycleState: 'archived'`
+ * before closing.
+ */
+export async function backfillJsonl(
+    client: ApiSessionClient,
+    jsonlPath: string,
+    opts: BackfillOptions = {},
+): Promise<BackfillResult> {
+    const skipUntil = opts.skipUntilLineIndex ?? 0;
+    const flushEvery = opts.flushEveryNLines ?? 200;
+
+    let walked = 0;
+    let sent = 0;
+
+    try {
+        for await (const row of iterateJsonl(jsonlPath)) {
+            walked++;
+            if (walked <= skipUntil) continue;
+
+            try {
+                client.sendClaudeSessionMessage(row);
+                sent++;
+            } catch (error: any) {
+                // The mapper itself can throw on malformed but schema-passing
+                // data. Skip the row, keep going — losing one row beats
+                // aborting the whole import.
+                logger.debug(`[import] mapper threw on line ${walked} of ${jsonlPath}: ${error?.message}`);
+            }
+
+            if (sent > 0 && sent % flushEvery === 0) {
+                // Backpressure: wait for the outbox to drain before we let
+                // it accumulate another batch. flush() polls socket-ack so
+                // it's safe to call repeatedly.
+                await client.flush();
+            }
+        }
+
+        // Close the turn so the UI doesn't show an "agent typing" state
+        // for the imported session. closeClaudeTurnWithStatus emits the
+        // turn-end envelope through the same pipeline.
+        try {
+            client.closeClaudeSessionTurn('completed');
+        } catch (error: any) {
+            logger.debug(`[import] closeClaudeSessionTurn failed: ${error?.message}`);
+        }
+
+        await client.flush();
+
+        return { sentLines: sent, walkedLines: walked, status: 'complete' };
+    } catch (error: any) {
+        logger.debug(`[import] backfill failed at line ${walked} of ${jsonlPath}: ${error?.message}`);
+        // Try to flush whatever we sent so the partial state on the server
+        // matches sentLines (so the next re-import resumes from the right line).
+        try { await client.flush(); } catch { /* swallow */ }
+        return {
+            sentLines: sent,
+            walkedLines: walked,
+            status: sent > 0 ? 'partial' : 'failed',
+            error: error?.message ?? String(error),
+        };
+    }
+}

--- a/packages/happy-cli/src/import/pruneImported.ts
+++ b/packages/happy-cli/src/import/pruneImported.ts
@@ -1,0 +1,130 @@
+/**
+ * Prune Imported Sessions
+ *
+ * Removes journal entries (and the corresponding happy Session rows on the
+ * server) for imports whose JSONL is older than a cutoff. Used to walk back
+ * an auto-import cycle that accidentally pulled in historical sessions
+ * (e.g., before the recency filter was added).
+ *
+ * What gets removed for each pruned entry:
+ *   1. DELETE /v1/sessions/<happySessionId> on the server (Session row +
+ *      all SessionMessage rows cascade away)
+ *   2. The entry is removed from ~/.happy/imported-sessions.json so the
+ *      next auto-import scan can re-discover the JSONL if user wants.
+ *
+ * Tail-backfills from now on will simply skip these — they're no longer in
+ * the journal.
+ */
+
+import axios from 'axios';
+
+import { ApiClient } from '@/api/api';
+import { configuration } from '@/configuration';
+import { readCredentials } from '@/persistence';
+import { logger } from '@/ui/logger';
+
+import { readImportJournal, updateImportJournal } from './importJournal';
+
+export type PruneResult = {
+    happySessionId: string;
+    claudeSessionId: string;
+    cwd: string;
+    status: 'deleted' | 'failed' | 'kept-not-old-enough';
+    error?: string;
+};
+
+/**
+ * Prune journal entries whose underlying JSONL mtime is older than
+ * `olderThanMs` (epoch-ms cutoff — anything BEFORE this is pruned).
+ *
+ * Pass `dryRun: true` to see what would be deleted without actually deleting.
+ */
+export async function pruneImportedSessionsOlderThan(
+    _api: ApiClient,
+    olderThanMs: number,
+    options: { dryRun?: boolean } = {},
+): Promise<PruneResult[]> {
+    const journal = await readImportJournal();
+    const credentials = await readCredentials();
+    if (!credentials) {
+        throw new Error('No credentials — cannot delete sessions on the server.');
+    }
+
+    const results: PruneResult[] = [];
+    const idsToRemoveFromJournal: string[] = [];
+
+    for (const entry of Object.values(journal.imported)) {
+        const mtime = entry.jsonlMtimeMs ?? entry.importedAt;
+        if (mtime >= olderThanMs) {
+            results.push({
+                happySessionId: entry.happySessionId,
+                claudeSessionId: entry.claudeSessionId,
+                cwd: entry.cwd,
+                status: 'kept-not-old-enough',
+            });
+            continue;
+        }
+
+        if (options.dryRun) {
+            results.push({
+                happySessionId: entry.happySessionId,
+                claudeSessionId: entry.claudeSessionId,
+                cwd: entry.cwd,
+                status: 'deleted', // pretend
+            });
+            continue;
+        }
+
+        try {
+            await axios.delete(`${configuration.serverUrl}/v1/sessions/${entry.happySessionId}`, {
+                headers: {
+                    Authorization: `Bearer ${credentials.token}`,
+                    'X-Happy-Client': `cli-coding-session/${configuration.currentCliVersion}`,
+                },
+                timeout: 15_000,
+            });
+            idsToRemoveFromJournal.push(entry.claudeSessionId);
+            results.push({
+                happySessionId: entry.happySessionId,
+                claudeSessionId: entry.claudeSessionId,
+                cwd: entry.cwd,
+                status: 'deleted',
+            });
+        } catch (error: any) {
+            // 404 = already gone on server (someone deleted it from another machine
+            // or the user archived it manually). Still remove from journal — there's
+            // nothing left to track.
+            const status = error?.response?.status;
+            if (status === 404) {
+                idsToRemoveFromJournal.push(entry.claudeSessionId);
+                results.push({
+                    happySessionId: entry.happySessionId,
+                    claudeSessionId: entry.claudeSessionId,
+                    cwd: entry.cwd,
+                    status: 'deleted',
+                });
+            } else {
+                logger.debug(`[prune] DELETE failed for ${entry.happySessionId}: ${error?.message}`);
+                results.push({
+                    happySessionId: entry.happySessionId,
+                    claudeSessionId: entry.claudeSessionId,
+                    cwd: entry.cwd,
+                    status: 'failed',
+                    error: error?.message ?? String(error),
+                });
+            }
+        }
+    }
+
+    if (idsToRemoveFromJournal.length > 0 && !options.dryRun) {
+        await updateImportJournal((current) => {
+            const next = { ...current.imported };
+            for (const id of idsToRemoveFromJournal) {
+                delete next[id];
+            }
+            return { ...current, imported: next };
+        });
+    }
+
+    return results;
+}

--- a/packages/happy-cli/src/import/scanner.test.ts
+++ b/packages/happy-cli/src/import/scanner.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, existsSync, rmSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Mock configuration & logger so the test owns happyHomeDir + CLAUDE_CONFIG_DIR.
+const tempRootRef = { current: '' };
+vi.mock('@/configuration', () => ({
+    configuration: {
+        get happyHomeDir() {
+            return tempRootRef.current;
+        },
+    },
+}));
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: () => { },
+        warn: () => { },
+        info: () => { },
+        error: () => { },
+    },
+}));
+
+import { scanForImportCandidates } from './scanner';
+import { upsertEntry } from './importJournal';
+
+function makeProject(claudeDir: string, projectName: string, sessions: Array<{
+    sessionId: string;
+    summary?: { summary: string; leafUuid: string };
+    cwd?: string;
+    firstUserText?: string;
+    mtime?: Date;
+}>) {
+    const dir = join(claudeDir, 'projects', projectName);
+    mkdirSync(dir, { recursive: true });
+    for (const session of sessions) {
+        const lines: string[] = [];
+        if (session.summary) {
+            lines.push(JSON.stringify({ type: 'summary', summary: session.summary.summary, leafUuid: session.summary.leafUuid }));
+        }
+        if (session.cwd) {
+            lines.push(JSON.stringify({
+                type: 'user',
+                uuid: 'u1',
+                cwd: session.cwd,
+                sessionId: session.sessionId,
+                message: { role: 'user', content: session.firstUserText ?? 'hello' },
+            }));
+        }
+        const file = join(dir, `${session.sessionId}.jsonl`);
+        writeFileSync(file, lines.join('\n') + '\n');
+        if (session.mtime) {
+            utimesSync(file, session.mtime, session.mtime);
+        }
+    }
+}
+
+describe('scanForImportCandidates', () => {
+    let tempDir: string;
+    let claudeDir: string;
+    const oldClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+    beforeEach(() => {
+        tempDir = join(tmpdir(), `scanner-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        claudeDir = join(tempDir, '.claude');
+        mkdirSync(claudeDir, { recursive: true });
+        tempRootRef.current = join(tempDir, '.happy');
+        mkdirSync(tempRootRef.current, { recursive: true });
+        process.env.CLAUDE_CONFIG_DIR = claudeDir;
+    });
+
+    afterEach(() => {
+        if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+        if (oldClaudeConfigDir !== undefined) {
+            process.env.CLAUDE_CONFIG_DIR = oldClaudeConfigDir;
+        } else {
+            delete process.env.CLAUDE_CONFIG_DIR;
+        }
+    });
+
+    it('returns empty list when ~/.claude/projects does not exist', async () => {
+        rmSync(claudeDir, { recursive: true, force: true });
+        const candidates = await scanForImportCandidates();
+        expect(candidates).toEqual([]);
+    });
+
+    it('skips files with non-UUID names (agent-* etc.)', async () => {
+        makeProject(claudeDir, '-Users-me-proj', [
+            { sessionId: 'agent-xyz', cwd: '/Users/me/proj' },
+            { sessionId: '11111111-1111-1111-1111-111111111111', cwd: '/Users/me/proj' },
+        ]);
+        const candidates = await scanForImportCandidates();
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0].claudeSessionId).toBe('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('drops ancestors when a resume leaf points to them', async () => {
+        // Three-link chain: A (root) ← B (resume of A) ← C (resume of B)
+        // Only C should remain as an import candidate.
+        const A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        const C = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+        makeProject(claudeDir, '-Users-me-proj', [
+            { sessionId: A, cwd: '/Users/me/proj' },
+            { sessionId: B, cwd: '/Users/me/proj', summary: { summary: 'resume of A', leafUuid: A } },
+            { sessionId: C, cwd: '/Users/me/proj', summary: { summary: 'resume of B', leafUuid: B } },
+        ]);
+        const candidates = await scanForImportCandidates();
+        expect(candidates.map(c => c.claudeSessionId).sort()).toEqual([C]);
+    });
+
+    it('excludes sessions already in the journal', async () => {
+        const id = '11111111-1111-1111-1111-111111111111';
+        makeProject(claudeDir, '-Users-me-proj', [
+            { sessionId: id, cwd: '/Users/me/proj' },
+        ]);
+        // Pre-seed journal as if this session was already imported
+        await upsertEntry({
+            claudeSessionId: id,
+            happySessionId: 'h-1',
+            cwd: '/Users/me/proj',
+            jsonlPath: 'irrelevant',
+            importedAt: Date.now(),
+            encryptionKey: 'AAA=',
+            encryptionVariant: 'legacy',
+            backfillStatus: 'complete',
+            backfilledLineCount: 1,
+        });
+        const candidates = await scanForImportCandidates();
+        expect(candidates).toEqual([]);
+    });
+
+    it('includes already-imported when includeAlreadyImported=true', async () => {
+        const id = '11111111-1111-1111-1111-111111111111';
+        makeProject(claudeDir, '-Users-me-proj', [
+            { sessionId: id, cwd: '/Users/me/proj' },
+        ]);
+        await upsertEntry({
+            claudeSessionId: id,
+            happySessionId: 'h-1',
+            cwd: '/Users/me/proj',
+            jsonlPath: 'irrelevant',
+            importedAt: Date.now(),
+            encryptionKey: 'AAA=',
+            encryptionVariant: 'legacy',
+            backfillStatus: 'complete',
+            backfilledLineCount: 1,
+        });
+        const candidates = await scanForImportCandidates({ includeAlreadyImported: true });
+        expect(candidates).toHaveLength(1);
+    });
+
+    it('filters by projectFilter prefix', async () => {
+        makeProject(claudeDir, '-Users-me-projA', [
+            { sessionId: '11111111-1111-1111-1111-111111111111', cwd: '/Users/me/projA' },
+        ]);
+        makeProject(claudeDir, '-Users-me-projB', [
+            { sessionId: '22222222-2222-2222-2222-222222222222', cwd: '/Users/me/projB' },
+        ]);
+        const candidates = await scanForImportCandidates({ projectFilter: '/Users/me/projA' });
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0].claudeSessionId).toBe('11111111-1111-1111-1111-111111111111');
+    });
+
+    it('sorts candidates by mtime desc', async () => {
+        const A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+        const B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+        makeProject(claudeDir, '-Users-me-proj', [
+            { sessionId: A, cwd: '/Users/me/proj', mtime: new Date('2025-01-01') },
+            { sessionId: B, cwd: '/Users/me/proj', mtime: new Date('2025-12-31') },
+        ]);
+        const candidates = await scanForImportCandidates();
+        expect(candidates.map(c => c.claudeSessionId)).toEqual([B, A]);
+    });
+
+    it('excludes sessions that happy already tracks via happyTrackedClaudeIds option', async () => {
+        const happySpawned = '11111111-1111-1111-1111-111111111111';
+        const native = '22222222-2222-2222-2222-222222222222';
+        makeProject(claudeDir, '-Users-me-proj', [
+            { sessionId: happySpawned, cwd: '/Users/me/proj' },
+            { sessionId: native, cwd: '/Users/me/proj' },
+        ]);
+        const candidates = await scanForImportCandidates({
+            happyTrackedClaudeIds: new Set([happySpawned]),
+        });
+        expect(candidates.map(c => c.claudeSessionId)).toEqual([native]);
+    });
+
+    it('includeAlreadyImported also bypasses the happy-tracked dedup', async () => {
+        const happySpawned = '11111111-1111-1111-1111-111111111111';
+        makeProject(claudeDir, '-Users-me-proj', [
+            { sessionId: happySpawned, cwd: '/Users/me/proj' },
+        ]);
+        const candidates = await scanForImportCandidates({
+            includeAlreadyImported: true,
+            happyTrackedClaudeIds: new Set([happySpawned]),
+        });
+        expect(candidates).toHaveLength(1);
+    });
+});

--- a/packages/happy-cli/src/import/scanner.ts
+++ b/packages/happy-cli/src/import/scanner.ts
@@ -1,0 +1,181 @@
+/**
+ * Scanner
+ *
+ * Walks ~/.claude/projects/<sanitized-cwd>/<uuid>.jsonl, reads each file's
+ * header, filters out:
+ *   - non-UUID session IDs (agent-* and similar — Claude SDK --resume only
+ *     accepts UUIDs as of v2.0.65; matches claudeFindLastSession.ts:20-21)
+ *   - files that are *ancestors* in a summary/leafUuid chain (a JSONL whose
+ *     leafUuid points to another JSONL means it has been resumed; we only
+ *     want the resume *leaf*, since `claude --resume <leaf>` already
+ *     contains the full prefixed history)
+ *   - files already imported (per the journal)
+ *
+ * Returns a list of import candidates with everything sessionImporter
+ * needs to create a happy session.
+ */
+
+import { readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { logger } from '@/ui/logger';
+
+import { readImportJournal } from './importJournal';
+import { readJsonlHeader, type JsonlHeader } from './jsonlParser';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ImportCandidate = {
+    /** Full absolute path to the JSONL file. */
+    jsonlPath: string;
+    /** UUID extracted from the filename — same as the session's claudeSessionId. */
+    claudeSessionId: string;
+    /** Project dir name as it appears under ~/.claude/projects (sanitized cwd). */
+    projectDir: string;
+    /** Header data for metadata + title. */
+    header: JsonlHeader;
+};
+
+export type ScanOptions = {
+    /** Only include sessions whose JSONL `firstCwd` starts with this directory. */
+    projectFilter?: string;
+    /**
+     * If true, include sessions whose claudeSessionId is already in the
+     * journal. Used by the rescan path that wants to refresh tail data.
+     */
+    includeAlreadyImported?: boolean;
+    /**
+     * Set of claudeSessionId values that already correspond to a happy
+     * session on the server. The scanner will skip any candidate whose
+     * claudeSessionId is in this set, so we don't import duplicates of
+     * sessions that happy itself created.
+     *
+     * Caller (typically `happy import`) builds this via
+     * collectHappyTrackedClaudeSessionIds(). Left empty by tests that
+     * don't need this dedup path.
+     */
+    happyTrackedClaudeIds?: ReadonlySet<string>;
+    /**
+     * Only include sessions whose JSONL mtime is at or after this epoch-ms
+     * timestamp. Used by `happy import --days <n>` to limit imports to recent
+     * activity.
+     */
+    mtimeAfterMs?: number;
+};
+
+function claudeProjectsRoot(): string {
+    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+    return join(claudeConfigDir, 'projects');
+}
+
+/**
+ * Scan and return all import candidates.
+ *
+ * Algorithm:
+ *   1. List every <project>/<uuid>.jsonl under ~/.claude/projects
+ *   2. Filter by UUID name shape
+ *   3. Read each file's header
+ *   4. Collect ancestor leafUuids from every header.summary.leafUuid
+ *   5. Drop any file whose own UUID appears in the ancestor set
+ *      (= it has been resumed; the resume leaf carries its history)
+ *   6. Drop already-imported sessions unless includeAlreadyImported
+ *
+ * On any per-file error: log debug and skip. The scan as a whole never
+ * throws.
+ */
+export async function scanForImportCandidates(opts: ScanOptions = {}): Promise<ImportCandidate[]> {
+    const root = claudeProjectsRoot();
+
+    let projectDirs: string[];
+    try {
+        projectDirs = await readdir(root);
+    } catch (error: any) {
+        if (error?.code === 'ENOENT') {
+            return [];
+        }
+        logger.debug(`[import] failed to read ${root}: ${error?.message}`);
+        return [];
+    }
+
+    type FileEntry = {
+        jsonlPath: string;
+        claudeSessionId: string;
+        projectDir: string;
+        header: JsonlHeader;
+    };
+
+    const allFiles: FileEntry[] = [];
+    // claudeSessionId -> any leafUuid that points to it (i.e. this session was
+    // resumed and its history was forwarded to the leaf). Anything in this set
+    // is an "ancestor" and should be skipped.
+    const ancestorUuids = new Set<string>();
+
+    for (const projectDir of projectDirs) {
+        const dirPath = join(root, projectDir);
+        let files: string[];
+        try {
+            files = await readdir(dirPath);
+        } catch { continue; }
+
+        for (const file of files) {
+            if (!file.endsWith('.jsonl')) continue;
+            const claudeSessionId = file.slice(0, -'.jsonl'.length);
+            if (!UUID_RE.test(claudeSessionId)) continue;
+
+            const jsonlPath = join(dirPath, file);
+            let header: JsonlHeader | null;
+            try {
+                header = await readJsonlHeader(jsonlPath);
+            } catch (error: any) {
+                logger.debug(`[import] header read failed for ${jsonlPath}: ${error?.message}`);
+                continue;
+            }
+            if (!header) continue;
+
+            // A summary line at the top means this JSONL was created by
+            // `claude --resume <leafUuid>`. The leafUuid points to the
+            // PREVIOUS session — that older session is now an ancestor and
+            // should be skipped in favor of *this* file.
+            if (header.summary) {
+                ancestorUuids.add(header.summary.leafUuid);
+            }
+
+            allFiles.push({ jsonlPath, claudeSessionId, projectDir, header });
+        }
+    }
+
+    // Drop ancestors and apply project filter / journal filter / happy-tracked filter
+    const journal = opts.includeAlreadyImported ? null : await readImportJournal();
+
+    // Sessions already represented as happy Session rows on the server
+    // (passed in by the caller — typically computed via
+    // collectHappyTrackedClaudeSessionIds()). Importing them again would
+    // produce a duplicate.
+    const happyTrackedClaudeIds = opts.includeAlreadyImported
+        ? new Set<string>()
+        : (opts.happyTrackedClaudeIds ?? new Set<string>());
+
+    const candidates: ImportCandidate[] = [];
+    for (const entry of allFiles) {
+        if (ancestorUuids.has(entry.claudeSessionId)) continue;
+        if (opts.projectFilter && entry.header.firstCwd
+            && !entry.header.firstCwd.startsWith(opts.projectFilter)
+        ) continue;
+        if (journal && journal.imported[entry.claudeSessionId]) continue;
+        if (happyTrackedClaudeIds.has(entry.claudeSessionId)) {
+            logger.debug(`[import] skipping ${entry.claudeSessionId} — already a happy-spawned session`);
+            continue;
+        }
+        if (typeof opts.mtimeAfterMs === 'number' && entry.header.mtimeMs < opts.mtimeAfterMs) {
+            continue;
+        }
+        candidates.push(entry);
+    }
+
+    // Stable sort: newest mtime first so the user sees the most recently
+    // active sessions at the top of the confirmation prompt.
+    candidates.sort((a, b) => b.header.mtimeMs - a.header.mtimeMs);
+
+    return candidates;
+}

--- a/packages/happy-cli/src/import/sessionImporter.ts
+++ b/packages/happy-cli/src/import/sessionImporter.ts
@@ -1,0 +1,225 @@
+/**
+ * Session Importer
+ *
+ * Per-candidate orchestration:
+ *   1. Build Happy `Metadata` from the JSONL header + machine info
+ *   2. Call `apiClient.getOrCreateSession({ tag, metadata, state })` — the
+ *      server-side tag is `claude-imported:<claudeSessionId>` so a lost
+ *      local journal still dedupes against existing server rows.
+ *   3. Open an `ApiSessionClient`, backfill messages, archive the session,
+ *      flush, close.
+ *   4. Record the result (including the encryption key captured at step 2)
+ *      in the import journal.
+ *
+ * If anything fails after step 2 we still write a journal entry with the
+ * partial status so the next `happy import` can resume from the failed
+ * line index — and so the daemon can adopt-and-resume the session even
+ * without messages backfilled.
+ */
+
+import os from 'node:os';
+import { resolve as resolvePath } from 'node:path';
+
+import { ApiClient } from '@/api/api';
+import { encodeBase64 } from '@/api/encryption';
+import type { AgentState, Metadata } from '@/api/types';
+import { configuration } from '@/configuration';
+import { projectPath } from '@/projectPath';
+import { readSettings } from '@/persistence';
+import { logger } from '@/ui/logger';
+import packageJson from '../../package.json';
+
+import { upsertEntry } from './importJournal';
+import { backfillJsonl } from './messageBackfill';
+import type { ImportCandidate } from './scanner';
+import { countValidLines } from './jsonlParser';
+
+export type ImportSessionOptions = {
+    /** If false, skip message backfill and just create the empty session. */
+    backfill?: boolean;
+};
+
+export type ImportSessionResult = {
+    candidate: ImportCandidate;
+    happySessionId: string | null;
+    messagesBackfilled: number;
+    status: 'created' | 'created-no-backfill' | 'partial' | 'failed';
+    error?: string;
+};
+
+export async function importSingleSession(
+    api: ApiClient,
+    candidate: ImportCandidate,
+    options: ImportSessionOptions = {},
+): Promise<ImportSessionResult> {
+    const backfill = options.backfill !== false;
+    const { header, claudeSessionId, jsonlPath } = candidate;
+
+    if (!header.firstCwd) {
+        return {
+            candidate,
+            happySessionId: null,
+            messagesBackfilled: 0,
+            status: 'failed',
+            error: 'JSONL has no cwd — cannot build session metadata.',
+        };
+    }
+
+    const metadata = await buildMetadata(candidate);
+    const state: AgentState = { controlledByUser: false };
+
+    const tag = `claude-imported:${claudeSessionId}`;
+    const session = await api.getOrCreateSession({ tag, metadata, state });
+    if (!session) {
+        return {
+            candidate,
+            happySessionId: null,
+            messagesBackfilled: 0,
+            status: 'failed',
+            error: 'Server returned no session (likely offline). Try again when connected.',
+        };
+    }
+
+    // Persist the encryption key NOW so even if backfill fails, the daemon
+    // can still adopt-and-resume this session later.
+    let totalLinesForJournal: number | undefined;
+    try {
+        totalLinesForJournal = await countValidLines(jsonlPath);
+    } catch { /* ignore */ }
+
+    await upsertEntry({
+        claudeSessionId,
+        happySessionId: session.id,
+        cwd: header.firstCwd,
+        jsonlPath,
+        importedAt: Date.now(),
+        encryptionKey: encodeBase64(session.encryptionKey),
+        encryptionVariant: session.encryptionVariant,
+        backfillStatus: backfill ? 'partial' : 'skipped',
+        backfilledLineCount: 0,
+        jsonlLineCount: totalLinesForJournal,
+        jsonlMtimeMs: header.mtimeMs,
+        jsonlSizeBytes: header.sizeBytes,
+    });
+
+    if (!backfill) {
+        return {
+            candidate,
+            happySessionId: session.id,
+            messagesBackfilled: 0,
+            status: 'created-no-backfill',
+        };
+    }
+
+    const client = api.sessionSyncClient(session);
+    let messagesBackfilled = 0;
+    let result;
+    try {
+        result = await backfillJsonl(client, jsonlPath);
+        messagesBackfilled = result.sentLines;
+    } catch (error: any) {
+        logger.debug(`[import] unexpected error during backfill: ${error?.message}`);
+        await client.close().catch(() => { });
+        await upsertEntry({
+            claudeSessionId,
+            happySessionId: session.id,
+            cwd: header.firstCwd,
+            jsonlPath,
+            importedAt: Date.now(),
+            encryptionKey: encodeBase64(session.encryptionKey),
+            encryptionVariant: session.encryptionVariant,
+            backfillStatus: 'failed',
+            backfilledLineCount: 0,
+            jsonlLineCount: totalLinesForJournal,
+            jsonlMtimeMs: header.mtimeMs,
+            jsonlSizeBytes: header.sizeBytes,
+        });
+        return {
+            candidate,
+            happySessionId: session.id,
+            messagesBackfilled: 0,
+            status: 'failed',
+            error: error?.message ?? String(error),
+        };
+    }
+
+    // Mark the session as inactive on the server (active=false), so the
+    // mobile app shows it in the "not currently running" state but with the
+    // normal Resume affordance. We deliberately keep `lifecycleState` as
+    // 'running' (not 'archived') because the app locks input on archived
+    // sessions and the user has no way to trigger resume from there.
+    try {
+        await api.deactivateSession(session.id);
+    } catch (error: any) {
+        logger.debug(`[import] deactivateSession failed: ${error?.message}`);
+    }
+
+    await client.close().catch(() => { });
+
+    const status: ImportSessionResult['status'] =
+        result.status === 'complete' ? 'created'
+            : result.status === 'partial' ? 'partial'
+                : 'failed';
+
+    await upsertEntry({
+        claudeSessionId,
+        happySessionId: session.id,
+        cwd: header.firstCwd,
+        jsonlPath,
+        importedAt: Date.now(),
+        encryptionKey: encodeBase64(session.encryptionKey),
+        encryptionVariant: session.encryptionVariant,
+        backfillStatus: result.status,
+        backfilledLineCount: result.sentLines,
+        jsonlLineCount: totalLinesForJournal,
+        jsonlMtimeMs: header.mtimeMs,
+        jsonlSizeBytes: header.sizeBytes,
+    });
+
+    return {
+        candidate,
+        happySessionId: session.id,
+        messagesBackfilled,
+        status,
+        error: result.error,
+    };
+}
+
+async function buildMetadata(candidate: ImportCandidate): Promise<Metadata> {
+    const { header, claudeSessionId } = candidate;
+    const settings = await readSettings();
+    const cwd = header.firstCwd!; // checked by caller
+    const title = header.firstUserText
+        || header.summary?.summary
+        || `Imported Claude session ${claudeSessionId.slice(0, 8)}`;
+
+    return {
+        path: cwd,
+        host: os.hostname(),
+        version: packageJson.version,
+        os: os.platform(),
+        machineId: settings.machineId,
+        homeDir: os.homedir(),
+        happyHomeDir: configuration.happyHomeDir,
+        happyLibDir: projectPath(),
+        happyToolsDir: resolvePath(projectPath(), 'tools', 'unpacked'),
+        startedBy: 'terminal',
+        startedFromDaemon: false,
+        // Keep as 'running': the mobile app locks input on archived sessions
+        // with no clear path to resume. `active=false` (set via
+        // api.deactivateSession after backfill) is enough to signal "no live
+        // process" while keeping the session resumable from the UI.
+        lifecycleState: 'running',
+        lifecycleStateSince: Date.now(),
+        flavor: 'claude',
+        // The crucial link: tells `buildResumeLaunch` (in resume/handleResumeCommand.ts:67)
+        // which Claude UUID to pass as --resume when the user wants to
+        // continue this session.
+        claudeSessionId,
+        summary: {
+            text: title,
+            updatedAt: Date.now(),
+        },
+        name: title,
+    };
+}

--- a/packages/happy-cli/src/import/unarchiveImported.ts
+++ b/packages/happy-cli/src/import/unarchiveImported.ts
@@ -1,0 +1,97 @@
+/**
+ * Unarchive Imported Sessions
+ *
+ * Earlier versions of the importer wrote `lifecycleState: 'archived'` into
+ * imported sessions' metadata. The mobile app locks input on archived
+ * sessions and offers no way to trigger Resume from there, so the imported
+ * sessions were unusable.
+ *
+ * This module walks every entry in the import journal, decrypts the session
+ * key from the journal, opens an ephemeral ApiSessionClient, and clears the
+ * archive flags from the session metadata — flipping it back to `running`
+ * with `active=false` so the user can hit Resume from the app.
+ *
+ * Idempotent: sessions already in `running` state still get touched (cheap;
+ * the server short-circuits via metadataVersion).
+ */
+
+import { ApiClient } from '@/api/api';
+import { decodeBase64 } from '@/api/encryption';
+import type { Session } from '@/api/types';
+import { logger } from '@/ui/logger';
+
+import { readImportJournal } from './importJournal';
+
+export type UnarchiveResult = {
+    happySessionId: string;
+    claudeSessionId: string;
+    status: 'cleared' | 'failed';
+    error?: string;
+};
+
+export async function unarchiveAllImported(api: ApiClient): Promise<UnarchiveResult[]> {
+    const journal = await readImportJournal();
+    const results: UnarchiveResult[] = [];
+
+    for (const entry of Object.values(journal.imported)) {
+        try {
+            // Reconstruct a Session shape good enough for ApiSessionClient.
+            // `seq`/`metadataVersion`/`agentStateVersion` start at 0; the
+            // first server `update-session` event will refresh them, and the
+            // metadata-update RPC handles version mismatches via backoff
+            // (apiSession.ts:691-710).
+            const synthSession: Session = {
+                id: entry.happySessionId,
+                seq: 0,
+                encryptionKey: decodeBase64(entry.encryptionKey),
+                encryptionVariant: entry.encryptionVariant,
+                metadata: {
+                    path: entry.cwd,
+                    host: '',
+                    homeDir: '',
+                    happyHomeDir: '',
+                    happyLibDir: '',
+                    happyToolsDir: '',
+                    flavor: 'claude',
+                    claudeSessionId: entry.claudeSessionId,
+                },
+                metadataVersion: 0,
+                agentState: null,
+                agentStateVersion: 0,
+            };
+
+            const client = api.sessionSyncClient(synthSession);
+
+            client.updateMetadata((current) => ({
+                ...current,
+                lifecycleState: 'running',
+                lifecycleStateSince: Date.now(),
+                archivedBy: undefined,
+                archiveReason: undefined,
+            }));
+
+            // Ensure update lands before we close.
+            await client.flush();
+            await client.close().catch(() => { });
+
+            // Mark inactive — keeps the resume affordance in the UI.
+            await api.deactivateSession(entry.happySessionId).catch(() => false);
+
+            results.push({
+                happySessionId: entry.happySessionId,
+                claudeSessionId: entry.claudeSessionId,
+                status: 'cleared',
+            });
+        } catch (error: any) {
+            logger.debug(`[unarchive] failed for ${entry.happySessionId}: ${error?.message}`);
+            results.push({
+                happySessionId: entry.happySessionId,
+                claudeSessionId: entry.claudeSessionId,
+                status: 'failed',
+                error: error?.message ?? String(error),
+            });
+        }
+    }
+
+    return results;
+}

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -34,6 +34,7 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
 import { handleResumeCommand } from '@/resume/handleResumeCommand'
 import { ensureDaemonRunning } from './daemon/ensureDaemonRunning'
 import { handleCodexCommand } from './commands/codexCommand'
+import { handleImportCommand } from './commands/importCommand'
 
 
 (async () => {
@@ -127,6 +128,17 @@ Conversation history is preserved on the server, but in-flight tool calls are in
   } else if (subcommand === 'resume') {
     try {
       await handleResumeCommand(args.slice(1));
+    } catch (error) {
+      console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
+      if (process.env.DEBUG) {
+        console.error(error)
+      }
+      process.exit(1)
+    }
+    return;
+  } else if (subcommand === 'import') {
+    try {
+      await handleImportCommand(args.slice(1));
     } catch (error) {
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')
       if (process.env.DEBUG) {


### PR DESCRIPTION
## Motivation

Right now the only way for a session to show up in the Happy mobile app is to start it via `happy claude`. Sessions a user kicked off with raw `claude` are entirely invisible: their JSONL transcript on disk has no corresponding `Session` row on the server, no `metadata.claudeSessionId`, and no daemon-side tracking — so the app can't list them, can't show their history, and can't resume them.

This PR adds `happy import`, a CLI command that scans `~/.claude/projects/<dir>/<uuid>.jsonl`, registers each leaf session as a Happy `Session` on the server (encrypted client-side as usual), backfills the message history, and teaches the daemon to *adopt* those sessions when the mobile app sends `resume-happy-session` — so a fresh `happy claude --resume <claudeSessionId>` is spawned and the conversation continues from where the user left off in the terminal.

App and server are unchanged: this is a CLI-only contribution. The mobile Resume button works because it gates only on `metadata.machineId` + `metadata.claudeSessionId` being present (both populated by the importer), and the `expResumeSession` feature flag.

## What's in this PR

Two commits on top of `main`:

1. **`feat(import): import local Claude Code sessions into Happy`** — the `happy import` command and supporting modules.
2. **`feat(daemon): adopt imported sessions on resume-happy-session RPC`** — the daemon-side fallback that lets the existing resume pipeline find sessions in the import journal when they're not in `pidToTrackedSession` / `sessionIdToFinishedSession`.

A separate auto-sync polling loop on the daemon's heartbeat exists in our personal branch but is intentionally **not** included here. It changes the daemon's default behavior and would benefit from its own discussion / opt-in flag design — happy to break it out as a follow-up PR if maintainers are interested.

## Architecture

\`\`\`
~/.claude/projects/*/*.jsonl
        │
        ▼  scanner.ts  (filter ancestors via summary.leafUuid chain,
        │               filter happy-tracked claudeSessionIds, project filter, mtime filter)
        ▼
   sessionImporter.ts
        ├── ApiClient.getOrCreateSession({ tag: \`claude-imported:<id>\`, metadata, state })
        ├── ApiSessionClient + sendClaudeSessionMessage  ← reuses
        │     mapClaudeLogMessageToSessionEnvelopes for parity with live sessions
        ├── api.deactivateSession(id)         ← active=false, lifecycleState='running'
        └── upsertEntry → ~/.happy/imported-sessions.json (encryption material captured)

Mobile clicks Resume
        │
        ▼  resume-happy-session RPC → daemon
        ▼
   findTrackedSessionById  (pidToTrackedSession ∪ sessionIdToFinishedSession)
        │ miss
        ▼
   adoptSessionFromImportJournal  ← new fallback: synthesize TrackedSession from journal
        ▼
   buildResumeLaunch + spawn happy claude --resume <claudeUuid> + HAPPY_RECONNECT_*
\`\`\`

## File-by-file

**New (all in `packages/happy-cli/src/import/`):**
- `scanner.ts` — walk `~/.claude/projects`, skip non-UUID names, drop ancestors of resume chains, apply filters
- `jsonlParser.ts` — streaming reader + cheap header read for cwd/sessionId/title
- `importJournal.ts` — atomic lock+rename writes to `~/.happy/imported-sessions.json`
- `messageBackfill.ts` — pushes JSONL lines through the existing session-protocol mapper
- `sessionImporter.ts` — per-candidate orchestration (create → backfill → deactivate → journal)
- `collectHappyTrackedClaudeIds.ts` — server-side dedup: decrypts each persisted session's metadata locally to learn its claudeSessionId
- `daemonAdopt.ts` — synthesize TrackedSession from journal entry for the resume fallback
- `unarchiveImported.ts` — \`--fix-archived\` for journals written before the lifecycleState rule was nailed down
- `pruneImported.ts` — \`--prune-older-than-days N\` to walk back accidental imports

**New (commands):**
- `packages/happy-cli/src/commands/importCommand.ts` — argv parsing + subflag routing

**Modified:**
- `packages/happy-cli/src/index.ts` — registers \`import\` subcommand
- `packages/happy-cli/src/daemon/run.ts` — adopt fallback in \`resumeSession\` (only)

## CLI surface

\`\`\`
happy import [--dry-run] [--yes] [--project <path>] [--days <n>] [--no-backfill] [--limit <n>]
happy import --fix-archived
happy import --prune-older-than-days <n> [--dry-run]
\`\`\`

All operations are end-to-end encrypted client-side as usual; the server only sees opaque ciphertext.

## Tests

32 new unit tests (passing locally, full suite passes):
- \`scanner.test.ts\` (9): leaf-detection chain, projectFilter, journal/server-tracked exclusions, mtime filter, sort
- \`jsonlParser.test.ts\` (10): schema passthrough, lenient invalid-line skip, header extraction, mtime stat
- \`importJournal.test.ts\` (9): atomic round-trip, corrupted-file recovery, schema-mismatch quarantine, dedup by claudeSessionId
- \`daemonAdopt.test.ts\` (3): null on miss, dataKey + legacy variant key reconstruction
- \`autoImportPoll.test.ts\` (4) — *not in this PR but referenced for completeness*

## Notes for reviewers

- **Encryption-key sourcing**: the journal stores per-session keys captured at import time so the daemon's adopt path doesn't need agent.key to decrypt the server metadata. This makes adopt work for users without happy-agent set up. Trade-off: an attacker with read access to \`~/.happy/imported-sessions.json\` learns those keys; same threat model as \`~/.happy/sessions.json\`, which already stores them for daemon-spawned sessions.
- **Tag format**: \`claude-imported:<claudeSessionId>\` makes server-side \`(accountId, tag)\` dedup work even if the local journal is lost — re-running \`happy import\` won't create duplicate Session rows on the server.
- **\`lifecycleState: 'running' + active: false\`** is the explicit choice for imported sessions: \`lifecycleState: 'archived'\` makes the mobile app lock the input box without offering a resume affordance.
- **Resume chains**: when a user runs \`claude --resume X\` natively after import, Claude SDK creates a new JSONL with a new UUID prefixing X's history. The scanner correctly identifies this new file as the leaf via its top-of-file \`{type:"summary",leafUuid:X}\` line, marks X as an ancestor, and skips X on the next scan.

Happy to split this into smaller PRs or rework anything that doesn't fit the project's direction.