### PR TITLE
fix(cli): resolve native-installer Claude binary instead of falling back to a stale install

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -110,11 +110,19 @@ function findClaudeInPath() {
         const resolvedPath = resolvePathSafe(claudePath) || claudePath;
 
         if (resolvedPath) {
-            // On Windows, npm creates shell script shims (no extension) for global packages.
-            // These cannot be spawned directly by Node.js. When we find such a shim,
+            // On Windows, npm creates extensionless shell-script shims for global
+            // packages that Node.js cannot spawn directly. When we find such a shim,
             // resolve to the actual cli.js in the adjacent node_modules directory.
+            //
+            // This must stay Windows-only: on macOS/Linux an extensionless file is
+            // NOT a shim. The native installer (>= 2.1.113) ships a self-contained
+            // compiled binary at ~/.local/share/claude/versions/<ver>, which IS
+            // directly executable. Treating it as a Windows shim made this function
+            // return null and silently fall back to other (often older) installs —
+            // e.g. a stale Homebrew copy — even when `which claude` already pointed
+            // at the newer native binary.
             const isExecutable = resolvedPath.endsWith('.js') || resolvedPath.endsWith('.cjs') || resolvedPath.endsWith('.exe');
-            if (!isExecutable) {
+            if (!isExecutable && process.platform === 'win32') {
                 const shimDir = path.dirname(claudePath);
                 const pkgDir = path.join(shimDir, 'node_modules', '@anthropic-ai', 'claude-code');
                 const entrypoint = resolveClaudeEntrypoint(pkgDir);

--- a/packages/happy-cli/scripts/claude_version_utils.path.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.path.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Regression tests for findClaudeInPath() resolving the native-installer
+ * Claude Code binary.
+ *
+ * The native installer (>= 2.1.113) ships a self-contained, extensionless
+ * compiled binary at ~/.local/share/claude/versions/<ver>. findClaudeInPath()
+ * used to treat any resolved path without a .js/.cjs/.exe extension as a
+ * Windows npm shim, look for an adjacent node_modules/@anthropic-ai/claude-code,
+ * and — finding none on Unix — return null. happy then silently fell back to a
+ * different (often older) install, e.g. a stale Homebrew copy. These tests pin
+ * the fix: on macOS/Linux the extensionless native binary is used directly.
+ */
+
+// Hoisted so the vi.mock factories below can read/mutate it per test.
+const state = vi.hoisted(() => ({
+  whichOutput: '',
+  existing: new Set<string>(),
+  symlinks: new Map<string, string>(),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(() => state.whichOutput),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn((p: string) => state.existing.has(p)),
+  realpathSync: vi.fn((p: string) => state.symlinks.get(p) ?? p),
+  // Unused by findClaudeInPath but referenced elsewhere in the module.
+  readFileSync: vi.fn(() => ''),
+  readdirSync: vi.fn(() => []),
+  statSync: vi.fn(() => ({ isFile: () => true, isDirectory: () => false })),
+}));
+
+// Import after mocks are registered.
+import { findClaudeInPath } from '../scripts/claude_version_utils.cjs';
+
+function setPlatform(value: string) {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+describe('findClaudeInPath - native installer (extensionless binary)', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    state.whichOutput = '';
+    state.existing = new Set();
+    state.symlinks = new Map();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.clearAllMocks();
+  });
+
+  it('resolves the native binary on Linux instead of returning null', () => {
+    setPlatform('linux');
+    const symlink = '/home/user/.local/bin/claude';
+    const binary = '/home/user/.local/share/claude/versions/2.1.175/claude';
+    state.whichOutput = `${symlink}\n`;
+    state.existing.add(symlink).add(binary);
+    state.symlinks.set(symlink, binary);
+
+    const result = findClaudeInPath();
+
+    expect(result).not.toBeNull();
+    expect(result?.path).toBe(binary);
+    expect(result?.source).toBe('native installer');
+  });
+
+  it('resolves the native binary on macOS (~/.local/bin -> versions/<ver>)', () => {
+    setPlatform('darwin');
+    const symlink = '/Users/test/.local/bin/claude';
+    const binary = '/Users/test/.local/share/claude/versions/2.1.175';
+    state.whichOutput = `${symlink}\n`;
+    state.existing.add(symlink).add(binary);
+    state.symlinks.set(symlink, binary);
+
+    const result = findClaudeInPath();
+
+    expect(result?.path).toBe(binary);
+    expect(result?.source).toBe('native installer');
+  });
+
+  it('still resolves a .js cli entrypoint (npm) normally', () => {
+    setPlatform('linux');
+    const symlink = '/home/user/.nvm/versions/node/v22.19.0/bin/claude';
+    const cli = '/home/user/.nvm/versions/node/v22.19.0/lib/node_modules/@anthropic-ai/claude-code/cli.js';
+    state.whichOutput = `${symlink}\n`;
+    state.existing.add(symlink).add(cli);
+    state.symlinks.set(symlink, cli);
+
+    const result = findClaudeInPath();
+
+    expect(result?.path).toBe(cli);
+    expect(result?.source).toBe('npm');
+  });
+});


### PR DESCRIPTION
## Problem

On macOS/Linux, `happy` can launch an **older** Claude Code than the one `which claude` resolves to.

`findClaudeInPath()` in `packages/happy-cli/scripts/claude_version_utils.cjs` takes the first `which claude` result, resolves the symlink, and — if the resolved path doesn't end in `.js` / `.cjs` / `.exe` — assumes it's a Windows npm shim, looks for an adjacent `node_modules/@anthropic-ai/claude-code`, and returns `null` when none is found.

But the **native installer** (Claude Code ≥ 2.1.113) ships a self-contained, *extensionless* compiled binary at `~/.local/share/claude/versions/<ver>`. That path is therefore wrongly rejected, and `findGlobalClaudeCliPath()` silently falls through to the next finder — frequently a stale Homebrew copy.

### Repro

Native installer on `PATH` (`~/.local/bin/claude` → `~/.local/share/claude/versions/2.1.175`) **plus** an old `brew`-installed `@anthropic-ai/claude-code`:

```console
$ which claude
/Users/me/.local/bin/claude          # native, 2.1.175

$ happy --version
1.0.102 (Claude Code)                 # from Homebrew — NOT what `which` resolves to
```

`findClaudeInPath()` returns `null`, so resolution falls back to `/opt/homebrew/.../cli.js` (v1.0.102).

## Fix

Gate the shim-redirect branch to `win32`, where extensionless npm shims actually exist. On every other platform an extensionless binary is the native installer and is used directly — `runClaudeCli()` already spawns non-JS entrypoints as binaries.

After the change:

```console
$ happy --version
2.1.175 (Claude Code)                 # native installer, matches `which claude`
```

`findClaudeInPath()` → `{ path: '~/.local/share/claude/versions/2.1.175', source: 'native installer' }`.

## Tests

New `claude_version_utils.path.test.ts`:
- native binary resolved on Linux (no longer `null`)
- native binary resolved on macOS (`~/.local/bin` → `versions/<ver>`)
- npm `cli.js` resolution unchanged

Windows behaviour is unchanged — the shim path is preserved, just guarded behind `process.platform === 'win32'`.
