### PR TITLE
fix: handle CJK characters in file paths and CLI input

### DIFF
--- a/packages/happy-app/sources/app/(app)/session/[id]/file.tsx
+++ b/packages/happy-app/sources/app/(app)/session/[id]/file.tsx
@@ -12,6 +12,7 @@ import { layout } from '@/components/layout';
 import { t } from '@/text';
 import { FileIcon } from '@/components/FileIcon';
 import { resolveSessionFilePath } from '@/utils/sessionFileLinks';
+import { decodeFilePath } from '@/utils/pathUtils';
 
 interface FileContent {
     content: string;
@@ -96,7 +97,7 @@ export default React.memo(function FileScreen() {
 
     // Decode base64 path with error handling
     try {
-        rawPath = encodedPath ? atob(encodedPath) : '';
+        rawPath = encodedPath ? decodeFilePath(encodedPath) : '';
     } catch (error) {
         console.error('Failed to decode file path:', error);
         rawPath = encodedPath || '';

--- a/packages/happy-app/sources/app/(app)/session/[id]/files.tsx
+++ b/packages/happy-app/sources/app/(app)/session/[id]/files.tsx
@@ -13,6 +13,7 @@ import { useSessionGitStatus } from '@/sync/storage';
 import { useGitStatusFiles } from '@/hooks/useGitStatusFiles';
 import { useUnistyles, StyleSheet } from 'react-native-unistyles';
 import { layout } from '@/components/layout';
+import { encodeFilePath } from '@/utils/pathUtils';
 import { FileIcon } from '@/components/FileIcon';
 import { Shaker, ShakeInstance } from '@/components/Shaker';
 import { usePrefetchFileContents } from '@/hooks/usePrefetchFileContents';
@@ -69,7 +70,7 @@ export default React.memo(function FilesScreen() {
             shakerRefs.current.get(file.fullPath)?.shake();
             return;
         }
-        const encodedPath = btoa(file.fullPath);
+        const encodedPath = encodeFilePath(file.fullPath);
         router.push(`/session/${sessionId}/file?path=${encodedPath}`);
     }, [router, sessionId]);
 

--- a/packages/happy-app/sources/components/FilesSidebar.tsx
+++ b/packages/happy-app/sources/components/FilesSidebar.tsx
@@ -15,6 +15,7 @@ import { FileIcon } from '@/components/FileIcon';
 import { Typography } from '@/constants/Typography';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { t } from '@/text';
+import { encodeFilePath } from '@/utils/pathUtils';
 
 export type SidebarMode = 'changes' | 'allFiles';
 
@@ -179,7 +180,7 @@ export const FilesSidebar = React.memo<FilesSidebarProps>(({
             onFilePress(file);
             return;
         }
-        const encodedPath = btoa(file.fullPath);
+        const encodedPath = encodeFilePath(file.fullPath);
         router.push(`/session/${sessionId}/file?path=${encodedPath}`);
     }, [router, sessionId, onFilePress]);
 

--- a/packages/happy-app/sources/components/ToolGroupView.tsx
+++ b/packages/happy-app/sources/components/ToolGroupView.tsx
@@ -18,6 +18,7 @@ import { t } from '@/text';
 import { Message, ToolCallMessage } from '@/sync/typesMessage';
 import { getToolSummaryCategory, getToolSummaryDetail, ToolSummaryCategory } from '@/utils/toolDisplay';
 import { useRouter } from 'expo-router';
+import { encodeFilePath } from '@/utils/pathUtils';
 import { formatMCPTitle } from './tools/views/MCPToolView';
 
 interface ToolGroupViewProps {
@@ -48,7 +49,7 @@ export const ToolGroupView = React.memo<ToolGroupViewProps>((props) => {
             ? singleToolMessage.tool.input.file_path
             : null;
         if (filePath) {
-            router.push(`/session/${sessionId}/file?path=${btoa(filePath)}`);
+            router.push(`/session/${sessionId}/file?path=${encodeFilePath(filePath)}`);
             return;
         }
         router.push(`/session/${sessionId}/message/${singleToolMessage.id}`);
@@ -320,7 +321,7 @@ function ToolSummaryRow(props: {
     const isPressable = Boolean(props.sessionId);
     const handlePress = React.useCallback(() => {
         if (filePath) {
-            router.push(`/session/${props.sessionId}/file?path=${btoa(filePath)}`);
+            router.push(`/session/${props.sessionId}/file?path=${encodeFilePath(filePath)}`);
             return;
         }
         router.push(`/session/${props.sessionId}/message/${props.message.id}`);

--- a/packages/happy-app/sources/components/tools/ToolView.tsx
+++ b/packages/happy-app/sources/components/tools/ToolView.tsx
@@ -13,6 +13,7 @@ import { Metadata } from '@/sync/storageTypes';
 import { useRouter } from 'expo-router';
 import { PermissionFooter } from './PermissionFooter';
 import { parseToolUseError } from '@/utils/toolErrorParser';
+import { encodeFilePath } from '@/utils/pathUtils';
 import { formatMCPTitle } from './views/MCPToolView';
 import { t } from '@/text';
 import { getTerminalToolCommand, shouldRenderToolCardHeader } from '@/utils/toolDisplay';
@@ -41,7 +42,7 @@ export const ToolView = React.memo<ToolViewProps>((props) => {
         if (onPress) {
             onPress();
         } else if (sessionId && filePath) {
-            router.push(`/session/${sessionId}/file?path=${btoa(filePath)}`);
+            router.push(`/session/${sessionId}/file?path=${encodeFilePath(filePath)}`);
         } else if (sessionId && messageId) {
             router.push(`/session/${sessionId}/message/${messageId}`);
         }

--- a/packages/happy-app/sources/utils/pathUtils.ts
+++ b/packages/happy-app/sources/utils/pathUtils.ts
@@ -1,6 +1,41 @@
 import { Metadata } from '@/sync/storageTypes';
 
 /**
+ * Encode a file path to a URL-safe string that handles Unicode (CJK, etc.).
+ *
+ * The previous implementation used btoa() which only supports Latin-1 characters.
+ * Chinese/Japanese/Korean characters have code points above U+00FF, causing btoa()
+ * to either throw or silently corrupt the path.
+ *
+ * This function uses TextEncoder → Uint8Array → base64 to safely encode any
+ * Unicode path string. Decoded with `decodeFilePath()`.
+ */
+export function encodeFilePath(path: string): string {
+    const bytes = new TextEncoder().encode(path);
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+}
+
+/**
+ * Decode a file path that was encoded with `encodeFilePath()`.
+ *
+ * Handles full Unicode including CJK characters by decoding base64 → bytes
+ * → TextDecoder (UTF-8), instead of the previous atob() which only produces
+ * Latin-1 strings.
+ */
+export function decodeFilePath(encoded: string): string {
+    const binary = atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
+}
+
+/**
  * Resolves a path relative to the root path from metadata.
  * ALL paths are treated as relative to the metadata root, regardless of their format.
  * If metadata is not provided, returns the original path.

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -506,6 +506,12 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                 logger.debug(`[remote]: stdin drain ${event.bytes}B / ${event.chunks} chunk(s) +${Date.now() - t0}ms`);
             },
         });
+        // Reset stdin encoding to binary so the next child process (claude
+        // via stdio:'inherit') receives raw bytes — not UTF-8-decoded strings.
+        // Without this, Node.js's internal StringDecoder can hold partial
+        // multi-byte sequences from the remote-mode session that corrupt
+        // subsequent CJK IME input (e.g. typing "大" produces "大大大").
+        process.stdin.setEncoding(null);
         logger.debug(`[remote]: cleanup done +${Date.now() - t0}ms rawMode=${(process.stdin as any).isRaw}`);
         messageBuffer.clear();
 


### PR DESCRIPTION
## Summary

Two fixes for Chinese/Japanese/Korean users.

### Fix 1: Garbled Chinese filenames in file list (closes #1368)

**Root cause**: `btoa()` only supports Latin-1 characters (code points 0–255). Chinese characters like "测" (U+6D4B) cause `btoa()` to throw `Invalid character` or silently corrupt the path.

**Fix**: Added `encodeFilePath()`/`decodeFilePath()` in `utils/pathUtils.ts` that use `TextEncoder` → bytes → `btoa()` for safe UTF-8 roundtrip. Replaced all 5 `btoa()` and 1 `atob()` calls for path encoding.

**Verified**: Tested with Chinese (`测试文件.py`), Korean (`한국어.md`), Japanese (`日本語ディレクトリ`), emoji (`🎉`), and ASCII paths — all 8/8 pass.

### Fix 2: Chinese input corruption after remote→local switch (closes #1364)

**Root cause**: `process.stdin.setEncoding("utf8")` is called when entering remote mode (line 68), but never reset when switching back to local mode. Node.js's internal `StringDecoder` holds partial multi-byte sequences that corrupt subsequent CJK IME input (e.g. typing "大" produces "大大大").

**Fix**: Added `process.stdin.setEncoding(null)` after `cleanupStdinAfterInk()` in `claudeRemoteLauncher.ts` to reset stdin to binary mode before the local child process takes over.

**Note**: Gemini and Codex don't have remote→local switching, so they don't have this issue.

## Files changed

| File | Change |
|------|--------|
| `utils/pathUtils.ts` | Added `encodeFilePath()` + `decodeFilePath()` |
| `files.tsx` | `btoa(path)` → `encodeFilePath(path)` |
| `FilesSidebar.tsx` | `btoa(path)` → `encodeFilePath(path)` |
| `ToolView.tsx` | `btoa(path)` → `encodeFilePath(path)` |
| `ToolGroupView.tsx` | `btoa(path)` → `encodeFilePath(path)` (×2) |
| `file.tsx` | `atob(path)` → `decodeFilePath(path)` |
| `claudeRemoteLauncher.ts` | Added `setEncoding(null)` after cleanup |

## Testing

- [x] encode/decode roundtrip verified with 8 test cases (CJK + emoji + ASCII)
- [x] No remaining `btoa(path)` calls in the codebase
- [x] `file.tsx:23` `atob(base64)` for file content decoding is **not** affected (correctly handles binary data)
