### PR TITLE
perf(chat): swap FlatList for FlashList in ChatList

### DIFF
--- a/packages/happy-app/sources/components/ChatList.tsx
+++ b/packages/happy-app/sources/components/ChatList.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { useSession, useSessionMessages, useSetting } from "@/sync/storage";
 import { sync } from '@/sync/sync';
-import { ActivityIndicator, FlatList, NativeScrollEvent, NativeSyntheticEvent, Platform, Pressable, View } from 'react-native';
+import { ActivityIndicator, NativeScrollEvent, NativeSyntheticEvent, Platform, Pressable, View } from 'react-native';
+import { FlashList, FlashListRef } from '@shopify/flash-list';
 import { useCallback } from 'react';
 import { useHeaderHeight } from '@/utils/responsive';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -66,7 +67,7 @@ const ChatListInternal = React.memo((props: {
     isLoadingOlder: boolean,
 }) => {
     const { theme } = useUnistyles();
-    const flatListRef = React.useRef<FlatList>(null);
+    const flatListRef = React.useRef<FlashListRef<DisplayItem>>(null);
     const [showScrollButton, setShowScrollButton] = React.useState(false);
     // Tracks whether the scroll-button is currently shown, so we only call
     // setShowScrollButton when the threshold is actually crossed instead of
@@ -202,30 +203,23 @@ const ChatListInternal = React.memo((props: {
 
     return (
         <View style={{ flex: 1 }}>
-            <FlatList
+            <FlashList
                 ref={flatListRef}
                 data={displayItems}
                 inverted={true}
                 keyExtractor={keyExtractor}
                 maintainVisibleContentPosition={{
-                    // Anchor on the second-newest message (index 1), not the
-                    // newest. The newest slot (index 0) gets a brand-new item
-                    // each agent token, which would otherwise destabilise the
-                    // anchor and drag the viewport up.
-                    //
-                    // autoscrollToTopThreshold: for INVERTED lists this is
-                    // actually the auto-stick-to-visual-bottom threshold —
-                    // contentOffset 0 is at the visual bottom in an inverted
-                    // list, and this prop sticks the viewport to offset 0
-                    // when the user is within N units of it.
-                    minIndexForVisible: 1,
+                    // FlashList v2 MVCP. With inverted=true, the FlashList
+                    // engine renders newest (data[0]) at the visual bottom
+                    // and prepends new items there, so autoscrollToTopThreshold
+                    // is the prop that auto-sticks the viewport to newest
+                    // content as new agent tokens stream in.
                     autoscrollToTopThreshold: 50,
                 }}
                 keyboardShouldPersistTaps="handled"
                 keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'none'}
                 renderItem={renderItem}
                 onScroll={handleScroll}
-                scrollEventThrottle={16}
                 ListHeaderComponent={<ListFooter sessionId={props.sessionId} />}
                 ListFooterComponent={<ListHeader isLoadingOlder={props.isLoadingOlder} />}
                 onEndReached={handleLoadOlder}


### PR DESCRIPTION
## Summary

Swap `FlatList` → `@shopify/flash-list` v2 in `ChatList.tsx`. Net diff: -15/+9, single file.

## Motivation

Two cherry-picked perf PRs already land on `chphch/happy:custom` (my self-host daily-driver) — #1245 (re-render isolation) and #1242 (lazy-load + parallel decrypt). Despite these, **clicking into a long session on web (~hundreds of messages) still blocks the paint for multiple seconds.**

#1154 ("perf(chat): fix UI freeze entering large chats on tablets") diagnosed the same root cause for the tablet path and shipped a band-aid (`initialNumToRender=8`, `windowSize=5`, `removeClippedSubviews=true`, etc.). That PR's body explicitly notes:

> `FlashList` would be a better long-term fit for inverted chat lists with variable heights. Also out of scope for this fix.

This PR is that long-term fix.

## Why FlatList tuning props don't help on web

`react-native-web`'s `FlatList` virtualizer does **not** honor `initialNumToRender` / `maxToRenderPerBatch` / `windowSize` / `removeClippedSubviews` the way native does. With `inverted=true` + `maintainVisibleContentPosition` + variable-height messages and no `getItemLayout`, the web shim mounts essentially the full data set on first render to measure heights and compute the inverted scroll anchor. So even with #1154's tuning props the web entry stays slow — it's a fundamental virtualizer mismatch, not a config gap.

## Why FlashList v2

`@shopify/flash-list` v2's RecyclerView engine has first-class web virtualization, supports inverted lists, and exposes the same imperative API we already depend on (`scrollToOffset`, `getScrollableNode`) — so the scroll-to-bottom button and the macOS Shift+wheel handler keep working unchanged.

`@shopify/flash-list` is already a dependency — used by `packages/happy-app/sources/app/(app)/dev/inverted-list.tsx` as a perf experiment page. No `package.json` change.

## Changes

- Replace `FlatList` import + ref type with `FlashList` / `FlashListRef`.
- MVCP semantics change: FlashList v2 inverted uses `autoscrollToTopThreshold` to auto-stick to newest content; `minIndexForVisible: 1` is dropped (FlashList's anchoring is internal).
- Drop unused-by-FlashList tuning props: `scrollEventThrottle={16}` (FlashList manages this).

## Testing

**Dogfood-validated on web:** built `chphch/happy:custom` with this swap, deployed to my self-host (`https://happy.bingsucouple.com`), opened a session with hundreds of messages — **noticeably faster paint, scroll/MVCP behave correctly.** No regressions in basic chat flow, scroll-to-bottom, or new-message auto-stick.

- [x] `pnpm --filter happy-app typecheck` — clean
- [x] Web dogfood on self-host (long session click → fast paint, MVCP sticks on incoming, scroll-to-bottom works)
- [ ] Native iOS / Android verification — **not yet** (I don't have an Android e-ink tablet to verify the #1154 scenario; happy to defer to anyone who does)
- [x] Proof GIF (smoke — chat renders correctly with FlashList) — see comment below

## Interaction with #1154

Both PRs target the same code path. If #1154 lands first, this PR rebases trivially: every tuning prop that #1154 adds (`initialNumToRender`, `maxToRenderPerBatch`, `windowSize`, `removeClippedSubviews`, `scrollEventThrottle=32`) becomes a no-op under FlashList and can be dropped in the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
