### PR TITLE
feat(server): add archived session timestamp

### DIFF
--- a/packages/happy-server/prisma/migrations/20260608171100_add_session_archived_at/migration.sql
+++ b/packages/happy-server/prisma/migrations/20260608171100_add_session_archived_at/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Session" ADD COLUMN "archivedAt" TIMESTAMP(3);

--- a/packages/happy-server/prisma/schema.prisma
+++ b/packages/happy-server/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Session {
     seq               Int              @default(0)
     active            Boolean          @default(true)
     lastActiveAt      DateTime         @default(now())
+    archivedAt        DateTime?
     createdAt         DateTime         @default(now())
     updatedAt         DateTime         @updatedAt
     messages          SessionMessage[]


### PR DESCRIPTION
## Summary

- Adds nullable `Session.archivedAt` to the Prisma schema.
- Adds migration `20260608171100_add_session_archived_at` with `ALTER TABLE "Session" ADD COLUMN "archivedAt" TIMESTAMP(3);`.
- Intentionally does not change app/server/CLI runtime behavior in this PR.

## Migration plan

1. Merge and deploy this schema PR first.
2. Run the Prisma migration before shipping archive-aware runtime code.
3. Merge/deploy follow-up archive lifecycle PR #1371 after this column exists.
4. Rollback is low-risk: the column is nullable and old runtime code ignores it.

## Test plan

- `pnpm --dir packages/happy-server generate`
- `git diff --check upstream/main..feat/session-archived-at-schema`
