### PR TITLE
feat(session): add ?autoVoice=1 deep-link param to auto-start realtime voice

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -52,7 +52,7 @@ import { useUnistyles } from 'react-native-unistyles';
 import type { ModelMode, PermissionMode } from '@/components/PermissionModeSelector';
 import { resolveAgentDefaultConfig } from '@/sync/agentDefaults';
 
-export const SessionView = React.memo((props: { id: string }) => {
+export const SessionView = React.memo((props: { id: string; autoVoice?: boolean }) => {
     const sessionId = props.id;
     const router = useRouter();
     const session = useSession(sessionId);
@@ -255,7 +255,7 @@ export const SessionView = React.memo((props: { id: string }) => {
                         <Text style={{ color: theme.colors.textSecondary, fontSize: 15, marginTop: 8, textAlign: 'center', paddingHorizontal: 32 }}>{t('errors.sessionDeletedDescription')}</Text>
                     </View>
                 ) : (
-                    <SessionViewLoaded key={sessionId} sessionId={sessionId} session={session} />
+                    <SessionViewLoaded key={sessionId} sessionId={sessionId} session={session} autoVoice={props.autoVoice} />
                 )}
             </View>
         </>
@@ -407,7 +407,7 @@ const ChatComposer = React.memo(function ChatComposer(props: ChatComposerProps) 
     );
 });
 
-function SessionViewLoaded({ sessionId, session }: { sessionId: string, session: Session }) {
+function SessionViewLoaded({ sessionId, session, autoVoice }: { sessionId: string, session: Session, autoVoice?: boolean }) {
     const { theme } = useUnistyles();
     const router = useRouter();
     const safeArea = useSafeAreaInsets();
@@ -613,6 +613,19 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
         onMicPress: handleMicrophonePress,
         isMicActive: realtimeStatus === 'connected' || realtimeStatus === 'connecting'
     }), [handleMicrophonePress, realtimeStatus]);
+
+    // Auto-start a realtime voice session when the route is opened with `?autoVoice=1`.
+    // Fires once per mount, only when the realtime layer is idle, so a deep-link
+    // (e.g. from a Siri Shortcut or other automation) can land directly in voice
+    // mode without an additional user tap.
+    const autoVoiceFiredRef = React.useRef(false);
+    React.useEffect(() => {
+        if (!autoVoice) return;
+        if (autoVoiceFiredRef.current) return;
+        if (realtimeStatus !== 'disconnected') return;
+        autoVoiceFiredRef.current = true;
+        handleMicrophonePress();
+    }, [autoVoice, realtimeStatus, handleMicrophonePress]);
 
     // Trigger session visibility and initialize git status sync
     React.useLayoutEffect(() => {

--- a/packages/happy-app/sources/app/(app)/session/[id].tsx
+++ b/packages/happy-app/sources/app/(app)/session/[id].tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { useRoute } from "@react-navigation/native";
+import { useLocalSearchParams } from 'expo-router';
 import { SessionView } from '@/-session/SessionView';
 
 
 export default React.memo(() => {
-    const route = useRoute();
-    const sessionId = (route.params! as any).id as string;
-    return (<SessionView id={sessionId} />);
+    const { id, autoVoice } = useLocalSearchParams<{ id: string; autoVoice?: string }>();
+    const shouldAutoStartVoice = autoVoice === '1' || autoVoice === 'true';
+    return (<SessionView id={id} autoVoice={shouldAutoStartVoice} />);
 });


### PR DESCRIPTION
## Summary
Adds an opt-in `?autoVoice=1` query param to the session route so external automations can open a session and start the realtime voice assistant in a single step.

Before this PR: a deep-link can land you on `session/<id>`, but the voice session still requires a manual mic tap.
After: `happy://session/<id>?autoVoice=1` (or the universal-link equivalent) lands you straight into voice mode.

## Why
This unlocks a class of integrations that were previously two-tap:
- Siri Shortcuts → "Hey Siri, ask Happy about X"
- Push notifications that should resume voice (e.g. follow-up tap)
- Custom URL schemes from other apps / OS automations

The param is **opt-in**: existing links and the in-app session opener behave exactly as before.

## Implementation
- `session/[id].tsx`: switch from `@react-navigation/native`'s `useRoute` to `expo-router`'s `useLocalSearchParams` so we can read both the path param (`id`) and the query string (`autoVoice`). Per the project CLAUDE.md ("Always use expo-router api, not react-navigation one"), this also brings this route in line with the rest of the codebase.
- `SessionView.tsx`: thread an optional `autoVoice?: boolean` prop through `SessionView` → `SessionViewLoaded`.
- One small `useEffect` in `SessionViewLoaded`, gated by a `useRef`, fires `handleMicrophonePress()` exactly once on mount **and only when `realtimeStatus === 'disconnected'`** — so it never racing-stacks against an already-connecting/connected session.

Accepts `autoVoice=1` and `autoVoice=true`; everything else (including absent) is a no-op.

## Test plan
- [x] `pnpm typecheck` clean
- [ ] Manual: open `happy://session/<id>?autoVoice=1` from Siri Shortcut → voice connects without tapping the mic
- [ ] Manual: open `https://app.happy.engineering/session/<id>?autoVoice=1` on web → same
- [ ] Manual: open `happy://session/<id>` (no param) → unchanged behavior, no auto-mic
- [ ] Manual: deep-link in while a session is already voice-active → does not re-trigger

🧙 Built with [WOZCODE](https://wozcode.com)