### PR TITLE
fix(deps): bump zod to ^4 to resolve claude-agent-sdk peer conflict

### DIFF
--- a/packages/happy-app/package.json
+++ b/packages/happy-app/package.json
@@ -198,7 +198,7 @@
     "twrnc": "^4.9.1",
     "uuid": "^11.1.0",
     "vitest": "^3.2.4",
-    "zod": "3.25.76",
+    "zod": "^4.0.0",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -106,7 +106,7 @@
     "tmp": "^0.2.5",
     "tweetnacl": "^1.0.3",
     "ws": "^8.19.0",
-    "zod": "3.25.76"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@eslint/compat": "^1",

--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -92,7 +92,7 @@
     "cross-spawn": "^7.0.6",
     "expo-server-sdk": "^3.15.0",
     "fastify": "^5.6.2",
-    "fastify-type-provider-zod": "4.0.2",
+    "fastify-type-provider-zod": "^6.1.0",
     "http-proxy": "^1.18.1",
     "http-proxy-middleware": "^3.0.5",
     "ink": "^6.5.1",

--- a/packages/happy-server/package.json
+++ b/packages/happy-server/package.json
@@ -82,7 +82,7 @@
     "dotenv": "^16.4.5",
     "elevenlabs": "^1.54.0",
     "fastify": "^5.2.0",
-    "fastify-type-provider-zod": "^4.0.2",
+    "fastify-type-provider-zod": "^6.1.0",
     "ioredis": "^5.6.1",
     "jsonwebtoken": "^9.0.2",
     "minio": "^8.0.5",
@@ -102,7 +102,7 @@
     "tmp": "^0.2.3",
     "tweetnacl": "^1.0.3",
     "uuid": "^9.0.1",
-    "zod": "3.25.76",
+    "zod": "^4.0.0",
     "zod-to-json-schema": "^3.24.3"
   },
   "publishConfig": {

--- a/packages/happy-wire/package.json
+++ b/packages/happy-wire/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^2.2.2",
-    "zod": "3.25.76"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": ">=20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,8 +849,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.4.3
       zustand:
         specifier: ^5.0.6
         version: 5.0.10(@types/react@19.1.17)(immer@11.1.3)(react@19.2.0)(use-sync-external-store@1.6.0(react@19.2.0))
@@ -908,16 +908,16 @@ importers:
     dependencies:
       '@agentclientprotocol/sdk':
         specifier: ^0.14.1
-        version: 0.14.1(zod@3.25.76)
+        version: 0.14.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.96
-        version: 0.2.96(zod@3.25.76)
+        version: 0.2.96(zod@4.4.3)
       '@anthropic-ai/sandbox-runtime':
         specifier: ^0.0.37
         version: 0.0.37
       '@modelcontextprotocol/sdk':
         specifier: 1.25.3
-        version: 1.25.3(hono@4.12.12)(zod@3.25.76)
+        version: 1.25.3(hono@4.12.12)(zod@4.4.3)
       '@noble/ed25519':
         specifier: ^3.0.0
         version: 3.0.0
@@ -953,7 +953,7 @@ importers:
         version: 0.2.6
       ai:
         specifier: ^5.0.107
-        version: 5.0.123(zod@3.25.76)
+        version: 5.0.123(zod@4.4.3)
       axios:
         specifier: ^1.13.2
         version: 1.13.4
@@ -971,7 +971,7 @@ importers:
         version: 5.7.2
       fastify-type-provider-zod:
         specifier: 4.0.2
-        version: 4.0.2(fastify@5.7.2)(zod@3.25.76)
+        version: 4.0.2(fastify@5.7.2)(zod@4.4.3)
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1(debug@4.4.3)
@@ -1012,8 +1012,8 @@ importers:
         specifier: ^8.19.0
         version: 8.19.0
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@eslint/compat':
         specifier: ^1
@@ -1103,8 +1103,8 @@ importers:
         specifier: ^5.2.0
         version: 5.7.2
       fastify-type-provider-zod:
-        specifier: ^4.0.2
-        version: 4.0.2(fastify@5.7.2)(zod@3.25.76)
+        specifier: ^6.1.0
+        version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.7.2)(openapi-types@12.1.3)(zod@4.4.3)
       ioredis:
         specifier: ^5.6.1
         version: 5.9.2
