### PR TITLE
fix(app,cli): fix remote messages, goal handling, and Codex suggestions

### DIFF
--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { View, Text, Pressable, Platform } from "react-native";
 import { StyleSheet } from 'react-native-unistyles';
+import { Ionicons } from '@expo/vector-icons';
 import { MarkdownView } from "./markdown/MarkdownView";
 import { t } from '@/text';
 import { Message, UserTextMessage, AgentTextMessage, ToolCallMessage } from "@/sync/typesMessage";
@@ -122,6 +123,26 @@ function UserTextBlock(props: {
   const parsed = parseLocalCommandMessage(props.message.displayText || props.message.text);
   if (parsed.kind === 'caveat') {
     return null;
+  }
+  if (parsed.kind === 'goal-confirmation') {
+    return null;
+  }
+  if (parsed.kind === 'goal-run') {
+    return (
+      <View style={styles.userMessageContainer}>
+        <Pressable
+          onLongPress={canFork ? handleLongPress : undefined}
+          delayLongPress={400}
+          style={[styles.userMessageBubble, styles.goalMessageBubble]}
+        >
+          <MarkdownView markdown={parsed.goal} onOptionPress={handleOptionPress} sessionId={props.sessionId} />
+        </Pressable>
+        <View style={styles.goalSentRow}>
+          <Ionicons name="locate-outline" size={16} color={styles.goalSentText.color} />
+          <Text style={styles.goalSentText}>{t('message.sentAsGoal')}</Text>
+        </View>
+      </View>
+    );
   }
   if (parsed.kind === 'command-run') {
     return (
@@ -258,6 +279,21 @@ const styles = StyleSheet.create((theme) => ({
     borderRadius: 12,
     marginBottom: 12,
     maxWidth: '100%',
+  },
+  goalMessageBubble: {
+    marginBottom: 6,
+  },
+  goalSentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 12,
+    maxWidth: '100%',
+    opacity: 0.72,
+  },
+  goalSentText: {
+    color: theme.colors.agentEventText,
+    fontSize: 14,
   },
   commandChip: {
     backgroundColor: theme.colors.userMessageBackground,

--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -147,6 +147,15 @@ function UserTextBlock(props: {
   if (parsed.kind === 'command-run') {
     return (
       <View style={styles.userMessageContainer}>
+        {parsed.args ? (
+          <Pressable
+            onLongPress={canFork ? handleLongPress : undefined}
+            delayLongPress={400}
+            style={[styles.userMessageBubble, styles.commandMessageBubble]}
+          >
+            <MarkdownView markdown={parsed.args} onOptionPress={handleOptionPress} sessionId={props.sessionId} />
+          </Pressable>
+        ) : null}
         <View style={styles.commandChip}>
           <Text style={styles.commandChipText}>/{parsed.commandName}</Text>
         </View>
@@ -281,6 +290,9 @@ const styles = StyleSheet.create((theme) => ({
     maxWidth: '100%',
   },
   goalMessageBubble: {
+    marginBottom: 6,
+  },
+  commandMessageBubble: {
     marginBottom: 6,
   },
   goalSentRow: {

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
@@ -54,6 +54,22 @@ describe('parseLocalCommandMessage', () => {
         });
     });
 
+    it('collapses a trailing raw skill slash command to a command display with preceding args', () => {
+        expect(parseLocalCommandMessage('  привет давай /maintain  ')).toEqual({
+            kind: 'command-run',
+            commandName: 'maintain',
+            args: 'привет давай',
+        });
+    });
+
+    it('collapses a middle raw skill slash command and preserves surrounding args', () => {
+        expect(parseLocalCommandMessage('  привет /maintain давай  ')).toEqual({
+            kind: 'command-run',
+            commandName: 'maintain',
+            args: 'привет давай',
+        });
+    });
+
     it('hides Claude local-command stdout for a successful /goal command', () => {
         const text = '<local-command-stdout>Goal set: проанализируй проект</local-command-stdout>';
         expect(parseLocalCommandMessage(text)).toEqual({
@@ -112,6 +128,10 @@ describe('isUserSlashCommandEcho', () => {
         expect(isUserSlashCommandEcho('/compact', false)).toBe(false);
     });
 
+    it('detects a trailing command echo with a localId', () => {
+        expect(isUserSlashCommandEcho('привет давай /maintain', true)).toBe(true);
+    });
+
     it('does not treat the SDK wrapper itself as a raw echo', () => {
         const wrapper =
             '<command-message>x</command-message><command-name>/x</command-name><command-args>a</command-args>';
@@ -125,7 +145,7 @@ describe('isUserSlashCommandEcho', () => {
 
     it('does not match a lone slash or ordinary text', () => {
         expect(isUserSlashCommandEcho('/', true)).toBe(false);
-        expect(isUserSlashCommandEcho('please run /compact later', true)).toBe(false);
+        expect(isUserSlashCommandEcho('please run / later', true)).toBe(false);
     });
 
     it('tolerates surrounding whitespace', () => {

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
@@ -46,6 +46,14 @@ describe('parseLocalCommandMessage', () => {
         });
     });
 
+    it('collapses a raw skill slash command to a command display with args', () => {
+        expect(parseLocalCommandMessage('  /superpowers:brainstorming привет давай спланируем что-нибудь  ')).toEqual({
+            kind: 'command-run',
+            commandName: 'superpowers:brainstorming',
+            args: 'привет давай спланируем что-нибудь',
+        });
+    });
+
     it('hides Claude local-command stdout for a successful /goal command', () => {
         const text = '<local-command-stdout>Goal set: проанализируй проект</local-command-stdout>';
         expect(parseLocalCommandMessage(text)).toEqual({

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
@@ -28,6 +28,32 @@ describe('parseLocalCommandMessage', () => {
         });
     });
 
+    it('collapses a /goal wrapper to a goal display', () => {
+        const text =
+            '<command-message>goal</command-message>' +
+            '<command-name>/goal</command-name>' +
+            '<command-args>проанализируй проект</command-args>';
+        expect(parseLocalCommandMessage(text)).toEqual({
+            kind: 'goal-run',
+            goal: 'проанализируй проект',
+        });
+    });
+
+    it('collapses a raw /goal command to a goal display', () => {
+        expect(parseLocalCommandMessage('  /goal проанализируй проект  ')).toEqual({
+            kind: 'goal-run',
+            goal: 'проанализируй проект',
+        });
+    });
+
+    it('hides Claude local-command stdout for a successful /goal command', () => {
+        const text = '<local-command-stdout>Goal set: проанализируй проект</local-command-stdout>';
+        expect(parseLocalCommandMessage(text)).toEqual({
+            kind: 'goal-confirmation',
+            goal: 'проанализируй проект',
+        });
+    });
+
     it('trims surrounding whitespace inside command-args', () => {
         const text =
             '<command-message>x</command-message><command-name>/x</command-name>' +
@@ -68,6 +94,10 @@ describe('isUserSlashCommandEcho', () => {
 
     it('detects a command-with-args echo with a localId', () => {
         expect(isUserSlashCommandEcho('/superpowers:brainstorming make me rich', true)).toBe(true);
+    });
+
+    it('detects a /goal echo with a localId', () => {
+        expect(isUserSlashCommandEcho('/goal проанализируй проект', true)).toBe(true);
     });
 
     it('ignores echoes without a localId (SDK-originated, not user-sent)', () => {

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.ts
@@ -32,13 +32,20 @@ const COMMAND_ARGS_RE = /<command-args>\s*([\s\S]*?)\s*<\/command-args>/;
 const COMMAND_MESSAGE_RE = /<command-message>[\s\S]*?<\/command-message>/g;
 const COMMAND_NAME_TAG_RE = /<command-name>[\s\S]*?<\/command-name>/g;
 const COMMAND_ARGS_TAG_RE = /<command-args>[\s\S]*?<\/command-args>/g;
-const GOAL_COMMAND_RE = /^\s*\/goal(?:\s+([\s\S]*?))?\s*$/i;
+const RAW_SLASH_COMMAND_RE = /^\s*\/([a-zA-Z][\w:-]*)(?:\s+([\s\S]*?))?\s*$/;
 const GOAL_STDOUT_RE = /^Goal set:\s*([\s\S]*?)\s*$/i;
 
-function goalFromSlashCommand(text: string): string | undefined {
-    const match = text.match(GOAL_COMMAND_RE);
-    const goal = match?.[1]?.trim();
-    return goal && goal.length > 0 ? goal : undefined;
+function rawSlashCommand(text: string): { commandName: string; args?: string } | undefined {
+    const match = text.match(RAW_SLASH_COMMAND_RE);
+    if (!match) {
+        return undefined;
+    }
+    const commandName = match[1].trim();
+    const args = match[2]?.trim();
+    return {
+        commandName,
+        args: args && args.length > 0 ? args : undefined,
+    };
 }
 
 function goalFromStdout(text: string): string | undefined {
@@ -62,9 +69,16 @@ export function parseLocalCommandMessage(text: string): LocalCommandMessage {
         return { kind: 'text', text: stdout };
     }
 
-    const rawGoal = goalFromSlashCommand(text);
-    if (rawGoal) {
-        return { kind: 'goal-run', goal: rawGoal };
+    const rawCommand = rawSlashCommand(text);
+    if (rawCommand) {
+        if (rawCommand.commandName.toLowerCase() === 'goal' && rawCommand.args) {
+            return { kind: 'goal-run', goal: rawCommand.args };
+        }
+        return {
+            kind: 'command-run',
+            commandName: rawCommand.commandName,
+            args: rawCommand.args,
+        };
     }
 
     const nameMatch = text.match(COMMAND_NAME_RE);
@@ -102,12 +116,6 @@ export function parseLocalCommandMessage(text: string): LocalCommandMessage {
     return { kind: 'text', text };
 }
 
-// A pure slash-command invocation: starts with `/`, a command token
-// (letters, digits, `:`, `-`, `_`), optionally followed by whitespace +
-// args. Deliberately strict so paths like `/etc/hosts` or a lone `/`
-// do NOT match.
-const SLASH_COMMAND_RE = /^\/[a-zA-Z][\w:-]*(?:\s[\s\S]*)?$/;
-
 /**
  * True when this user-text message is the user's OWN echoed slash-command
  * input (e.g. `/superpowers:brainstorming do the thing`) that the Claude
@@ -127,11 +135,11 @@ export function isUserSlashCommandEcho(text: string, hasLocalId: boolean): boole
         return false;
     }
     const trimmed = text.trim();
-    if (!SLASH_COMMAND_RE.test(trimmed)) {
+    if (!rawSlashCommand(trimmed)) {
         return false;
     }
     // Guard: a real wrapper message also contains <command-name>; never
     // treat that as a raw echo.
     const parsed = parseLocalCommandMessage(trimmed);
-    return parsed.kind === 'text' || parsed.kind === 'goal-run';
+    return parsed.kind === 'command-run' || parsed.kind === 'goal-run';
 }

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.ts
@@ -21,24 +21,57 @@
 export type LocalCommandMessage =
     | { kind: 'caveat' }
     | { kind: 'command-run'; commandName: string; args?: string }
+    | { kind: 'goal-run'; goal: string }
+    | { kind: 'goal-confirmation'; goal: string }
     | { kind: 'text'; text: string };
 
 const CAVEAT_RE = /^\s*<local-command-caveat>[\s\S]*?<\/local-command-caveat>\s*$/;
+const STDOUT_RE = /^\s*<local-command-stdout>\s*([\s\S]*?)\s*<\/local-command-stdout>\s*$/;
 const COMMAND_NAME_RE = /<command-name>\s*\/?([^<]+?)\s*<\/command-name>/;
 const COMMAND_ARGS_RE = /<command-args>\s*([\s\S]*?)\s*<\/command-args>/;
 const COMMAND_MESSAGE_RE = /<command-message>[\s\S]*?<\/command-message>/g;
 const COMMAND_NAME_TAG_RE = /<command-name>[\s\S]*?<\/command-name>/g;
 const COMMAND_ARGS_TAG_RE = /<command-args>[\s\S]*?<\/command-args>/g;
+const GOAL_COMMAND_RE = /^\s*\/goal(?:\s+([\s\S]*?))?\s*$/i;
+const GOAL_STDOUT_RE = /^Goal set:\s*([\s\S]*?)\s*$/i;
+
+function goalFromSlashCommand(text: string): string | undefined {
+    const match = text.match(GOAL_COMMAND_RE);
+    const goal = match?.[1]?.trim();
+    return goal && goal.length > 0 ? goal : undefined;
+}
+
+function goalFromStdout(text: string): string | undefined {
+    const match = text.trim().match(GOAL_STDOUT_RE);
+    const goal = match?.[1]?.trim();
+    return goal && goal.length > 0 ? goal : undefined;
+}
 
 export function parseLocalCommandMessage(text: string): LocalCommandMessage {
     if (CAVEAT_RE.test(text)) {
         return { kind: 'caveat' };
     }
 
+    const stdoutMatch = text.match(STDOUT_RE);
+    if (stdoutMatch) {
+        const stdout = stdoutMatch[1].trim();
+        const goal = goalFromStdout(stdout);
+        if (goal) {
+            return { kind: 'goal-confirmation', goal };
+        }
+        return { kind: 'text', text: stdout };
+    }
+
+    const rawGoal = goalFromSlashCommand(text);
+    if (rawGoal) {
+        return { kind: 'goal-run', goal: rawGoal };
+    }
+
     const nameMatch = text.match(COMMAND_NAME_RE);
     if (nameMatch) {
         const argsMatch = text.match(COMMAND_ARGS_RE);
         const args = argsMatch?.[1].trim();
+        const commandName = nameMatch[1].trim();
 
         // If the message is just the command wrappers (after stripping all of
         // them only whitespace remains), collapse to a chip. The args, if any,
@@ -50,9 +83,15 @@ export function parseLocalCommandMessage(text: string): LocalCommandMessage {
             .replace(COMMAND_ARGS_TAG_RE, '')
             .trim();
         if (stripped.length === 0) {
+            if (commandName.toLowerCase() === 'goal' && args && args.length > 0) {
+                return {
+                    kind: 'goal-run',
+                    goal: args,
+                };
+            }
             return {
                 kind: 'command-run',
-                commandName: nameMatch[1],
+                commandName,
                 args: args && args.length > 0 ? args : undefined,
             };
         }
@@ -93,5 +132,6 @@ export function isUserSlashCommandEcho(text: string, hasLocalId: boolean): boole
     }
     // Guard: a real wrapper message also contains <command-name>; never
     // treat that as a raw echo.
-    return parseLocalCommandMessage(trimmed).kind === 'text';
+    const parsed = parseLocalCommandMessage(trimmed);
+    return parsed.kind === 'text' || parsed.kind === 'goal-run';
 }

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.ts
@@ -33,17 +33,31 @@ const COMMAND_MESSAGE_RE = /<command-message>[\s\S]*?<\/command-message>/g;
 const COMMAND_NAME_TAG_RE = /<command-name>[\s\S]*?<\/command-name>/g;
 const COMMAND_ARGS_TAG_RE = /<command-args>[\s\S]*?<\/command-args>/g;
 const RAW_SLASH_COMMAND_RE = /^\s*\/([a-zA-Z][\w:-]*)(?:\s+([\s\S]*?))?\s*$/;
+const RAW_SLASH_COMMAND_TOKEN_RE = /(^|\s)\/([a-zA-Z][\w:-]*)(?=$|\s)/;
 const GOAL_STDOUT_RE = /^Goal set:\s*([\s\S]*?)\s*$/i;
 
 function rawSlashCommand(text: string): { commandName: string; args?: string } | undefined {
     const match = text.match(RAW_SLASH_COMMAND_RE);
-    if (!match) {
+    if (match) {
+        const commandName = match[1].trim();
+        const args = match[2]?.trim();
+        return {
+            commandName,
+            args: args && args.length > 0 ? args : undefined,
+        };
+    }
+
+    const tokenMatch = text.match(RAW_SLASH_COMMAND_TOKEN_RE);
+    if (!tokenMatch || tokenMatch.index === undefined) {
         return undefined;
     }
-    const commandName = match[1].trim();
-    const args = match[2]?.trim();
+    const commandStart = tokenMatch.index + tokenMatch[1].length;
+    const commandEnd = commandStart + tokenMatch[2].length + 1;
+    const before = text.slice(0, commandStart).trim();
+    const after = text.slice(commandEnd).trim();
+    const args = [before, after].filter(Boolean).join(' ');
     return {
-        commandName,
+        commandName: tokenMatch[2].trim(),
         args: args && args.length > 0 ? args : undefined,
     };
 }

--- a/packages/happy-app/sources/components/tools/knownTools.spec.ts
+++ b/packages/happy-app/sources/components/tools/knownTools.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@expo/vector-icons', () => ({
+    Ionicons: () => null,
+    Octicons: () => null,
+}));
+
+vi.mock('@/text', () => ({
+    t: (key: string) => key,
+}));
+
+import { knownTools } from './knownTools';
+
+describe('knownTools', () => {
+    it('hides Claude Skill tool calls from chat rendering', () => {
+        expect((knownTools as Record<string, { hidden?: boolean }>).Skill?.hidden).toBe(true);
+    });
+});

--- a/packages/happy-app/sources/components/tools/knownTools.tsx
+++ b/packages/happy-app/sources/components/tools/knownTools.tsx
@@ -919,6 +919,15 @@ export const knownTools = {
         }
     },
     // Internal Claude Code tool for loading deferred tools - no user-visible output
+    'Skill': {
+        icon: ICON_TASK,
+        hidden: true,
+        minimal: true,
+        input: z.object({
+            skill: z.string().optional().describe('The skill to load')
+        }).partial().passthrough(),
+        result: z.object({}).partial().passthrough()
+    },
     'ToolSearch': {
         icon: ICON_SEARCH,
         hidden: true,

--- a/packages/happy-app/sources/hooks/useGroupedMessages.test.ts
+++ b/packages/happy-app/sources/hooks/useGroupedMessages.test.ts
@@ -3,7 +3,9 @@ import { groupMessagesForDisplay, groupToolCallsForDisplay } from './useGroupedM
 import { Message, ToolCallMessage } from '@/sync/typesMessage';
 
 vi.mock('@/components/tools/knownTools', () => ({
-    knownTools: {},
+    knownTools: {
+        Skill: { hidden: true },
+    },
 }));
 
 vi.mock('@/text', () => ({
@@ -34,6 +36,17 @@ function toolMessage(id: string, createdAt: number, options: { pendingPermission
                 : {}),
         },
         children: [],
+    };
+}
+
+function namedToolMessage(id: string, name: string, createdAt: number): ToolCallMessage {
+    const message = toolMessage(id, createdAt);
+    return {
+        ...message,
+        tool: {
+            ...message.tool,
+            name,
+        },
     };
 }
 
@@ -259,6 +272,30 @@ describe('useGroupedMessages', () => {
 
         expect(items.map((item) => item.type)).toEqual(['message', 'message']);
         expect(items[0]).toMatchObject({ type: 'message', id: 'tool-only' });
+    });
+
+    it('hides Claude Skill tool calls from the display list', () => {
+        const messages: Message[] = [
+            {
+                kind: 'agent-text',
+                id: 'agent-final',
+                localId: null,
+                createdAt: 3,
+                text: 'done',
+            },
+            namedToolMessage('skill-tool', 'Skill', 2),
+            {
+                kind: 'user-text',
+                id: 'user',
+                localId: null,
+                createdAt: 1,
+                text: 'run skill',
+            },
+        ];
+
+        const items = groupMessagesForDisplay(messages, true);
+
+        expect(items.map((item) => item.id)).toEqual(['agent-final', 'user']);
     });
 
     it('can collapse single standalone tool calls for nested work details', () => {

--- a/packages/happy-app/sources/sync/reducer/reducer.spec.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.spec.ts
@@ -50,6 +50,7 @@ describe('reducer', () => {
             expect(result.messages[0].kind).toBe('user-text');
             if (result.messages[0].kind === 'user-text') {
                 expect(result.messages[0].text).toBe('Hello');
+                expect(result.messages[0].localId).toBe('local123');
             }
             expect(state.localIds.has('local123')).toBe(true);
         });

--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -119,6 +119,7 @@ import { parseMessageAsEvent } from "./messageToEvent";
 
 type ReducerMessage = {
     id: string;
+    localId?: string | null;
     realID: string | null;
     createdAt: number;
     role: 'user' | 'agent';
@@ -660,6 +661,7 @@ export function reducer(state: ReducerState, messages: NormalizedMessage[], agen
             let mid = allocateId();
             state.messages.set(mid, {
                 id: mid,
+                localId: msg.localId,
                 realID: msg.id,
                 role: 'user',
                 createdAt: msg.createdAt,
@@ -1164,7 +1166,7 @@ function convertReducerMessageToMessage(reducerMsg: ReducerMessage, state: Reduc
     if (reducerMsg.role === 'user' && reducerMsg.text !== null) {
         return {
             id: reducerMsg.id,
-            localId: null,
+            localId: reducerMsg.localId ?? null,
             createdAt: reducerMsg.createdAt,
             kind: 'user-text',
             text: reducerMsg.text,

--- a/packages/happy-app/sources/sync/suggestionCommands.spec.ts
+++ b/packages/happy-app/sources/sync/suggestionCommands.spec.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { Session } from './storageTypes';
+
+const mockSessions: Record<string, Partial<Session>> = {};
 
 vi.mock('./storage', () => ({
     storage: {
-        getState: () => ({ sessions: {} }),
+        getState: () => ({ sessions: mockSessions }),
     },
 }));
 
@@ -17,6 +20,23 @@ describe('suggestionCommands', () => {
                 command: 'goal',
                 description: 'Set a session goal',
             }),
+        ]));
+    });
+
+    it('includes skills from session metadata in slash command suggestions', () => {
+        mockSessions['codex-session'] = {
+            metadata: {
+                path: '/tmp/project',
+                host: 'localhost',
+                skills: ['plan-to-beads', 'superpowers:brainstorming'],
+            },
+        } as Partial<Session>;
+
+        const commands = getAllCommands('codex-session');
+
+        expect(commands).toEqual(expect.arrayContaining([
+            expect.objectContaining({ command: 'plan-to-beads' }),
+            expect.objectContaining({ command: 'superpowers:brainstorming' }),
         ]));
     });
 });

--- a/packages/happy-app/sources/sync/suggestionCommands.spec.ts
+++ b/packages/happy-app/sources/sync/suggestionCommands.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./storage', () => ({
+    storage: {
+        getState: () => ({ sessions: {} }),
+    },
+}));
+
+import { getAllCommands } from './suggestionCommands';
+
+describe('suggestionCommands', () => {
+    it('includes /goal in the default slash command suggestions', () => {
+        const commands = getAllCommands('missing-session');
+
+        expect(commands).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                command: 'goal',
+                description: 'Set a session goal',
+            }),
+        ]));
+    });
+});

--- a/packages/happy-app/sources/sync/suggestionCommands.ts
+++ b/packages/happy-app/sources/sync/suggestionCommands.ts
@@ -89,20 +89,22 @@ function getCommandsFromSession(sessionId: string): CommandItem[] {
     }
 
     const commands: CommandItem[] = [...DEFAULT_COMMANDS];
-    
-    // Add commands from metadata.slashCommands (filter with ignore list)
-    if (session.metadata.slashCommands) {
-        for (const cmd of session.metadata.slashCommands) {
-            // Skip if in ignore list
-            if (IGNORED_COMMANDS.includes(cmd)) continue;
-            
-            // Check if it's already in default commands
-            if (!commands.find(c => c.command === cmd)) {
-                commands.push({
-                    command: cmd,
-                    description: COMMAND_DESCRIPTIONS[cmd]  // Optional description
-                });
-            }
+
+    const metadataCommands = [
+        ...(session.metadata.slashCommands ?? []),
+        ...(session.metadata.skills ?? []),
+    ];
+
+    for (const cmd of metadataCommands) {
+        // Skip if in ignore list
+        if (IGNORED_COMMANDS.includes(cmd)) continue;
+
+        // Check if it's already in default commands or slash commands
+        if (!commands.find(c => c.command === cmd)) {
+            commands.push({
+                command: cmd,
+                description: COMMAND_DESCRIPTIONS[cmd]  // Optional description
+            });
         }
     }
     

--- a/packages/happy-app/sources/sync/suggestionCommands.ts
+++ b/packages/happy-app/sources/sync/suggestionCommands.ts
@@ -55,6 +55,7 @@ export const IGNORED_COMMANDS = [
 const DEFAULT_COMMANDS: CommandItem[] = [
     { command: 'compact', description: 'Compact the conversation history' },
     { command: 'clear', description: 'Clear the conversation' },
+    { command: 'goal', description: 'Set a session goal' },
     { command: 'mcp', description: 'Show connected MCP servers' },
     { command: 'skills', description: 'Show available skills' },
 ];
@@ -63,6 +64,7 @@ const DEFAULT_COMMANDS: CommandItem[] = [
 const COMMAND_DESCRIPTIONS: Record<string, string> = {
     // Default commands
     compact: 'Compact the conversation history',
+    goal: 'Set a session goal',
     
     // Common tool commands
     help: 'Show available commands',

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -852,6 +852,7 @@ export const en = {
         switchedToMode: ({ mode }: { mode: string }) => `Switched to ${mode} mode`,
         unknownEvent: 'Unknown event',
         usageLimitUntil: ({ time }: { time: string }) => `Usage limit reached until ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: 'unknown time',
     },
 

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -837,6 +837,7 @@ export const ca: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `S'ha canviat al mode ${mode}`,
         unknownEvent: 'Esdeveniment desconegut',
         usageLimitUntil: ({ time }: { time: string }) => `Límit d'ús assolit fins a ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: 'temps desconegut',
     },
 

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -851,6 +851,7 @@ export const en: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `Switched to ${mode} mode`,
         unknownEvent: 'Unknown event',
         usageLimitUntil: ({ time }: { time: string }) => `Usage limit reached until ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: 'unknown time',
     },
 

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -837,6 +837,7 @@ export const es: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `Cambiado al modo ${mode}`,
         unknownEvent: 'Evento desconocido',
         usageLimitUntil: ({ time }: { time: string }) => `Límite de uso alcanzado hasta ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: 'tiempo desconocido',
     },
 

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -835,6 +835,7 @@ export const it: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `Passato alla modalità ${mode}`,
         unknownEvent: 'Evento sconosciuto',
         usageLimitUntil: ({ time }: { time: string }) => `Limite di utilizzo raggiunto fino a ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: 'ora sconosciuta',
     },
 

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -838,6 +838,7 @@ export const ja: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `${mode}モードに切り替えました`,
         unknownEvent: '不明なイベント',
         usageLimitUntil: ({ time }: { time: string }) => `${time}まで使用制限中`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: '不明な時間',
     },
 

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -853,6 +853,7 @@ export const pl: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `Przełączono na tryb ${mode}`,
         unknownEvent: 'Nieznane zdarzenie',
         usageLimitUntil: ({ time }: { time: string }) => `Osiągnięto limit użycia do ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: 'nieznany czas',
     },
 

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -836,6 +836,7 @@ export const pt: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `Mudou para o modo ${mode}`,
         unknownEvent: 'Evento desconhecido',
         usageLimitUntil: ({ time }: { time: string }) => `Limite de uso atingido até ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: 'horário desconhecido',
     },
 

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -841,6 +841,7 @@ export const ru: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `Переключено в режим ${mode}`,
         unknownEvent: 'Неизвестное событие',
         usageLimitUntil: ({ time }: { time: string }) => `Лимит использования достигнут до ${time}`,
+        sentAsGoal: 'Отправлено в качестве цели',
         unknownTime: 'неизвестное время',
     },
 

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -838,6 +838,7 @@ export const zhHans: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `已切换到 ${mode} 模式`,
         unknownEvent: '未知事件',
         usageLimitUntil: ({ time }: { time: string }) => `使用限制到 ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: '未知时间',
     },
 

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -837,6 +837,7 @@ export const zhHant: TranslationStructure = {
         switchedToMode: ({ mode }: { mode: string }) => `已切換到 ${mode} 模式`,
         unknownEvent: '未知事件',
         usageLimitUntil: ({ time }: { time: string }) => `使用限制到 ${time}`,
+        sentAsGoal: 'Sent as goal',
         unknownTime: '未知時間',
     },
 

--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.167",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.179",
     "@anthropic-ai/sandbox-runtime": "^0.0.37",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@noble/ed25519": "^3.0.0",

--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -12,7 +12,7 @@
  * 4. PATH fallback: bun, pnpm, or any other package manager
  */
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -475,6 +475,20 @@ function getVersion(cliPath) {
             return pkg.version;
         }
     } catch (e) {}
+
+    try {
+        const isJsFile = cliPath.endsWith('.js') || cliPath.endsWith('.cjs');
+        const command = isJsFile ? process.execPath : cliPath;
+        const args = isJsFile ? [cliPath, '--version'] : ['--version'];
+        const output = execFileSync(command, args, {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 3000,
+        });
+        const match = output.match(/(\d+\.\d+\.\d+)/);
+        return match?.[1] ?? null;
+    } catch (e) {}
+
     return null;
 }
 
@@ -493,6 +507,33 @@ function compareVersions(a, b) {
         if (partsA[i] < partsB[i]) return -1;
     }
     return 0;
+}
+
+const GOAL_HOOK_JSON_VALIDATION_FIXED_VERSION = '2.1.179';
+
+function isThirdPartyAnthropicBaseUrl(value) {
+    if (!value || typeof value !== 'string' || value.trim() === '') return false;
+    try {
+        const hostname = new URL(value).hostname.toLowerCase();
+        return hostname !== 'api.anthropic.com' && !hostname.endsWith('.anthropic.com');
+    } catch (e) {
+        // A malformed non-empty override is still not the default Anthropic API.
+        return true;
+    }
+}
+
+function shouldWarnAboutGoalHookJsonValidationRisk(version, env = process.env) {
+    if (!version) return false;
+    if (!isThirdPartyAnthropicBaseUrl(env.ANTHROPIC_BASE_URL)) return false;
+    return compareVersions(version, GOAL_HOOK_JSON_VALIDATION_FIXED_VERSION) < 0;
+}
+
+function formatGoalHookJsonValidationWarning(version) {
+    return [
+        `\x1b[33mWarning:\x1b[0m Claude Code v${version} may hit /goal Stop hook JSON validation failures`,
+        `with ANTHROPIC_BASE_URL backends. Upgrade Claude Code to ${GOAL_HOOK_JSON_VALIDATION_FIXED_VERSION}+`,
+        'or use Happy remote mode with the bundled Claude Code runtime.'
+    ].join(' ');
 }
 
 /**
@@ -520,6 +561,9 @@ function getClaudeCliPath() {
     const version = getVersion(result.path);
     const versionStr = version ? ` v${version}` : '';
     console.error(`\x1b[90mUsing Claude Code${versionStr} from ${result.source}\x1b[0m`);
+    if (shouldWarnAboutGoalHookJsonValidationRisk(version)) {
+        console.error(formatGoalHookJsonValidationWarning(version));
+    }
 
     return result.path;
 }
@@ -616,7 +660,9 @@ module.exports = {
     findNativeInstallerCliPath,
     getVersion,
     compareVersions,
+    shouldWarnAboutGoalHookJsonValidationRisk,
+    formatGoalHookJsonValidationWarning,
+    GOAL_HOOK_JSON_VALIDATION_FIXED_VERSION,
     getClaudeCliPath,
     runClaudeCli
 };
-

--- a/packages/happy-cli/scripts/claude_version_utils.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.test.ts
@@ -9,7 +9,8 @@ import {
   findHomebrewCliPath,
   findNativeInstallerCliPath,
   getVersion,
-  compareVersions
+  compareVersions,
+  shouldWarnAboutGoalHookJsonValidationRisk,
 } from '../scripts/claude_version_utils.cjs';
 
 describe('Claude Version Utils - Cross-Platform Detection', () => {
@@ -230,6 +231,41 @@ describe('Claude Version Utils - Cross-Platform Detection', () => {
       expect(() => compareVersions('', '2.0.0')).not.toThrow();
       expect(() => compareVersions('invalid', '2.0.0')).not.toThrow();
       expect(() => compareVersions('2.0.0', '')).not.toThrow();
+    });
+  });
+
+  describe('getVersion', () => {
+    it('falls back to --version for native binaries without adjacent package.json', () => {
+      const testCliPath = `/tmp/test-claude-version-${process.pid}-${Date.now()}`;
+      fs.writeFileSync(testCliPath, '#!/bin/sh\necho "2.1.177 (Claude Code)"\n');
+      fs.chmodSync(testCliPath, 0o755);
+
+      try {
+        expect(getVersion(testCliPath)).toBe('2.1.177');
+      } finally {
+        fs.unlinkSync(testCliPath);
+      }
+    });
+  });
+
+  describe('/goal hook JSON validation warning', () => {
+    it('warns for third-party Anthropic-compatible backends on affected Claude Code versions', () => {
+      expect(shouldWarnAboutGoalHookJsonValidationRisk('2.1.177', {
+        ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
+      })).toBe(true);
+    });
+
+    it('does not warn without ANTHROPIC_BASE_URL or on the fixed version floor', () => {
+      expect(shouldWarnAboutGoalHookJsonValidationRisk('2.1.177', {})).toBe(false);
+      expect(shouldWarnAboutGoalHookJsonValidationRisk('2.1.179', {
+        ANTHROPIC_BASE_URL: 'https://api.deepseek.com/anthropic',
+      })).toBe(false);
+    });
+
+    it('does not warn for the default Anthropic API host', () => {
+      expect(shouldWarnAboutGoalHookJsonValidationRisk('2.1.177', {
+        ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+      })).toBe(false);
     });
   });
 

--- a/packages/happy-cli/src/api/apiSession.test.ts
+++ b/packages/happy-cli/src/api/apiSession.test.ts
@@ -772,9 +772,10 @@ describe('ApiSessionClient v3 messages API migration', () => {
         expect(mockAxiosGet.mock.calls[0][1].params.after_seq).toBe(1);
     });
 
-    it('invalidates receive sync on first message when lastSeq is 0', async () => {
+    it('applies first live new-message update directly when lastSeq is 0', async () => {
         const client = new ApiSessionClient('fake-token', session);
-
+        const onUserMessage = vi.fn();
+        client.onUserMessage(onUserMessage);
         mockAxiosGet.mockResolvedValueOnce({
             data: {
                 messages: [],
@@ -782,15 +783,21 @@ describe('ApiSessionClient v3 messages API migration', () => {
             }
         });
 
-        emitSocketEvent('update', createNewMessageUpdate(1, encryptContent(session, {
+        const firstMessage = {
             role: 'user',
             content: { type: 'text', text: 'first' }
-        })));
+        };
 
-        await waitForCheck(() => {
-            expect(mockAxiosGet).toHaveBeenCalledTimes(1);
-        });
-        expect(mockAxiosGet.mock.calls[0][1].params.after_seq).toBe(0);
+        try {
+            emitSocketEvent('update', createNewMessageUpdate(1, encryptContent(session, firstMessage)));
+
+            expect(onUserMessage).toHaveBeenCalledTimes(1);
+            expect(onUserMessage).toHaveBeenCalledWith(firstMessage);
+            expect((client as any).lastSeq).toBe(1);
+            expect(mockAxiosGet).not.toHaveBeenCalled();
+        } finally {
+            await client.close();
+        }
     });
 
     it('invalidates receive sync for duplicate and stale seq values', async () => {

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -200,10 +200,6 @@ export class ApiSessionClient extends EventEmitter {
 
                 if (data.body.t === 'new-message') {
                     const messageSeq = data.body.message?.seq;
-                    if (this.lastSeq === 0) {
-                        this.receiveSync.invalidate();
-                        return;
-                    }
                     if (typeof messageSeq !== 'number' || messageSeq !== this.lastSeq + 1 || data.body.message.content.t !== 'encrypted') {
                         this.receiveSync.invalidate();
                         return;

--- a/packages/happy-cli/src/codex/codexSkills.test.ts
+++ b/packages/happy-cli/src/codex/codexSkills.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { discoverCodexSkillCommands } from './codexSkills';
+
+const tempRoots: string[] = [];
+
+async function makeTempRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'happy-codex-skills-'));
+    tempRoots.push(root);
+    return root;
+}
+
+async function addSkill(root: string, pathParts: string[]): Promise<void> {
+    const skillDir = join(root, ...pathParts);
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, 'SKILL.md'), '---\nname: test\n---\n');
+}
+
+afterEach(async () => {
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('discoverCodexSkillCommands', () => {
+    it('discovers user, project, system, and plugin skills as slash commands', async () => {
+        const root = await makeTempRoot();
+        const cwd = join(root, 'project');
+        const codexHome = join(root, 'codex-home');
+
+        await addSkill(cwd, ['.agents', 'skills', 'agent-browser']);
+        await addSkill(codexHome, ['skills', 'plan-to-beads']);
+        await addSkill(codexHome, ['skills', '.system', 'imagegen']);
+        await addSkill(codexHome, ['plugins', 'cache', 'openai-curated', 'superpowers', '43313cc9', 'skills', 'brainstorming']);
+        await addSkill(codexHome, ['plugins', 'cache', 'openai-primary-runtime', 'documents', '26.614.11602', 'skills', 'documents']);
+
+        const commands = await discoverCodexSkillCommands({ cwd, codexHome });
+
+        expect(commands).toEqual([
+            'agent-browser',
+            'documents:documents',
+            'imagegen',
+            'plan-to-beads',
+            'superpowers:brainstorming',
+        ]);
+    });
+
+    it('deduplicates skills discovered from multiple locations', async () => {
+        const root = await makeTempRoot();
+        const cwd = join(root, 'project');
+        const codexHome = join(root, 'codex-home');
+
+        await addSkill(cwd, ['.agents', 'skills', 'plan-to-beads']);
+        await addSkill(codexHome, ['skills', 'plan-to-beads']);
+
+        const commands = await discoverCodexSkillCommands({ cwd, codexHome });
+
+        expect(commands).toEqual(['plan-to-beads']);
+    });
+});

--- a/packages/happy-cli/src/codex/codexSkills.ts
+++ b/packages/happy-cli/src/codex/codexSkills.ts
@@ -1,0 +1,102 @@
+import { readdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, dirname, join, relative, sep } from 'node:path';
+
+const SKILL_FILE = 'SKILL.md';
+const MAX_SKILL_SCAN_DEPTH = 10;
+
+export interface DiscoverCodexSkillCommandsOptions {
+    cwd?: string;
+    codexHome?: string;
+    homeDir?: string;
+}
+
+type SkillCommandResolver = (skillFilePath: string) => string | null;
+
+function expandHomePath(path: string, homeDir: string): string {
+    if (path === '~') return homeDir;
+    if (path.startsWith(`~${sep}`)) return join(homeDir, path.slice(2));
+    return path;
+}
+
+async function collectSkillCommands(
+    root: string,
+    resolveCommand: SkillCommandResolver,
+    commands: Set<string>,
+): Promise<void> {
+    async function walk(dir: string, depth: number): Promise<void> {
+        let entries;
+        try {
+            entries = await readdir(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+
+        for (const entry of entries) {
+            const entryPath = join(dir, entry.name);
+            if (entry.isFile() && entry.name === SKILL_FILE) {
+                const command = resolveCommand(entryPath);
+                if (command) {
+                    commands.add(command);
+                }
+                continue;
+            }
+
+            if (entry.isDirectory() && depth < MAX_SKILL_SCAN_DEPTH) {
+                await walk(entryPath, depth + 1);
+            }
+        }
+    }
+
+    await walk(root, 0);
+}
+
+function parentDirectorySkillName(skillFilePath: string): string | null {
+    const skillName = basename(dirname(skillFilePath));
+    return skillName.length > 0 ? skillName : null;
+}
+
+function pluginSkillName(pluginCacheRoot: string, skillFilePath: string): string | null {
+    const parts = relative(pluginCacheRoot, skillFilePath).split(sep);
+    const skillsIndex = parts.indexOf('skills');
+    const pluginName = parts[1];
+    const skillName = skillsIndex >= 0 ? parts[skillsIndex + 1] : undefined;
+
+    if (pluginName && skillName) {
+        return `${pluginName}:${skillName}`;
+    }
+
+    return parentDirectorySkillName(skillFilePath);
+}
+
+export async function discoverCodexSkillCommands(
+    opts: DiscoverCodexSkillCommandsOptions = {},
+): Promise<string[]> {
+    const homeDir = opts.homeDir ?? homedir();
+    const cwd = opts.cwd ?? process.cwd();
+    const codexHome = expandHomePath(
+        opts.codexHome ?? process.env.CODEX_HOME ?? '~/.codex',
+        homeDir,
+    );
+    const commands = new Set<string>();
+
+    await collectSkillCommands(
+        join(cwd, '.agents', 'skills'),
+        parentDirectorySkillName,
+        commands,
+    );
+    await collectSkillCommands(
+        join(codexHome, 'skills'),
+        parentDirectorySkillName,
+        commands,
+    );
+
+    const pluginCacheRoot = join(codexHome, 'plugins', 'cache');
+    await collectSkillCommands(
+        pluginCacheRoot,
+        (skillFilePath) => pluginSkillName(pluginCacheRoot, skillFilePath),
+        commands,
+    );
+
+    return [...commands].sort((a, b) => a.localeCompare(b));
+}

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -43,6 +43,7 @@ import {
     hashCodexEnhancedMode,
     type CodexEnhancedMode,
 } from './codexPrompt';
+import { discoverCodexSkillCommands } from './codexSkills';
 
 /**
  * Extracts a human-readable error from a codex task_complete/turn_aborted event.
@@ -139,6 +140,12 @@ export async function runCodex(opts: {
         ...(forkedFromSessionId ? { parentSessionId: forkedFromSessionId } : {}),
         ...(forkedFromMessageId ? { forkedFromMessageId } : {}),
     });
+
+    const skillCommands = await discoverCodexSkillCommands();
+    if (skillCommands.length > 0) {
+        metadata.skills = skillCommands;
+        metadata.slashCommands = Array.from(new Set([...(metadata.slashCommands ?? []), ...skillCommands]));
+    }
 
     // Check for session reconnection env vars (set by daemon for resume-in-place)
     const reconnectSessionId = process.env.HAPPY_RECONNECT_SESSION_ID;

--- a/packages/happy-cli/vitest.config.ts
+++ b/packages/happy-cli/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
                 extends: true,
                 test: {
                     name: 'unit',
-                    include: ['src/**/*.test.ts'],
+                    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
                     exclude: ['src/**/*.integration.test.ts'],
                     sequence: {
                         groupOrder: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,8 +910,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.167
-        version: 0.3.167(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.3.179
+        version: 0.3.179(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sandbox-runtime':
         specifier: ^0.0.37
         version: 0.0.37
@@ -1279,8 +1279,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.179':
+    resolution: {integrity: sha512-2QoEl7p+RTkF4ARZ40N9OWWi+at8Iy9ZZg3UeP6sWoGrM0GL6NJSv8pbYUdoSRySbNeZshqWar5DF41265J5Sg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.167':
     resolution: {integrity: sha512-24WCqqXc9SBliROFQz+JhO8+u9DARqhmMGWAZwT+/fs9RDJtHd2SZ7o8rWPAVnUicKQCMsjxdhtp/vFWELGenA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.179':
+    resolution: {integrity: sha512-U5683Hi4uP5Wkg9IhHayqx8co9rgeZaAJcutLAgJiAN9ZnL128+WT0K4DKaBVuMbeeoORodVs9IJgM38lBxUxg==}
     cpu: [x64]
     os: [darwin]
 
@@ -1289,8 +1299,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.179':
+    resolution: {integrity: sha512-ehqWR9bV0dJONkoKleKg/LJIGDVevLGLPVIQpol+Bqrgyv05DE1hx68g6mBnfp9IEKo2BMZCba3aHKhkHlZvnQ==}
+    cpu: [arm64]
+    os: [linux]
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.167':
     resolution: {integrity: sha512-f6269JZ8KngRIHDK9tmQMFWHg8XhOyJww6pbTVHqlUnf70pJPEP7hsmg6OQErRIvqQzHQWBiakQA8VIdRrOrjw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.179':
+    resolution: {integrity: sha512-Io9X2xF5J3cHR20b0oflLe0sLHyT/KFMCA7sVJhwuSvcqeCHqXTxn6sG+4lArD9wNf+RtLVKgSvOt5Oz4j7mew==}
     cpu: [arm64]
     os: [linux]
 
@@ -1299,8 +1319,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.179':
+    resolution: {integrity: sha512-Q+clijh01m+Gg/tSNjHQWfPFRvXSVMIQJZqu6v28vFduaucL7ZL+p6o6VOSdlgLjhqtIFFjOO37aL+VkvEu9MQ==}
+    cpu: [x64]
+    os: [linux]
+
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.167':
     resolution: {integrity: sha512-ecxQI20+Fr+PexMgmHlG9/WrUOUi9uQT9n1laUDn4bQAcQX3xDqgZbiH7RErCuTJW+mBSauSh4X68b4jmf64Bg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.179':
+    resolution: {integrity: sha512-Ck2pLG2GJ5lYULK0Rb6FvAUhkLSvIFgJ77MsbVhvBJHG3C31Fuk6FnkXEL614WSZZdI1ST0Y7s7wc9yLI2kmiQ==}
     cpu: [x64]
     os: [linux]
 
@@ -1309,13 +1339,31 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.179':
+    resolution: {integrity: sha512-7wc4j3vDE/TiuiCEPV024U/TDNKXUJ89V0N9WteYJ57YrIUm0RA51WiKCrEmSxSqstQ7Slq26e0gWGHRf7ljDQ==}
+    cpu: [arm64]
+    os: [win32]
+
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.167':
     resolution: {integrity: sha512-r2IzO8ADzu4uRorXSs07baXee0LtTUIVDXP2ubYW32oTcAr98eip2VfkxwL9xm0tHXN63rp4fporU0eAy9fLPA==}
     cpu: [x64]
     os: [win32]
 
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.179':
+    resolution: {integrity: sha512-gFad1AVUZOXbEyS9lf3Pr0LDXrLuO6limZoZoUZQmjhjy0LnudnTU8P/VbCY0AHmT46YMZ/ieisFzeq8X5jTcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@anthropic-ai/claude-agent-sdk@0.3.167':
     resolution: {integrity: sha512-FTwjBkfcJlqDugBp/kR2GtQ7wPE1ekU4IJzIuUni0pVikdrOVmAPel3EE9LMSJ0WVqFVnHvoYIuj4U9z4gC+5w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/claude-agent-sdk@0.3.179':
+    resolution: {integrity: sha512-BlZULVW61ZCcho6mb026QoOQbGZnfxbsEtcoNaW5lF0sIEu7D+/nnQjHSMK8buS/h7HVmIx2RtGbHVX1y4V0uQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -12671,25 +12719,49 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.167':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.179':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.167':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.179':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.167':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.179':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.167':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.179':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.167':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.179':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.167':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.179':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.167':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.179':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.167':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.179':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk@0.3.167(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
@@ -12706,6 +12778,21 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.167
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.167
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.167
+
+  '@anthropic-ai/claude-agent-sdk@0.3.179(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.96.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.179
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.179
 
   '@anthropic-ai/claude-code-darwin-arm64@2.1.143':
     optional: true


### PR DESCRIPTION
## Summary

This PR is a mass-fix branch for a few agent/session polish issues across `happy-cli` and `happy-app`:

- fixes the first remote message being dropped in fresh sessions
- updates the `/goal` hook compatibility path and warning behavior for third-party Claude-compatible backends
- makes `/goal` render as a first-class goal message instead of leaking local command internals into chat
- surfaces Codex skills in the slash-command dropdown, matching the Claude behavior
- renders slash/skill invocations consistently across Claude and Codex: message text plus the command chip underneath
- hides Claude's internal `Skill` tool call card from chat/work groups

## Fixes

### Fixes #1408

Remote sessions could silently drop the first live app message because `apiSession.ts` treated `lastSeq === 0` as a reason to invalidate sync and return, even when the socket already delivered the encrypted `seq: 1` message.

This PR removes that special-case drop and adds coverage that the first live encrypted message is routed immediately, advances `lastSeq`, and does not wait for REST catch-up.

### Fixes #1405

Updates the Claude Agent SDK dependency to a version that carries the `/goal` Stop-hook JSON validation fix path, and adds defensive version detection for externally installed Claude CLIs.

When Happy is pointed at a third-party Anthropic-compatible backend through `ANTHROPIC_BASE_URL`, old external Claude versions can still hit the markdown-wrapped JSON failure mode. Happy now detects that risky combination and prints an explicit warning instead of silently running with the known-bad hook behavior.

## Additional changes

### `/goal` chat UX

- Parses raw `/goal ...`, Claude SDK command wrappers, and `Goal set: ...` local stdout confirmations.
- Renders goal commands as a user bubble with the goal text and a "Sent as goal" status line.
- Hides the local-command stdout confirmation so chat no longer shows `<local-command-stdout>...` internals.
- Preserves `localId` through the app reducer so optimistic goal messages can be deduped against the echoed command message.
- Adds `/goal` to the default slash-command suggestions.
- Adds localized `message.sentAsGoal` copy.

### Slash/skill invocation rendering

- Parses raw slash commands such as `/superpowers:brainstorming plan this` into the same display intent as Claude SDK command wrappers.
- Also parses slash commands in the middle or end of a message, for example `привет давай /maintain` -> bubble `привет давай` plus chip `/maintain`.
- Renders command args as the user message bubble and places the `/<command>` chip underneath it.
- Keeps Claude optimistic-echo dedupe so Claude does not show both the raw echo and the SDK wrapper.
- Gives Codex the same visual shape even though Codex does not emit Claude's `<command-name>` wrapper messages.
- Hides Claude's internal `Skill` tool calls from the display list so skill invocation does not render as an expanded tool card.

### Codex skills in suggestions

- Discovers Codex skills from project `.agents/skills`, `$CODEX_HOME/skills`, and `$CODEX_HOME/plugins/cache`.
- Stores discovered Codex skills in session metadata and exposes them as slash suggestions for the app dropdown.
- Makes the app suggestion source merge both `metadata.slashCommands` and `metadata.skills`, so skills show even when they are provided separately from slash commands.

## Review notes

- Codex skill discovery is best-effort and bounded; missing skill directories are ignored.
- Plugin skills use the same visible command shape as Codex skill names, for example `superpowers:brainstorming`.
- The `/goal` stdout confirmation is intentionally hidden because the user-facing bubble now carries the goal state.
- Slash commands without args still render as a chip only; commands with args render bubble plus chip.

## Test plan

- [x] `pnpm --filter happy exec vitest run --project unit src/codex/codexSkills.test.ts src/api/apiSession.test.ts scripts/claude_version_utils.test.ts` — 71 tests
- [x] `pnpm --filter happy-app exec vitest run sources/components/parseLocalCommandMessage.spec.ts sources/components/tools/knownTools.spec.ts sources/hooks/useGroupedMessages.test.ts sources/sync/suggestionCommands.spec.ts sources/sync/reducer/reducer.spec.ts` — 89 tests
- [x] `pnpm --filter happy run typecheck`
- [x] `pnpm --filter happy-app run typecheck`
- [x] `git diff --check upstream/main..HEAD`