### PR TITLE
feat: fetch full model list from gateway for app model picker

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -46,7 +46,9 @@ export async function claudeRemote(opts: {
     onSessionReset?: () => void,
     onSDKMetadata?: (metadata: { tools?: string[]; slashCommands?: string[]; mcpServers?: { name: string; status: string }[]; skills?: string[] }) => void,
     /** Per-turn plan rate-limit delta; the launcher merges it into agent state. */
-    onUsageLimits?: (patch: UsageLimitsPatch) => void
+    onUsageLimits?: (patch: UsageLimitsPatch) => void,
+    /** Called with available models from the SDK right after the query starts */
+    onModelsFound?: (models: Array<{ code: string; value: string; description: string | null }>) => void
 }) {
 
     // Check if session is valid
@@ -169,6 +171,22 @@ export async function claudeRemote(opts: {
         prompt: messages,
         options: sdkOptions,
     });
+
+    // Fetch available models from the SDK.  The SDK returns its native
+    // model list (~5 Claude models).  The full gateway model list is
+    // fetched separately via HTTP in runClaude.ts; this callback adds
+    // any SDK models not already in that list.
+    if (opts.onModelsFound) {
+        response.supportedModels().then((models) => {
+            opts.onModelsFound!(models.map((m) => ({
+                code: m.value,
+                value: m.displayName,
+                description: m.description ?? null,
+            })));
+        }).catch((err) => {
+            logger.debug('[claudeRemote] supportedModels() failed:', err);
+        });
+    }
 
     // Expose query control methods to permission handler
     if (opts.onQueryReady) {

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -392,6 +392,24 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                         sdkToLogConverter.updateSessionId(sessionId);
                         session.onSessionFound(sessionId);
                     },
+                    onModelsFound: (sdkModels) => {
+                        // The primary model list comes from the gateway HTTP
+                        // call in runClaude.ts.  SDK models are a fallback
+                        // enrichment — useful when ANTHROPIC_BASE_URL is not
+                        // set (original Claude Code) and only hardcoded
+                        // aliases are available.
+                        session.client.updateMetadata((currentMetadata) => {
+                            const existing = currentMetadata.models ?? [];
+                            const existingCodes = new Set(existing.map((m) => m.code));
+                            const merged = [...existing];
+                            for (const sdk of sdkModels) {
+                                if (!existingCodes.has(sdk.code)) {
+                                    merged.push(sdk);
+                                }
+                            }
+                            return { ...currentMetadata, models: merged };
+                        });
+                    },
                     onSDKMetadata: (metadata) => {
                         logger.debug('[remote] SDK metadata received, updating session:', metadata);
                         session.client.updateMetadata((currentMetadata) => ({

--- a/packages/happy-cli/src/claude/fetchAvailableModels.ts
+++ b/packages/happy-cli/src/claude/fetchAvailableModels.ts
@@ -1,0 +1,75 @@
+/**
+ * Fetch available models from the Claude-compatible API gateway.
+ *
+ * Reads ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN from the environment
+ * and fetches the /v1/models listing so the Happy app can display
+ * all gateway models — including provider models, 1M-context variants,
+ * and discoverable models — alongside standard Claude aliases.
+ *
+ * Falls back to hardcoded defaults on any error.
+ */
+
+import axios from 'axios';
+
+const HARDCODED_CLAUDE_MODELS: Array<{
+  code: string;
+  value: string;
+  description: string | null;
+}> = [
+  { code: 'default', value: 'default model', description: null },
+  { code: 'opus', value: 'opus 4.7', description: null },
+  { code: 'sonnet', value: 'sonnet 4.6', description: null },
+  { code: 'haiku', value: 'haiku 4.5', description: null },
+];
+
+interface GatewayModel {
+  id: string;
+  display_name: string;
+  created_at: string;
+}
+
+export async function fetchAvailableModels(): Promise<
+  Array<{ code: string; value: string; description: string | null }> | null
+> {
+  const baseUrl = process.env.ANTHROPIC_BASE_URL;
+  if (!baseUrl) return null;
+
+  const authToken = process.env.ANTHROPIC_AUTH_TOKEN || process.env.ANTHROPIC_API_KEY;
+  if (!authToken) return null;
+
+  try {
+    const response = await axios.get<{ data: GatewayModel[] }>(
+      `${baseUrl.replace(/\/+$/, '')}/v1/models`,
+      {
+        headers: { 'x-api-key': authToken },
+        timeout: 10_000,
+        validateStatus: (status) => status < 500,
+      },
+    );
+
+    if (response.status !== 200 || !Array.isArray(response.data?.data)) {
+      return null;
+    }
+
+    const gatewayModels = response.data.data.map((m) => ({
+      code: m.id,
+      value: m.display_name,
+      description: null as string | null,
+    }));
+
+    const seen = new Set(HARDCODED_CLAUDE_MODELS.map((m) => m.code));
+    const deduped = gatewayModels.filter((m) => !seen.has(m.code));
+
+    return [...HARDCODED_CLAUDE_MODELS, ...deduped];
+  } catch {
+    return null;
+  }
+}
+
+export function getHardcodedModels(): Array<{
+  code: string;
+  value: string;
+  description: string | null;
+}> {
+  return HARDCODED_CLAUDE_MODELS;
+}

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -22,6 +22,7 @@ import { registerKillSessionHandler } from './registerKillSessionHandler';
 import { projectPath } from '../projectPath';
 import { resolve } from 'node:path';
 import { startOfflineReconnection, connectionState } from '@/utils/serverConnectionErrors';
+import { fetchAvailableModels, getHardcodedModels } from './fetchAvailableModels';
 import { claudeLocal } from '@/claude/claudeLocal';
 import { createSessionScanner } from '@/claude/utils/sessionScanner';
 import {
@@ -124,6 +125,21 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     const forkedFromMessageId = process.env.HAPPY_FORKED_FROM_MESSAGE_ID;
     const isSideChat = process.env.HAPPY_SIDE_CHAT === '1';
 
+    // Apply Claude env vars early so fetchAvailableModels can reach the
+    // gateway API (needs ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN).
+    if (options.claudeEnvVars) {
+        Object.entries(options.claudeEnvVars).forEach(([key, value]) => {
+            process.env[key] = value;
+        });
+    }
+
+    // Fetch available models from the gateway so the app can display
+    // the full model list — including provider models, 1M-context
+    // variants, and all discoverable models (same source as /model).
+    const availableModels =
+      (await fetchAvailableModels()) ?? getHardcodedModels();
+    const currentModelCode = options.model ?? DEFAULT_CLAUDE_MODEL;
+
     let metadata: Metadata = {
         path: workingDirectory,
         host: os.hostname(),
@@ -143,6 +159,8 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         flavor: 'claude',
         sandbox: sandboxConfig?.enabled ? sandboxConfig : null,
         dangerouslySkipPermissions,
+        models: availableModels,
+        currentModelCode,
         ...(forkedFromSessionId ? { parentSessionId: forkedFromSessionId } : {}),
         ...(forkedFromMessageId ? { forkedFromMessageId } : {}),
         ...(isSideChat ? { isSideChat: true } : {}),
@@ -684,6 +702,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         if (message.meta?.hasOwnProperty('model')) {
             messageModel = message.meta.model || undefined; // null becomes undefined
             currentModel = messageModel;
+            session.updateMetadata((meta) => ({ ...meta, currentModelCode: messageModel ?? undefined }));
             logger.debug(`[loop] Model updated from user message: ${messageModel || 'reset to default'}`);
         } else {
             logger.debug(`[loop] User message received with no model override, using current: ${currentModel || 'default'}`);


### PR DESCRIPTION
Summary

Mobile app's model picker only showed 4 hardcoded Claude aliases (default, opus, sonnet, haiku) — even when connected to a gateway with 100+ available models (using free-claude-code for example). This fetches the full catalog from the
gateway's /v1/models at session start so the app displays every model the gateway exposes: provider models, 1M-context variants, everything. When no gateway is configured, it falls back to the existing
hardcoded list plus SDK-reported models.

What changed

- fetchAvailableModels.ts (new) — GET /v1/models from ANTHROPIC_BASE_URL, merges with 4 hardcoded aliases, deduplicates, falls back on any error
- runClaude.ts — applies gateway env vars early, seeds metadata.models with the full list, propagates currentModelCode on model selection
- claudeRemote.ts — adds onModelsFound callback from supportedModels()
- claudeRemoteLauncher.ts — merges SDK models as fallback enrichment

Proof

Tested end-to-end with a gateway that exposes 135+ models. Before: 4 models in the picker. After: all gateway models appear and are selectable. Fallback path works correctly with ANTHROPIC_BASE_URL unset.

Behavior

| ANTHROPIC_BASE_URL | Models shown                     |
|--------------------|----------------------------------|
| Not set            | 4 hardcoded + SDK models         |
| Gateway configured | 4 aliases + full gateway catalog |