@@ -1163,11 +1163,11 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.4.3
       zod-to-json-schema:
         specifier: ^3.24.3
-        version: 3.25.2(zod@3.25.76)
+        version: 3.25.2(zod@4.4.3)
     devDependencies:
       '@types/chalk':
         specifier: ^2.2.0
@@ -1218,8 +1218,8 @@ importers:
         specifier: ^2.2.2
         version: 2.3.1
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: '>=20'
@@ -2904,6 +2904,9 @@ packages:
 
   '@fastify/static@8.3.0':
     resolution: {integrity: sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
@@ -5694,6 +5697,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -7901,6 +7905,14 @@ packages:
       fastify: ^5.0.0
       zod: ^3.14.2
 
+  fastify-type-provider-zod@6.1.0:
+    resolution: {integrity: sha512-Sl19VZFSX4W/+AFl3hkL5YgWk3eDXZ4XYOdrq94HunK+o7GQBCAqgk7+3gPXoWkF0bNxOiIgfnFGJJ3i9a2BtQ==}
+    peerDependencies:
+      '@fastify/swagger': '>=9.5.1'
+      fastify: ^5.5.0
+      openapi-types: ^12.1.3
+      zod: '>=4.1.5'
+
   fastify@5.7.2:
     resolution: {integrity: sha512-dBJolW+hm6N/yJVf6J5E1BxOBNkuXNl405nrfeR8SpvGWG3aCC2XDHyiFBdow8Win1kj7sjawQc257JlYY6M/A==}
 
@@ -8885,6 +8897,10 @@ packages:
 
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
 
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
@@ -9978,6 +9994,9 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -12652,23 +12671,23 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@0.14.1(zod@3.25.76)':
+  '@agentclientprotocol/sdk@0.14.1(zod@4.4.3)':
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
-  '@ai-sdk/gateway@2.0.29(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.29(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.4.3)
       '@vercel/oidc': 3.1.0
-      zod: 3.25.76
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.20(zod@3.25.76)':
+  '@ai-sdk/provider-utils@3.0.20(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@ai-sdk/provider@2.0.1':
     dependencies:
@@ -12710,11 +12729,11 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.143':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.96(zod@3.25.76)':
+  '@anthropic-ai/claude-agent-sdk@0.2.96(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.80.0(zod@3.25.76)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
-      zod: 3.25.76
+      '@anthropic-ai/sdk': 0.80.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -12788,11 +12807,11 @@ snapshots:
       shell-quote: 1.8.3
       zod: 3.25.76
 
-  '@anthropic-ai/sdk@0.80.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.80.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
   '@anthropic-ai/sdk@0.96.0(zod@4.4.3)':
     dependencies:
@@ -14519,6 +14538,16 @@ snapshots:
       fastq: 1.20.1
       glob: 11.1.0
 
+  '@fastify/swagger@9.7.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -15393,7 +15422,7 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@modelcontextprotocol/sdk@1.25.3(hono@4.12.12)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.25.3(hono@4.12.12)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.12)
       ajv: 8.17.1
@@ -15409,32 +15438,10 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - hono
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.12)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
-      jose: 6.2.2
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
       - supports-color
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
@@ -17940,13 +17947,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.123(zod@3.25.76):
+  ai@5.0.123(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 2.0.29(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.29(zod@4.4.3)
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
@@ -20337,12 +20344,20 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify-type-provider-zod@4.0.2(fastify@5.7.2)(zod@3.25.76):
+  fastify-type-provider-zod@4.0.2(fastify@5.7.2)(zod@4.4.3):
     dependencies:
       '@fastify/error': 4.2.0
       fastify: 5.7.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+
+  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.7.2)(openapi-types@12.1.3)(zod@4.4.3):
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@fastify/swagger': 9.7.0
+      fastify: 5.7.2
+      openapi-types: 12.1.3
+      zod: 4.4.3
 
   fastify@5.7.2:
     dependencies:
@@ -21460,6 +21475,14 @@ snapshots:
   json-schema-ref-resolver@3.0.0:
     dependencies:
       dequal: 2.0.3
+
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3
+      fast-uri: 3.1.0
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   json-schema-to-ts@3.1.1:
     dependencies:
@@ -22967,6 +22990,8 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openapi-types@12.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -26038,10 +26063,6 @@ snapshots:
   yoctocolors@2.1.2: {}
 
   yoga-layout@3.2.1: {}
-
-  zod-to-json-schema@3.25.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -970,8 +970,8 @@ importers:
         specifier: ^5.6.2
         version: 5.7.2
       fastify-type-provider-zod:
-        specifier: 4.0.2
-        version: 4.0.2(fastify@5.7.2)(zod@4.4.3)
+        specifier: ^6.1.0
+        version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.7.2)(openapi-types@12.1.3)(zod@4.4.3)
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1(debug@4.4.3)
@@ -7898,12 +7898,6 @@ packages:
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
-
-  fastify-type-provider-zod@4.0.2:
-    resolution: {integrity: sha512-FDRzSL3ZuoZ+4YDevR1YOinmDKkxOdy3QB9dDR845sK+bQvDroPKhHAXLEAOObDxL7SMA0OZN/A4osrNBTdDTQ==}
-    peerDependencies:
-      fastify: ^5.0.0
-      zod: ^3.14.2
 
   fastify-type-provider-zod@6.1.0:
     resolution: {integrity: sha512-Sl19VZFSX4W/+AFl3hkL5YgWk3eDXZ4XYOdrq94HunK+o7GQBCAqgk7+3gPXoWkF0bNxOiIgfnFGJJ3i9a2BtQ==}
