### PR TITLE
fix(app): filter recent paths while typing & keep keyboard off the list

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -11,6 +11,7 @@ import {
     ScrollView,
     LayoutAnimation,
     ActivityIndicator,
+    Keyboard,
     TextInputSelectionChangeEventData,
     NativeSyntheticEvent,
     Image as RNImage,
@@ -59,6 +60,7 @@ import { isRunningOnMac } from '@/utils/platform';
 import { getNewSessionSidebarLayout } from '@/utils/newSessionSidebarLayout';
 import { getAgentPickerItems, getModePickerItems } from '@/utils/newSessionPickerItems';
 import { resolveAgentDefaultConfig } from '@/sync/agentDefaults';
+import { filterPickerItems } from '@/utils/filterPickerItems';
 
 // Agent icon assets
 const agentIcons = {
@@ -322,6 +324,7 @@ function PathPickerContent({
     onChangeValue,
     onDone,
     embedded = false,
+    fillHeight = false,
 }: {
     title: string;
     items: PickerItem[];
@@ -330,6 +333,7 @@ function PathPickerContent({
     onChangeValue: (value: string) => void;
     onDone?: () => void;
     embedded?: boolean;
+    fillHeight?: boolean;
 }) {
     const { theme } = useUnistyles();
     const inputRef = React.useRef<TextInput>(null);
@@ -342,6 +346,28 @@ function PathPickerContent({
         }, 50);
         return () => clearTimeout(timeout);
     }, []);
+
+    // Track the keyboard so the recent list can pad itself clear of it. The
+    // path picker renders inside a modal sheet on native, which the screen's
+    // KeyboardAvoidingView doesn't reach, so the keyboard would otherwise
+    // float over the list. Web has no software keyboard to account for.
+    const [keyboardHeight, setKeyboardHeight] = React.useState(0);
+    React.useEffect(() => {
+        if (Platform.OS === 'web') {
+            return;
+        }
+        const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+        const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+        const showSub = Keyboard.addListener(showEvent, (e) => setKeyboardHeight(e.endCoordinates?.height ?? 0));
+        const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0));
+        return () => {
+            showSub.remove();
+            hideSub.remove();
+        };
+    }, []);
+
+    // Typing in the path field doubles as a filter over the recent projects.
+    const filteredItems = React.useMemo(() => filterPickerItems(items, currentValue), [items, currentValue]);
 
     const matchedItemKey = React.useMemo(() => {
         const normalizedValue = normalizePathForComparison(currentValue, homeDir);
@@ -375,7 +401,7 @@ function PathPickerContent({
     const doneIconColor = theme.colors.header.tint;
 
     return (
-        <View style={[pickerStyles.container, embedded && pickerStyles.embeddedContainer]}>
+        <View style={[pickerStyles.container, embedded && pickerStyles.embeddedContainer, fillHeight && pickerStyles.containerFill]}>
             {!embedded && (
                 <View style={pickerStyles.titleRow}>
                     <Text style={[pickerStyles.title, { color: theme.colors.text }]}>{title}</Text>
@@ -456,11 +482,12 @@ function PathPickerContent({
             </Text>
 
             <ScrollView
-                style={[pickerStyles.optionList, embedded && pickerStyles.embeddedOptionList]}
-                contentContainerStyle={embedded && pickerStyles.embeddedOptionListContent}
+                style={[pickerStyles.optionList, embedded && pickerStyles.embeddedOptionList, fillHeight && pickerStyles.optionListFill]}
+                contentContainerStyle={[embedded && pickerStyles.embeddedOptionListContent, { paddingBottom: keyboardHeight }]}
                 keyboardShouldPersistTaps="handled"
+                keyboardDismissMode="none"
             >
-                {items.map((item) => {
+                {filteredItems.map((item) => {
                     const isSelected = item.key === matchedItemKey;
 
                     return (
@@ -494,9 +521,9 @@ function PathPickerContent({
                     );
                 })}
 
-                {items.length === 0 && (
+                {filteredItems.length === 0 && (
                     <Text style={[pickerStyles.emptyText, { color: theme.colors.textSecondary }]}>
-                        no recent projects yet
+                        {items.length === 0 ? 'no recent projects yet' : 'no matches'}
                     </Text>
                 )}
             </ScrollView>
@@ -1434,6 +1461,7 @@ function NewSessionScreen() {
                             homeDir={selectedHomeDir}
                             onChangeValue={setSelectedPath}
                             onDone={() => setActivePicker(null)}
+                            fillHeight
                         />
                     ) : pickerData ? (
                         <PickerContent {...pickerData} onSelect={handlePickerSelect} />
@@ -1795,6 +1823,9 @@ const pickerStyles = {
         paddingHorizontal: 16,
         paddingBottom: 8,
     } as const,
+    containerFill: {
+        flex: 1,
+    } as const,
     embeddedContainer: {
         width: '100%',
         maxWidth: '100%',
@@ -1941,6 +1972,10 @@ const pickerStyles = {
     } as const,
     optionList: {
         flexGrow: 0,
+        flexShrink: 1,
+    } as const,
+    optionListFill: {
+        flexGrow: 1,
         flexShrink: 1,
     } as const,
     embeddedOptionList: {

--- a/packages/happy-app/sources/utils/filterPickerItems.test.ts
+++ b/packages/happy-app/sources/utils/filterPickerItems.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { filterPickerItems } from './filterPickerItems';
+
+const items = [
+    { key: '/Users/jane/Code/happy', label: '~/Code/happy' },
+    { key: '/Users/jane/Code/seneca', label: '~/Code/seneca' },
+    { key: '/Users/jane/work/api', label: '~/work/api' },
+];
+
+describe('filterPickerItems', () => {
+    it('returns all items for an empty or whitespace query', () => {
+        expect(filterPickerItems(items, '')).toEqual(items);
+        expect(filterPickerItems(items, '   ')).toEqual(items);
+    });
+
+    it('matches on the label, case-insensitively', () => {
+        expect(filterPickerItems(items, 'HAPPY').map((i) => i.label)).toEqual(['~/Code/happy']);
+    });
+
+    it('matches on the full key path too', () => {
+        expect(filterPickerItems(items, '/work/').map((i) => i.label)).toEqual(['~/work/api']);
+    });
+
+    it('returns multiple matches when the query is a shared fragment', () => {
+        expect(filterPickerItems(items, 'code').map((i) => i.label)).toEqual([
+            '~/Code/happy',
+            '~/Code/seneca',
+        ]);
+    });
+
+    it('returns an empty array when nothing matches', () => {
+        expect(filterPickerItems(items, 'zzz')).toEqual([]);
+    });
+});

--- a/packages/happy-app/sources/utils/filterPickerItems.ts
+++ b/packages/happy-app/sources/utils/filterPickerItems.ts
@@ -1,0 +1,17 @@
+export interface FilterablePickerItem {
+    key: string;
+    label: string;
+}
+
+// Case-insensitive substring filter over a picker item's label and key.
+// An empty/whitespace query returns the list unchanged. Used by the
+// new-session path picker so typing narrows the recent-projects list.
+export function filterPickerItems<T extends FilterablePickerItem>(items: T[], query: string): T[] {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+        return items;
+    }
+    return items.filter((item) =>
+        item.label.toLowerCase().includes(q) || item.key.toLowerCase().includes(q),
+    );
+}


### PR DESCRIPTION
## Problem

In the new-session **path picker**:

1. The *Recent* list rendered every project regardless of what was typed — no filtering.
2. On native the picker lives in a modal `BottomSheet` that the screen's `KeyboardAvoidingView` doesn't reach, so the software keyboard floated **in front of** the list, hiding it.

## Fix

- **Typing filters the list.** The path field now doubles as a filter over the recent projects — case-insensitive substring over both the label and the full key path, via a new pure `filterPickerItems` helper. Empty input shows everything; no-match shows "no matches".
- **Keyboard no longer covers the list.** `PathPickerContent` tracks keyboard height (`keyboardWillShow`/`Hide` on iOS, `keyboardDidShow`/`Hide` on Android) and pads its scroll content by it, and a new `fillHeight` prop makes the list fill the sheet so every entry can be scrolled clear of the keyboard.

Scope is contained: `fillHeight` is passed only at the native bottom-sheet instance. The web popover and the embedded sidebar variant are unaffected (no software keyboard, no `fillHeight`).

## Tests

`filterPickerItems.test.ts` covers empty/whitespace passthrough, case-insensitive label match, key-path match, multi-match, and no-match. Full suite green; `pnpm typecheck` clean.

## Note

Keyboard avoidance is inherently device-behaviour; verified by reasoning about the modal/KAV boundary and the standard pad-by-keyboard-height pattern. Worth a quick on-device check on an iOS build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)