### PR TITLE
fix(app): unread sessions show a bold title when stopped, not an overloaded status dot

### DIFF
--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -225,12 +225,13 @@ export function ActiveSessionsGroupCompact({ sessions, selectedSessionId }: Acti
 export const CompactSessionRow = React.memo(({ session, selected, showBorder }: { session: SessionRowData; selected?: boolean; showBorder?: boolean }) => {
     const styles = stylesheet;
     const { theme } = useUnistyles();
-    const baseStatus = STATUS_CONFIG[session.state];
+    const status = STATUS_CONFIG[session.state];
     const needsUserAction = session.state === 'permission_required' || session.state === 'input_required';
-    // User action stays orange and pulsing even when the request also marked the session unread.
-    const status = session.hasUnread && !needsUserAction
-        ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
-        : baseStatus;
+    // Unread is shown as a bold title only once the agent has stopped — never
+    // while it's still running (thinking), so a re-activated session doesn't
+    // read as unread mid-turn. A session waiting on the user keeps its orange
+    // pulsing dot; that state outranks unread.
+    const showUnreadTitle = session.hasUnread && session.state !== 'thinking';
     const navigateToSession = useNavigateToSession();
     const swipeableRef = React.useRef<Swipeable | null>(null);
     const swipeEnabled = Platform.OS !== 'web';
@@ -274,8 +275,6 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
 
         if (needsUserAction) {
             indicator = <StatusDot color={status.dotColor} isPulsing={status.isPulsing} />;
-        } else if (session.hasUnread) {
-            indicator = <StatusDot color={status.dotColor} isPulsing={false} />;
         } else if (session.state === 'waiting' && session.hasDraft) {
             indicator = (
                 <Ionicons
@@ -312,7 +311,8 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
                     <Text
                         style={[
                             styles.sessionTitle,
-                            status.isConnected ? styles.sessionTitleConnected : styles.sessionTitleDisconnected
+                            status.isConnected ? styles.sessionTitleConnected : styles.sessionTitleDisconnected,
+                            showUnreadTitle && styles.sessionTitleUnread
                         ]}
                         numberOfLines={2}
                     >
@@ -509,6 +509,13 @@ const stylesheet = StyleSheet.create((theme) => ({
     },
     sessionTitleDisconnected: {
         color: theme.colors.textSecondary,
+    },
+    sessionTitleUnread: {
+        // Bold via the SemiBold face, not fontWeight: web sets
+        // `font-synthesis: none` and bundles no Bold(700) face, so a numeric
+        // fontWeight would render identically to the regular title.
+        ...Typography.default('semiBold'),
+        color: theme.colors.text,
     },
     // 18 wide so the dot's center lines up with the center of the project
     // header's "+" button above the card, on both platform paddings.

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -199,9 +199,12 @@ const stylesheet = StyleSheet.create((theme) => ({
     },
     sessionTitle: {
         fontSize: 15,
-        fontWeight: '500',
         flex: 1,
-        ...Typography.default('semiBold'),
+    },
+    // Lighter title weight for read (non-unread) rows, so unread rows stand out
+    // by contrast.
+    sessionTitleWeightRegular: {
+        ...Typography.default('regular'),
     },
     sessionShortcutBadge: {
         flexShrink: 0,
@@ -212,6 +215,13 @@ const stylesheet = StyleSheet.create((theme) => ({
     },
     sessionTitleDisconnected: {
         color: theme.colors.textSecondary,
+    },
+    sessionTitleUnread: {
+        // Bold via the SemiBold face, not fontWeight: web sets
+        // `font-synthesis: none` and bundles no Bold(700) face, so a numeric
+        // fontWeight would render identically to the regular title.
+        ...Typography.default('semiBold'),
+        color: theme.colors.text,
     },
     sessionSubtitleRow: {
         flexDirection: 'row',
@@ -612,12 +622,11 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
     const styles = stylesheet;
     const navigateToSession = useNavigateToSession();
     const [actionsAnchor, setActionsAnchor] = React.useState<SessionActionsAnchor | null>(null);
-    const baseStatus = STATUS_CONFIG[session.state];
-    const needsUserAction = session.state === 'permission_required' || session.state === 'input_required';
-    // User action stays orange and pulsing even when the request also marked the session unread.
-    const status = session.hasUnread && !needsUserAction
-        ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
-        : baseStatus;
+    const status = STATUS_CONFIG[session.state];
+    // Unread is shown as a bold title only once the agent has stopped — never
+    // while it's still running (thinking), so a re-activated session doesn't
+    // read as unread mid-turn.
+    const showUnreadTitle = session.hasUnread && session.state !== 'thinking';
 
     const vibingMessage = React.useMemo(() => {
         return vibingMessages[Math.floor(Math.random() * vibingMessages.length)].toLowerCase() + '…';
@@ -627,13 +636,11 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
         ? t('status.inputRequired')
         : session.state === 'permission_required'
             ? t('status.permissionRequired')
-            : session.hasUnread
-                ? t('status.unread')
-                : session.state === 'thinking'
-                    ? vibingMessage
-                    : session.state === 'disconnected'
-                        ? t('status.lastSeen', { time: formatLastSeen(session.activeAt!, false) })
-                        : t('status.online');
+            : session.state === 'thinking'
+                ? vibingMessage
+                : session.state === 'disconnected'
+                    ? t('status.lastSeen', { time: formatLastSeen(session.activeAt!, false) })
+                    : t('status.online');
 
     const handlePress = React.useCallback(() => {
         navigateToSession(session.id);
@@ -690,7 +697,8 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
                 <View style={styles.sessionTitleRow}>
                     <Text style={[
                         styles.sessionTitle,
-                        status.isConnected ? styles.sessionTitleConnected : styles.sessionTitleDisconnected
+                        status.isConnected ? styles.sessionTitleConnected : styles.sessionTitleDisconnected,
+                        showUnreadTitle ? styles.sessionTitleUnread : styles.sessionTitleWeightRegular,
                     ]} numberOfLines={1}>
                         {session.name}
                     </Text>


### PR DESCRIPTION
The session-list status dot is overloaded: a session with unread results is forced to a solid blue dot — the same color as the "thinking" (running) state, differing only by a pulse — so a finished, idle session looks like it is still running until you open it (which clears the unread flag).

This decouples the two signals. The status dot always reflects true liveness (disconnected / thinking / waiting / permission), and unread is shown instead as a **bold title** — but only once the agent has **stopped**, never while it is still running, so a re-activated session never reads as unread mid-turn. Blue goes back to meaning exactly one thing: running. Applies to both the session list rows and the compact active-sessions group.

The bold is applied via the SemiBold font *family* (read titles are Regular) rather than a numeric `fontWeight`, because the web build sets `font-synthesis: none` and bundles no Bold(700) IBM Plex Sans face — a `fontWeight: 700` override would render identically to the regular title on web.

## Proof

Captured locally on web — standalone `happy-server` (PGlite) + Expo web, driven headlessly with Playwright. The row's computed `font-family` flips Regular → SemiBold at the exact moment the turn stops and the session becomes unread; it stays Regular the whole time the agent is running.

| agent running → title **not** bold | turn stopped + unread → title **bold**, no marker dot |
|:---:|:---:|
| <img width="280" src="https://github.com/chphch/happy/releases/download/pr-proofs/1374-unread-running.png"> | <img width="280" src="https://github.com/chphch/happy/releases/download/pr-proofs/1374-unread-stopped.png"> |

Note the leading status dot stays a true-liveness indicator across the transition (blue "thinking" while running → neutral once idle), and the old trailing blue accent dot is gone — unread is conveyed entirely by the title weight.

## Verification

`pnpm typecheck` clean; app suite green.
