### PR TITLE
fix(app): preserve localId in reducer UserTextMessage for slash command suppress

### DIFF
--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -128,6 +128,7 @@ type ReducerMessage = {
     tool: ToolCall | null;
     meta?: MessageMeta;
     claudeUuid?: string;
+    localId?: string | null;
 }
 
 type StoredPermission = {
@@ -667,6 +668,7 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
                 event: null,
                 meta: msg.meta,
                 claudeUuid: msg.claudeUuid,
+                localId: msg.localId ?? null,
             });
 
             // Track both localId and messageId
@@ -1162,7 +1164,7 @@ function convertReducerMessageToMessage(reducerMsg: ReducerMessage, state: Reduc
     if (reducerMsg.role === 'user' && reducerMsg.text !== null) {
         return {
             id: reducerMsg.id,
-            localId: null,
+            localId: reducerMsg.localId ?? null,
             createdAt: reducerMsg.createdAt,
             kind: 'user-text',
             text: reducerMsg.text,


### PR DESCRIPTION
## Summary

`convertReducerMessageToMessage` hardcoded `localId: null` for `user-text` messages, causing `isUserSlashCommandEcho` to always receive `hasLocalId=false` and never suppress the optimistic echo. The slash command chip feature introduced in commit 3204dd2f was therefore broken from the start — the suppress logic existed but never triggered on mobile platforms where the reducer path is used.

## Root Cause

`ReducerMessage` type had no `localId` field. The `localId` was stored in `state.localIds` map (for deduplication purposes) but was dropped when building the `ReducerMessage` object and again when `convertReducerMessageToMessage` converted it to `Message`. As a result, `MessageView.tsx`'s suppress check:

```typescript
if (isClaudeFlavor && isUserSlashCommandEcho(props.message.text, props.message.localId != null)) {
    return null;
}
```

had `props.message.localId` always `null`, so the condition was never satisfied.

## Fix

Three minimal changes (+3 lines, -1 line) to `reducer.ts`:

1. Add `localId?: string | null` field to `ReducerMessage` type
2. Propagate `localId: msg.localId ?? null` when creating UserText ReducerMessage  
3. Use `reducerMsg.localId ?? null` in `convertReducerMessageToMessage` instead of hardcoded `null`

## Reproducer

Send `/foo bar` in any session with an active CC process. Before this fix, the optimistic echo bubble remains permanently visible. After the fix, the echo is suppressed once the SDK injects the `<command-message>` wrapper.

## Verification

Full-stack E2E verified on iOS Simulator — TC-B55-07 in easyfan/happy IT26 (2026-06-05). The `parseLocalCommandMessage.spec.ts` unit tests (14 cases) already cover `isUserSlashCommandEcho` correctly; the bug was upstream in the reducer layer which unit tests couldn't reach.