### PR TITLE
Fix Claude yolo permissions across remote control handoffs

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
@@ -53,7 +53,7 @@ describe('claudeLocalLauncher', () => {
         });
     });
 
-    it('does not abort local Claude Code when an app message requests remote control', async () => {
+    it('aborts local Claude Code when an app message requests remote control', async () => {
         const localRun = createDeferred<void>();
         const observed: {
             queueHandler?: QueueHandler;
@@ -114,7 +114,9 @@ describe('claudeLocalLauncher', () => {
         }
         handler('from app', { permissionMode: 'default' });
 
-        expect(signal.aborted).toBe(false);
+        await vi.waitFor(() => {
+            expect(signal.aborted).toBe(true);
+        });
         expect(session.client.closeClaudeSessionTurn).not.toHaveBeenCalledWith('cancelled');
 
         localRun.resolve();

--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -66,15 +66,17 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
         async function doSwitch() {
             logger.debug('[local]: doSwitch');
             switchRequested = true;
+            if (!processAbortController.signal.aborted) {
+                processAbortController.abort();
+            }
         }
 
         // When to abort
         session.client.rpcHandlerManager.registerHandler('abort', doAbort); // Abort current process, clean queue and switch to remote mode
         session.client.rpcHandlerManager.registerHandler('switch', doSwitch); // When user wants to switch to remote mode
         session.queue.setOnMessage((_message: string, _mode) => {
-            // Remote messages request control from the app, but must not kill
-            // the active local Claude Code process. The message remains queued
-            // and is picked up by remote mode after local exits naturally.
+            // Remote messages request control from the app. Stop local Claude
+            // so queued app messages can be picked up by remote mode now.
             void doSwitch();
         });
 

--- a/packages/happy-cli/src/claude/runClaude.test.ts
+++ b/packages/happy-cli/src/claude/runClaude.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+    mockApiClientCreate,
+    mockCreateSessionScanner,
+    mockLoop,
+    mockNotifyDaemonSessionStarted,
+    mockReadSettings,
+    mockStartHappyServer,
+    mockStartHookServer,
+    mockRegisterKillSessionHandler,
+} = vi.hoisted(() => ({
+    mockApiClientCreate: vi.fn(),
+    mockCreateSessionScanner: vi.fn(),
+    mockLoop: vi.fn(),
+    mockNotifyDaemonSessionStarted: vi.fn(),
+    mockReadSettings: vi.fn(),
+    mockStartHappyServer: vi.fn(),
+    mockStartHookServer: vi.fn(),
+    mockRegisterKillSessionHandler: vi.fn(),
+}));
+
+vi.mock('@/api/api', () => ({
+    ApiClient: {
+        create: mockApiClientCreate,
+    },
+}));
+
+vi.mock('@/persistence', () => ({
+    readSettings: mockReadSettings,
+}));
+
+vi.mock('@/claude/utils/sessionScanner', () => ({
+    createSessionScanner: mockCreateSessionScanner,
+}));
+
+vi.mock('@/claude/loop', () => ({
+    loop: mockLoop,
+}));
+
+vi.mock('@/daemon/controlClient', () => ({
+    notifyDaemonSessionStarted: mockNotifyDaemonSessionStarted,
+}));
+
+vi.mock('@/daemon/run', () => ({
+    initialMachineMetadata: {},
+}));
+
+vi.mock('@/claude/utils/startHappyServer', () => ({
+    startHappyServer: mockStartHappyServer,
+}));
+
+vi.mock('@/claude/utils/startHookServer', () => ({
+    startHookServer: mockStartHookServer,
+}));
+
+vi.mock('@/claude/utils/generateHookSettings', () => ({
+    generateHookSettingsFile: vi.fn(() => '/tmp/happy-hook-settings.json'),
+    cleanupHookSettingsFile: vi.fn(),
+}));
+
+vi.mock('./registerKillSessionHandler', () => ({
+    registerKillSessionHandler: mockRegisterKillSessionHandler,
+}));
+
+vi.mock('@/ui/logger', () => ({
+    logger: {
+        debug: vi.fn(),
+        debugLargeJson: vi.fn(),
+        infoDeveloper: vi.fn(),
+    },
+}));
+
+vi.mock('@/ui/doctor', () => ({
+    getEnvironmentInfo: vi.fn(() => ({})),
+}));
+
+vi.mock('@/utils/serverConnectionErrors', () => ({
+    connectionState: {
+        setBackend: vi.fn(),
+        notifyOffline: vi.fn(),
+        fail: vi.fn(),
+    },
+    startOfflineReconnection: vi.fn(),
+}));
+
+vi.mock('@/claude/claudeLocal', () => ({
+    claudeLocal: vi.fn(),
+}));
+
+import { runClaude } from './runClaude';
+
+function createDeferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe('runClaude remote JSONL scanner', () => {
+    const processEvents = ['SIGTERM', 'SIGINT', 'uncaughtException', 'unhandledRejection'] as const;
+    const originalListeners = new Map<string, Array<(...args: any[]) => void>>();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        for (const event of processEvents) {
+            originalListeners.set(event, process.listeners(event as any) as Array<(...args: any[]) => void>);
+        }
+
+        delete process.env.HAPPY_RECONNECT_SESSION_ID;
+        delete process.env.HAPPY_RECONNECT_ENCRYPTION_KEY;
+        delete process.env.HAPPY_RECONNECT_ENCRYPTION_VARIANT;
+        delete process.env.HAPPY_RECONNECT_SEQ;
+        delete process.env.HAPPY_RECONNECT_METADATA_VERSION;
+        delete process.env.HAPPY_RECONNECT_AGENT_STATE_VERSION;
+        delete process.env.HAPPY_FORKED_FROM_SESSION_ID;
+        delete process.env.HAPPY_FORKED_FROM_MESSAGE_ID;
+        delete process.env.HAPPY_FORK_CLAUDE_SESSION_ID;
+
+        mockReadSettings.mockResolvedValue({
+            machineId: 'machine-1',
+            sandboxConfig: undefined,
+        });
+        mockNotifyDaemonSessionStarted.mockResolvedValue({});
+        mockStartHappyServer.mockResolvedValue({
+            url: 'http://127.0.0.1:12345',
+            toolNames: ['change_title'],
+            stop: vi.fn(),
+        });
+        mockStartHookServer.mockResolvedValue({
+            port: 23456,
+            stop: vi.fn(),
+        });
+        mockCreateSessionScanner.mockResolvedValue({
+            onNewSession: vi.fn(),
+            cleanup: vi.fn(),
+        });
+    });
+
+    afterEach(() => {
+        for (const [event, listeners] of originalListeners) {
+            process.removeAllListeners(event as any);
+            for (const listener of listeners) {
+                process.on(event as any, listener);
+            }
+        }
+        originalListeners.clear();
+    });
+
+    it('does not forward terminal JSONL messages while local mode owns the transcript', async () => {
+        const sentMessages: unknown[] = [];
+        const sessionClient = {
+            sessionId: 'happy-session-1',
+            suppressNextArchiveSignal: vi.fn(),
+            skipExistingMessages: vi.fn(),
+            updateMetadata: vi.fn(),
+            sendClaudeSessionMessage: vi.fn((message: unknown) => {
+                sentMessages.push(message);
+            }),
+            onUserMessage: vi.fn(),
+            onFileEvent: vi.fn(),
+            on: vi.fn(),
+            trackAttachmentDownload: vi.fn(),
+            drainAttachmentsForUserMessage: vi.fn(async () => []),
+            downloadAndDecryptAttachment: vi.fn(),
+            getMetadata: vi.fn(() => ({})),
+            sendSessionEvent: vi.fn(),
+            updateAgentState: vi.fn(),
+            rpcHandlerManager: {
+                registerHandler: vi.fn(),
+            },
+            sendSessionDeath: vi.fn(),
+            flush: vi.fn(async () => {}),
+            close: vi.fn(async () => {}),
+        };
+        const api = {
+            getOrCreateMachine: vi.fn(async () => ({})),
+            getOrCreateSession: vi.fn(async () => ({
+                id: 'happy-session-1',
+                seq: 0,
+                metadata: {},
+                metadataVersion: 0,
+                agentState: {},
+                agentStateVersion: 0,
+                encryptionKey: new Uint8Array(32),
+                encryptionVariant: 'legacy' as const,
+            })),
+            sessionSyncClient: vi.fn(() => sessionClient),
+            deactivateSession: vi.fn(async () => {}),
+        };
+        mockApiClientCreate.mockResolvedValue(api);
+
+        const loopDeferred = createDeferred<number>();
+        mockLoop.mockReturnValue(loopDeferred.promise);
+
+        const runPromise = runClaude({
+            token: 'token',
+            encryption: { type: 'legacy', secret: new Uint8Array(32) },
+        } as any, {
+            startingMode: 'local',
+            shouldStartDaemon: false,
+        });
+
+        await vi.waitFor(() => {
+            expect(mockLoop).toHaveBeenCalled();
+            expect(mockCreateSessionScanner).toHaveBeenCalled();
+        });
+
+        const scannerOptions = mockCreateSessionScanner.mock.calls[0][0];
+        scannerOptions.onMessage({
+            type: 'user',
+            uuid: 'local-owned-user',
+            parentUuid: null,
+            isSidechain: false,
+            sessionId: 'claude-session-1',
+            timestamp: new Date().toISOString(),
+            message: {
+                role: 'user',
+                content: 'typed in local terminal',
+            },
+        });
+
+        expect(sentMessages).toHaveLength(0);
+
+        const loopOptions = mockLoop.mock.calls[0][0];
+        loopOptions.onModeChange('remote');
+        scannerOptions.onMessage({
+            type: 'user',
+            uuid: 'remote-terminal-user',
+            parentUuid: null,
+            isSidechain: false,
+            sessionId: 'claude-session-1',
+            timestamp: new Date().toISOString(),
+            message: {
+                role: 'user',
+                content: 'typed in parallel remote terminal',
+            },
+        });
+
+        expect(sentMessages).toHaveLength(1);
+        expect(sessionClient.sendClaudeSessionMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ uuid: 'remote-terminal-user' }),
+        );
+
+        loopDeferred.resolve(0);
+        const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+            throw new Error('process.exit');
+        }) as never);
+        await expect(runPromise).rejects.toThrow('process.exit');
+        exitSpy.mockRestore();
+    });
+});

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -25,7 +25,7 @@ import { startOfflineReconnection, connectionState } from '@/utils/serverConnect
 import { claudeLocal } from '@/claude/claudeLocal';
 import { createSessionScanner } from '@/claude/utils/sessionScanner';
 import { Session } from './session';
