### PR TITLE
fix(cli): surface adaptive thinking content via display: summarized

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -131,6 +131,14 @@ export async function claudeRemote(opts: {
         allowedTools: initial.mode.allowedTools ? initial.mode.allowedTools.concat(opts.allowedTools) : opts.allowedTools,
         disallowedTools: initial.mode.disallowedTools,
         effort: initial.mode.effort,
+        // Surface adaptive thinking content to clients. Without `display: 'summarized'` the
+        // SDK defaults to `omitted` for adaptive thinking — the model still thinks (and the
+        // wire still carries a `thinking` envelope so UIs can render a "thinking…" badge),
+        // but the content body comes back empty, leaving expanded ThinkingTrail panels blank.
+        // Gate on `effort` so users who explicitly opted out of thinking aren't forced back in.
+        thinking: initial.mode.effort
+            ? { type: 'adaptive', display: 'summarized' }
+            : undefined,
         canCallTool: (toolName: string, input: unknown, options: { signal: AbortSignal; toolUseID: string }) => opts.canCallTool(toolName, input, mode, options),
         abort: opts.signal,
         settingsPath: opts.hookSettingsPath,

--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -44,6 +44,7 @@ export function query(params: { prompt: QueryPrompt; options?: QueryOptions }): 
         strictMcpConfig: opts?.strictMcpConfig,
         sessionId: undefined,
         effort: opts?.effort,
+        thinking: opts?.thinking,
     }
 
     // Map abort signal -> AbortController

--- a/packages/happy-cli/src/claude/sdk/types.ts
+++ b/packages/happy-cli/src/claude/sdk/types.ts
@@ -50,6 +50,16 @@ export interface QueryOptions {
      * applies on each turn ('low' | 'medium' | 'high' | 'max').
      */
     effort?: 'low' | 'medium' | 'high' | 'max'
+    /**
+     * Thinking config passed through to the Claude Agent SDK. Set
+     * `display: 'summarized'` on adaptive thinking to expose the thinking
+     * content to clients — without it the SDK defaults to `omitted` and
+     * UIs only see an empty "thinking…" envelope with no body.
+     */
+    thinking?:
+        | { type: 'adaptive'; display?: 'summarized' | 'omitted' }
+        | { type: 'enabled'; budgetTokens?: number; display?: 'summarized' | 'omitted' }
+        | { type: 'disabled' }
 }
 
 /**


### PR DESCRIPTION
## Problem

When `effort` is set, the Claude Agent SDK uses adaptive thinking with `display` defaulting to `omitted`. The model still thinks and the stream still carries a `thinking` envelope (so UIs show a "thinking…" badge), but the content body comes back empty — expanded thinking panels in the app render blank.

## Fix

Pass `thinking: { type: 'adaptive', display: 'summarized' }` through `QueryOptions` when `effort` is set, so clients receive the summarized thinking content. Gated on `effort` so sessions that opted out of thinking are unaffected.

3 files, 19 lines: `claudeRemote.ts` sets the option, `sdk/query.ts` forwards it, `sdk/types.ts` adds the `thinking` field to `QueryOptions`.

Verified locally: with this patch the thinking content shows up in the mobile client; without it the panel is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)