### PR TITLE
fix(cli): follow EnterWorktree cwd changes in session metadata

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -222,6 +222,9 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
                         void session.sendClaudeSessionMessageFromLocalTranscript(msg);
                     },
                     onTranscriptEvent: updateClaudeGoalState,
+                    // Follow mid-session cwd changes (EnterWorktree fires no hook) so
+                    // the app's dir/diff/file views and --resume track the worktree.
+                    onCwdChange: (cwd) => session.updateMetadata((m) => ({ ...m, path: cwd })),
                 });
                 if (offlineSessionId) scanner.onNewSession(offlineSessionId);
                 return { session, scanner };
@@ -456,6 +459,9 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             session.sendClaudeSessionMessage(raw);
         },
         onTranscriptEvent: updateClaudeGoalState,
+        // Follow mid-session cwd changes (EnterWorktree fires no hook) so the
+        // app's dir/diff/file views and --resume track the worktree.
+        onCwdChange: (cwd) => session.updateMetadata((m) => ({ ...m, path: cwd })),
     });
 
     // Start Happy MCP server

--- a/packages/happy-cli/src/claude/utils/sessionScanner.test.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.test.ts
@@ -381,4 +381,40 @@ describe('sessionScanner', () => {
       apiErrorStatus: 429,
     })
   })
+
+  it('follows cwd only into/out of a worktree, not a transient subdir cd', async () => {
+    // Regression for a3f5bae1: onCwdChange fired on EVERY transcript-record cwd
+    // change, so a plain `cd packages/x && pnpm t` (whose cwd is stamped on the
+    // record) yanked the app's dir/diff/--resume into that subdir. Only a real
+    // relocation — a worktree root, or a return to the launch dir — should fire.
+    const cwdChanges: string[] = []
+    scanner = await createSessionScanner({
+      sessionId: null,
+      workingDirectory: testDir,
+      onMessage: (msg) => collectedMessages.push(msg),
+      onCwdChange: (cwd) => cwdChanges.push(cwd),
+    })
+
+    // Clone a real user record, overriding cwd + uuid so each line is distinct.
+    const fixture = await readFile(join(__dirname, '__fixtures__', '0-say-lol-session.jsonl'), 'utf-8')
+    const baseRecord = JSON.parse(fixture.split('\n').filter((l) => l.trim())[0])
+    const rec = (cwd: string, i: number) =>
+      JSON.stringify({ ...baseRecord, uuid: `cwd-test-${i}`, cwd }) + '\n'
+
+    const worktree = join(testDir, '.dev/worktree/feature-x')
+    const sessionId = 'c0ffee00-0000-4000-8000-000000000000'
+    const sessionFile = join(projectDir, `${sessionId}.jsonl`)
+    await writeFile(
+      sessionFile,
+      rec(join(testDir, 'packages/happy-cli'), 1) + // transient cd -> ignored
+      rec(worktree, 2) +                            // EnterWorktree -> fire
+      rec(join(worktree, 'packages/app'), 3) +      // cd inside worktree -> ignored
+      rec(testDir, 4),                              // back to launch (exit) -> fire
+    )
+
+    scanner.onNewSession(sessionId)
+    await new Promise((r) => setTimeout(r, 200))
+
+    expect(cwdChanges).toEqual([worktree, testDir])
+  })
 })

