### PR TITLE
feat: add Claude Fable 5 model

### DIFF
--- a/packages/codium/sources/plugins/anthropic/index.ts
+++ b/packages/codium/sources/plugins/anthropic/index.ts
@@ -10,6 +10,7 @@ import type {
 const STORAGE_KEY = 'codium.plugin.anthropic.apiKey'
 
 const MODELS: ModelDescriptor[] = [
+    { id: 'claude-fable-5',    label: 'Fable 5',    group: 'Anthropic', description: 'Most capable model, long-horizon agentic work.' },
     { id: 'claude-opus-4-8',   label: 'Opus 4.8',   group: 'Anthropic', description: 'Latest Opus generation.' },
     { id: 'claude-opus-4-7',   label: 'Opus 4.7',   group: 'Anthropic', description: 'Previous Opus generation.' },
     { id: 'claude-opus-4-6',   label: 'Opus 4.6',   group: 'Anthropic', description: 'Deepest reasoning, slowest.' },

--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     getAvailableModels,
     getAvailablePermissionModes,
+    getClaudeModelModes,
     getCodexModelModes,
     getClaudePermissionModes,
     getDefaultEffortKey,
@@ -28,6 +29,20 @@ describe('modelModeOptions', () => {
         const modes = getClaudePermissionModes(translate);
         expect(modes.map((mode) => mode.key)).toEqual(['default', 'plan', 'dontAsk', 'acceptEdits', 'bypassPermissions']);
         expect(modes[0].name).toBe('tr:agentInput.permissionMode.default');
+    });
+
+    it('builds claude model fallbacks including fable 5', () => {
+        const models = getClaudeModelModes();
+        expect(models.map((model) => model.key)).toEqual([
+            'default',
+            'claude-fable-5',
+            'opus',
+            'sonnet',
+            'haiku',
+        ]);
+        // Fable 5 is a new family with no short alias, so the picker sends the
+        // full model id; the CLI passes it through to the API unchanged.
+        expect(models.find((model) => model.key === 'claude-fable-5')?.name).toBe('fable 5');
     });
 
     it('builds codex model fallbacks', () => {

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -77,6 +77,7 @@ export function getGeminiPermissionModes(translate: Translate): PermissionMode[]
 export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
+        { key: 'claude-fable-5', name: 'fable 5', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },


### PR DESCRIPTION
## What

Adds **Claude Fable 5** (`claude-fable-5`) to the Claude model pickers. Anthropic shipped Fable 5 as a GA model on 2026-06-09 — a Mythos-class, most-capable model for long-horizon agentic work (1M context, adaptive thinking always-on, no extended thinking).

## Changes

- **codium** `plugins/anthropic/index.ts`: add `claude-fable-5` to the full-ID `MODELS` list (top slot).
- **happy-app** `modelModeOptions.ts`: add `claude-fable-5` to `getClaudeModelModes()` fallback.
  - Fable 5 is a new family with **no short alias** (unlike `opus`/`sonnet`/`haiku`), so the picker sends the full model id; the Claude CLI passes it through to the API unchanged.
  - The live model list still comes from CLI session metadata when present — this only changes the offline fallback.
- **happy-app** `modelModeOptions.test.ts`: new test asserting the Claude fallback list and that the full id is used for Fable 5.

## Verification

- `modelModeOptions.test.ts` — 10 passed
- `happy-app` typecheck — pass
- `codium` typecheck — pass

Follows the same pattern as the Opus 4.8 addition (#1363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)