### PR TITLE
fix(android): smooth session composer keyboard tracking

### DIFF
--- a/packages/happy-app/sources/components/AgentContentView.tsx
+++ b/packages/happy-app/sources/components/AgentContentView.tsx
@@ -1,8 +1,9 @@
 import { useHeaderHeight } from '@/utils/responsive';
 import * as React from 'react';
-import { View } from 'react-native';
+import { View, Platform } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { useKeyboardState } from 'react-native-keyboard-controller';
+import { useKeyboardHandler, useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface AgentContentViewProps {
@@ -14,35 +15,56 @@ interface AgentContentViewProps {
 export const AgentContentView: React.FC<AgentContentViewProps> = React.memo(({ input, content, placeholder }) => {
     const safeArea = useSafeAreaInsets();
     const headerHeight = useHeaderHeight();
-    const state = useKeyboardState();
+    const keyboard = useReanimatedKeyboardAnimation();
+    const animatedPadding = useSharedValue(0);
+
+    useKeyboardHandler({
+        onEnd(e) {
+            'worklet';
+            animatedPadding.value = e.progress === 1 ? (-keyboard.height.value - safeArea.bottom) : 0;
+        },
+        onStart(e) {
+            'worklet';
+            animatedPadding.value = 0;
+        },
+    }, [safeArea.bottom]);
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        paddingTop: animatedPadding.value,
+        transform: [{ translateY: keyboard.height.value + safeArea.bottom * keyboard.progress.value }],
+    }), [safeArea.bottom]);
+
+    const animatedInputStyle = useAnimatedStyle(() => ({
+        transform: [{ translateY: keyboard.height.value + safeArea.bottom * keyboard.progress.value }],
+    }), [safeArea.bottom]);
+
+    const animatedPlaceholderStyle = useAnimatedStyle(() => ({
+        paddingTop: keyboard.progress.value === 1 ? keyboard.height.value : 0,
+        transform: [{ translateY: (keyboard.height.value + safeArea.bottom * keyboard.progress.value) / 2 }],
+    }), [safeArea.bottom]);
+
     return (
-        <View style={{ flexBasis:0, flexGrow:1, paddingBottom: state.isVisible ? state.height - safeArea.bottom : 0 }}>
-            <View style={{ flexBasis:0, flexGrow:1 }}>
+        <View style={{ flexBasis: 0, flexGrow: 1 }}>
+            <View style={{ flexBasis: 0, flexGrow: 1 }}>
                 {content && (
-                    <View style={[{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }]}>
+                    <Animated.View style={[{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }, animatedStyle]}>
                         {content}
-                    </View>
+                    </Animated.View>
                 )}
                 {placeholder && (
-                    <ScrollView
-                        style={[{ position: 'absolute', top: safeArea.top + headerHeight, left: 0, right: 0, bottom: 0 }]}
+                    <Animated.ScrollView
+                        style={[{ position: 'absolute', top: safeArea.top + headerHeight, left: 0, right: 0, bottom: 0 }, animatedPlaceholderStyle]}
                         contentContainerStyle={{ alignItems: 'center', justifyContent: 'center', flex: 1 }}
                         keyboardShouldPersistTaps="handled"
                         alwaysBounceVertical={false}
                     >
                         {placeholder}
-                    </ScrollView>
+                    </Animated.ScrollView>
                 )}
             </View>
-            <View>
+            <Animated.View style={[animatedInputStyle]}>
                 {input}
-            </View>
+            </Animated.View>
         </View>
     );
 });
-
-// const FallbackKeyboardAvoidingView: React.FC<AgentContentViewProps> = React.memo(({
-//     children,
-// }) => {
-    
-// });


### PR DESCRIPTION
### Problem

On Android, when tapping the composer in an existing session, the composer jumps to its final position **after** the keyboard finishes animating, rather than tracking the IME animation continuously. This is because the default `AgentContentView` uses `useKeyboardState()` which only exposes the settled keyboard height, not the animated values.

The iOS implementation (`AgentContentView.ios.tsx`) already uses `useReanimatedKeyboardAnimation` for smooth tracking — Android was falling back to the default file.

### Fix

Update the default `AgentContentView.tsx` to use the same Reanimated keyboard-animation pattern as the iOS variant:

- Replace `useKeyboardState` with `useReanimatedKeyboardAnimation` for continuous keyboard height/progress values
- Use `useKeyboardHandler` + `useSharedValue` for persisted content padding after keyboard settles
- Apply `useAnimatedStyle` transforms to content, placeholder, and input views so they track the IME animation frame-by-frame
- Replace `View` / `ScrollView` with `Animated.View` / `Animated.ScrollView` from `react-native-reanimated`

The iOS file (`AgentContentView.ios.tsx`) is left unchanged — this only affects the fallback path used by Android and web.

### Files changed

- `packages/happy-app/sources/components/AgentContentView.tsx`

### Before:
<img width="456" height="1020" alt="会话未优雅上移的GIF" src="https://github.com/user-attachments/assets/34c59dca-31eb-40fd-a173-549c7fd6ade1" />

### After
<img width="456" height="1020" alt="带对话的优雅上移压缩" src="https://github.com/user-attachments/assets/acca2447-74c4-41f2-85f4-cefaaac66623" />


