### PR TITLE
fix(app): re-fetch visible session messages on foreground resume

### DIFF
--- a/packages/happy-app/sources/sync/foregroundResync.test.ts
+++ b/packages/happy-app/sources/sync/foregroundResync.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resyncOnForeground, type Invalidatable } from './foregroundResync';
+
+const makeSync = (): Invalidatable => ({ invalidate: vi.fn() });
+
+describe('resyncOnForeground', () => {
+    it('invalidates every global sync on resume', () => {
+        const globalSyncs = [makeSync(), makeSync(), makeSync()];
+
+        resyncOnForeground({
+            globalSyncs,
+            currentViewingSessionId: null,
+            onSessionVisible: vi.fn(),
+        });
+
+        for (const sync of globalSyncs) {
+            expect(sync.invalidate).toHaveBeenCalledTimes(1);
+        }
+    });
+
+    // Regression for slopus/happy#1308: a backgrounded socket misses realtime
+    // message deliveries, and before this the open chat was never re-fetched on
+    // foreground — it stayed stale until the user left and re-entered the chat.
+    it('re-fetches the visible session messages on resume when a chat is open', () => {
+        const onSessionVisible = vi.fn();
+
+        resyncOnForeground({
+            globalSyncs: [],
+            currentViewingSessionId: 'session-123',
+            onSessionVisible,
+        });
+
+        expect(onSessionVisible).toHaveBeenCalledTimes(1);
+        expect(onSessionVisible).toHaveBeenCalledWith('session-123');
+    });
+
+    it('does not re-fetch a session when no chat is open', () => {
+        const onSessionVisible = vi.fn();
+
+        resyncOnForeground({
+            globalSyncs: [makeSync()],
+            currentViewingSessionId: null,
+            onSessionVisible,
+        });
+
+        expect(onSessionVisible).not.toHaveBeenCalled();
+    });
+});

--- a/packages/happy-app/sources/sync/foregroundResync.ts
+++ b/packages/happy-app/sources/sync/foregroundResync.ts
@@ -1,0 +1,42 @@
+/**
+ * Foreground-resume resync.
+ *
+ * iOS/Android suspend the websocket when the app is backgrounded, locked, or the
+ * user switches apps. The server intentionally does NOT push a notification for
+ * every `new-message`, so a suspended socket silently misses realtime message
+ * deliveries. The metadata syncs below already refresh on resume — but before
+ * this helper existed, the currently-open conversation's *messages* were never
+ * re-fetched on foreground, so the open chat stayed stale until the user backed
+ * out to the session list and re-entered (which fires `onSessionVisible`).
+ *
+ * This refreshes the global state AND the currently-visible session's messages
+ * on every foreground resume. See slopus/happy#1308.
+ */
+
+/** Minimal shape of an InvalidateSync — only `.invalidate()` is needed here. */
+export interface Invalidatable {
+    invalidate(): void;
+}
+
+export interface ForegroundResyncDeps {
+    /** Global, session-independent syncs refreshed on every foreground resume. */
+    globalSyncs: Invalidatable[];
+    /** The session the user currently has open, or null if none is visible. */
+    currentViewingSessionId: string | null;
+    /**
+     * Re-fetches a session's messages (and git status). This is the per-session
+     * path the suspended socket may have missed while backgrounded.
+     */
+    onSessionVisible: (sessionId: string) => void;
+}
+
+export function resyncOnForeground(deps: ForegroundResyncDeps): void {
+    for (const sync of deps.globalSyncs) {
+        sync.invalidate();
+    }
+    // Re-fetch the open conversation's messages so it doesn't stay stale after a
+    // backgrounded socket missed realtime deliveries (slopus/happy#1308).
+    if (deps.currentViewingSessionId) {
+        deps.onSessionVisible(deps.currentViewingSessionId);
+    }
+}

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -37,6 +37,7 @@ import { getServerUrl } from './serverConfig';
 import { config } from '@/config';
 import { log } from '@/log';
 import { gitStatusSync } from './gitStatusSync';
+import { resyncOnForeground } from './foregroundResync';
 import { AsyncLock } from '@/utils/lock';
 import { voiceHooks } from '@/realtime/hooks/voiceHooks';
 import { Message } from './typesMessage';
@@ -177,17 +178,23 @@ class Sync {
                     this.failPendingOutboxMessages('Message failed to send in background after 30s. Please retry.');
                 }
                 log.log('📱 App became active');
-                this.purchasesSync.invalidate();
-                this.profileSync.invalidate();
-                this.machinesSync.invalidate();
-                this.pushTokenSync.invalidate();
-                this.sessionsSync.invalidate();
-                this.nativeUpdateSync.invalidate();
                 log.log('📱 App became active: Invalidating artifacts sync');
-                this.artifactsSync.invalidate();
-                this.friendsSync.invalidate();
-                this.friendRequestsSync.invalidate();
-                this.feedSync.invalidate();
+                resyncOnForeground({
+                    globalSyncs: [
+                        this.purchasesSync,
+                        this.profileSync,
+                        this.machinesSync,
+                        this.pushTokenSync,
+                        this.sessionsSync,
+                        this.nativeUpdateSync,
+                        this.artifactsSync,
+                        this.friendsSync,
+                        this.friendRequestsSync,
+                        this.feedSync,
+                    ],
+                    currentViewingSessionId: storage.getState().currentViewingSessionId,
+                    onSessionVisible: this.onSessionVisible,
+                });
             } else {
                 log.log(`📱 App state changed to: ${nextAppState}`);
                 this.maybeStartBackgroundSendWatchdog();


### PR DESCRIPTION
## Problem

Addresses the app-side half of #1308. When the mobile app is backgrounded/locked, iOS suspends the websocket. The server intentionally does not push a notification for every `new-message`, so a suspended socket silently misses realtime message deliveries.

On foreground resume, the `AppState` `active` handler refreshed global state and session **metadata** (`sessionsSync`) but never invalidated the **currently-open conversation's messages**. Result: the open chat stays stale until the user backs out to the session list and re-enters it (which fires `onSessionVisible`). Conversation titles update; the reply body doesn't appear.

## Fix

Extract the resume-resync sequence into a small dependency-injected helper (`resyncOnForeground`) and add a per-session invalidation for the visible session via `onSessionVisible(currentViewingSessionId)`. Global-sync behavior is unchanged (same syncs, same order); the only new behavior is re-fetching the open session's messages on resume.

## Test

`foregroundResync.test.ts` covers the helper in isolation (the regression: resume re-fetches the visible session's messages; no-op when no chat is open). Unit-tested standalone because `Sync` is an import-time singleton with heavy socket/storage deps.

## Scope

Only the app-side foreground recovery. The server-side push-suppression problem in #1308 (session-scoped CLI sockets counting as active user surfaces) is **not** touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)