### PR TITLE
feat: add Fable 5 to Claude model picker

### DIFF
--- a/packages/codium/sources/plugins/anthropic/index.ts
+++ b/packages/codium/sources/plugins/anthropic/index.ts
@@ -10,6 +10,7 @@ import type {
 const STORAGE_KEY = 'codium.plugin.anthropic.apiKey'
 
 const MODELS: ModelDescriptor[] = [
+    { id: 'claude-fable-5',    label: 'Fable 5',    group: 'Anthropic', description: 'Newest Claude generation.' },
     { id: 'claude-opus-4-8',   label: 'Opus 4.8',   group: 'Anthropic', description: 'Latest Opus generation.' },
     { id: 'claude-opus-4-7',   label: 'Opus 4.7',   group: 'Anthropic', description: 'Previous Opus generation.' },
     { id: 'claude-opus-4-6',   label: 'Opus 4.6',   group: 'Anthropic', description: 'Deepest reasoning, slowest.' },

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -77,6 +77,7 @@ export function getGeminiPermissionModes(translate: Translate): PermissionMode[]
 export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
+        { key: 'claude-fable-5', name: 'fable 5', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },


### PR DESCRIPTION
## Summary

- Adds `claude-fable-5` to `getClaudeModelModes()` in `packages/happy-app/sources/components/modelModeOptions.ts` so the new model shows up in the mobile/desktop app's Claude model selector
- Adds `claude-fable-5` to the `MODELS` array in `packages/codium/sources/plugins/anthropic/index.ts` so codium's Anthropic plugin lists it in its picker

Opus 4.8 was already added in #1363 / a8a4008d, but Fable 5 wasn't, so users currently can't pick it from the UI.

## Design notes

- Uses the **full model id** `claude-fable-5` as the option key (rather than a short `fable` alias). The SDK transparently passes `model` through (`runClaude.ts` → Agent SDK), but `fable` as an alias hasn't been confirmed in the SDK yet, so the full id is safer. Once the SDK gains a `fable` alias, this can be normalized to match the `opus` / `sonnet` / `haiku` entries.
- No server-side change is needed — verified that `packages/happy-wire/src/messageMeta.ts` defines `model: z.string().nullable().optional()` (open string), and `packages/happy-server` does not hard-code any Claude model id.

## Out of scope

- `packages/happy-cli/src/utils/pricing.ts` — Fable 5 pricing isn't published yet; leaving for a follow-up so we don't bake in guessed numbers.
- `packages/codium/sources/agents/catalog.ts` — only carries abstract `opus` / `sonnet` aliases, no per-version entries to maintain.

Closes #1380

## Test plan

- [ ] Open the Happy app, start a Claude session → model picker shows "fable 5" between "default model" and "opus 4.8"
- [ ] Open codium → Anthropic plugin model picker lists "Fable 5" at the top
- [ ] Select Fable 5 in either UI → next user message round-trips through the Agent SDK without a schema/validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)