### PR TITLE
feat(effort): add 'auto' adaptive effort level for Claude

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -10,6 +10,7 @@ import {
     getCodexModelModes,
     getCodexPermissionModes,
     getClaudeModelModes,
+    getClaudeEffortLevels,
     getClaudePermissionModes,
     getGeminiPermissionModes,
     getDefaultEffortKey,
@@ -178,6 +179,12 @@ describe('modelModeOptions', () => {
         expect(getDefaultPermissionModeKey('codex')).toBe('yolo');
         expect(getDefaultModelKey('codex')).toBe('gpt-5.6-sol');
         expect(getDefaultEffortKey('codex')).toBe('medium');
+    });
+
+    it('exposes the auto effort level first for claude', () => {
+        const levels = getClaudeEffortLevels();
+        expect(levels.map((level) => level.key)).toEqual(['auto', 'low', 'medium', 'high', 'xhigh', 'max']);
+        expect(levels[0]).toEqual({ key: 'auto', name: 'auto', description: 'let Claude decide' });
     });
 
     it('prefers metadata models over hardcoded fallbacks', () => {

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -507,7 +507,14 @@ const CODEX_EFFORTS_BY_MODEL: Record<string, readonly string[]> = {
 const CODEX_EFFORTS_FALLBACK = ['low', 'medium', 'high', 'xhigh'] as const;
 
 export function getClaudeEffortLevels(): EffortLevel[] {
-    return effortLevels(CLAUDE_EFFORTS);
+    return [
+        // 'auto' pins no effort level — the model self-paces via adaptive
+        // thinking (Claude decides how much to think per turn). The CLI maps it
+        // to an omitted SDK `effort` option. See happy-cli loop.ts toSdkEffort().
+        // Carried separately because it is the one level with a description.
+        { key: 'auto', name: 'auto', description: 'let Claude decide' },
+        ...effortLevels(CLAUDE_EFFORTS),
+    ];
 }
 
 /**

--- a/packages/happy-app/sources/sync/messageMeta.test.ts
+++ b/packages/happy-app/sources/sync/messageMeta.test.ts
@@ -134,6 +134,17 @@ describe('resolveMessageModeMeta', () => {
         });
     });
 
+    it('transports the auto effort level to the CLI', () => {
+        const meta = resolveMessageModeMeta({
+            permissionMode: null,
+            modelMode: null,
+            effortLevel: 'auto',
+            metadata: { flavor: 'claude' },
+        } as any);
+
+        expect(meta).toEqual({ effort: 'auto' });
+    });
+
     it('sends settings-level overrides when session has no override', () => {
         const meta = resolveMessageModeMeta({
             permissionMode: null,

--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -1,4 +1,4 @@
-import { EnhancedMode } from "./loop";
+import { EnhancedMode, toSdkEffort } from "./loop";
 import { query, type CanCallToolOptions, type QueryOptions, type SDKMessage, type SDKSystemMessage, AbortError, SDKUserMessage } from '@/claude/sdk'
 import type { MessageParam } from '@anthropic-ai/sdk/resources'
 import { mapToClaudeMode } from "./utils/permissionMode";
@@ -135,11 +135,15 @@ export async function claudeRemote(opts: {
         appendSystemPrompt: initial.mode.appendSystemPrompt ? initial.mode.appendSystemPrompt + '\n\n' + systemPrompt : systemPrompt,
         allowedTools: initial.mode.allowedTools ? initial.mode.allowedTools.concat(opts.allowedTools) : opts.allowedTools,
         disallowedTools: initial.mode.disallowedTools,
-        effort: initial.mode.effort,
+        effort: toSdkEffort(initial.mode.effort),
         canCallTool: (toolName: string, input: unknown, options: CanCallToolOptions) => opts.canCallTool(toolName, input, mode, options),
         abort: opts.signal,
         settingsPath: opts.hookSettingsPath,
     }
+
+    // 'auto' pins no effort — toSdkEffort() returns undefined so the `effort`
+    // option is omitted and the model self-paces via adaptive thinking.
+    logger.debug(`[claudeRemote] effort: mode='${initial.mode.effort ?? '<unset>'}' -> sdk=${sdkOptions.effort ?? '<omitted: adaptive/auto>'}`);
 
     // Track thinking state
     let thinking = false;

--- a/packages/happy-cli/src/claude/loop.test.ts
+++ b/packages/happy-cli/src/claude/loop.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Unit coverage for the 'auto' effort mapping:
+ *   toSdkEffort() collapses the Happy-only 'auto' level to `undefined`, so the
+ *   SDK `effort` option is omitted and the model self-paces via adaptive
+ *   thinking (Claude decides how much to think per turn).
+ */
+import { describe, it, expect } from 'vitest';
+import { toSdkEffort } from './loop';
+
+describe('toSdkEffort', () => {
+    it("maps 'auto' to undefined (omit the SDK effort option)", () => {
+        expect(toSdkEffort('auto')).toBeUndefined();
+    });
+
+    it('passes every real SDK effort through unchanged', () => {
+        for (const e of ['low', 'medium', 'high', 'xhigh', 'max'] as const) {
+            expect(toSdkEffort(e)).toBe(e);
+        }
+    });
+
+    it('passes undefined through (SDK default)', () => {
+        expect(toSdkEffort(undefined)).toBeUndefined();
+    });
+});

--- a/packages/happy-cli/src/claude/loop.ts
+++ b/packages/happy-cli/src/claude/loop.ts
@@ -13,7 +13,30 @@ import type { SandboxConfig } from "@/persistence"
 export type { PermissionMode } from "@/api/types"
 import type { PermissionMode } from "@/api/types"
 
-export type ClaudeEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+/**
+ * Effort levels the Claude Agent SDK accepts directly for its `effort` option.
+ */
+export type SdkEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+/**
+ * Happy's effort levels. Superset of {@link SdkEffort}: 'auto' is a Happy-only
+ * level meaning "let Claude decide how much to think" — no effort is pinned and
+ * the model self-paces via adaptive thinking (the SDK default for supporting
+ * models). It carries no SDK thinking level of its own. See {@link toSdkEffort}.
+ */
+export type ClaudeEffort = SdkEffort | 'auto';
+
+/**
+ * Resolve a Happy effort to the value handed to the SDK's `effort` option.
+ * 'auto' has no fixed thinking level, so it maps to `undefined` — the `effort`
+ * option is omitted and the model's adaptive thinking decides the depth.
+ */
+export function toSdkEffort(effort: ClaudeEffort | undefined): SdkEffort | undefined {
+    if (effort === undefined || effort === 'auto') {
+        return undefined;
+    }
+    return effort;
+}
 
 export interface EnhancedMode {
     /** Unset means "no override" — Claude uses its own configured mode. */

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -7,7 +7,7 @@ import { loop } from '@/claude/loop';
 import { AgentGoalStatus, AgentState, Metadata } from '@/api/types';
 import packageJson from '../../package.json';
 import { Credentials, readSettings } from '@/persistence';
-import { EnhancedMode, PermissionMode } from './loop';
+import { EnhancedMode, PermissionMode, type ClaudeEffort } from './loop';
 import { MessageQueue2 } from '@/utils/MessageQueue2';
 import { hashObject } from '@/utils/deterministicJson';
 import { parseSpecialCommand } from '@/parsers/specialCommands';
@@ -46,7 +46,7 @@ export type JsRuntime = 'node' | 'bun'
 export interface StartOptions {
     model?: string
     permissionMode?: PermissionMode
-    effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+    effort?: ClaudeEffort
     startingMode?: 'local' | 'remote'
     shouldStartDaemon?: boolean
     claudeEnvVars?: Record<string, string>
@@ -64,7 +64,7 @@ export interface StartOptions {
 // The model works the same way: no default. This used to be 'opus', which
 // pinned every remote turn to the 200K model even when the user's own Claude
 // config (settings.json, ANTHROPIC_MODEL) said e.g. claude-opus-5[1m] (#1721).
-const DEFAULT_CLAUDE_EFFORT: 'low' | 'medium' | 'high' | 'xhigh' | 'max' = 'medium';
+const DEFAULT_CLAUDE_EFFORT: ClaudeEffort = 'medium';
 type ClaudeGoalCommand = NonNullable<ReturnType<typeof parseClaudeGoalActionParams>>;
 type PendingClaudeGoalAction = {
     command: ClaudeGoalCommand;
@@ -541,7 +541,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     let currentAppendSystemPrompt: string | undefined = undefined; // Track current append system prompt
     let currentAllowedTools: string[] | undefined = undefined; // Track current allowed tools
     let currentDisallowedTools: string[] | undefined = undefined; // Track current disallowed tools
-    let currentEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined = options.effort ?? DEFAULT_CLAUDE_EFFORT; // Track current Claude effort (thinking depth)
+    let currentEffort: ClaudeEffort | undefined = options.effort ?? DEFAULT_CLAUDE_EFFORT; // Track current Claude effort (thinking depth)
 
     const resetCurrentModeDefaults = () => {
         // Model and effort are deliberately NOT reset here. The app sends them
@@ -753,7 +753,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         // Validate against the SDK's accepted set so a stale/garbage value
         // from the wire doesn't poison the session.
         let messageEffort = currentEffort;
-        const VALID_EFFORTS: ReadonlySet<string> = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+        const VALID_EFFORTS: ReadonlySet<string> = new Set(['low', 'medium', 'high', 'xhigh', 'max', 'auto']);
         if (message.meta?.hasOwnProperty('effort')) {
             const incoming = (message.meta as Record<string, unknown>).effort;
             if (incoming === null || incoming === undefined) {
@@ -761,7 +761,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
                 currentEffort = undefined;
                 logger.debug(`[loop] Effort reset to default`);
             } else if (typeof incoming === 'string' && VALID_EFFORTS.has(incoming)) {
-                messageEffort = incoming as 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+                messageEffort = incoming as ClaudeEffort;
                 currentEffort = messageEffort;
                 logger.debug(`[loop] Effort updated from user message: ${messageEffort}`);
             } else {

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -648,7 +648,7 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
       } else if (arg === '--permission-mode') {
         options.permissionMode = args[++i] as StartOptions['permissionMode']
       } else if (arg === '--effort') {
-        options.effort = z.enum(['low', 'medium', 'high', 'xhigh', 'max']).parse(args[++i])
+        options.effort = z.enum(['low', 'medium', 'high', 'xhigh', 'max', 'auto']).parse(args[++i])
       } else if (arg === '--started-by') {
         options.startedBy = args[++i] as 'daemon' | 'terminal'
       } else if (arg === '--js-runtime') {


### PR DESCRIPTION
Adds an `auto` reasoning-effort level for Claude that pins no effort — the model self-paces via adaptive thinking (Claude decides how much to think per turn) instead of being held at a fixed `low`/`medium`/`high`/`xhigh`/`max` level. It mirrors Claude Code's own "auto" effort: `auto` is the first option in the Claude effort picker, and the CLI maps it to an **omitted** SDK `effort` option through a new `toSdkEffort()` helper, so the Claude Agent SDK runs with adaptive thinking and no pinned reasoning depth.

The default effort is unchanged (`medium`) — this PR only adds the option, always available rather than behind an experiment flag, since an adaptive level is a standard part of the effort scale rather than a trial feature.

## Proof

Verified end-to-end with a standalone `happy-server` (PGlite) + Expo web + a paired `happy-cli` daemon, so a **real Claude round-trip** flows CLI ↔ server ↔ app. Driven headlessly with Playwright.

**The new `auto` option in the effort picker** ("let Claude decide", first in the list):

![effort picker with auto](https://github.com/chphch/happy/releases/download/pr-proofs/1401-auto-effort-picker.png)

**A real session whose effort resolved to `auto` ran with the SDK `effort` option omitted (adaptive) and completed normally** (prompt → `ready`):

![auto session works](https://github.com/chphch/happy/releases/download/pr-proofs/1401-auto-effort-chat.png)

Daemon log from that session:

```
[loop] User message received with no effort override, using current: auto
[claudeRemote] effort: mode='auto' -> sdk=<omitted: adaptive/auto>
{ "type": "result", "result": "ready", "stop_reason": "end_turn", "num_turns": 1 }
```

The visible behaviour maps to the diff: `toSdkEffort('auto')` returns `undefined` (`packages/happy-cli/src/claude/loop.ts`), so `claudeRemote.ts` omits the SDK `effort` option and the Agent SDK self-paces.

## Verification

`pnpm typecheck` clean for both `happy-app` and `happy-cli`. Three unit tests cover the `toSdkEffort` mapping, the picker option ordering, and the wire transport.
