### PR TITLE
fix(app): render markdown SVG images on native via react-native-svg

### DIFF
--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -17,6 +17,8 @@ import { MermaidRenderer } from './MermaidRenderer';
 import { t } from '@/text';
 import { isHttpMarkdownLink } from './linkUtils';
 import { openExternalUrl } from '@/utils/openExternalUrl';
+import { SvgUri, SvgXml } from 'react-native-svg';
+import { parseSvgImageSource } from './svgImageSource';
 
 // Option type for callback
 export type Option = {
@@ -209,15 +211,30 @@ function RenderCodeBlock(props: { content: string, language: string | null, firs
 
 function RenderImageBlock(props: { url: string, alt: string, first: boolean, last: boolean }) {
     const accessibleLabel = props.alt || 'Markdown image';
+    // RN's <Image> only decodes raster formats, so an SVG (data URI or .svg)
+    // renders blank on native. Route SVG through react-native-svg instead:
+    // SvgXml for inline markup decoded from a data URI, SvgUri for a remote
+    // .svg. Non-SVG images keep using <Image> unchanged.
+    const svg = React.useMemo(() => parseSvgImageSource(props.url), [props.url]);
 
     return (
         <View style={[style.imageBlock, props.first && style.first, props.last && style.last]}>
-            <Image
-                source={{ uri: props.url }}
-                style={style.image}
-                accessibilityLabel={accessibleLabel}
-                resizeMode="contain"
-            />
+            {svg ? (
+                <View style={[style.image, style.svgImage]} accessible accessibilityLabel={accessibleLabel}>
+                    {svg.kind === 'xml' ? (
+                        <SvgXml xml={svg.xml} width="100%" height="100%" />
+                    ) : (
+                        <SvgUri uri={svg.uri} width="100%" height="100%" />
+                    )}
+                </View>
+            ) : (
+                <Image
+                    source={{ uri: props.url }}
+                    style={style.image}
+                    accessibilityLabel={accessibleLabel}
+                    resizeMode="contain"
+                />
+            )}
             {props.alt ? (
                 <Text style={style.imageCaption}>{props.alt}</Text>
             ) : null}
@@ -542,6 +559,10 @@ const style = StyleSheet.create((theme) => ({
         height: 240,
         borderRadius: 12,
         backgroundColor: theme.colors.surfaceHighest,
+    },
+    svgImage: {
+        // Clip the rendered SVG to the rounded image frame.
+        overflow: 'hidden',
     },
     imageCaption: {
         ...Typography.default(),

--- a/packages/happy-app/sources/components/markdown/svgImageSource.test.ts
+++ b/packages/happy-app/sources/components/markdown/svgImageSource.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { isSvgImageUrl, parseSvgImageSource } from './svgImageSource';
+
+const SVG = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+
+describe('parseSvgImageSource', () => {
+    it('decodes a base64 svg data URI to xml', () => {
+        const b64 = Buffer.from(SVG).toString('base64');
+        expect(parseSvgImageSource(`data:image/svg+xml;base64,${b64}`)).toEqual({
+            kind: 'xml',
+            xml: SVG,
+        });
+    });
+
+    it('decodes a base64 svg data URI with a charset parameter', () => {
+        const b64 = Buffer.from(SVG).toString('base64');
+        expect(parseSvgImageSource(`data:image/svg+xml;charset=utf-8;base64,${b64}`)).toEqual({
+            kind: 'xml',
+            xml: SVG,
+        });
+    });
+
+    it('decodes a percent-encoded utf8 svg data URI to xml', () => {
+        expect(parseSvgImageSource(`data:image/svg+xml;utf8,${encodeURIComponent(SVG)}`)).toEqual({
+            kind: 'xml',
+            xml: SVG,
+        });
+    });
+
+    it('handles a raw (unencoded) utf8 svg data URI', () => {
+        const src = parseSvgImageSource(`data:image/svg+xml,${SVG}`);
+        expect(src?.kind).toBe('xml');
+        expect((src as { kind: 'xml'; xml: string }).xml).toContain('<svg');
+    });
+
+    it('treats a remote .svg URL as a passthrough uri', () => {
+        expect(parseSvgImageSource('https://example.com/diagram.svg')).toEqual({
+            kind: 'uri',
+            uri: 'https://example.com/diagram.svg',
+        });
+    });
+
+    it('ignores query string / hash when detecting .svg', () => {
+        expect(parseSvgImageSource('https://example.com/d.svg?v=2')).toEqual({
+            kind: 'uri',
+            uri: 'https://example.com/d.svg?v=2',
+        });
+    });
+
+    it('returns null for raster images so <Image> is used', () => {
+        expect(parseSvgImageSource('https://example.com/x.png')).toBeNull();
+        expect(parseSvgImageSource('data:image/png;base64,iVBORw0KGgo')).toBeNull();
+        expect(parseSvgImageSource('file:///tmp/a.jpg')).toBeNull();
+    });
+
+    it('returns null for a malformed svg data URI (no comma)', () => {
+        expect(parseSvgImageSource('data:image/svg+xml;base64')).toBeNull();
+    });
+});
+
+describe('isSvgImageUrl', () => {
+    it('agrees with parseSvgImageSource', () => {
+        const b64 = Buffer.from(SVG).toString('base64');
+        expect(isSvgImageUrl(`data:image/svg+xml;base64,${b64}`)).toBe(true);
+        expect(isSvgImageUrl('https://example.com/a.svg')).toBe(true);
+        expect(isSvgImageUrl('https://example.com/a.png')).toBe(false);
+    });
+});

--- a/packages/happy-app/sources/components/markdown/svgImageSource.ts
+++ b/packages/happy-app/sources/components/markdown/svgImageSource.ts
@@ -1,0 +1,68 @@
+import { decodeBase64 } from '@/encryption/base64';
+import { decodeUTF8 } from '@/encryption/text';
+
+const SVG_DATA_PREFIX = 'data:image/svg+xml';
+
+export type SvgImageSource =
+    | { kind: 'xml'; xml: string }
+    | { kind: 'uri'; uri: string };
+
+/**
+ * Parse a markdown image URL into a renderable SVG source, or `null` if it is
+ * not an SVG (caller then falls back to RN's `<Image>`).
+ *
+ * RN's core `<Image>` cannot decode SVG on native (iOS/Android) — it only
+ * renders raster formats — so SVG markdown images render blank on phones while
+ * working on web. Routing SVG through `react-native-svg` (`SvgXml`/`SvgUri`)
+ * fixes that on every platform.
+ *
+ *  - `data:image/svg+xml;base64,…`            → `{ kind: 'xml' }` (decoded markup)
+ *  - `data:image/svg+xml;utf8,…` / `,<enc>`   → `{ kind: 'xml' }` (decoded markup)
+ *  - `https://…/x.svg` (or any `.svg` path)   → `{ kind: 'uri' }` (passthrough)
+ *  - anything else (png/jpg/data:image/png…)  → `null`
+ */
+export function parseSvgImageSource(url: string): SvgImageSource | null {
+    const trimmed = url.trim();
+
+    if (trimmed.toLowerCase().startsWith(SVG_DATA_PREFIX)) {
+        const comma = trimmed.indexOf(',');
+        if (comma === -1) {
+            return null;
+        }
+        const meta = trimmed.slice(SVG_DATA_PREFIX.length, comma).toLowerCase();
+        const data = trimmed.slice(comma + 1);
+
+        let xml: string;
+        if (meta.includes(';base64')) {
+            try {
+                xml = decodeUTF8(decodeBase64(data.trim()));
+            } catch {
+                return null;
+            }
+        } else {
+            // `;utf8,` or a percent-encoded payload — `decodeURIComponent`
+            // throws on a stray `%`, in which case the data is already raw.
+            try {
+                xml = decodeURIComponent(data);
+            } catch {
+                xml = data;
+            }
+        }
+
+        xml = xml.trim();
+        return xml ? { kind: 'xml', xml } : null;
+    }
+
+    // Remote or local `.svg` file — ignore any query string / hash fragment.
+    const pathOnly = trimmed.split(/[?#]/, 1)[0].toLowerCase();
+    if (pathOnly.endsWith('.svg')) {
+        return { kind: 'uri', uri: trimmed };
+    }
+
+    return null;
+}
+
+/** True if the markdown image URL points at an SVG (data URI or `.svg`). */
+export function isSvgImageUrl(url: string): boolean {
+    return parseSvgImageSource(url) !== null;
+}


### PR DESCRIPTION
Markdown images whose source is an SVG — a `data:image/svg+xml` data URI or a `.svg` URL — render correctly on web but appear **blank on iOS/Android**, because `RenderImageBlock` (`MarkdownView.tsx`) renders every image through React Native's `<Image>`, which only decodes raster formats. This routes SVG sources through `react-native-svg` instead — `SvgXml` for inline markup decoded from a data URI, `SvgUri` for a remote `.svg` — while raster images keep using `<Image>` unchanged. A new `svgImageSource` helper detects SVG sources and decodes base64 / utf8 / percent-encoded data URIs, with unit tests.

`SvgXml` parses the SVG into `react-native-svg` components rather than injecting raw markup, so this adds no `dangerouslySetInnerHTML` sink (cf. #1086).

## Proof

Verified locally against a standalone `happy-server` (PGlite) + Expo web, authenticated via the `getDevWebQueryCredentials()` dev URL bypass and driven with Playwright. A markdown message carrying a base64 `data:image/svg+xml` image now renders the SVG (shapes + text); a PNG data URI still renders via `<Image>` (no raster regression). `tsc --noEmit` is clean and `vitest` passes (9 new `svgImageSource` tests + the markdown suite). `SvgXml` is already used on native elsewhere (`FileIcon.tsx`), so the web render exercises the same cross-platform component path that was previously failing on device. Screenshot in the comment below.

Before/after emulator screenshots are in the comments below.