-import { applySandboxPermissionPolicy, resolveInitialClaudePermissionMode } from './utils/permissionMode';
+import { applySandboxPermissionPolicy, resolveInitialClaudePermissionMode, resolveRemoteClaudePermissionMode } from './utils/permissionMode';
 import { decodeBase64, encodeBase64 } from '@/api/encryption';
 import type { Session as ApiSession } from '@/api/types';
 import { getProjectPath } from './utils/path';
@@ -314,6 +314,8 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         return false;
     };
 
+    let currentRunMode: 'local' | 'remote' = options.startingMode ?? 'local';
+
     // Remote-mode session scanner: catches user-typed prompts that
     // appeared in the Claude JSONL while we weren't looking — typically
     // because the user opened `claude --resume <id>` in a terminal next
@@ -327,6 +329,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         sessionId: initialScannerSessionId,
         workingDirectory,
         onMessage: (raw) => {
+            if (currentRunMode !== 'remote') return;
             // Only user-typed prompts. SDK pipeline owns assistant and
             // tool_result-bearing user messages.
             if (raw.type !== 'user') return;
@@ -419,7 +422,6 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     let currentAllowedTools: string[] | undefined = undefined; // Track current allowed tools
     let currentDisallowedTools: string[] | undefined = undefined; // Track current disallowed tools
     let currentEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined = DEFAULT_CLAUDE_EFFORT; // Track current Claude effort (thinking depth)
-    let currentRunMode: 'local' | 'remote' = options.startingMode ?? 'local';
 
     const resetCurrentModeDefaults = () => {
         currentPermissionMode = initialPermissionMode;
@@ -479,9 +481,22 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         // Resolve permission mode from meta - pass through as-is, mapping happens at SDK boundary
         let messagePermissionMode: PermissionMode | undefined = currentPermissionMode;
         if (message.meta?.permissionMode) {
-            messagePermissionMode = applySandboxPermissionPolicy(message.meta.permissionMode, sandboxEnabled);
+            const previousPermissionMode = currentPermissionMode;
+            messagePermissionMode = resolveRemoteClaudePermissionMode(
+                currentPermissionMode,
+                message.meta.permissionMode,
+                sandboxEnabled,
+            );
             currentPermissionMode = messagePermissionMode;
-            logger.debug(`[loop] Permission mode updated from user message to: ${currentPermissionMode}`);
+            const ignoredDefaultDowngrade =
+                (previousPermissionMode === 'bypassPermissions' || previousPermissionMode === 'yolo')
+                && message.meta.permissionMode === 'default'
+                && currentPermissionMode === previousPermissionMode;
+            if (ignoredDefaultDowngrade) {
+                logger.debug(`[loop] Ignoring permission mode downgrade from ${previousPermissionMode} to default`);
+            } else {
+                logger.debug(`[loop] Permission mode updated from user message to: ${currentPermissionMode}`);
+            }
         } else {
             logger.debug(`[loop] User message received with no permission mode override, using current: ${currentPermissionMode}`);
         }

--- a/packages/happy-cli/src/claude/utils/permissionMode.test.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applySandboxPermissionPolicy, extractPermissionModeFromClaudeArgs, mapToClaudeMode, resolveInitialClaudePermissionMode } from './permissionMode';
+import { applySandboxPermissionPolicy, extractPermissionModeFromClaudeArgs, mapToClaudeMode, resolveInitialClaudePermissionMode, resolveRemoteClaudePermissionMode } from './permissionMode';
 import type { PermissionMode } from '@/api/types';
 
 describe('mapToClaudeMode', () => {
@@ -92,5 +92,23 @@ describe('applySandboxPermissionPolicy', () => {
 
     it('returns original mode when sandbox is disabled', () => {
         expect(applySandboxPermissionPolicy('acceptEdits', false)).toBe('acceptEdits');
+    });
+});
+
+describe('resolveRemoteClaudePermissionMode', () => {
+    it('preserves bypassPermissions when an app message sends the default mode', () => {
+        expect(resolveRemoteClaudePermissionMode('bypassPermissions', 'default', false)).toBe('bypassPermissions');
+    });
+
+    it('preserves yolo when an app message sends the default mode', () => {
+        expect(resolveRemoteClaudePermissionMode('yolo', 'default', false)).toBe('yolo');
+    });
+
+    it('still allows explicit plan mode after bypassPermissions was active', () => {
+        expect(resolveRemoteClaudePermissionMode('bypassPermissions', 'plan', false)).toBe('plan');
+    });
+
+    it('applies sandbox policy to incoming modes', () => {
+        expect(resolveRemoteClaudePermissionMode('default', 'plan', true)).toBe('bypassPermissions');
     });
 });

--- a/packages/happy-cli/src/claude/utils/permissionMode.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.ts
@@ -100,3 +100,33 @@ export function applySandboxPermissionPolicy(
     }
     return 'bypassPermissions';
 }
+
+function isClaudeBypassEquivalent(mode: PermissionMode | undefined): boolean {
+    return mode === 'bypassPermissions' || mode === 'yolo';
+}
+
+/**
+ * Resolve permission mode overrides from remote app messages.
+ *
+ * Happy app versions can send `permissionMode: "default"` with every message
+ * even when the CLI process was started in yolo/bypass mode. Since Claude maps
+ * both `yolo` and `bypassPermissions` to bypass at the SDK boundary, do not let
+ * that ambient default downgrade either mode, but still allow explicit modes
+ * such as plan to take effect.
+ */
+export function resolveRemoteClaudePermissionMode(
+    currentMode: PermissionMode | undefined,
+    incomingMode: PermissionMode | undefined,
+    sandboxEnabled: boolean,
+): PermissionMode | undefined {
+    if (!incomingMode) {
+        return currentMode;
+    }
+
+    const nextMode = applySandboxPermissionPolicy(incomingMode, sandboxEnabled);
+    if (isClaudeBypassEquivalent(currentMode) && nextMode === 'default') {
+        return currentMode;
+    }
+
+    return nextMode;
+}


### PR DESCRIPTION
## Summary
- preserve Claude `--yolo` / `bypassPermissions` when browser or mobile messages arrive with the default permission mode
- stop local Claude immediately when an app message takes remote control, so queued remote turns run without waiting for local stdin
- keep the remote JSONL scanner from forwarding messages while local mode owns the transcript, preventing duplicate bubbles after remote/local switching

## Test Plan
- [x] `pnpm --filter happy exec vitest run src/claude/runClaude.test.ts src/claude/claudeLocalLauncher.test.ts src/claude/claudeRemote.test.ts src/claude/utils/permissionMode.test.ts src/claude/utils/sessionScanner.test.ts`
- [x] `pnpm --filter happy run typecheck`
- [x] `git diff --check`