### PR TITLE
fix(app): stop complex Mermaid diagrams rendering as an oversized empty box on native

### DIFF
--- a/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
+++ b/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
@@ -114,8 +114,8 @@ export const MermaidRenderer = React.memo((props: {
         <html>
         <head>
             <meta charset="utf-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+            <meta name="viewport" content="width=${Math.round(dimensions.width) || 'device-width'}, initial-scale=1.0">
+            <script src="https://cdn.jsdelivr.net/npm/mermaid@11.12.2/dist/mermaid.min.js"></script>
             <style>
                 body {
                     margin: 0;
@@ -143,10 +143,18 @@ export const MermaidRenderer = React.memo((props: {
             <div id="mermaid-container"></div>
             <script>
                 function reportHeight() {
-                    const height = Math.max(
-                        document.body.scrollHeight,
-                        document.documentElement.scrollHeight
-                    );
+                    // Measure the rendered SVG's own box, not document.body.scrollHeight.
+                    // A mermaid v11 flowchart lays its SVG out at width:100% with no
+                    // intrinsic height, so scrollHeight over-reports the natural
+                    // (unscaled) height — the source of the oversized empty box. The
+                    // SVG's getBoundingClientRect() height is the actual on-screen size
+                    // after max-width:100% scaling.
+                    const svg = document.querySelector('#mermaid-container svg');
+                    const measured = svg
+                        ? svg.getBoundingClientRect().height
+                        : Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);
+                    // + body vertical padding (16px top + 16px bottom).
+                    const height = Math.ceil(measured) + 32;
                     if (window.ReactNativeWebView) {
                         window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'dimensions', height: height }));
                     }
@@ -184,20 +192,25 @@ export const MermaidRenderer = React.memo((props: {
     return (
         <View style={style.container} onLayout={onLayout}>
             <View style={[style.innerContainer, { height: Math.min(dimensions.height, MAX_DIAGRAM_HEIGHT) }]}>
-                <WebView
-                    source={{ html }}
-                    style={{ flex: 1 }}
-                    scrollEnabled={true}
-                    onMessage={(event) => {
-                        const data = JSON.parse(event.nativeEvent.data);
-                        if (data.type === 'dimensions') {
-                            setDimensions(prev => ({
-                                ...prev,
-                                height: Math.max(prev.height, data.height)
-                            }));
-                        }
-                    }}
-                />
+                {dimensions.width > 0 && (
+                    <WebView
+                        source={{ html }}
+                        style={{ flex: 1 }}
+                        scrollEnabled={true}
+                        onMessage={(event) => {
+                            const data = JSON.parse(event.nativeEvent.data);
+                            if (data.type === 'dimensions' && typeof data.height === 'number') {
+                                // Trust the latest measurement (no Math.max latch) so the
+                                // 2-phase re-measure can shrink an initially-oversized
+                                // diagram back down instead of freezing at the larger value.
+                                setDimensions(prev => ({
+                                    ...prev,
+                                    height: Math.max(40, data.height)
+                                }));
+                            }
+                        }}
+                    />
+                )}
             </View>
         </View>
     );


### PR DESCRIPTION
Fixes #1475.

On iOS/Android a Mermaid diagram is drawn inside a `WebView` that reports its rendered height back to React Native, and the container sizes itself from that report. The reporting mechanism works, but every input to it is wrong for a non-trivial diagram: complex flowcharts (`flowchart TB` with nested subgraphs) render as a giant mostly-empty box with a thin vertical strip of diagram in it.

> Note on #1475: that issue's first root cause — "no height reporting from WebView → React Native" — is already resolved on `main`, which now has `reportHeight()` posting through `window.ReactNativeWebView.postMessage` plus `scrollEnabled` and a 600px cap. What's left is that the reported number is wrong, which turns the old clipping into an oversized empty box. This PR fixes the measurement rather than adding the reporter.

Four causes, all in `MermaidRenderer.tsx`:

**1. Over-measurement.** `reportHeight()` measured `Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)`. A mermaid v11 flowchart lays its SVG out at `width: 100%` with no intrinsic height, so `scrollHeight` reports the natural *unscaled* height — much taller than what is actually on screen after `max-width: 100%` scaling. That over-report is the empty box. It now measures the rendered SVG's own `getBoundingClientRect().height` (plus the 32px of body padding), falling back to the old `scrollHeight` path only if no SVG is found.

**2. A height latch.** `onMessage` applied `Math.max(prev.height, data.height)`, so the first oversized measurement froze the container and the second-phase re-measure could never bring it back down. It now trusts the latest measurement, with a 40px floor.

**3. Width mismatch.** The injected `<meta name="viewport">` used `width=device-width`, so the diagram was laid out at full screen width and a wide flowchart overflowed the narrower chat bubble. The measured container width is now injected instead. Verified in a headless browser: a 358px SVG inside a 340px bubble becomes 308px after the fix.

**4. Measuring before the width is known.** The WebView now mounts only once `onLayout` has produced a width (`dimensions.width > 0`), so the first measurement is taken at the real container width rather than at a placeholder one.

Also pins the native mermaid CDN to `@11.12.2` so the WebView and the web bundle render with the same version instead of drifting on `@11`.

The web path (direct SVG via `dangerouslySetInnerHTML`) is untouched.

## Proof

![before/after — native Mermaid height](https://github.com/chphch/happy/releases/download/pr-proofs/mermaid-fix-proof.png)

The native WebView path can't run in the web/Expo harness, so this was verified by loading the **exact** injected HTML in headless Chromium behind a `window.ReactNativeWebView` shim, which is also where the 358px → 308px width measurement above comes from.

## Scope

One file, `packages/happy-app/sources/components/markdown/MermaidRenderer.tsx`. No new dependencies, no API or schema change. `pnpm typecheck` clean.
