### PR TITLE
fix(app): restore saved model & permission picks in new session

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -51,6 +51,7 @@ import {
     getHardcodedModelModes,
     getEffortLevelsForModel,
     getSupportsWorktree,
+    resolveModeIndex,
     type PermissionMode,
     type ModelMode,
     type EffortLevel,
@@ -752,16 +753,16 @@ function NewSessionScreen() {
     const showEffort = effortLevels.length > 0;
     const showPermission = permissionModes.length > 1;
 
-    // Reset indices when agent/default settings change.
+    // Restore the user's saved pick (or fall back to the agent default) when
+    // the agent / default settings change. The draft persists the last
+    // explicit model & permission pick; prefer it so selections survive
+    // navigation and app restarts, else use the agent default.
     React.useEffect(() => {
-        const defaultPermIdx = permissionModes.findIndex(m => m.key === effectiveAgentDefaults.permissionMode);
-        setPermissionIndex(defaultPermIdx >= 0 ? defaultPermIdx : 0);
-
-        const defaultModelIdx = modelModes.findIndex(m => m.key === effectiveAgentDefaults.modelMode);
-        setModelIndex(defaultModelIdx >= 0 ? defaultModelIdx : 0);
+        setPermissionIndex(resolveModeIndex(permissionModes, draft.permissionMode, effectiveAgentDefaults.permissionMode));
+        setModelIndex(resolveModeIndex(modelModes, draft.modelMode, effectiveAgentDefaults.modelMode));
 
         if (!supportsWorktree) setWorktreeKey('__none__');
-    }, [permissionModes, modelModes, supportsWorktree, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode]);
+    }, [permissionModes, modelModes, supportsWorktree, draft.permissionMode, draft.modelMode, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode]);
 
     // Reset effort when model changes
     React.useEffect(() => {

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -178,6 +178,26 @@ export function findOptionByKey<T extends ModeOption>(options: T[], key: string 
     return options.find((option) => option.key === key) ?? null;
 }
 
+// Pick which mode index to pre-select in the new-session screen. Prefers the
+// user's saved draft pick (if that key is still available for the current
+// agent), then the agent default, then index 0. `draftKey` is null/undefined
+// when the user has never explicitly picked — only then does the agent default
+// apply, so an explicit "default" pick is distinct from "unset".
+export function resolveModeIndex(
+    modes: ModeOption[],
+    draftKey: string | null | undefined,
+    fallbackKey: string | null | undefined,
+): number {
+    if (draftKey) {
+        const draftIdx = modes.findIndex((m) => m.key === draftKey);
+        if (draftIdx >= 0) {
+            return draftIdx;
+        }
+    }
+    const fallbackIdx = modes.findIndex((m) => m.key === fallbackKey);
+    return fallbackIdx >= 0 ? fallbackIdx : 0;
+}
+
 export function resolveCurrentOption<T extends ModeOption>(
     options: T[],
     preferredKeys: Array<string | null | undefined>,

--- a/packages/happy-app/sources/components/resolveModeIndex.test.ts
+++ b/packages/happy-app/sources/components/resolveModeIndex.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { resolveModeIndex, type ModeOption } from './modelModeOptions';
+
+const modes: ModeOption[] = [
+    { key: 'default', name: 'default model' },
+    { key: 'opus', name: 'opus 4.8' },
+    { key: 'sonnet', name: 'sonnet 4.6' },
+    { key: 'haiku', name: 'haiku 4.5' },
+];
+
+describe('resolveModeIndex', () => {
+    it('restores the saved draft pick when it is still available', () => {
+        // User explicitly picked sonnet last time; agent default is opus.
+        expect(resolveModeIndex(modes, 'sonnet', 'opus')).toBe(2);
+    });
+
+    it('restores an explicit "default model" pick (not the same as unset)', () => {
+        // Picking the literal default-model entry must survive, even though
+        // the agent default is opus.
+        expect(resolveModeIndex(modes, 'default', 'opus')).toBe(0);
+    });
+
+    it('falls back to the agent default when there is no saved pick', () => {
+        // null draftKey means "never picked" → use agent default (opus).
+        expect(resolveModeIndex(modes, null, 'opus')).toBe(1);
+        expect(resolveModeIndex(modes, undefined, 'opus')).toBe(1);
+    });
+
+    it('falls back to the agent default when the saved pick is not available for this agent', () => {
+        // Draft holds a model from a different agent that this agent lacks.
+        expect(resolveModeIndex(modes, 'gpt-5.5', 'opus')).toBe(1);
+    });
+
+    it('falls back to index 0 when neither pick nor default is available', () => {
+        expect(resolveModeIndex(modes, 'nope', 'also-nope')).toBe(0);
+        expect(resolveModeIndex(modes, null, null)).toBe(0);
+    });
+});

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.ts
@@ -18,8 +18,8 @@ interface NewSessionDraftState {
     selectedMachineId: string | null;
     selectedPath: string | null;
     agentType: NewSessionAgentType;
-    permissionMode: PermissionModeKey;
-    modelMode: string;
+    permissionMode: PermissionModeKey | null;
+    modelMode: string | null;
     sessionType: NewSessionSessionType;
     worktreeKey: string | null;
 
@@ -54,8 +54,8 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     selectedMachineId: initial?.selectedMachineId ?? null,
     selectedPath: initial?.selectedPath ?? null,
     agentType: initial?.agentType ?? 'claude',
-    permissionMode: initial?.permissionMode ?? 'default',
-    modelMode: initial?.modelMode ?? 'default',
+    permissionMode: initial?.permissionMode ?? null,
+    modelMode: initial?.modelMode ?? null,
     sessionType: initial?.sessionType ?? 'simple',
     worktreeKey: initial?.worktreeKey ?? null,
 

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -20,8 +20,8 @@ export interface NewSessionDraft {
     selectedMachineId: string | null;
     selectedPath: string | null;
     agentType: NewSessionAgentType;
-    permissionMode: PermissionModeKey;
-    modelMode: string;
+    permissionMode: PermissionModeKey | null;
+    modelMode: string | null;
     sessionType: NewSessionSessionType;
     worktreeKey: string | null;
     updatedAt: number;
@@ -148,10 +148,10 @@ export function loadNewSessionDraft(): NewSessionDraft | null {
         const agentType: NewSessionAgentType = parsed.agentType === 'codex' || parsed.agentType === 'gemini' || parsed.agentType === 'openclaw'
             ? parsed.agentType
             : 'claude';
-        const permissionMode: PermissionModeKey = typeof parsed.permissionMode === 'string'
+        const permissionMode: PermissionModeKey | null = typeof parsed.permissionMode === 'string'
             ? parsed.permissionMode
-            : 'default';
-        const modelMode: string = typeof parsed.modelMode === 'string' ? parsed.modelMode : 'default';
+            : null;
+        const modelMode: string | null = typeof parsed.modelMode === 'string' ? parsed.modelMode : null;
         const sessionType: NewSessionSessionType = parsed.sessionType === 'worktree' ? 'worktree' : 'simple';
         const worktreeKey = typeof parsed.worktreeKey === 'string' ? parsed.worktreeKey : null;
         const updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now();


### PR DESCRIPTION
## Problem

The new-session screen persists the user's **model** and **permission** picks to the draft (MMKV) — `useNewSessionDraft` even documents that it restores them — but it never reads them back. The mount effect always reseeds the picker indices from the *agent defaults*, so a selection silently resets to the default on every remount. This is most visible on iOS, where navigation remounts the screen, so users report "iOS doesn't save model settings." Machine / path / agent restore correctly; model and permission don't.

## Root cause

`new/index.tsx` reset effect:

```ts
const defaultModelIdx = modelModes.findIndex(m => m.key === effectiveAgentDefaults.modelMode);
setModelIndex(defaultModelIdx >= 0 ? defaultModelIdx : 0);
```

`draft.modelMode` / `draft.permissionMode` are written on pick but never consulted here. The draft's initial `'default'` value also collides with the literal `'default'` model/permission key, so "never picked" couldn't be told apart from an explicit "default" pick.

## Fix

- Make the draft's `modelMode` / `permissionMode` nullable (`null` = unset), so an explicit "default" pick is distinct from never having picked.
- Add a pure, tested `resolveModeIndex(modes, draftKey, fallbackKey)` helper: prefer the saved pick when still available for the current agent, else the agent default, else index 0.
- Use it in the reset effect (model + permission), with the draft values added to the dependency list.

Selecting a different agent still falls back to that agent's default (a pick from another agent won't be in its mode list). Setting a global default in **Settings → Agent Defaults** still applies for users who never picked in the new-session screen.

## Tests

`resolveModeIndex.test.ts` covers: restore saved pick, explicit-`default` vs unset, fallback to agent default, cross-agent fallback, and the index-0 floor. Full suite green; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)