### PR TITLE
feat(app): opus 4.8[1m] picker entry + per-model effort gating

### DIFF
--- a/packages/codium/sources/plugins/anthropic/index.ts
+++ b/packages/codium/sources/plugins/anthropic/index.ts
@@ -11,7 +11,8 @@ const STORAGE_KEY = 'codium.plugin.anthropic.apiKey'
 
 const MODELS: ModelDescriptor[] = [
     { id: 'claude-fable-5',    label: 'Fable 5',    group: 'Anthropic', description: 'Most capable model, long-horizon agentic work.' },
-    { id: 'claude-opus-4-8',   label: 'Opus 4.8',   group: 'Anthropic', description: 'Latest Opus generation.' },
+    { id: 'claude-opus-4-8',     label: 'Opus 4.8',      group: 'Anthropic', description: 'Latest Opus generation.' },
+    { id: 'claude-opus-4-8[1m]', label: 'Opus 4.8 (1M)', group: 'Anthropic', description: '1M-token context window.' },
     { id: 'claude-opus-4-7',   label: 'Opus 4.7',   group: 'Anthropic', description: 'Previous Opus generation.' },
     { id: 'claude-opus-4-6',   label: 'Opus 4.6',   group: 'Anthropic', description: 'Deepest reasoning, slowest.' },
     { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', group: 'Anthropic', description: 'Balanced reasoning + speed.' },

--- a/packages/codium/sources/plugins/anthropic/index.ts
+++ b/packages/codium/sources/plugins/anthropic/index.ts
@@ -10,6 +10,7 @@ import type {
 const STORAGE_KEY = 'codium.plugin.anthropic.apiKey'
 
 const MODELS: ModelDescriptor[] = [
+    { id: 'claude-fable-5',    label: 'Fable 5',    group: 'Anthropic', description: 'Most capable model, long-horizon agentic work.' },
     { id: 'claude-opus-4-8',   label: 'Opus 4.8',   group: 'Anthropic', description: 'Latest Opus generation.' },
     { id: 'claude-opus-4-7',   label: 'Opus 4.7',   group: 'Anthropic', description: 'Previous Opus generation.' },
     { id: 'claude-opus-4-6',   label: 'Opus 4.6',   group: 'Anthropic', description: 'Deepest reasoning, slowest.' },

--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     getAvailableModels,
     getAvailablePermissionModes,
+    getClaudeModelModes,
     getCodexModelModes,
     getClaudePermissionModes,
     getDefaultEffortKey,
@@ -28,6 +29,20 @@ describe('modelModeOptions', () => {
         const modes = getClaudePermissionModes(translate);
         expect(modes.map((mode) => mode.key)).toEqual(['default', 'plan', 'dontAsk', 'acceptEdits', 'bypassPermissions']);
         expect(modes[0].name).toBe('tr:agentInput.permissionMode.default');
+    });
+
+    it('builds claude model fallbacks including fable 5', () => {
+        const models = getClaudeModelModes();
+        expect(models.map((model) => model.key)).toEqual([
+            'default',
+            'claude-fable-5',
+            'opus',
+            'sonnet',
+            'haiku',
+        ]);
+        // Fable 5 is a new family with no short alias, so the picker sends the
+        // full model id; the CLI passes it through to the API unchanged.
+        expect(models.find((model) => model.key === 'claude-fable-5')?.name).toBe('fable 5');
     });
 
     it('builds codex model fallbacks', () => {

--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -8,6 +8,7 @@ import {
     getDefaultEffortKey,
     getDefaultModelKey,
     getDefaultPermissionModeKey,
+    getEffortLevelsForModel,
     mapMetadataOptions,
     resolveCurrentOption,
 } from './modelModeOptions';
@@ -31,18 +32,37 @@ describe('modelModeOptions', () => {
         expect(modes[0].name).toBe('tr:agentInput.permissionMode.default');
     });
 
-    it('builds claude model fallbacks including fable 5', () => {
+    it('builds claude model fallbacks including fable 5 and the 1M opus variant', () => {
         const models = getClaudeModelModes();
         expect(models.map((model) => model.key)).toEqual([
             'default',
             'claude-fable-5',
             'opus',
+            'claude-opus-4-8[1m]',
             'sonnet',
             'haiku',
         ]);
-        // Fable 5 is a new family with no short alias, so the picker sends the
-        // full model id; the CLI passes it through to the API unchanged.
+        // Fable 5 and the 1M variant are new entries with no short alias, so the
+        // picker sends the full model id; the CLI passes it through unchanged.
         expect(models.find((model) => model.key === 'claude-fable-5')?.name).toBe('fable 5');
+        expect(models.find((model) => model.key === 'claude-opus-4-8[1m]')?.name).toBe('opus 4.8 (1M)');
+    });
+
+    it('gates claude effort levels per model', () => {
+        const keys = (modelKey: string) => getEffortLevelsForModel('claude', modelKey).map((l) => l.key);
+        // Fable 5 / Opus 4.8 (+ 1M variant) / the opus alias: full set incl. xhigh + max.
+        expect(keys('claude-fable-5')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+        expect(keys('opus')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+        expect(keys('claude-opus-4-8[1m]')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+        // Sonnet 4.6 and Opus 4.6: max but no xhigh.
+        expect(keys('sonnet')).toEqual(['low', 'medium', 'high', 'max']);
+        expect(keys('claude-opus-4-6')).toEqual(['low', 'medium', 'high', 'max']);
+        // Opus 4.5: neither xhigh nor max.
+        expect(keys('claude-opus-4-5')).toEqual(['low', 'medium', 'high']);
+        // Haiku exposes no effort parameter.
+        expect(keys('haiku')).toEqual([]);
+        // Unknown/custom models keep the full set (can't infer narrower support).
+        expect(keys('some-gateway-model')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
     });
 
     it('builds codex model fallbacks', () => {

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -79,6 +79,7 @@ export function getClaudeModelModes(): ModelMode[] {
         { key: 'default', name: 'default model', description: null },
         { key: 'claude-fable-5', name: 'fable 5', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
+        { key: 'claude-opus-4-8[1m]', name: 'opus 4.8 (1M)', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },
     ];
@@ -231,14 +232,46 @@ export function getDefaultEffortKey(flavor: AgentFlavor): string | null {
     return getCodeAgentDefaults(flavor).effortLevel;
 }
 
+// Effort support varies by Claude model (per platform.claude.com/docs/.../effort):
+//   - Fable 5 / Opus 4.8 / Opus 4.7: low, medium, high, xhigh, max
+//   - Sonnet 4.6 / Opus 4.6:         low, medium, high, max   (no xhigh)
+//   - Opus 4.5:                      low, medium, high        (no xhigh, no max)
+//   - Haiku 4.5:                     none — the effort parameter errors
+// Sending an unsupported level returns a 400, so the picker must only offer
+// what the selected model accepts.
+const CLAUDE_EFFORT_NO_XHIGH: EffortLevel[] = [
+    { key: 'low', name: 'low' },
+    { key: 'medium', name: 'medium' },
+    { key: 'high', name: 'high' },
+    { key: 'max', name: 'max' },
+];
+
+const CLAUDE_EFFORT_BASIC: EffortLevel[] = [
+    { key: 'low', name: 'low' },
+    { key: 'medium', name: 'medium' },
+    { key: 'high', name: 'high' },
+];
+
+// Maps a model key (picker alias like `opus`/`sonnet`, or a full model id like
+// `claude-opus-4-8[1m]` from gateway/SDK metadata) to its supported effort levels.
+function getClaudeEffortLevelsForModel(modelKey: string): EffortLevel[] {
+    const m = modelKey.toLowerCase();
+    // Haiku exposes no effort parameter at all.
+    if (m.includes('haiku')) return [];
+    // Sonnet 4.6 and Opus 4.6 support max but not xhigh.
+    if (m.includes('sonnet') || m.includes('opus-4-6')) return CLAUDE_EFFORT_NO_XHIGH;
+    // Opus 4.5 supports neither xhigh nor max.
+    if (m.includes('opus-4-5')) return CLAUDE_EFFORT_BASIC;
+    // Fable/Mythos, Opus 4.7/4.8 (incl. the `opus` alias → latest and the [1m]
+    // variant), and any unknown/custom model get the full set — we can't infer
+    // narrower support for models we don't recognise, so we preserve all levels.
+    return getClaudeEffortLevels();
+}
+
 // Per-model effort: returns effort levels for a specific model, or empty if the model has no effort
-export function getEffortLevelsForModel(flavor: AgentFlavor, _modelKey: string): EffortLevel[] {
-    // Claude and Codex expose effort/thought levels regardless of which
-    // specific model is picked — the same low/medium/high/max scale applies
-    // to the whole flavor (mirrors how Codex already worked, which the user
-    // asked Claude to match).
+export function getEffortLevelsForModel(flavor: AgentFlavor, modelKey: string): EffortLevel[] {
     if (flavor === 'claude') {
-        return getClaudeEffortLevels();
+        return getClaudeEffortLevelsForModel(modelKey);
     }
     if (flavor === 'codex') {
         return getCodexEffortLevels();

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -77,6 +77,7 @@ export function getGeminiPermissionModes(translate: Translate): PermissionMode[]
 export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
+        { key: 'claude-fable-5', name: 'fable 5', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },


### PR DESCRIPTION
> **Stacked on #1372** (Fable 5). Until that merges, this PR's diff includes the Fable 5 commit; rebase after #1372 lands.

## What

Two Claude model-picker improvements:

### 1. `claude-opus-4-8[1m]` picker entry
Adds the 1M-context Opus 4.8 variant as a distinct, selectable entry in both the happy-app Claude fallback (`opus 4.8 (1M)`) and the codium Anthropic plugin. No short alias exists, so the full model id is sent and passed through to the API unchanged.

### 2. Per-model effort gating
`getEffortLevelsForModel` previously **ignored the model** and returned the full Claude effort set for every model — offering levels the API rejects. Per the [Anthropic effort docs](https://platform.claude.com/docs/en/build-with-claude/effort):

| Model | low | med | high | xhigh | max |
|---|---|---|---|---|---|
| Fable 5 / Opus 4.8 (+1M) / Opus 4.7 | ✓ | ✓ | ✓ | ✓ | ✓ |
| Sonnet 4.6 / Opus 4.6 | ✓ | ✓ | ✓ | ✗ | ✓ |
| Opus 4.5 | ✓ | ✓ | ✓ | ✗ | ✗ |
| Haiku 4.5 | — | — | — | — | — |

This fixes a latent bug: the picker offered `xhigh`/`max` for Haiku (effort errors entirely on Haiku) and `xhigh` for Sonnet 4.6 (unsupported). Unknown/custom gateway models keep the full set (support can't be inferred). Matching handles both picker aliases (`opus`/`sonnet`) and full model ids from gateway/SDK metadata.

## Verification

- `modelModeOptions.test.ts` — 11 passed (new model-list + per-model effort matrix tests)
- `happy-app` typecheck — pass
- `codium` typecheck — pass

Smoke-tested live in the running app via the `dev/session-composer` picker:

**`opus 4.8 (1M)` entry present:**

![opus 4.8 (1M)](https://raw.githubusercontent.com/jlixfeld/happy/pr-assets/pr-assets/opus-4-8-1m.png)

**Fable 5 offers `xhigh` (full effort set):**

![fable 5 xhigh](https://raw.githubusercontent.com/jlixfeld/happy/pr-assets/pr-assets/fable-5-xhigh.png)

**Haiku 4.5 hides the effort control entirely (no effort param):**

![haiku no effort](https://raw.githubusercontent.com/jlixfeld/happy/pr-assets/pr-assets/haiku-no-effort.png)

Sonnet 4.6 was confirmed to cycle low/medium/high/max with **no** `xhigh`.

The relabel-to-4.8 (#1345) and `xhigh` effort level (#1269) work this builds on is already in `main` via #1363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)