### PR TITLE
feat(app): update Claude opus display label to 4.8

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -77,7 +77,7 @@ export function getGeminiPermissionModes(translate: Translate): PermissionMode[]
 export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
-        { key: 'opus', name: 'opus 4.7', description: null },
+        { key: 'opus', name: 'opus 4.8', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },
     ];


### PR DESCRIPTION
## Summary

Claude Opus 4.8 (`claude-opus-4-8`) shipped 2026-05-28. This bumps the Claude model selector's display label from `opus 4.7` → `opus 4.8`.

The `opus` key is a CLI alias that auto-resolves to the latest Opus version over the wire, so the wire/runtime path needs no change — only the dropdown label was stale.

## Changes

- `getClaudeModelModes()` in `packages/happy-app/sources/components/modelModeOptions.ts`: `opus 4.7` → `opus 4.8`

## Verification

- `pnpm --filter happy-app typecheck` passes
- Proof GIF of the model selector showing `opus 4.8` posted below