--- a/packages/happy-cli/src/claude/utils/sessionScanner.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.ts
@@ -35,10 +35,32 @@ export async function createSessionScanner(opts: {
      * (60s). Exposed mainly so tests can exercise the drop path quickly.
      */
     missingFileTimeoutMs?: number
+    /**
+     * Called when a newly-seen transcript record indicates the session has been
+     * RELOCATED into (or back out of) a git worktree — e.g. Claude entered a
+     * worktree via the EnterWorktree tool, which fires NO hook. The transcript
+     * stays in this project dir (only each record's `cwd` flips), so the record
+     * cwd is the only observable signal.
+     *
+     * IMPORTANT: a record's `cwd` is the persistent Bash-shell working directory
+     * at write time, so it flips on EVERY `cd subdir && cmd` (typecheck/build/git
+     * in a package) — not just on a real relocation. We therefore only fire for
+     * cwds that look like a worktree root (`.../worktree[s]/<name>`) or the launch
+     * dir (worktree exited); transient subdir `cd`s are ignored. Without this gate
+     * the app's dir/diff/file views and `--resume` would chase the last `cd`'d
+     * subdir around. Lets the caller follow it (e.g. update session metadata.path).
+     */
+    onCwdChange?: (newCwd: string) => void
 }) {
 
     // Resolve project directory
     const projectDir = getProjectPath(opts.workingDirectory);
+
+    // Track the cwd reported by transcript records so we can fire onCwdChange
+    // when Claude switches working directory mid-session (EnterWorktree). Seeded
+    // with the launch cwd so the first real switch (and not the initial state)
+    // triggers the callback.
+    let lastCwd = opts.workingDirectory;
 
     // Finished, pending finishing and current session
     let finishedSessions = new Set<string>();
@@ -100,6 +122,23 @@ export async function createSessionScanner(opts: {
                 }
                 processedEntryKeys.add(entry.key);
                 if (entry.kind === 'message') {
+                    // EnterWorktree (and any mid-session cd) changes the cwd recorded
+                    // on each transcript record but fires no hook. Only follow it when
+                    // it looks like a real session relocation — a worktree root, or a
+                    // return to the launch dir (worktree exited) — NOT the transient
+                    // `cd packages/x && pnpm t` that every build/typecheck does, which
+                    // would otherwise yank the app's dir/diff/--resume into a subdir.
+                    const recordCwd = (entry.message as { cwd?: unknown }).cwd;
+                    if (
+                        typeof recordCwd === 'string' &&
+                        recordCwd.length > 0 &&
+                        recordCwd !== lastCwd &&
+                        (recordCwd === opts.workingDirectory || isWorktreeRoot(recordCwd))
+                    ) {
+                        lastCwd = recordCwd;
+                        logger.debug(`[SESSION_SCANNER] session relocated via transcript record: ${recordCwd}`);
+                        opts.onCwdChange?.(recordCwd);
+                    }
                     logger.debug(`[SESSION_SCANNER] Sending new message: type=${entry.message.type}, uuid=${entry.message.type === 'summary' ? entry.message.leafUuid : entry.message.uuid}`);
                     opts.onMessage(entry.message);
                     sentMessages++;
@@ -212,6 +251,16 @@ export type SessionScanner = ReturnType<typeof createSessionScanner>;
 //
 // Helpers
 //
+
+/**
+ * Whether a path is a git-worktree ROOT the EnterWorktree tool relocates into,
+ * by convention `<repo>/.dev/worktree/<name>` or `<repo>/.claude/worktrees/<name>`.
+ * Matches only the worktree root (not a deeper subdir inside it), so a `cd` into
+ * a package under the worktree doesn't keep yanking the session path around.
+ */
+function isWorktreeRoot(cwd: string): boolean {
+    return /\/worktrees?\/[^/]+$/.test(cwd);
+}
 
 function messageKey(message: RawJSONLines): string {
     if (message.type === 'user') {


### PR DESCRIPTION
When Claude switches working directory mid-session via the `EnterWorktree` tool, happy-cli never learns the cwd moved — `EnterWorktree` fires no hook (unlike a Bash `cd`, which fires `CwdChanged`), so the session's `metadata.path` stays pinned to the launch directory. The app keeps showing the original dir, the git-diff / file-browser views stay there, and `--resume` relaunches the session at the old dir, dropping the worktree entirely. This wires the session scanner — which already reads every transcript record — to follow the `cwd` field on those records and sync `metadata.path` when it changes, on both the local and remote (SDK) scanners.

The key detail: when `EnterWorktree` switches cwd, the transcript file stays in the launch project dir (only each record's `cwd` field flips), so the scanner keeps receiving records after the switch. That makes the record `cwd` the one observable signal for the no-hook `EnterWorktree` case — there's no `PreToolUse`/`CwdChanged` hook to catch it, and the file never moves to a new project dir for a watcher to follow.

A relocation gate keeps this from over-firing: only a worktree root or the launch directory counts as a relocation. Without it, a transient `cd subdir && cmd` would drag `metadata.path` around after the last build/typecheck subdirectory.

## Proof

Verified end-to-end on a live SDK/remote session (the path the mobile app drives): standalone `happy-server` + a paired `happy-cli` daemon built from this branch, a session spawned in a git repo, then Claude calls `EnterWorktree`. The session-info **Path** row updates from the repo root to the worktree, driven by the new `metadata.path` sync:

![worktree metadata follows](https://github.com/chphch/happy/releases/download/pr-proofs/1407-worktree-metadata.gif)

- **Before:** `Path → …/cwd`
- **After `EnterWorktree`:** `Path → …/cwd/.claude/worktrees/gifprobe`

Daemon log confirms the scanner detects the switch from the transcript record's `cwd` field:

```
[SESSION_SCANNER] cwd changed via transcript record: …/.claude/worktrees/gifprobe
```

`metadata.path` is what the app's directory / git-diff / file-browser views and `--resume` all read, so each of them now tracks the worktree instead of staying pinned to the launch directory.

Reproduction:
1. Start a session in a git repo (mobile or `happy claude`).
2. Ask Claude to "work in a worktree" → it calls `EnterWorktree`, switching into `.claude/worktrees/<name>`.
3. **Before:** the app still shows the repo root as the session directory; after archive + `--resume` the session relaunches at the repo root, not the worktree.
4. **After this change:** `metadata.path` follows the worktree, so the dir / diff / file views and `--resume` all track it.

## Related

#1116 wires the `SessionStart`-hook cwd into the scanner's *watch path*. That hook doesn't fire for `EnterWorktree` (no hook at all) and targets the message-stream watch dir rather than `metadata.path`, so the two are complementary — this PR covers the `EnterWorktree` case and fixes the `--resume` / app-directory surface via `metadata.path`.

`pnpm typecheck` clean; CLI suite 782/782, including a regression test for the cwd-follow path.
