### PR TITLE
fix: permission mode switching not detected by remote session

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -402,7 +402,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
 
     // Import MessageQueue2 and create message queue
     const messageQueue = new MessageQueue2<EnhancedMode>(mode => hashObject({
-        isPlan: mode.permissionMode === 'plan',
+        permissionMode: mode.permissionMode,
         model: mode.model,
         fallbackModel: mode.fallbackModel,
         customSystemPrompt: mode.customSystemPrompt,

--- a/packages/happy-cli/src/claude/utils/permissionHandler.ts
+++ b/packages/happy-cli/src/claude/utils/permissionHandler.ts
@@ -55,6 +55,11 @@ export class PermissionHandler {
 
     handleModeChange(mode: PermissionMode) {
         this.permissionMode = mode;
+        if (this.setPermissionModeCallback) {
+            this.setPermissionModeCallback(mode).catch((err) => {
+                logger.debug('Failed to set permission mode via SDK:', err);
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

Switching permission modes (default → bypassPermissions/yolo) in the mobile app has no effect on the active Claude remote session. The session continues using the old permission mode, making mode switching appear "stuck".

## Root Cause

Two bugs in the permission mode change detection pipeline:

### Bug 1: Hash function doesn't capture permission mode changes

In `runClaude.ts`, the `MessageQueue2` hash function uses:
```typescript
isPlan: mode.permissionMode === 'plan',
```

This reduces all non-plan modes to `isPlan: false`, producing identical hashes. When `nextMessage` compares the incoming message's hash with the current mode hash, it never detects a change between `default`, `acceptEdits`, `bypassPermissions`, etc.

### Bug 2: handleModeChange doesn't propagate to SDK

`PermissionHandler.handleModeChange()` only updates its internal `permissionMode` field but never calls the `setPermissionModeCallback` that propagates the change to the active Claude SDK query via `q.setPermissionMode()`.

## Fix

1. Replace `isPlan: mode.permissionMode === 'plan'` with `permissionMode: mode.permissionMode` in the hash function — mode changes now produce different hashes, triggering the `nextMessage` mode-change detection path.

2. Call `setPermissionModeCallback` in `handleModeChange()` — the active SDK query immediately picks up the new permission mode.

## Testing

Verified on a live server: after applying these fixes, switching to YOLO mode in the mobile app correctly changes the Claude session's permission mode (confirmed by `--permission-mode plan` in the spawned process args and successful auto-approval of tool calls).