### PR TITLE
fix(parser): handle nested command tags in skill bodies (#1340)

### DIFF
--- a/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
@@ -59,6 +59,26 @@ describe('parseLocalCommandMessage', () => {
         const text = 'just a normal message';
         expect(parseLocalCommandMessage(text)).toEqual({ kind: 'text', text });
     });
+
+    it('collapses a command whose skill body contains nested command-message examples', () => {
+        // Reproduces #1340: a /go skill whose markdown body references other
+        // commands ends up with nested <command-message>/<command-name> tags
+        // inside the outer SDK wrapper. The old lazy regex stopped at the
+        // inner closer and rendered the whole skill body as plain text.
+        const text =
+            '<command-message>\n' +
+            'You are the /go skill. Available examples:\n' +
+            '<command-message>compact</command-message><command-name>/compact</command-name>\n' +
+            'more skill body content here\n' +
+            '</command-message>' +
+            '<command-name>/go</command-name>' +
+            '<command-args>deploy</command-args>';
+        expect(parseLocalCommandMessage(text)).toEqual({
+            kind: 'command-run',
+            commandName: 'go',
+            args: 'deploy',
+        });
+    });
 });
 
 describe('isUserSlashCommandEcho', () => {

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.ts
@@ -26,7 +26,12 @@ export type LocalCommandMessage =
 const CAVEAT_RE = /^\s*<local-command-caveat>[\s\S]*?<\/local-command-caveat>\s*$/;
 const COMMAND_NAME_RE = /<command-name>\s*\/?([^<]+?)\s*<\/command-name>/;
 const COMMAND_ARGS_RE = /<command-args>\s*([\s\S]*?)\s*<\/command-args>/;
-const COMMAND_MESSAGE_RE = /<command-message>[\s\S]*?<\/command-message>/g;
+// Greedy on purpose: skill bodies often contain literal `<command-message>`
+// examples in their markdown, producing nested closing tags inside the SDK
+// wrapper. A lazy match stops at the inner closer and leaves the outer tail
+// behind, which then falls through to `kind: 'text'` and renders the whole
+// skill body as plain text in the chat.
+const COMMAND_MESSAGE_RE = /<command-message>[\s\S]*<\/command-message>/g;
 const COMMAND_NAME_TAG_RE = /<command-name>[\s\S]*?<\/command-name>/g;
 const COMMAND_ARGS_TAG_RE = /<command-args>[\s\S]*?<\/command-args>/g;
 
@@ -35,17 +40,21 @@ export function parseLocalCommandMessage(text: string): LocalCommandMessage {
         return { kind: 'caveat' };
     }
 
-    const nameMatch = text.match(COMMAND_NAME_RE);
+    // Strip <command-message> blocks first so any nested <command-name> /
+    // <command-args> examples in a skill body don't get picked up by the
+    // extractors below — only the outer wrapper's tags should be visible.
+    const withoutMessageBlocks = text.replace(COMMAND_MESSAGE_RE, '');
+
+    const nameMatch = withoutMessageBlocks.match(COMMAND_NAME_RE);
     if (nameMatch) {
-        const argsMatch = text.match(COMMAND_ARGS_RE);
+        const argsMatch = withoutMessageBlocks.match(COMMAND_ARGS_RE);
         const args = argsMatch?.[1].trim();
 
         // If the message is just the command wrappers (after stripping all of
         // them only whitespace remains), collapse to a chip. The args, if any,
         // are surfaced separately so the renderer can show them as the user's
         // actual prompt rather than as raw XML.
-        const stripped = text
-            .replace(COMMAND_MESSAGE_RE, '')
+        const stripped = withoutMessageBlocks
             .replace(COMMAND_NAME_TAG_RE, '')
             .replace(COMMAND_ARGS_TAG_RE, '')
             .trim();


### PR DESCRIPTION
## Summary
- Fixes #1340: when a slash-command's skill body contains literal `<command-message>` / `<command-name>` examples in its markdown, the SDK wrapper ends up with nested closing tags, and the parser falls through to `kind: 'text'` — rendering the entire skill body as plain text in the chat.
- Two changes in `parseLocalCommandMessage.ts`:
  1. `COMMAND_MESSAGE_RE` becomes greedy so the whole outer block (including any nested example tags) is consumed in one pass.
  2. `<command-message>` blocks are stripped **before** the name/args extractors run, so a nested `<command-name>/compact</command-name>` example inside the wrapper can't be mistaken for the real command name.
- Adds one regression test reproducing the `/go` skill scenario from the issue.

## Why both changes are needed
Either fix alone is insufficient:
- Greedy alone → stripping is fixed, but `text.match(COMMAND_NAME_RE)` still finds the **first** `<command-name>` tag in the original input, which is the nested example (`/compact`) rather than the outer wrapper's real command (`/go`).
- Reorder alone → without greedy, the lazy match still stops at the inner closer, leaving the outer `</command-message>` behind.

The community comment on #1340 caught the lazy/greedy half but missed the extraction-order half; this PR addresses both.

## Test plan
- [x] `pnpm vitest run sources/components/parseLocalCommandMessage.spec.ts` — 15/15 tests pass (14 existing + 1 new regression test).
- [x] `pnpm typecheck` — clean.
- [x] All existing test cases (caveat, no-arg, with-args, empty-args, mixed-content, plain-text, echo detection) still pass — no behavior change for non-nested inputs.

🧙 Built with [WOZCODE](https://wozcode.com)