@@ -20343,13 +20337,6 @@ snapshots:
       strnum: 1.1.2
 
   fastify-plugin@5.1.0: {}
-
-  fastify-type-provider-zod@4.0.2(fastify@5.7.2)(zod@4.4.3):
-    dependencies:
-      '@fastify/error': 4.2.0
-      fastify: 5.7.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.7.2)(openapi-types@12.1.3)(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## Summary

`happy@1.1.8+` pins `zod@3.25.76` while `@anthropic-ai/claude-agent-sdk` (≥0.2.119) requires `zod@^4.0.0`. Every `npm install -g happy` produces ERESOLVE warnings and risks two zod copies sharing module boundaries at runtime. This PR bumps zod to `^4` across all four workspace packages and updates `fastify-type-provider-zod` to the zod-4-compatible major.

Fixes #1265. Unblocks #1344 (Opus 4.8 selection — model label refresh remains the cosmetic change tracked in #1345).

## Changes

- `zod`: `3.25.76` → `^4.0.0` in
  - `packages/happy-app/package.json`
  - `packages/happy-cli/package.json`
  - `packages/happy-server/package.json`
  - `packages/happy-wire/package.json`
- `fastify-type-provider-zod`: `^4.0.2` → `^6.1.0` in `packages/happy-server/package.json`
  - v4 only supports zod 3; without this bump, request validation errors surface as `500` instead of `400` (caught by `v3SessionRoutes.test.ts` and `attachmentRoutes.spec.ts`).
- `pnpm-lock.yaml` regenerated.

No source code migration was required — existing schema definitions (`z.record(K, V)` two-arg form, `z.string().uuid()`, `z.preprocess`, `.passthrough()`, etc.) are already zod-4 compatible.

`packages/codium` was already on `zod@4.4.3`; this PR brings the rest of the monorepo in line.

## Verification

All package builds and test suites green on this branch:

| Package | Command | Result |
|---|---|---|
| happy-wire | `pnpm --filter @slopus/happy-wire test` | 19/19 pass |
| happy-cli | `pnpm --filter happy test` | 512/512 pass |
| happy-server | `pnpm --filter happy-server-self-host test` | 67/67 pass (the 4 previously-failing validation tests now pass thanks to the fastify-type-provider-zod bump) |
| happy-app | `pnpm --filter happy-app test --run` | 487/487 pass (57 platform-specific skipped) |
| codium | `pnpm --filter codium build` | bundles cleanly |

Typecheck passes for every package.

## Notes

- This PR is **scoped to the peer-dep fix only**. The Opus 4.8 model-label refresh is a separate cosmetic change already up as #1345.
- Visual proof of "before/after install warnings" isn't applicable here — the change is in lockfile/peer-dep resolution. Reproduce locally: `npm install -g happy@1.1.10` warns, `npm install -g .` from this branch's `packages/happy-cli` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)