### PR TITLE
fix(app): avoid overriding WebRTC audio routing

### DIFF
--- a/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
+++ b/packages/happy-app/sources/realtime/RealtimeVoiceSession.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import { AudioSession, AndroidAudioTypePresets } from '@livekit/react-native';
 import { useConversation } from '@elevenlabs/react-native';
 import { registerVoiceSession } from './RealtimeSession';
 import { storage } from '@/sync/storage';
@@ -14,6 +16,36 @@ const VAD_THRESHOLD = 0.5;
 const VAD_SILENCE_MS = 300;
 let vadSilenceTimer: ReturnType<typeof setTimeout> | null = null;
 let agentIsSpeaking = false;
+
+async function configureVoiceAudioSession(): Promise<void> {
+    if (Platform.OS !== 'android') {
+        return;
+    }
+
+    await AudioSession.configureAudio({
+        android: {
+            preferredOutputList: ['bluetooth', 'headset', 'earpiece', 'speaker'],
+            audioTypeOptions: {
+                ...AndroidAudioTypePresets.communication,
+                forceHandleAudioRouting: true,
+            },
+        },
+    });
+    await AudioSession.startAudioSession();
+
+    const outputs = await AudioSession.getAudioOutputs();
+    if (outputs.includes('bluetooth')) {
+        await AudioSession.selectAudioOutput('bluetooth');
+    }
+}
+
+async function stopVoiceAudioSession(): Promise<void> {
+    if (Platform.OS !== 'android') {
+        return;
+    }
+
+    await AudioSession.stopAudioSession();
+}
 
 // Global voice session implementation
 class RealtimeVoiceSessionImpl implements VoiceSession {
@@ -53,7 +85,8 @@ class RealtimeVoiceSessionImpl implements VoiceSession {
                     }
                 },
             };
-            
+
+            await configureVoiceAudioSession();
             await conversationInstance.startSession(sessionConfig);
             return conversationInstance.getId?.() ?? null;
         } catch (error) {
@@ -74,6 +107,11 @@ class RealtimeVoiceSessionImpl implements VoiceSession {
         } catch (error) {
             console.error('Failed to end realtime session:', error);
         } finally {
+            try {
+                await stopVoiceAudioSession();
+            } catch (error) {
+                console.warn('Failed to stop voice audio session:', error);
+            }
             storage.getState().setRealtimeStatus('disconnected');
         }
     }

--- a/packages/happy-app/sources/utils/microphonePermissions.ts
+++ b/packages/happy-app/sources/utils/microphonePermissions.ts
@@ -32,12 +32,10 @@ export async function requestMicrophonePermission(): Promise<MicrophonePermissio
       const result = await AudioModule.requestRecordingPermissionsAsync();
 
       if (result.granted) {
-        // Configure audio mode for recording
-        await AudioModule.setAudioModeAsync({
-          allowsRecording: true,
-          playsInSilentMode: true,
-        });
-
+        // NOTE: Do NOT call AudioModule.setAudioModeAsync here.
+        // expo-audio 55+ activates AVAudioSession when setAudioModeAsync is called,
+        // taking ownership without Bluetooth routing options and clobbering the
+        // WebRTC audio session that ElevenLabs/LiveKit configures on session start.
         return { granted: true, canAskAgain: result.canAskAgain };
       }
 


### PR DESCRIPTION
Fixes #1109.

This PR fixes an Android voice-session routing issue where Happy voice audio stays on the phone speaker / speakerphone route even when a Bluetooth headset is connected.

I recently subscribed to the paid voice assistant service and noticed that, on Android, enabling Bluetooth did not make the voice assistant use my Bluetooth headset microphone/output. Instead, the session continued to behave like a speakerphone call.

## What seems to be causing this

The issue appears to be related to the recent Expo audio migration / `expo-audio` changes.

From testing, there seemed to be two related problems:

1. `requestMicrophonePermission()` was calling `AudioModule.setAudioModeAsync(...)`.
   - With `expo-audio`, this can activate/configure the platform audio session before the ElevenLabs/LiveKit WebRTC session starts.
   - That appears to interfere with the WebRTC audio session routing that should happen when the realtime voice session starts.

2. The Android LiveKit audio session was not explicitly selecting the Bluetooth/headset output before starting the voice session.
   - The session appeared to be on a call/communication-style path already, but it stayed routed to speakerphone instead of the connected Bluetooth headset.
   - Explicitly configuring the LiveKit audio session and preferring Bluetooth/headset outputs fixed the routing on my Android device.

## Changes

This PR makes two changes:

1. Removes the eager `AudioModule.setAudioModeAsync(...)` call from microphone permission handling.
   - The permission helper should only request microphone permission.
   - It should not take ownership of or reconfigure the audio session before WebRTC starts.

2. Configures the LiveKit audio session on Android before starting the realtime voice session.
   - Uses `AndroidAudioTypePresets.communication`
   - Starts the LiveKit `AudioSession`
   - Prefers Bluetooth/headset outputs
   - Stops the LiveKit `AudioSession` when the realtime voice session ends

## Testing

Tested:

- Android device with Bluetooth headset
  - Before this change: voice stayed routed to speakerphone even with Bluetooth connected
  - After this change: Bluetooth headset routing worked correctly
- Web
  - Verified the web version still starts/runs

Not tested:

- iOS

I do not currently have a way to test this on iOS.

Claude Code suggested that the iOS impact should be low because the new LiveKit audio-session configuration is guarded behind `Platform.OS === 'android'`. Also, LiveKit appears to handle iOS audio session setup separately when audio capture starts, so this Android-specific routing change should not be necessary on iOS.

That said, if someone has an iOS device available, it would be great to verify that voice sessions still behave correctly there.

## Notes

I am not attached to this exact implementation. If there is a better place to configure Android LiveKit/WebRTC audio routing, I would be happy with that approach too.

Even if this PR is not merged as-is, I would really appreciate a fix for this issue. For now, I plan to use a local build from this PR branch because it fixes the Bluetooth headset routing problem on my Android device.

Thanks for building and maintaining Happy — I use it a lot and really appreciate the work going into it.