### PR TITLE
fix(app): don't silently drop hasMoreOlder when entry is queued

### DIFF
--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -793,12 +793,33 @@ export const storage = create<StorageState>()((set, get) => {
         applyOlderMessagesPagination: (sessionId: string, info: { hasMore: boolean }) => set((state) => {
             const existing = state.sessionMessages[sessionId];
             if (!existing) {
-                // Pagination metadata is only meaningful once the session has
-                // a SessionMessages entry. The fetch path always creates one
-                // through applyMessages / applyMessagesLoaded before calling
-                // this — but if for any reason it hasn't, ignore the update
-                // rather than synthesize a partial entry.
-                return state;
+                // The fetch path normally creates the SessionMessages entry
+                // through applyMessages / applyMessagesLoaded before reaching
+                // here. With the queue-based scheduler (enqueueMessages), the
+                // actual applyMessages call runs in a separate `lock.inLock`
+                // task that is queued behind the currently-running
+                // fetchInitialLatestPage. So when fetchInitialLatestPage
+                // finishes with `applyOlderMessagesPagination(..., { hasMore })`,
+                // the entry does not exist yet — silently dropping the update
+                // here leaves hasMoreOlder=false forever, which then makes
+                // prefetchOlderMessagesInBackground return immediately and
+                // ChatList's onEndReached handler no-op. Synthesize a minimal
+                // entry so the metadata survives; the queued applyMessages
+                // will merge into it preserving hasMoreOlder.
+                return {
+                    ...state,
+                    sessionMessages: {
+                        ...state.sessionMessages,
+                        [sessionId]: {
+                            messages: [],
+                            messagesMap: {},
+                            reducerState: createReducer(),
+                            isLoaded: false,
+                            hasMoreOlder: info.hasMore,
+                            isLoadingOlder: false
+                        } satisfies SessionMessages
+                    }
+                };
             }
             return {
                 ...state,


### PR DESCRIPTION
## Background

PR #1242 introduced lazy-loaded backward pagination for `GET /v3/sessions/:id/messages` (`before_seq=N`, DESC). Opening a session for the first time fetches the latest 100 messages via `fetchInitialLatestPage`; older history streams in either through `prefetchOlderMessagesInBackground` or, on user scroll, through `ChatList`'s `onEndReached` → `loadOlderMessages`.

Both consumers gate on `state.sessionMessages[sid].hasMoreOlder`. That flag is set by `applyOlderMessagesPagination(sid, { hasMore })`, called at the end of `fetchInitialLatestPage` once the server's `hasMore` is known.

## Problem

When a session has more than ~100 messages, only the latest page is ever visible. Scrolling to the top of the inverted list does nothing, and the background prefetch loop exits at the first iteration. The chat presents as "history truncated".

The bug is silent — no error is logged and the server-side response is correct (the route returns `hasMore: true` as expected).

## Root cause

`fetchInitialLatestPage` (in `packages/happy-app/sources/sync/sync.ts`) runs while `fetchMessages` holds the per-session `sessionMessageLock`. The two relevant lines:

```ts
await this.applyFetchedMessages(sessionId, encryption, messages);   // enqueueMessages
// …compute maxSeq/minSeq, set sessionOldestSeq…
storage.getState().applyOlderMessagesPagination(sessionId, {
    hasMore: !!data.hasMore && messages.length > 0
});
```

`applyFetchedMessages` calls `enqueueMessages`, which pushes the decrypted batch into the per-session queue and schedules a drain via `scheduleQueuedMessagesProcessing`. That drain acquires the **same** `sessionMessageLock` we currently hold — so the actual `applyMessages` call (which is what creates the `SessionMessages` entry in storage) is queued, **not yet executed**.

Then `applyOlderMessagesPagination(sid, { hasMore: true })` runs. Its previous behavior was:

```ts
const existing = state.sessionMessages[sessionId];
if (!existing) {
    // The fetch path always creates one through applyMessages /
    // applyMessagesLoaded before calling this … ignore the update.
    return state;
}
```

That comment was wrong for the initial-load path with the queue-based scheduler — the entry does **not** exist yet. So `hasMore: true` is silently dropped. `applyMessagesLoaded` (called right after) then synthesizes a fresh entry with the default `hasMoreOlder: false`. When the queued `applyMessages` finally runs, it merges the messages into that entry, preserving the false value.

Net effect: `sessionMessages[sid].hasMoreOlder` is permanently `false`. Both consumers bail:

- `sync.prefetchOlderMessagesInBackground` checks `hasMoreOlder` at the top of the loop and returns immediately, so the background fill never runs.
- `ChatList.handleLoadOlder` (the `onEndReached` handler) also checks `hasMoreOlder` and no-ops, so pulling up to load older history does nothing visible.

## Fix

In `applyOlderMessagesPagination`, when no entry exists yet, synthesize a minimal `SessionMessages` with `hasMoreOlder: info.hasMore` and `isLoaded: false` instead of dropping the update.

This mirrors how `applyMessagesLoaded` already handles a missing entry (it synthesizes one with defaults). The queued `applyMessages` later merges its messages into this entry, preserving `hasMoreOlder`; `applyMessagesLoaded`'s else branch (entry already exists) just flips `isLoaded: true`.

Net diff: one branch in one Zustand action.

## Why this didn't regress in #1242's own testing

The smoke path (a fresh session with `messages.length < 100`) has `hasMore: false` from the server, so the dropped update was a no-op anyway. The bug only manifests when a session crosses the initial-page limit — exactly the case the lazy-load PR was designed to fix.

## Proof

Captured by driving the **real store reducers** in the exact order the queue-based scheduler produces: `applyOlderMessagesPagination({ hasMore: true })` lands **before** the `SessionMessages` entry exists, then `applyMessagesLoaded` runs.

![hasMoreOlder race before/after](https://github.com/chphch/happy/releases/download/pr-proofs/1338-hasmoreolder-race.png)

- **Before** — the pagination update is dropped (early-return on the missing entry) → `hasMoreOlder=false` forever → `prefetchOlderMessagesInBackground` returns immediately and `onEndReached` no-ops.
- **After** — the synthesized minimal entry preserves `hasMoreOlder=true`, and the later `applyMessagesLoaded` merges into it (else-branch) keeping it `true` → load-older stays enabled.

Manually, against a session with >100 messages and a cleared local cache: before the fix DevTools shows exactly one `GET …?before_seq=2147483647&limit=100` and no follow-ups despite `hasMore: true` in the response body; after it, that first request is followed by a chain of `?before_seq=<minSeq>&limit=100` requests, and `hasMoreOlder` flips `true → false` only at the true start of history.

## Scope

- One file: `packages/happy-app/sources/sync/storage.ts`.
- No new public API; no schema change; no server change.
- Backward-compatible: sessions where the entry already exists when `applyOlderMessagesPagination` runs (subsequent `loadOlderMessages` paginations, long after the initial-page `applyMessages` has drained) go through the existing else branch unchanged.
- `pnpm --filter happy-app typecheck` clean.
