### PR TITLE
feat(session): use archivedAt for session archive lifecycle

### DIFF
--- a/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
+++ b/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { SessionListViewItem, useSessionListViewData, useSetting } from '@/sync/storage';
+import { isArchivedSession } from '@/sync/sessionArchiveState';
 
 export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
     const data = useSessionListViewData();
@@ -17,7 +18,7 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
         for (const item of data) {
             if (item.type === 'active-sessions') {
                 result.push(item);
-            } else if (item.type === 'session' && !item.session.active) {
+            } else if (item.type === 'session' && isArchivedSession(item.session)) {
                 hasInactive = true;
             }
         }
@@ -42,7 +43,7 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
                 }
 
                 if (item.type === 'session') {
-                    if (!item.session.active) {
+                    if (isArchivedSession(item.session)) {
                         if (pendingProjectGroup) {
                             result.push(pendingProjectGroup);
                             pendingProjectGroup = null;

--- a/packages/happy-app/sources/sync/apiTypes.ts
+++ b/packages/happy-app/sources/sync/apiTypes.ts
@@ -185,6 +185,7 @@ export const ApiEphemeralActivityUpdateSchema = z.object({
     active: z.boolean(),
     activeAt: z.number(),
     thinking: z.boolean(),
+    archivedAt: z.number().nullable().optional(),
 });
 
 export const ApiEphemeralUsageUpdateSchema = z.object({

--- a/packages/happy-app/sources/sync/reducer/activityUpdateAccumulator.test.ts
+++ b/packages/happy-app/sources/sync/reducer/activityUpdateAccumulator.test.ts
@@ -99,6 +99,34 @@ describe('ActivityUpdateAccumulator Smart Debounce', () => {
             );
         });
 
+        it('should emit immediately when archivedAt changes explicitly', () => {
+            const update1: ApiEphemeralActivityUpdate = {
+                type: 'activity',
+                id: 'session1',
+                active: false,
+                activeAt: 1000,
+                thinking: false,
+                archivedAt: null
+            };
+
+            const update2: ApiEphemeralActivityUpdate = {
+                type: 'activity',
+                id: 'session1',
+                active: false,
+                activeAt: 1000,
+                thinking: false,
+                archivedAt: 1000
+            };
+
+            accumulator.addUpdate(update1);
+            accumulator.addUpdate(update2);
+
+            expect(mockFlushHandler).toHaveBeenCalledTimes(2);
+            expect(mockFlushHandler).toHaveBeenNthCalledWith(2,
+                new Map([['session1', update2]])
+            );
+        });
+
         it('should emit immediately for first update to new session', () => {
             const update: ApiEphemeralActivityUpdate = {
                 type: 'activity',

--- a/packages/happy-app/sources/sync/reducer/activityUpdateAccumulator.ts
+++ b/packages/happy-app/sources/sync/reducer/activityUpdateAccumulator.ts
@@ -2,7 +2,7 @@ import type { ApiEphemeralActivityUpdate } from '../apiTypes';
 
 export class ActivityUpdateAccumulator {
     private pendingUpdates = new Map<string, ApiEphemeralActivityUpdate>();
-    private lastEmittedStates = new Map<string, { active: boolean; thinking: boolean; activeAt: number }>();
+    private lastEmittedStates = new Map<string, { active: boolean; thinking: boolean; activeAt: number; archivedAt?: number | null }>();
     private timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     constructor(
@@ -22,6 +22,7 @@ export class ActivityUpdateAccumulator {
         const isSignificantChange = !lastState || 
             lastState.active !== update.active || 
             lastState.thinking !== update.thinking ||
+            (update.archivedAt !== undefined && lastState.archivedAt !== update.archivedAt) ||
             isCriticalTimestamp;
 
         if (isSignificantChange) {
@@ -64,7 +65,8 @@ export class ActivityUpdateAccumulator {
                 this.lastEmittedStates.set(sessionId, {
                     active: update.active,
                     thinking: update.thinking,
-                    activeAt: update.activeAt
+                    activeAt: update.activeAt,
+                    archivedAt: update.archivedAt === undefined ? this.lastEmittedStates.get(sessionId)?.archivedAt : update.archivedAt
                 });
             }
             

--- a/packages/happy-app/sources/sync/sessionArchiveState.test.ts
+++ b/packages/happy-app/sources/sync/sessionArchiveState.test.ts
@@ -7,4 +7,22 @@ describe("isArchivedSession", () => {
         expect(isArchivedSession({ active: false, archivedAt: undefined })).toBe(false);
         expect(isArchivedSession({ active: true, archivedAt: 1710000000000 })).toBe(true);
     });
+
+    it("falls back to legacy lifecycle metadata when archivedAt has not been backfilled", () => {
+        expect(isArchivedSession({
+            active: false,
+            archivedAt: null,
+            metadata: { lifecycleState: "archived" },
+        })).toBe(true);
+        expect(isArchivedSession({
+            active: false,
+            archivedAt: undefined,
+            lifecycleState: "archiveRequested",
+        })).toBe(true);
+        expect(isArchivedSession({
+            active: false,
+            archivedAt: null,
+            metadata: { lifecycleState: "running" },
+        })).toBe(false);
+    });
 });

--- a/packages/happy-app/sources/sync/sessionArchiveState.test.ts
+++ b/packages/happy-app/sources/sync/sessionArchiveState.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { isArchivedSession } from "./sessionArchiveState";
+
+describe("isArchivedSession", () => {
+    it("uses archivedAt as the archive bucket signal instead of process liveness", () => {
+        expect(isArchivedSession({ active: false, archivedAt: null })).toBe(false);
+        expect(isArchivedSession({ active: false, archivedAt: undefined })).toBe(false);
+        expect(isArchivedSession({ active: true, archivedAt: 1710000000000 })).toBe(true);
+    });
+});

--- a/packages/happy-app/sources/sync/sessionArchiveState.ts
+++ b/packages/happy-app/sources/sync/sessionArchiveState.ts
@@ -1,0 +1,3 @@
+export function isArchivedSession(session: { active?: boolean; archivedAt?: number | null }): boolean {
+    return session.archivedAt != null;
+}

--- a/packages/happy-app/sources/sync/sessionArchiveState.ts
+++ b/packages/happy-app/sources/sync/sessionArchiveState.ts
@@ -1,3 +1,19 @@
-export function isArchivedSession(session: { active?: boolean; archivedAt?: number | null }): boolean {
-    return session.archivedAt != null;
+type ArchiveStateInput = {
+    active?: boolean;
+    archivedAt?: number | null;
+    lifecycleState?: string | null;
+    metadata?: {
+        lifecycleState?: string | null;
+    } | null;
+};
+
+const LEGACY_ARCHIVED_LIFECYCLE_STATES = new Set(["archiveRequested", "archived"]);
+
+export function isArchivedSession(session: ArchiveStateInput): boolean {
+    if (session.archivedAt != null) {
+        return true;
+    }
+
+    const lifecycleState = session.lifecycleState ?? session.metadata?.lifecycleState;
+    return lifecycleState != null && LEGACY_ARCHIVED_LIFECYCLE_STATES.has(lifecycleState);
 }

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -30,6 +30,7 @@ import { getCurrentRealtimeSessionId, getVoiceSession } from '@/realtime/Realtim
 import { isMutableTool } from "@/components/tools/knownTools";
 import { DecryptedArtifact } from "./artifactTypes";
 import { FeedItem } from "./feedTypes";
+import { isArchivedSession } from "./sessionArchiveState";
 
 // Debounce timer for realtimeMode changes
 let realtimeModeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -87,6 +88,7 @@ export interface SessionRowData {
     createdAt?: number;
     hasDraft: boolean;
     active: boolean;
+    archivedAt: number | null;
     machineId: string | null;
     path: string | null;
     homeDir: string | null;
@@ -120,6 +122,7 @@ function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): 
         ...(!session.active && { activeAt: session.activeAt, createdAt: session.createdAt }),
         hasDraft: !!session.draft,
         active: session.active,
+        archivedAt: session.archivedAt,
         machineId: session.metadata?.machineId ?? null,
         path: session.metadata?.path ?? null,
         homeDir: session.metadata?.homeDir ?? null,
@@ -235,15 +238,16 @@ function buildSessionListViewData(
     sessions: Record<string, Session>,
     unreadSessionIds?: Set<string>,
 ): SessionListViewItem[] {
-    // Separate active and inactive sessions
+    // Separate current and archived sessions. `active` is only process
+    // liveness; `archivedAt` is the user intent to retire a session.
     const activeSessions: Session[] = [];
     const inactiveSessions: Session[] = [];
 
     Object.values(sessions).forEach(session => {
-        if (isSessionActive(session)) {
-            activeSessions.push(session);
-        } else {
+        if (isArchivedSession(session)) {
             inactiveSessions.push(session);
+        } else {
+            activeSessions.push(session);
         }
     });
 
@@ -441,7 +445,7 @@ export const storage = create<StorageState>()((set, get) => {
             // Build active set from all sessions (including existing ones)
             const activeSet = new Set<string>();
             Object.values(mergedSessions).forEach(session => {
-                if (isSessionActive(session)) {
+                if (!isArchivedSession(session)) {
                     activeSet.add(session.id);
                 }
             });

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -89,6 +89,7 @@ export interface SessionRowData {
     hasDraft: boolean;
     active: boolean;
     archivedAt: number | null;
+    lifecycleState: string | null;
     machineId: string | null;
     path: string | null;
     homeDir: string | null;
@@ -123,6 +124,7 @@ function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): 
         hasDraft: !!session.draft,
         active: session.active,
         archivedAt: session.archivedAt,
+        lifecycleState: session.metadata?.lifecycleState ?? null,
         machineId: session.metadata?.machineId ?? null,
         path: session.metadata?.path ?? null,
         homeDir: session.metadata?.homeDir ?? null,

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -104,6 +104,7 @@ export interface Session {
     updatedAt: number,
     active: boolean,
     activeAt: number,
+    archivedAt: number | null,
     metadata: Metadata | null,
     metadataVersion: number,
     agentState: AgentState | null,

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -918,6 +918,7 @@ class Sync {
             dataEncryptionKey: string | null;
             active: boolean;
             activeAt: number;
+            archivedAt?: number | null;
             createdAt: number;
             updatedAt: number;
             lastMessage: ApiMessage | null;
@@ -958,6 +959,7 @@ class Sync {
             // Put it all together
             const processedSession = {
                 ...session,
+                archivedAt: session.archivedAt ?? null,
                 thinking: false,
                 thinkingAt: 0,
                 metadata,
@@ -2615,6 +2617,7 @@ class Sync {
                     ...session,
                     active: update.active,
                     activeAt: update.activeAt,
+                    archivedAt: update.archivedAt === undefined ? session.archivedAt : update.archivedAt,
                     thinking: update.thinking ?? false,
                     thinkingAt: update.activeAt // Always use activeAt for consistency
                 });

--- a/packages/happy-cli/src/api/api.ts
+++ b/packages/happy-cli/src/api/api.ts
@@ -404,15 +404,10 @@ export class ApiClient {
   }
 
   /**
-   * Mark a session as inactive on the server (active=false). Does NOT
-   * change `lifecycleState`, so the session remains visible in the app
-   * and resumable — same effect as the in-app "Archive" button hitting
-   * the /archive endpoint, but without the extra metadata.
+   * Mark a session as archived on the server.
    *
-   * Used during graceful shutdown (Ctrl-C / SIGTERM) as a synchronous
-   * fallback for the socket-based session-end signal: even if the
-   * socket emit doesn't drain before the process exits, the HTTP
-   * response confirms the deactivate landed.
+   * The endpoint writes server-side archive intent (`archivedAt`), so callers
+   * must only use it for explicit archive flows, not Ctrl-C/SIGTERM cleanup.
    */
   async deactivateSession(sessionId: string): Promise<boolean> {
     try {

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.test.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockClaudeRemote } = vi.hoisted(() => ({
+    mockClaudeRemote: vi.fn(),
+}));
+
+vi.mock('./claudeRemote', () => ({
+    claudeRemote: mockClaudeRemote,
+}));
+
+vi.mock('ink', () => ({
+    render: vi.fn(() => ({ unmount: vi.fn() })),
+}));
+
+vi.mock('@/ui/ink/messageBuffer', () => ({
+    MessageBuffer: class {
+        addMessage = vi.fn();
+        clear = vi.fn();
+    },
+}));
+
+vi.mock('@/ui/ink/RemoteModeDisplay', () => ({
+    RemoteModeDisplay: vi.fn(),
+}));
+
+vi.mock('@/ui/messageFormatterInk', () => ({
+    formatClaudeMessageForInk: vi.fn(),
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+    },
+}));
+
+vi.mock('@/utils/terminalStdinCleanup', () => ({
+    cleanupStdinAfterInk: vi.fn(async () => {}),
+}));
+
+vi.mock('./utils/questionNotification', () => ({
+    getAskUserQuestionToolCallIds: vi.fn(() => []),
+}));
+
+vi.mock('./utils/permissionHandler', () => ({
+    PermissionHandler: class {
+        handleToolCall = vi.fn();
+        handleModeChange = vi.fn();
+        isAborted = vi.fn(() => false);
+        reset = vi.fn();
+        setOnPermissionRequest = vi.fn();
+        setPermissionModeUpdater = vi.fn();
+        getResponses = vi.fn(() => new Map());
+    },
+}));
+
+vi.mock('./utils/sdkToLogConverter', () => ({
+    SDKToLogConverter: class {
+        convert = vi.fn(() => null);
+        convertSidechainUserMessage = vi.fn(() => null);
+        generateInterruptedToolResult = vi.fn(() => null);
+        resetParentChain = vi.fn();
+        updateSessionId = vi.fn();
+    },
+}));
+
+import { claudeRemoteLauncher } from './claudeRemoteLauncher';
+
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+    return new Promise((_, reject) => {
+        if (signal.aborted) {
+            reject(new Error('aborted'));
+            return;
+        }
+        signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+    });
+}
+
+function resolveOnAbort(signal: AbortSignal): Promise<void> {
+    return new Promise((resolve) => {
+        if (signal.aborted) {
+            resolve();
+            return;
+        }
+        signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+}
+
+describe('claudeRemoteLauncher', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('treats abort-triggered remote errors as cancelled turns', async () => {
+        const handlers = new Map<string, (payload?: unknown) => Promise<void>>();
+        const session = {
+            sessionId: 'claude-session-1',
+            path: '/tmp/project',
+            allowedTools: [],
+            mcpServers: {},
+            hookSettingsPath: '/tmp/hook-settings.json',
+            queue: {
+                waitForMessagesAndGetAsString: vi.fn(),
+                size: vi.fn(() => 0),
+            },
+            client: {
+                sessionId: 'happy-session-1',
+                sendClaudeSessionMessage: vi.fn(),
+                sendSessionEvent: vi.fn(),
+                closeClaudeSessionTurn: vi.fn(),
+                getMetadata: vi.fn(() => ({})),
+                updateMetadata: vi.fn(),
+                rpcHandlerManager: {
+                    registerHandler: vi.fn((name: string, handler: (payload?: unknown) => Promise<void>) => {
+                        handlers.set(name, handler);
+                    }),
+                },
+            },
+            api: {
+                push: vi.fn(() => ({
+                    sendSessionNotification: vi.fn(),
+                })),
+            },
+            onAbort: vi.fn(),
+            onSessionFound: vi.fn(),
+            onThinkingChange: vi.fn(),
+            clearSessionId: vi.fn(),
+            consumeOneTimeFlags: vi.fn(),
+        };
+
+        mockClaudeRemote
+            .mockImplementationOnce(async (opts: { signal: AbortSignal }) => {
+                await rejectOnAbort(opts.signal);
+            })
+            .mockImplementationOnce(async (opts: { signal: AbortSignal }) => {
+                await resolveOnAbort(opts.signal);
+            });
+
+        const launcher = claudeRemoteLauncher(session as any);
+
+        await vi.waitFor(() => {
+            expect(handlers.get('abort')).toBeDefined();
+        });
+
+        await handlers.get('abort')!({});
+
+        expect(session.client.closeClaudeSessionTurn).toHaveBeenCalledWith('cancelled');
+        expect(session.client.closeClaudeSessionTurn).not.toHaveBeenCalledWith('failed');
+        expect(session.client.sendSessionEvent).toHaveBeenCalledWith({ type: 'message', message: 'Aborted by user' });
+        expect(session.client.sendSessionEvent).not.toHaveBeenCalledWith({ type: 'message', message: 'Process exited unexpectedly' });
+
+        await vi.waitFor(() => {
+            expect(mockClaudeRemote).toHaveBeenCalledTimes(2);
+        });
+
+        await handlers.get('switch')!({});
+
+        await expect(launcher).resolves.toBe('switch');
+    });
+});

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -445,8 +445,13 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
             } catch (e) {
                 logger.debug('[remote]: launch error', e);
                 if (!exitReason) {
-                    session.client.closeClaudeSessionTurn('failed');
-                    session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                    if (abortController?.signal.aborted) {
+                        session.client.closeClaudeSessionTurn('cancelled');
+                        session.client.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
+                    } else {
+                        session.client.closeClaudeSessionTurn('failed');
+                        session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                    }
                     continue;
                 }
             } finally {

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -32,6 +32,7 @@ import { getProjectPath } from './utils/path';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { RawJSONLinesSchema, type RawJSONLines } from './types';
+import { shouldPostArchiveEndpoint } from '@/session/archiveIntent';
 
 /** JavaScript runtime to use for spawning Claude Code */
 export type JsRuntime = 'node' | 'bun'
@@ -704,17 +705,12 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
                 // Send session death message
                 session.sendSessionDeath();
 
-                // Belt-and-braces: also POST /v1/sessions/<id>/archive so
-                // the server flips active=false even if the socket emit
-                // didn't drain before close. The HTTP endpoint touches
-                // only `active` and `lastActiveAt` — it doesn't write
-                // archive metadata — so this is safe in the archive=false
-                // case too, and matches the "session goes inactive but
-                // stays resumable" semantics we want for Ctrl-C.
-                try {
-                    await api.deactivateSession(session.sessionId);
-                } catch (err) {
-                    logger.debug('[START] deactivateSession during cleanup failed:', err);
+                if (shouldPostArchiveEndpoint(opts)) {
+                    try {
+                        await api.deactivateSession(session.sessionId);
+                    } catch (err) {
+                        logger.debug('[START] archiveSession during cleanup failed:', err);
+                    }
                 }
 
                 await session.flush();

--- a/packages/happy-cli/src/codex/codexTurnErrorPolicy.test.ts
+++ b/packages/happy-cli/src/codex/codexTurnErrorPolicy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCodexTurnErrorDisposition } from './codexTurnErrorPolicy';
+
+describe('resolveCodexTurnErrorDisposition', () => {
+    it('treats errors after a user abort as aborts while the session stays alive', () => {
+        expect(resolveCodexTurnErrorDisposition({
+            abortRequested: true,
+            shouldExit: false,
+        })).toBe('user-abort');
+    });
+
+    it('keeps normal turn errors classified as unexpected exits', () => {
+        expect(resolveCodexTurnErrorDisposition({
+            abortRequested: false,
+            shouldExit: false,
+        })).toBe('unexpected-exit');
+    });
+
+    it('does not suppress errors while exiting the whole session', () => {
+        expect(resolveCodexTurnErrorDisposition({
+            abortRequested: true,
+            shouldExit: true,
+        })).toBe('unexpected-exit');
+    });
+});

--- a/packages/happy-cli/src/codex/codexTurnErrorPolicy.ts
+++ b/packages/happy-cli/src/codex/codexTurnErrorPolicy.ts
@@ -1,0 +1,11 @@
+export type CodexTurnErrorDisposition = 'user-abort' | 'unexpected-exit';
+
+export function resolveCodexTurnErrorDisposition(opts: {
+    abortRequested: boolean;
+    shouldExit: boolean;
+}): CodexTurnErrorDisposition {
+    if (opts.abortRequested && !opts.shouldExit) {
+        return 'user-abort';
+    }
+    return 'unexpected-exit';
+}

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -35,6 +35,7 @@ import { resolveCodexExecutionPolicy } from './executionPolicy';
 import { mapCodexMcpMessageToSessionEnvelopes, mapCodexProcessorMessageToSessionEnvelopes } from './utils/sessionProtocolMapper';
 import { resumeExistingThread } from './resumeExistingThread';
 import { emitReadyIfIdle } from './emitReadyIfIdle';
+import { resolveCodexTurnErrorDisposition } from './codexTurnErrorPolicy';
 
 /**
  * Extracts a human-readable error from a codex task_complete/turn_aborted event.
@@ -362,6 +363,7 @@ export async function runCodex(opts: {
     // Turn cancellation uses client.interruptTurn() — no AbortController hack needed.
     let abortController = new AbortController();
     let shouldExit = false;
+    let abortRequested = false;
 
     /**
      * Handles aborting the current task/inference without exiting the process.
@@ -375,6 +377,7 @@ export async function runCodex(opts: {
         }
 
         logger.debug('[Codex] Abort requested - stopping current task');
+        abortRequested = true;
         abortInProgress = (async () => {
             try {
                 // Resolve any pending permission requests as 'abort' first.
@@ -442,6 +445,7 @@ export async function runCodex(opts: {
                 
                 // Send session death message
                 session.sendSessionDeath();
+                await api.deactivateSession(session.sessionId);
                 await session.flush();
                 await session.close();
             }
@@ -718,6 +722,7 @@ export async function runCodex(opts: {
 
             // Display user messages in the UI
             messageBuffer.addMessage(message.message, 'user');
+            abortRequested = false;
 
             try {
                 // Map permission mode to approval policy and sandbox.
@@ -763,9 +768,16 @@ export async function runCodex(opts: {
             } catch (error) {
                 // Only actual errors reach here (process crash, connection failure, etc.)
                 logger.warn('Error in codex session:', error);
-                messageBuffer.addMessage('Process exited unexpectedly', 'status');
-                session.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                const disposition = resolveCodexTurnErrorDisposition({ abortRequested, shouldExit });
+                if (disposition === 'user-abort') {
+                    messageBuffer.addMessage('Aborted by user', 'status');
+                    session.sendSessionEvent({ type: 'message', message: 'Aborted by user' });
+                } else {
+                    messageBuffer.addMessage('Process exited unexpectedly', 'status');
+                    session.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                }
             } finally {
+                abortRequested = false;
                 // Reset permission handler, reasoning processor, and diff processor
                 permissionHandler.reset();
                 reasoningProcessor.abort();  // Use abort to properly finish any in-progress tool calls

--- a/packages/happy-cli/src/session/archiveIntent.test.ts
+++ b/packages/happy-cli/src/session/archiveIntent.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { shouldPostArchiveEndpoint } from './archiveIntent';
+
+describe('shouldPostArchiveEndpoint', () => {
+    it('posts archive only for explicit archive cleanup', () => {
+        expect(shouldPostArchiveEndpoint({ archive: true })).toBe(true);
+        expect(shouldPostArchiveEndpoint({ archive: false })).toBe(false);
+    });
+
+    it('preserves archived cleanup as the default for crash handlers', () => {
+        expect(shouldPostArchiveEndpoint({})).toBe(true);
+    });
+});

--- a/packages/happy-cli/src/session/archiveIntent.ts
+++ b/packages/happy-cli/src/session/archiveIntent.ts
@@ -1,0 +1,3 @@
+export function shouldPostArchiveEndpoint(opts: { archive?: boolean }): boolean {
+    return opts.archive ?? true;
+}

--- a/packages/happy-server/prisma/migrations/20260608171100_add_session_archived_at/migration.sql
+++ b/packages/happy-server/prisma/migrations/20260608171100_add_session_archived_at/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Session" ADD COLUMN "archivedAt" TIMESTAMP(3);

--- a/packages/happy-server/prisma/schema.prisma
+++ b/packages/happy-server/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Session {
     seq               Int              @default(0)
     active            Boolean          @default(true)
     lastActiveAt      DateTime         @default(now())
+    archivedAt        DateTime?
     createdAt         DateTime         @default(now())
     updatedAt         DateTime         @updatedAt
     messages          SessionMessage[]

--- a/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
@@ -7,6 +7,7 @@ import { log } from "@/utils/log";
 import { randomKeyNaked } from "@/utils/randomKeyNaked";
 import { allocateUserSeq } from "@/storage/seq";
 import { sessionDelete } from "@/app/session/sessionDelete";
+import { activityCache } from "@/app/presence/sessionCache";
 
 export function sessionRoutes(app: Fastify) {
 
@@ -32,6 +33,7 @@ export function sessionRoutes(app: Fastify) {
                 dataEncryptionKey: true,
                 active: true,
                 lastActiveAt: true,
+                archivedAt: true,
                 // messages: {
                 //     orderBy: { seq: 'desc' },
                 //     take: 1,
@@ -59,6 +61,7 @@ export function sessionRoutes(app: Fastify) {
                     updatedAt: sessionUpdatedAt,
                     active: v.active,
                     activeAt: v.lastActiveAt.getTime(),
+                    archivedAt: v.archivedAt?.getTime() ?? null,
                     metadata: v.metadata,
                     metadataVersion: v.metadataVersion,
                     agentState: v.agentState,
@@ -86,6 +89,7 @@ export function sessionRoutes(app: Fastify) {
             where: {
                 accountId: userId,
                 active: true,
+                archivedAt: null,
                 lastActiveAt: { gt: new Date(Date.now() - 1000 * 60 * 15) /* 15 minutes */ }
             },
             orderBy: { lastActiveAt: 'desc' },
@@ -102,6 +106,7 @@ export function sessionRoutes(app: Fastify) {
                 dataEncryptionKey: true,
                 active: true,
                 lastActiveAt: true,
+                archivedAt: true,
             }
         });
 
@@ -113,6 +118,7 @@ export function sessionRoutes(app: Fastify) {
                 updatedAt: v.updatedAt.getTime(),
                 active: v.active,
                 activeAt: v.lastActiveAt.getTime(),
+                archivedAt: v.archivedAt?.getTime() ?? null,
                 metadata: v.metadata,
                 metadataVersion: v.metadataVersion,
                 agentState: v.agentState,
@@ -182,6 +188,7 @@ export function sessionRoutes(app: Fastify) {
                 dataEncryptionKey: true,
                 active: true,
                 lastActiveAt: true,
+                archivedAt: true,
             }
         });
 
@@ -204,6 +211,7 @@ export function sessionRoutes(app: Fastify) {
                 updatedAt: v.updatedAt.getTime(),
                 active: v.active,
                 activeAt: v.lastActiveAt.getTime(),
+                archivedAt: v.archivedAt?.getTime() ?? null,
                 metadata: v.metadata,
                 metadataVersion: v.metadataVersion,
                 agentState: v.agentState,
@@ -238,19 +246,29 @@ export function sessionRoutes(app: Fastify) {
         });
         if (session) {
             log({ module: 'session-create', sessionId: session.id, userId, tag }, `Found existing session: ${session.id} for tag ${tag}`);
+            const resumedSession = await db.session.update({
+                where: { id: session.id },
+                data: {
+                    active: true,
+                    archivedAt: null,
+                    lastActiveAt: new Date()
+                }
+            });
+            activityCache.invalidateSession(resumedSession.id);
             return reply.send({
                 session: {
-                    id: session.id,
-                    seq: session.seq,
-                    metadata: session.metadata,
-                    metadataVersion: session.metadataVersion,
-                    agentState: session.agentState,
-                    agentStateVersion: session.agentStateVersion,
-                    dataEncryptionKey: session.dataEncryptionKey ? Buffer.from(session.dataEncryptionKey).toString('base64') : null,
-                    active: session.active,
-                    activeAt: session.lastActiveAt.getTime(),
-                    createdAt: session.createdAt.getTime(),
-                    updatedAt: session.updatedAt.getTime(),
+                    id: resumedSession.id,
+                    seq: resumedSession.seq,
+                    metadata: resumedSession.metadata,
+                    metadataVersion: resumedSession.metadataVersion,
+                    agentState: resumedSession.agentState,
+                    agentStateVersion: resumedSession.agentStateVersion,
+                    dataEncryptionKey: resumedSession.dataEncryptionKey ? Buffer.from(resumedSession.dataEncryptionKey).toString('base64') : null,
+                    active: resumedSession.active,
+                    activeAt: resumedSession.lastActiveAt.getTime(),
+                    archivedAt: resumedSession.archivedAt?.getTime() ?? null,
+                    createdAt: resumedSession.createdAt.getTime(),
+                    updatedAt: resumedSession.updatedAt.getTime(),
                     lastMessage: null
                 }
             });
@@ -297,6 +315,7 @@ export function sessionRoutes(app: Fastify) {
                     dataEncryptionKey: session.dataEncryptionKey ? Buffer.from(session.dataEncryptionKey).toString('base64') : null,
                     active: session.active,
                     activeAt: session.lastActiveAt.getTime(),
+                    archivedAt: session.archivedAt?.getTime() ?? null,
                     createdAt: session.createdAt.getTime(),
                     updatedAt: session.updatedAt.getTime(),
                     lastMessage: null
@@ -366,17 +385,19 @@ export function sessionRoutes(app: Fastify) {
         const userId = request.userId;
         const { sessionId } = request.params;
 
+        const archivedAt = new Date();
         const result = await db.session.updateMany({
             where: { id: sessionId, accountId: userId },
-            data: { active: false, lastActiveAt: new Date() }
+            data: { active: false, archivedAt, lastActiveAt: archivedAt }
         });
 
         if (result.count === 0) {
             return reply.code(404).send({ error: 'Session not found' });
         }
+        activityCache.invalidateSession(sessionId);
 
         // Notify all clients about the session deactivation
-        const sessionActivity = buildSessionActivityEphemeral(sessionId, false, Date.now(), false);
+        const sessionActivity = buildSessionActivityEphemeral(sessionId, false, archivedAt.getTime(), false, archivedAt.getTime());
         eventRouter.emitEphemeral({
             userId,
             payload: sessionActivity,

--- a/packages/happy-server/sources/app/events/eventRouter.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.ts
@@ -64,6 +64,7 @@ export type UpdateEvent = {
     dataEncryptionKey: string | null;
     active: boolean;
     activeAt: number;
+    archivedAt: number | null;
     createdAt: number;
     updatedAt: number;
 } | {
@@ -169,6 +170,7 @@ export type EphemeralEvent = {
     active: boolean;
     activeAt: number;
     thinking?: boolean;
+    archivedAt?: number | null;
 } | {
     type: 'machine-activity';
     id: string;
@@ -345,6 +347,7 @@ export function buildNewSessionUpdate(session: {
     dataEncryptionKey: Uint8Array | null;
     active: boolean;
     lastActiveAt: Date;
+    archivedAt: Date | null;
     createdAt: Date;
     updatedAt: Date;
 }, updateSeq: number, updateId: string): UpdatePayload {
@@ -362,6 +365,7 @@ export function buildNewSessionUpdate(session: {
             dataEncryptionKey: session.dataEncryptionKey ? Buffer.from(session.dataEncryptionKey).toString('base64') : null,
             active: session.active,
             activeAt: session.lastActiveAt.getTime(),
+            archivedAt: session.archivedAt?.getTime() ?? null,
             createdAt: session.createdAt.getTime(),
             updatedAt: session.updatedAt.getTime()
         },
@@ -496,13 +500,14 @@ export function buildDeleteMachineUpdate(machineId: string, updateSeq: number, u
     };
 }
 
-export function buildSessionActivityEphemeral(sessionId: string, active: boolean, activeAt: number, thinking?: boolean): EphemeralPayload {
+export function buildSessionActivityEphemeral(sessionId: string, active: boolean, activeAt: number, thinking?: boolean, archivedAt?: number | null): EphemeralPayload {
     return {
         type: 'activity',
         id: sessionId,
         active,
         activeAt,
-        thinking: thinking || false
+        thinking: thinking || false,
+        ...(archivedAt !== undefined ? { archivedAt } : {})
     };
 }
 

--- a/packages/happy-server/sources/app/presence/sessionCache.spec.ts
+++ b/packages/happy-server/sources/app/presence/sessionCache.spec.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock } = vi.hoisted(() => ({
+    dbMock: {
+        session: {
+            findUnique: vi.fn(),
+            update: vi.fn(),
+            updateMany: vi.fn(),
+        },
+        machine: {
+            findUnique: vi.fn(),
+            update: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/storage/db", () => ({ db: dbMock }));
+vi.mock("@/utils/log", () => ({ log: vi.fn() }));
+vi.mock("@/app/monitoring/metrics2", () => ({
+    sessionCacheCounter: { inc: vi.fn() },
+    databaseUpdatesSkippedCounter: { inc: vi.fn() },
+}));
+
+describe("ActivityCache session archive handling", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-06-08T00:00:00.000Z"));
+        dbMock.session.findUnique.mockReset();
+        dbMock.session.update.mockReset();
+        dbMock.session.updateMany.mockReset();
+        dbMock.machine.findUnique.mockReset();
+        dbMock.machine.update.mockReset();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("does not validate archived sessions for presence updates", async () => {
+        dbMock.session.findUnique.mockResolvedValue({
+            id: "session-1",
+            accountId: "user-1",
+            lastActiveAt: new Date(Date.now() - 60_000),
+            archivedAt: new Date(Date.now() - 1_000),
+        });
+
+        const { activityCache } = await import("./sessionCache");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(false);
+        expect(activityCache.queueSessionUpdate("session-1", Date.now())).toBe(false);
+    });
+
+    it("flushes stale pending heartbeats only for non-archived sessions", async () => {
+        dbMock.session.findUnique.mockResolvedValue({
+            id: "session-1",
+            accountId: "user-1",
+            lastActiveAt: new Date(Date.now() - 60_000),
+            archivedAt: null,
+        });
+        dbMock.session.updateMany.mockResolvedValue({ count: 1 });
+
+        const { activityCache } = await import("./sessionCache");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+        expect(activityCache.queueSessionUpdate("session-1", Date.now())).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        expect(dbMock.session.updateMany).toHaveBeenCalledWith({
+            where: { id: "session-1", archivedAt: null },
+            data: { lastActiveAt: new Date("2026-06-08T00:00:00.000Z"), active: true },
+        });
+        expect(dbMock.session.update).not.toHaveBeenCalled();
+    });
+
+    it("can invalidate a cached session after archive state changes", async () => {
+        dbMock.session.findUnique
+            .mockResolvedValueOnce({
+                id: "session-1",
+                accountId: "user-1",
+                lastActiveAt: new Date(Date.now() - 60_000),
+                archivedAt: null,
+            })
+            .mockResolvedValueOnce({
+                id: "session-1",
+                accountId: "user-1",
+                lastActiveAt: new Date(Date.now() - 60_000),
+                archivedAt: new Date(Date.now() - 1_000),
+            });
+
+        const { activityCache } = await import("./sessionCache");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+        activityCache.invalidateSession("session-1");
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(false);
+
+        expect(dbMock.session.findUnique).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/happy-server/sources/app/presence/sessionCache.ts
+++ b/packages/happy-server/sources/app/presence/sessionCache.ts
@@ -7,6 +7,7 @@ interface SessionCacheEntry {
     lastUpdateSent: number;
     pendingUpdate: number | null;
     userId: string;
+    archivedAt: number | null;
 }
 
 interface MachineCacheEntry {
@@ -53,7 +54,7 @@ class ActivityCache {
         // Check cache first
         if (cached && cached.validUntil > now && cached.userId === userId) {
             sessionCacheCounter.inc({ operation: 'session_validation', result: 'hit' });
-            return true;
+            return cached.archivedAt === null;
         }
         
         sessionCacheCounter.inc({ operation: 'session_validation', result: 'miss' });
@@ -70,9 +71,10 @@ class ActivityCache {
                     validUntil: now + this.CACHE_TTL,
                     lastUpdateSent: session.lastActiveAt.getTime(),
                     pendingUpdate: null,
-                    userId
+                    userId,
+                    archivedAt: session.archivedAt?.getTime() ?? null
                 });
-                return true;
+                return session.archivedAt === null;
             }
             
             return false;
@@ -128,6 +130,9 @@ class ActivityCache {
         if (!cached) {
             return false; // Should validate first
         }
+        if (cached.archivedAt !== null) {
+            return false;
+        }
         
         // Only queue if time difference is significant
         const timeDiff = Math.abs(timestamp - cached.lastUpdateSent);
@@ -138,6 +143,10 @@ class ActivityCache {
         
         databaseUpdatesSkippedCounter.inc({ type: 'session' });
         return false; // No update needed
+    }
+
+    invalidateSession(sessionId: string): void {
+        this.sessionCache.delete(sessionId);
     }
 
     queueMachineUpdate(machineId: string, timestamp: number): boolean {
@@ -186,12 +195,18 @@ class ActivityCache {
         // Batch update sessions
         if (sessionUpdates.length > 0) {
             try {
-                await Promise.all(sessionUpdates.map(update =>
-                    db.session.update({
-                        where: { id: update.id },
+                const results = await Promise.all(sessionUpdates.map(update =>
+                    db.session.updateMany({
+                        where: { id: update.id, archivedAt: null },
                         data: { lastActiveAt: new Date(update.timestamp), active: true }
                     })
                 ));
+
+                for (let i = 0; i < results.length; i++) {
+                    if (results[i].count === 0) {
+                        this.sessionCache.delete(sessionUpdates[i].id);
+                    }
+                }
                 
                 log({ module: 'session-cache' }, `Flushed ${sessionUpdates.length} session updates`);
             } catch (error) {

--- a/packages/happy-server/sources/storage/types.ts
+++ b/packages/happy-server/sources/storage/types.ts
@@ -41,6 +41,7 @@ declare global {
             dataEncryptionKey: string | null;
             active: boolean;
             activeAt: number;
+            archivedAt: number | null;
             createdAt: number;
             updatedAt: number;
         } | {


### PR DESCRIPTION
## Summary

- Uses `Session.archivedAt` as the archive intent signal while keeping `active` as process liveness.
- Updates server session routes/events/cache so archived sessions are not revived by presence heartbeats, and resume clears `archivedAt`.
- Carries `archivedAt` through app sync/list filtering with legacy lifecycle metadata fallback for already-archived sessions.
- Updates CLI archive/abort handling so explicit archive flows post the archive endpoint, while user abort paths report `Aborted by user` instead of unexpected exits.

## Stack / migration plan

Depends on #1370.

This branch is stacked on `Scoteezy:feat/session-archived-at-schema`. GitHub cannot use a fork-only branch as the base branch for an upstream `slopus/happy` PR, so this PR targets `main`. The first commit is the same schema/migration commit as #1370; the runtime-only diff is:

https://github.com/Scoteezy/happy/compare/feat/session-archived-at-schema...feat/session-archive-lifecycle

Merge order:

1. Merge/deploy #1370 first and run migration `20260608171100_add_session_archived_at`.
2. Rebase/update this branch after #1370 lands so the PR diff drops the duplicated schema commit.
3. Merge/deploy this PR after the nullable column exists.
4. New runtime semantics: `archivedAt = null` means current/resumable, non-null timestamp means user-archived.
5. Rollback order: revert this code PR first if needed; keep the nullable DB column in place because old code ignores it.

## Test plan

- `pnpm --dir packages/happy-server generate`
- `pnpm --dir packages/happy-app test sources/sync/sessionArchiveState.test.ts sources/sync/reducer/activityUpdateAccumulator.test.ts --run`
- `pnpm --filter happy exec vitest run --project unit src/session/archiveIntent.test.ts src/codex/codexTurnErrorPolicy.test.ts src/claude/claudeRemoteLauncher.test.ts`
- `pnpm --dir packages/happy-server exec vitest run sources/app/presence/sessionCache.spec.ts`
- `pnpm --dir packages/happy-app typecheck`
- `pnpm --dir packages/happy-server typecheck`
- `git diff --check feat/session-archived-at-schema..HEAD`
