### PR TITLE
fix: preserve permission mode across local/remote mode switches

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -5,6 +5,7 @@ import { RemoteModeDisplay } from "@/ui/ink/RemoteModeDisplay";
 import React from "react";
 import { claudeRemote } from "./claudeRemote";
 import { PermissionHandler } from "./utils/permissionHandler";
+import { resolveInitialClaudePermissionMode } from "./utils/permissionMode";
 import { Future } from "@/utils/future";
 import { SDKAssistantMessage, SDKMessage, SDKUserMessage } from "./sdk";
 import { formatClaudeMessageForInk } from "@/ui/messageFormatterInk";
@@ -99,8 +100,12 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
     session.client.rpcHandlerManager.registerHandler('switch', doSwitch); // When switch clicked
     // Removed catch-all stdin handler - now handled by RemoteModeDisplay keyboard handlers
 
-    // Create permission handler
-    const permissionHandler = new PermissionHandler(session);
+    // Create permission handler, restoring the initial permission mode from session
+    // args (e.g. --yolo / --permission-mode bypassPermissions) so that the phone UI
+    // reflects the correct mode immediately when entering remote mode, without waiting
+    // for the first message to arrive.
+    const initialPermissionMode = resolveInitialClaudePermissionMode(undefined, session.claudeArgs) ?? 'default';
+    const permissionHandler = new PermissionHandler(session, initialPermissionMode);
 
     // Drop any permission requests left over in agent state from a
     // previous CLI process that died while a tool prompt was open. The

--- a/packages/happy-cli/src/claude/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.ts
@@ -37,12 +37,15 @@ export class PermissionHandler {
     private allowedBashLiterals = new Set<string>();
     private allowedBashPrefixes = new Set<string>();
     private permissionMode: PermissionMode = 'default';
+    private initialPermissionMode: PermissionMode = 'default';
     private onPermissionRequestCallback?: (toolCallId: string) => void;
     /** Callback to change permission mode on the active query (set by claudeRemote) */
     private setPermissionModeCallback?: (mode: PermissionMode) => Promise<void>;
 
-    constructor(session: Session) {
+    constructor(session: Session, initialPermissionMode: PermissionMode = 'default') {
         this.session = session;
+        this.permissionMode = initialPermissionMode;
+        this.initialPermissionMode = initialPermissionMode;
         this.setupClientHandler();
     }
 
@@ -307,7 +310,7 @@ export class PermissionHandler {
         this.allowedTools.clear();
         this.allowedBashLiterals.clear();
         this.allowedBashPrefixes.clear();
-        this.permissionMode = 'default';
+        this.permissionMode = this.initialPermissionMode;
 
         // Cancel all pending requests
         for (const [, pending] of this.pendingRequests.entries()) {


### PR DESCRIPTION
## Problem

When switching between remote mode (phone) and local mode (terminal) and back, the permission mode shown on the phone UI resets to `default` — even if the session was started with `--yolo` or `--permission-mode bypassPermissions`.

## Root Cause

`claudeRemoteLauncher` creates a new `PermissionHandler` each time remote mode is entered. `PermissionHandler` was hardcoded to start with `permissionMode = 'default'`, ignoring the flags passed at startup (`--yolo`, `--dangerously-skip-permissions`, `--permission-mode`). Similarly, `reset()` hardcoded `this.permissionMode = 'default'`.

The session's `claudeArgs` (which contain the startup flags) were never consulted when initializing the handler.

**Trigger path:**
1. Start happy with `--yolo` or `--permission-mode bypassPermissions`
2. Send a message in remote mode → phone sees correct mode (set via `handleModeChange`)
3. Press space → switch to local mode → `finally` block calls `permissionHandler.reset()`
4. Press space again → switch back to remote mode → new `PermissionHandler('default')` created
5. Phone UI shows `default` until the next message arrives

## Fix

- `PermissionHandler` constructor now accepts an optional `initialPermissionMode` parameter
- `reset()` restores to `initialPermissionMode` instead of hardcoded `'default'`
- `claudeRemoteLauncher` resolves the initial mode from `session.claudeArgs` using the existing `resolveInitialClaudePermissionMode` utility and passes it to the handler

**Changed files:**
- `packages/happy-cli/src/claude/utils/permissionHandler.ts` — constructor + reset
- `packages/happy-cli/src/claude/claudeRemoteLauncher.ts` — pass initial mode

## Test

Start happy with `--yolo`, switch to remote mode, switch to local mode, switch back to remote — phone should show `bypassPermissions` immediately without needing to send a message first.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)