### PR TITLE
fix(agent-input): slash/@ autocomplete silently stops appearing under main-thread load

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -707,9 +707,14 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     }, [onChangeTextProp]);
 
     const handleInputStateChange = React.useCallback((newState: TextInputState) => {
-        React.startTransition(() => {
-            setInputState(newState);
-        });
+        // Autocomplete (slash / @ suggestions) is derived from inputState, so it
+        // must update urgently. Deferring it via startTransition lets a busy main
+        // thread (chat list render + WS sync + message decrypt) starve the commit,
+        // so the suggestion dropdown silently never appears under real load.
+        // Typing stays smooth regardless: the textarea is uncontrolled (keystrokes
+        // paint via the DOM, not this state) and the heavy sibling rows (status /
+        // context chips) are memoized away from this re-render.
+        setInputState(newState);
     }, []);
 
     // Use the tracked selection from inputState


### PR DESCRIPTION
Typing `/` (slash commands) or `@` (file mentions) in the chat composer is supposed to open the autocomplete dropdown, but under real main-thread load it silently never appears. The autocomplete query is derived from `inputState`, and `perf(agent-input): uncontrolled textarea + transitioned derived state` (514ef3f1) moved the `inputState` update inside `React.startTransition`. On a busy main thread (chat-list render + WebSocket sync + message decrypt) that low-priority update gets starved and never commits, so `useActiveWord(inputState)` never recomputes and the dropdown stays closed. It only reproduces under load — an idle dev server commits the transition immediately, which is why it slips through local testing.

This restores the pre-refactor synchronous `setInputState`. The keystroke-perf win the transition was protecting is preserved: the textarea is uncontrolled (keystrokes paint via the DOM, not this state), and the heavy sibling rows (`AgentInputStatusRow` / `AgentInputContextChips`) are already memoized out of this re-render — so an urgent `inputState` update only re-renders the autocomplete-relevant subtree.

## Proof

Verified on web (Expo **production** bundle, `--no-dev --minify`) with a simulated busy main thread (a sibling component burning ~9 ms every ~13 ms via `setInterval`, mirroring the real chat-list + sync + decrypt churn):

| | type `/` | type `/com` |
|---|---|---|
| **Before** (current `main`) | dropdown never renders — `compact`/`clear`/`skills` not visible | still nothing |
| **After** (this PR) | dropdown renders: `/compact /clear /mcp /skills` | filters to `/compact` |

With the load generator **off** (idle), both before and after render fine — which is exactly why this is invisible in dev.

Also confirmed end-to-end against a real `happy-cli` daemon + real session: typing `/` in the live SessionView renders the dropdown (`/compact /clear /mcp /skills`).

Diff is 8 lines in `AgentInput.tsx` (`handleInputStateChange`).
