### PR TITLE
fix(android): new session bottom sheet follows IME keyboard

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -15,6 +15,11 @@ import {
     NativeSyntheticEvent,
     Image as RNImage,
 } from 'react-native';
+import ReanimatedAnimated, {
+    useSharedValue,
+    useAnimatedStyle,
+    withTiming,
+} from 'react-native-reanimated';
 import { GlassView } from 'expo-glass-effect';
 import { Ionicons, Octicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
@@ -27,7 +32,7 @@ import {
 } from '@/components/MultiTextInput';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
+import { KeyboardAvoidingView, useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
 import Constants from 'expo-constants';
 import { useHeaderHeight } from '@/utils/responsive';
 import { t } from '@/text';
@@ -161,23 +166,28 @@ function BottomSheet({
         );
     }
 
-    // Android: slide-up sheet with backdrop
+    // Android: slide-up sheet with backdrop, follows keyboard
     const fadeAnim = React.useRef(new Animated.Value(0)).current;
-    const slideAnim = React.useRef(new Animated.Value(300)).current;
+    const slideAnim = useSharedValue(300);
+    const { height: keyboardAnimation } = useReanimatedKeyboardAnimation();
 
     React.useEffect(() => {
         if (visible) {
-            Animated.parallel([
-                Animated.timing(fadeAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
-                Animated.spring(slideAnim, { toValue: 0, damping: 25, stiffness: 300, useNativeDriver: true }),
-            ]).start();
+            Animated.timing(fadeAnim, { toValue: 1, duration: 250, useNativeDriver: true }).start();
+            slideAnim.value = withTiming(0, { duration: 200 });
         } else {
-            Animated.parallel([
-                Animated.timing(fadeAnim, { toValue: 0, duration: 200, useNativeDriver: true }),
-                Animated.timing(slideAnim, { toValue: 300, duration: 200, useNativeDriver: true }),
-            ]).start();
+            Animated.timing(fadeAnim, { toValue: 0, duration: 200, useNativeDriver: true }).start();
+            slideAnim.value = withTiming(300, { duration: 200 });
         }
     }, [visible, fadeAnim, slideAnim]);
+
+    const animatedSheetStyle = useAnimatedStyle(() => {
+        // keyboardAnimation.value is 0 when keyboard closed, negative when open
+        const kbOffset = keyboardAnimation.value < 0 ? keyboardAnimation.value + 8 : 0;
+        return {
+            transform: [{ translateY: slideAnim.value + kbOffset }],
+        };
+    });
 
     return (
         <RNModal
@@ -190,21 +200,21 @@ function BottomSheet({
                 <TouchableWithoutFeedback onPress={onClose}>
                     <Animated.View style={[sheetStyles.backdrop, { opacity: fadeAnim }]} />
                 </TouchableWithoutFeedback>
-                <Animated.View
+                <ReanimatedAnimated.View
                     style={[
                         sheetStyles.sheet,
                         {
                             backgroundColor: theme.colors.header.background,
                             paddingBottom: Math.max(16, safeArea.bottom),
-                            transform: [{ translateY: slideAnim }],
                         },
+                        animatedSheetStyle,
                     ]}
                 >
                     <View style={sheetStyles.handleRow}>
                         <View style={[sheetStyles.handle, { backgroundColor: theme.colors.textSecondary }]} />
                     </View>
                     {children}
-                </Animated.View>
+                </ReanimatedAnimated.View>
             </View>
         </RNModal>
     );


### PR DESCRIPTION
### Problem

On Android, when creating a new session and tapping the project/path or worktree row, a bottom sheet opens with a `TextInput`. The auto-focused text field triggers the software keyboard, but the bottom sheet (rendered inside `RNModal`) stays anchored to the physical screen bottom — the keyboard **covers** the input field, the Done button, and the lower portion of the picker list. The screen-level `KeyboardAvoidingView` cannot help because `RNModal` lives in a separate native surface.

### Fix

Make the Android branch of `BottomSheet` keyboard-aware by leveraging `useReanimatedKeyboardAnimation` from `react-native-keyboard-controller` (already a project dependency, already used in `AgentContentView.ios.tsx` and `PlaceholderContainerView.tsx`).

- Replace React Native `Animated.Value` with Reanimated `useSharedValue` for the sheet slide transform
- Read live IME height via `useReanimatedKeyboardAnimation` and combine it with the sheet's open/close translateY via `useAnimatedStyle`
- The sheet now tracks the keyboard animation continuously, staying above the IME with an 8px gap
- Replace `Animated.spring` (which caused a bouncy open animation that blocked input) with `withTiming(200ms)` for a smooth, responsive transition

**No changes** to iOS (`presentationStyle="formSheet"` handles this natively) or Web (uses inline popover).

Before：
*worktree
<img width="242" height="539" alt="worktree遮挡" src="https://github.com/user-attachments/assets/98140de7-651a-47bc-930a-48c5b934bcbe" />
(picker stays visible)
<img width="236" height="534" alt="键盘遮挡" src="https://github.com/user-attachments/assets/9b1f07be-4e07-4157-b011-9f637c997653" />

After：
<img width="235" height="542" alt="{1FCF9CA8-5D84-4746-B21D-DD4F4AB43651}" src="https://github.com/user-attachments/assets/5f89b469-a3d9-4c3c-a8b4-f9f824ea0cd0" />

### Files changed

- `packages/happy-app/sources/app/(app)/new/index.tsx` — Android `BottomSheet` component