### PR TITLE
fix(app): make buildSessionRowData's unread set required too

### DIFF
--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -113,7 +113,7 @@ export interface SessionRowData {
     workspaceName: string | null;
 }
 
-function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): SessionRowData {
+function buildSessionRowData(session: Session, unreadSessionIds: Set<string>): SessionRowData {
     const isOnline = session.presence === "online";
     const hasPermissions = !!(session.agentState?.requests && Object.keys(session.agentState.requests).length > 0);
 
@@ -152,7 +152,7 @@ function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): 
         homeDir: session.metadata?.homeDir ?? null,
         completedTodosCount: session.todos?.filter(todo => todo.status === 'completed').length ?? 0,
         totalTodosCount: session.todos?.length ?? 0,
-        hasUnread: unreadSessionIds?.has(session.id) ?? false,
+        hasUnread: unreadSessionIds.has(session.id),
         projectId: session.metadata?.project?.id ?? null,
         projectName: session.metadata?.project?.name ?? null,
         workspaceId: session.metadata?.workspace?.id ?? null,


### PR DESCRIPTION
## Re-scoped after #1567 landed

This PR originally fixed the whole unread-title flicker: it threaded `state.unreadSessionIds` through `updateSessionDraft` / `applyMachines` / `deleteMachine` and made `buildSessionListViewData`'s parameter required. **All of that landed independently in #1567**, so those hunks are gone from this branch. What is left is the one half #1567 did not take.

## What remains

#1567 made `buildSessionListViewData`'s `unreadSessionIds` required, and its own comment states the reasoning:

> Required on purpose: an omitted set silently rebuilds the list with `hasUnread=false` everywhere — exactly the bug this parameter caused twice.

But `buildSessionRowData` — the function that actually *reads* the set to compute `hasUnread` — is still optional on current main:

```ts
function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): SessionRowData {
    ...
    hasUnread: unreadSessionIds?.has(session.id) ?? false,
```

So the guard stops one level short of the place the silent wipe actually happens. This PR applies the same treatment there:

```ts
function buildSessionRowData(session: Session, unreadSessionIds: Set<string>): SessionRowData {
    ...
    hasUnread: unreadSessionIds.has(session.id),
```

## Risk

None at runtime. All three current call sites (`active-sessions`, the starred/date-grouped rows, and the fork-ordered rows) already pass the set, so this compiles as-is and behaves identically — `pnpm typecheck` is clean. Its only effect is that a future row-building path can't reintroduce the silent `hasUnread: false` wipe without a type error, which is the same protection #1567 added one level up.

## Relationship to #1580

Orthogonal, no merge-order dependency. #1580 changes *where the unread state lives* (a synced read position instead of a device-local set); this PR stops a rebuild from *dropping* it. If #1580 lands first this specific parameter goes away, but the equivalent guarantee carries over to its `currentViewingSessionId`, which that PR already declares as required — so the invariant survives either merge order.
