### PR TITLE
feat(app): circular context usage indicator in input bar

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -17,6 +17,7 @@ import { FloatingOverlay } from './FloatingOverlay';
 import { TextInputState, MultiTextInputHandle } from './MultiTextInput';
 import { applySuggestion } from './autocomplete/applySuggestion';
 import { GitStatusBadge, useHasMeaningfulGitStatus } from './GitStatusBadge';
+import { ContextRingIndicator } from './ContextRingIndicator';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useSetting } from '@/sync/storage';
 import { hackMode, hackModes } from '@/sync/modeHacks';
@@ -354,6 +355,13 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     const contextWarning = props.usageData?.contextSize
         ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme)
         : null;
+
+    // Context ring: show when alwaysShowContextSize is on, or when ≤20% remaining
+    const contextPercentUsed = props.usageData?.contextSize
+        ? (props.usageData.contextSize / MAX_CONTEXT_SIZE) * 100
+        : null;
+    const showContextRing = contextPercentUsed !== null
+        && (props.alwaysShowContextSize || (100 - contextPercentUsed) <= 20);
 
     const agentInputEnterToSend = useSetting('agentInputEnterToSend');
 
@@ -1172,6 +1180,13 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                             )}
                                         </Pressable>
                                     </Shaker>
+                                )}
+
+                                {/* Context ring indicator */}
+                                {showContextRing && contextPercentUsed !== null && (
+                                    <View style={{ justifyContent: 'center', height: 32 }}>
+                                        <ContextRingIndicator percentageUsed={contextPercentUsed} />
+                                    </View>
                                 )}
 
                                 {/* Git Status Badge */}

--- a/packages/happy-app/sources/components/ContextRingIndicator.tsx
+++ b/packages/happy-app/sources/components/ContextRingIndicator.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { View, Text, Platform } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+import { useUnistyles } from 'react-native-unistyles';
+import { Typography } from '@/constants/Typography';
+
+const SIZE = 24;
+const STROKE_WIDTH = 2.5;
+const RADIUS = (SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+interface ContextRingIndicatorProps {
+    /** 0–100 percentage of context already used */
+    percentageUsed: number;
+}
+
+function getRingColor(percentRemaining: number, theme: { colors: { success: string; warning: string; warningCritical: string } }) {
+    if (percentRemaining <= 5) return theme.colors.warningCritical;
+    if (percentRemaining <= 15) return theme.colors.warning;
+    return theme.colors.success;
+}
+
+export const ContextRingIndicator = React.memo(function ContextRingIndicator({ percentageUsed }: ContextRingIndicatorProps) {
+    const { theme } = useUnistyles();
+    const clamped = Math.max(0, Math.min(100, percentageUsed));
+    const percentRemaining = 100 - clamped;
+    const strokeDashoffset = CIRCUMFERENCE * (1 - clamped / 100);
+    const ringColor = getRingColor(percentRemaining, theme);
+
+    return (
+        <View style={{
+            width: SIZE,
+            height: SIZE,
+            alignItems: 'center',
+            justifyContent: 'center',
+        }}>
+            <Svg width={SIZE} height={SIZE}>
+                {/* Background track */}
+                <Circle
+                    cx={SIZE / 2}
+                    cy={SIZE / 2}
+                    r={RADIUS}
+                    stroke={theme.colors.divider}
+                    strokeWidth={STROKE_WIDTH}
+                    fill="none"
+                />
+                {/* Filled arc — starts from 12 o'clock */}
+                <Circle
+                    cx={SIZE / 2}
+                    cy={SIZE / 2}
+                    r={RADIUS}
+                    stroke={ringColor}
+                    strokeWidth={STROKE_WIDTH}
+                    fill="none"
+                    strokeDasharray={`${CIRCUMFERENCE}`}
+                    strokeDashoffset={strokeDashoffset}
+                    strokeLinecap="round"
+                    rotation={-90}
+                    origin={`${SIZE / 2}, ${SIZE / 2}`}
+                />
+            </Svg>
+            {/* Center percentage text */}
+            <Text style={{
+                position: 'absolute',
+                fontSize: 7,
+                color: ringColor,
+                ...Typography.default('semiBold'),
+                // Vertically center the text; web needs a small nudge
+                ...(Platform.OS === 'web' ? { top: 7.5 } : {}),
+            }}>
+                {Math.round(percentRemaining)}
+            </Text>
+        </View>
+    );
+});


### PR DESCRIPTION
## Summary

- Adds a compact circular ring indicator next to the abort button showing context window usage as a visual progress ring
- Ring shows remaining context percentage (number in center), with color transitions: green (>15%) → gray (5–15%) → red (≤5%)
- Appears when `alwaysShowContextSize` setting is enabled, or automatically when remaining context drops below 20%
- Uses `react-native-svg` (already a dependency) for the ring; ~75 lines in a standalone `ContextRingIndicator` component

Refs #582

## Proof

Building web proof — will post a screenshot/GIF as a follow-up comment.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)