### PR TITLE
feat(cli): add open_session, archive_session, archive_self MCP tools to the happy MCP server

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -528,7 +528,7 @@ export async function runAcp(opts: {
   let sawModes = false;
   let sawModels = false;
 
-  const happyServer = await startHappyServer(session);
+  const happyServer = await startHappyServer(session, { api });
   const mcpServers = {
     happy: {
       command: join(projectPath(), 'bin', 'happy-mcp.mjs'),

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -528,7 +528,10 @@ export async function runAcp(opts: {
   let sawModes = false;
   let sawModels = false;
 
-  const happyServer = await startHappyServer(session, { api });
+  // Wired below (after the kill handler) so the archive_self MCP tool can
+  // trigger the same graceful archive+exit as the app's Archive button.
+  let requestSelfArchive: (() => void) | undefined;
+  const happyServer = await startHappyServer(session, { api, archiveAndExit: () => requestSelfArchive?.() });
   const mcpServers = {
     happy: {
       command: join(projectPath(), 'bin', 'happy-mcp.mjs'),
@@ -871,12 +874,15 @@ export async function runAcp(opts: {
   }
 
   session.rpcHandlerManager.registerHandler('abort', handleAbort);
-  registerKillSessionHandler(session.rpcHandlerManager, async () => {
+  const handleKillSession = async () => {
     shouldExit = true;
     messageQueue.close();
     clearPendingTurn(new Error('Session terminated'));
     await handleAbort();
-  });
+  };
+  registerKillSessionHandler(session.rpcHandlerManager, handleKillSession);
+  // archive_self MCP tool → same graceful archive+exit as the kill RPC.
+  requestSelfArchive = () => { void handleKillSession(); };
 
   try {
     const started = await backend.startSession();

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -346,7 +346,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     });
 
     // Start Happy MCP server
-    const happyServer = await startHappyServer(session);
+    const happyServer = await startHappyServer(session, { api });
     logger.debug(`[START] Happy MCP server started at ${happyServer.url}`);
 
     // Variable to track current session instance (updated via onSessionReady callback)

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -346,7 +346,10 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     });
 
     // Start Happy MCP server
-    const happyServer = await startHappyServer(session, { api });
+    // Wired below (after `cleanup` is defined) so the archive_self MCP tool can
+    // trigger the same graceful archive+exit as the app's Archive button.
+    let requestSelfArchive: (() => void) | undefined;
+    const happyServer = await startHappyServer(session, { api, archiveAndExit: () => requestSelfArchive?.() });
     logger.debug(`[START] Happy MCP server started at ${happyServer.url}`);
 
     // Variable to track current session instance (updated via onSessionReady callback)
@@ -776,6 +779,9 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // want the metadata stamped — it's the user explicitly choosing to
     // retire the session, not just disconnecting.
     registerKillSessionHandler(session.rpcHandlerManager, () => cleanup({ archive: true }));
+
+    // archive_self MCP tool → same graceful archive+exit as the kill RPC above.
+    requestSelfArchive = () => { void cleanup({ archive: true }); };
 
     // Create claude loop
     const exitCode = await loop({

--- a/packages/happy-cli/src/claude/utils/startHappyServer.test.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.test.ts
@@ -33,13 +33,13 @@ describe('startHappyServer MCP tools', () => {
         return c;
     }
 
-    it('registers change_title, open_session, archive_session', async () => {
+    it('registers change_title, open_session, archive_session, archive_self', async () => {
         server = await startHappyServer(fakeSession([]));
-        expect(server.toolNames).toEqual(['change_title', 'open_session', 'archive_session']);
+        expect(server.toolNames).toEqual(['change_title', 'open_session', 'archive_session', 'archive_self']);
 
         client = await connect(server.url);
         const { tools } = await client.listTools();
-        expect(tools.map(t => t.name).sort()).toEqual(['archive_session', 'change_title', 'open_session']);
+        expect(tools.map(t => t.name).sort()).toEqual(['archive_self', 'archive_session', 'change_title', 'open_session']);
     });
 
     it('change_title still works after the refactor', async () => {
@@ -60,5 +60,30 @@ describe('startHappyServer MCP tools', () => {
         const res = await client.callTool({ name: 'archive_session', arguments: { sessionId: 'self-session' } });
         expect(res.isError).toBe(true);
         expect(JSON.stringify(res.content)).toContain('Cannot archive the current session');
+    });
+
+    it('archive_self reports unavailable when no archiveAndExit is wired', async () => {
+        server = await startHappyServer(fakeSession([]));
+        client = await connect(server.url);
+
+        const res = await client.callTool({ name: 'archive_self', arguments: {} });
+        expect(res.isError).toBe(true);
+        expect(JSON.stringify(res.content)).toContain('not available');
+    });
+
+    it('archive_self responds first, then triggers the wired archive+exit', async () => {
+        let archived = false;
+        server = await startHappyServer(fakeSession([]), { archiveAndExit: () => { archived = true; } });
+        client = await connect(server.url);
+
+        const res = await client.callTool({ name: 'archive_self', arguments: {} });
+        // Responds with success BEFORE the deferred archive+exit fires, so the
+        // client gets the goodbye before the process would terminate.
+        expect(res.isError).toBeFalsy();
+        expect(JSON.stringify(res.content)).toContain('Archiving this session');
+        expect(archived).toBe(false);
+
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        expect(archived).toBe(true);
     });
 });

--- a/packages/happy-cli/src/claude/utils/startHappyServer.test.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { startHappyServer } from './startHappyServer';
+import type { ApiSessionClient } from '@/api/apiSession';
+
+describe('startHappyServer MCP tools', () => {
+    let server: Awaited<ReturnType<typeof startHappyServer>> | null = null;
+    let client: Client | null = null;
+
+    afterEach(async () => {
+        try { await client?.close(); } catch { /* ignore */ }
+        client = null;
+        server?.stop();
+        server = null;
+    });
+
+    function fakeSession(summaries: string[], sessionId = 'self-session'): ApiSessionClient {
+        return {
+            sessionId,
+            getMetadata: () => ({ path: '/tmp/fake-project' }),
+            sendClaudeSessionMessage: (message: unknown) => {
+                if (message && typeof message === 'object' && (message as { type?: string }).type === 'summary') {
+                    summaries.push(String((message as { summary?: string }).summary ?? ''));
+                }
+            },
+        } as unknown as ApiSessionClient;
+    }
+
+    async function connect(url: string): Promise<Client> {
+        const c = new Client({ name: 'test', version: '1.0.0' }, { capabilities: {} });
+        await c.connect(new StreamableHTTPClientTransport(new URL(url)));
+        return c;
+    }
+
+    it('registers change_title, open_session, archive_session', async () => {
+        server = await startHappyServer(fakeSession([]));
+        expect(server.toolNames).toEqual(['change_title', 'open_session', 'archive_session']);
+
+        client = await connect(server.url);
+        const { tools } = await client.listTools();
+        expect(tools.map(t => t.name).sort()).toEqual(['archive_session', 'change_title', 'open_session']);
+    });
+
+    it('change_title still works after the refactor', async () => {
+        const summaries: string[] = [];
+        server = await startHappyServer(fakeSession(summaries));
+        client = await connect(server.url);
+
+        const res = await client.callTool({ name: 'change_title', arguments: { title: 'Hello world' } });
+        expect(res.isError).toBeFalsy();
+        expect(JSON.stringify(res.content)).toContain('Hello world');
+        expect(summaries).toContain('Hello world');
+    });
+
+    it('archive_session refuses to archive the current session (keepalive self-revive guard)', async () => {
+        server = await startHappyServer(fakeSession([], 'self-session'));
+        client = await connect(server.url);
+
+        const res = await client.callTool({ name: 'archive_session', arguments: { sessionId: 'self-session' } });
+        expect(res.isError).toBe(true);
+        expect(JSON.stringify(res.content)).toContain('Cannot archive the current session');
+    });
+});

--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -1,6 +1,8 @@
 /**
  * Happy MCP server
- * Provides Happy CLI specific tools including chat session title management
+ * Provides Happy CLI specific tools: chat title management plus session control
+ * (open a new session, archive a session) so a running agent can do
+ * programmatically what the mobile/web client UI does.
  *
  * Uses stateless StreamableHTTP: each request gets a fresh McpServer + transport.
  * This is required by MCP SDK >=1.27 which rejects reuse of an already-connected transport.
@@ -13,9 +15,23 @@ import { AddressInfo } from "node:net";
 import { z } from "zod";
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
+import { ApiClient } from "@/api/api";
+import { spawnDaemonSession, stopDaemonSession } from "@/daemon/controlClient";
+import { createWorktree } from "@/utils/createWorktree";
 import { randomUUID } from "node:crypto";
 
-function createMcpServer(handler: (title: string) => Promise<{ success: boolean; error?: string }>): McpServer {
+type ToolResult = { content: Array<{ type: 'text'; text: string }>; isError: boolean };
+
+function toolResult(text: string, isError = false): ToolResult {
+    return { content: [{ type: 'text', text }], isError };
+}
+
+export interface HappyServerDeps {
+    /** Account-scoped API client, used by archive_session to mark a session inactive on the server. */
+    api?: ApiClient;
+}
+
+function createMcpServer(client: ApiSessionClient, deps: HappyServerDeps): McpServer {
     const mcp = new McpServer({
         name: "Happy MCP",
         version: "1.0.0",
@@ -28,54 +44,95 @@ function createMcpServer(handler: (title: string) => Promise<{ success: boolean;
             title: z.string().describe('The new title for the chat session'),
         },
     }, async (args) => {
-        const response = await handler(args.title);
-        logger.debug('[happyMCP] Response:', response);
+        logger.debug('[happyMCP] Changing title to:', args.title);
+        try {
+            client.sendClaudeSessionMessage({
+                type: 'summary',
+                summary: args.title,
+                leafUuid: randomUUID(),
+            });
+            return toolResult(`Successfully changed chat title to: "${args.title}"`);
+        } catch (error) {
+            return toolResult(`Failed to change chat title: ${error instanceof Error ? error.message : String(error)}`, true);
+        }
+    });
 
-        if (response.success) {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Successfully changed chat title to: "${args.title}"`,
-                    },
-                ],
-                isError: false,
-            };
-        } else {
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Failed to change chat title: ${response.error || 'Unknown error'}`,
-                    },
-                ],
-                isError: true,
-            };
+    mcp.registerTool('open_session', {
+        description: 'Open a new Happy session (a separate agent process) on this machine — the programmatic equivalent of the client UI\'s "new session". Opens a top-level session by default (no parent lineage); set linkToParent to stamp it as forked-from the calling session. Optionally create an isolated git worktree first and open the session inside it. Returns the new session id.',
+        title: 'Open Happy Session',
+        inputSchema: {
+            directory: z.string().optional().describe("Absolute path to open the session in. Defaults to the current session's working directory."),
+            agent: z.enum(['claude', 'codex', 'gemini', 'openclaw']).optional().describe('Which agent to launch (default: claude).'),
+            worktree: z.boolean().optional().describe('If true, create a new git worktree under <directory>/.dev/worktree/<name> and open the session there. <directory> must be inside a git repo.'),
+            linkToParent: z.boolean().optional().describe('If true, stamp the new session as forked-from the calling session so it appears under "Forked from" in the app\'s fork-lineage view. Default false = a top-level session with no parent lineage (matches the client\'s "new session"). Lineage is metadata only; history is never backfilled.'),
+        },
+    }, async (args) => {
+        try {
+            let directory = args.directory || client.getMetadata()?.path || process.cwd();
+            let worktreeNote = '';
+            if (args.worktree) {
+                const worktree = await createWorktree(directory);
+                directory = worktree.worktreePath;
+                worktreeNote = ` (new worktree on branch '${worktree.branchName}')`;
+            }
+            const result = await spawnDaemonSession(directory, undefined, {
+                agent: args.agent,
+                // Default: a TOP-LEVEL session with no parent lineage (matches the
+                // client's "new session"). Opt in with linkToParent to stamp
+                // metadata.parentSessionId for the app's fork-lineage view —
+                // HAPPY_FORKED_FROM_SESSION_ID only sets the parent link, it never
+                // backfills history.
+                environmentVariables: args.linkToParent
+                    ? { HAPPY_FORKED_FROM_SESSION_ID: client.sessionId }
+                    : undefined,
+            });
+            if (result?.error) {
+                return toolResult(`Failed to open session: ${result.error}`, true);
+            }
+            if (!result?.success || !result?.sessionId) {
+                return toolResult(`Failed to open session: ${JSON.stringify(result)}`, true);
+            }
+            return toolResult(`Opened new ${args.agent ?? 'claude'} session ${result.sessionId} in ${directory}${worktreeNote}.`);
+        } catch (error) {
+            return toolResult(`Failed to open session: ${error instanceof Error ? error.message : String(error)}`, true);
+        }
+    });
+
+    mcp.registerTool('archive_session', {
+        description: 'Archive a Happy session by id — the programmatic equivalent of the client UI\'s "Archive". Stops the live process via the local daemon (so the archive sticks past the session keepalive) and marks the session inactive on the server. The session stays resumable. Cannot archive the current session from within itself.',
+        title: 'Archive Happy Session',
+        inputSchema: {
+            sessionId: z.string().describe('The Happy session id to archive.'),
+        },
+    }, async (args) => {
+        if (args.sessionId === client.sessionId) {
+            return toolResult('Cannot archive the current session from within itself — its keepalive would immediately re-activate it. Exit the session instead.', true);
+        }
+        try {
+            const stopped = await stopDaemonSession(args.sessionId);
+            let archived = false;
+            if (deps.api) {
+                archived = await deps.api.deactivateSession(args.sessionId);
+            }
+            const notes: string[] = [];
+            notes.push(stopped ? 'process stopped via daemon' : 'process not tracked by the local daemon (already stopped, or running on another machine)');
+            notes.push(deps.api ? (archived ? 'marked inactive on server' : 'server archive request failed') : 'server archive unavailable');
+            const ok = stopped || archived;
+            const tail = (!stopped && archived) ? ' Note: if the session is still live elsewhere, its keepalive may re-activate it.' : '';
+            return toolResult(`archive_session ${args.sessionId}: ${notes.join('; ')}.${tail}`, !ok);
+        } catch (error) {
+            return toolResult(`Failed to archive session: ${error instanceof Error ? error.message : String(error)}`, true);
         }
     });
 
     return mcp;
 }
 
-export async function startHappyServer(client: ApiSessionClient) {
+export async function startHappyServer(client: ApiSessionClient, deps: HappyServerDeps = {}) {
     logger.debug(`[happyMCP] server:start sessionId=${client.sessionId}`);
 
-    const handler = async (title: string) => {
-        logger.debug('[happyMCP] Changing title to:', title);
-        try {
-            client.sendClaudeSessionMessage({
-                type: 'summary',
-                summary: title,
-                leafUuid: randomUUID()
-            });
-            return { success: true };
-        } catch (error) {
-            return { success: false, error: String(error) };
-        }
-    };
-
     const server = createServer(async (req, res) => {
-        const mcp = createMcpServer(handler);
+        const mcp = createMcpServer(client, deps);
         try {
             const transport = new StreamableHTTPServerTransport({
                 sessionIdGenerator: undefined
@@ -106,7 +163,7 @@ export async function startHappyServer(client: ApiSessionClient) {
 
     return {
         url: baseUrl.toString(),
-        toolNames: ['change_title'],
+        toolNames: ['change_title', 'open_session', 'archive_session'],
         stop: () => {
             logger.debug(`[happyMCP] server:stop sessionId=${client.sessionId}`);
             server.close();

--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -1,8 +1,8 @@
 /**
  * Happy MCP server
  * Provides Happy CLI specific tools: chat title management plus session control
- * (open a new session, archive a session) so a running agent can do
- * programmatically what the mobile/web client UI does.
+ * (open a new session, archive another session, self-archive) so a running
+ * agent can do programmatically what the mobile/web client UI does.
  *
  * Uses stateless StreamableHTTP: each request gets a fresh McpServer + transport.
  * This is required by MCP SDK >=1.27 which rejects reuse of an already-connected transport.
@@ -26,9 +26,24 @@ function toolResult(text: string, isError = false): ToolResult {
     return { content: [{ type: 'text', text }], isError };
 }
 
+/**
+ * Delay before archive_self's deferred archive+exit fires, so the tool's
+ * response reaches the MCP client before the process terminates.
+ */
+const SELF_ARCHIVE_EXIT_DELAY_MS = 250;
+
 export interface HappyServerDeps {
     /** Account-scoped API client, used by archive_session to mark a session inactive on the server. */
     api?: ApiClient;
+    /**
+     * Archive THIS session and gracefully terminate the process. Wired by each
+     * runner to its kill-session handler — the same path the app's "Archive"
+     * button uses: stamps lifecycleState='archived', stops the keepalive, then
+     * exits, so the archive sticks past the keepalive (which would otherwise
+     * re-activate a still-live session). Absent → archive_self reports it's
+     * unavailable.
+     */
+    archiveAndExit?: () => void | Promise<void>;
 }
 
 function createMcpServer(client: ApiSessionClient, deps: HappyServerDeps): McpServer {
@@ -125,6 +140,22 @@ function createMcpServer(client: ApiSessionClient, deps: HappyServerDeps): McpSe
         }
     });
 
+    mcp.registerTool('archive_self', {
+        description: 'Archive the CURRENT session and exit — the self-archive that archive_session refuses (a live session\'s keepalive would otherwise immediately re-activate it). Stamps this session archived, stops its keepalive, and gracefully terminates the agent process so the archive sticks (same path as the app\'s "Archive" button). The session stays resumable. Call this only when the agent has finished its work and should retire itself; it ends the session, so emit any final message before calling.',
+        title: 'Archive Current Session',
+        inputSchema: {},
+    }, async () => {
+        if (!deps.archiveAndExit) {
+            return toolResult('Self-archive is not available in this session.', true);
+        }
+        // Defer so this tool's response reaches the client before the process
+        // exits. The wired handler stops the keepalive before archiving, so the
+        // archive sticks (no keepalive re-activation race).
+        const archiveAndExit = deps.archiveAndExit;
+        setTimeout(() => { void archiveAndExit(); }, SELF_ARCHIVE_EXIT_DELAY_MS);
+        return toolResult('Archiving this session and exiting now. It stays resumable.');
+    });
+
     return mcp;
 }
 
@@ -163,7 +194,7 @@ export async function startHappyServer(client: ApiSessionClient, deps: HappyServ
 
     return {
         url: baseUrl.toString(),
-        toolNames: ['change_title', 'open_session', 'archive_session'],
+        toolNames: ['change_title', 'open_session', 'archive_session', 'archive_self'],
         stop: () => {
             logger.debug(`[happyMCP] server:stop sessionId=${client.sessionId}`);
             server.close();

--- a/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
+++ b/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
@@ -141,6 +141,28 @@ async function main() {
     }
   );
 
+  server.registerTool(
+    'archive_self',
+    {
+      description: 'Archive the CURRENT session and exit — the self-archive that archive_session refuses (a live session\'s keepalive would otherwise immediately re-activate it). Stamps this session archived, stops its keepalive, and gracefully terminates the agent process so the archive sticks (same path as the app\'s "Archive" button). The session stays resumable. Call this only when the agent has finished its work and should retire itself; it ends the session, so emit any final message before calling.',
+      title: 'Archive Current Session',
+      inputSchema: {},
+    },
+    async (args) => {
+      try {
+        const client = await ensureHttpClient();
+        return await client.callTool({ name: 'archive_self', arguments: args }) as any;
+      } catch (error) {
+        return {
+          content: [
+            { type: 'text', text: `Failed to self-archive: ${error instanceof Error ? error.message : String(error)}` },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
   // Start STDIO transport
   const stdio = new StdioServerTransport();
   await server.connect(stdio);

--- a/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
+++ b/packages/happy-cli/src/codex/happyMcpStdioBridge.ts
@@ -1,9 +1,9 @@
 /**
  * Happy MCP STDIO Bridge
  *
- * Minimal STDIO MCP server exposing a single tool `change_title`.
- * On invocation it forwards the tool call to an existing Happy HTTP MCP server
- * using the StreamableHTTPClientTransport.
+ * STDIO MCP server exposing the Happy tools (change_title, open_session,
+ * archive_session). On invocation it forwards each tool call to an existing
+ * Happy HTTP MCP server using the StreamableHTTPClientTransport.
  *
  * Configure the target HTTP MCP URL via env var `HAPPY_HTTP_MCP_URL` or
  * via CLI flag `--url <http://127.0.0.1:PORT>`.
@@ -63,7 +63,9 @@ async function main() {
     version: '1.0.0',
   });
 
-  // Register the single tool and forward to HTTP MCP
+  // Register tools that mirror the HTTP MCP server
+  // (claude/utils/startHappyServer.ts is the source of truth for descriptions +
+  // schemas) and forward each call to it. Keep in sync when tools are added there.
   server.registerTool(
     'change_title',
     {
@@ -76,13 +78,62 @@ async function main() {
     async (args) => {
       try {
         const client = await ensureHttpClient();
-        const response = await client.callTool({ name: 'change_title', arguments: args });
-        // Pass-through response from HTTP server
-        return response as any;
+        return await client.callTool({ name: 'change_title', arguments: args }) as any;
       } catch (error) {
         return {
           content: [
             { type: 'text', text: `Failed to change chat title: ${error instanceof Error ? error.message : String(error)}` },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'open_session',
+    {
+      description: 'Open a new Happy session (a separate agent process) on this machine — the programmatic equivalent of the client UI\'s "new session". Opens a top-level session by default (no parent lineage); set linkToParent to stamp it as forked-from the calling session. Optionally create an isolated git worktree first and open the session inside it. Returns the new session id.',
+      title: 'Open Happy Session',
+      inputSchema: {
+        directory: z.string().optional().describe("Absolute path to open the session in. Defaults to the current session's working directory."),
+        agent: z.enum(['claude', 'codex', 'gemini', 'openclaw']).optional().describe('Which agent to launch (default: claude).'),
+        worktree: z.boolean().optional().describe('If true, create a new git worktree under <directory>/.dev/worktree/<name> and open the session there. <directory> must be inside a git repo.'),
+        linkToParent: z.boolean().optional().describe('If true, stamp the new session as forked-from the calling session so it appears under "Forked from" in the app\'s fork-lineage view. Default false = a top-level session with no parent lineage (matches the client\'s "new session"). Lineage is metadata only; history is never backfilled.'),
+      },
+    },
+    async (args) => {
+      try {
+        const client = await ensureHttpClient();
+        return await client.callTool({ name: 'open_session', arguments: args }) as any;
+      } catch (error) {
+        return {
+          content: [
+            { type: 'text', text: `Failed to open session: ${error instanceof Error ? error.message : String(error)}` },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    'archive_session',
+    {
+      description: 'Archive a Happy session by id — the programmatic equivalent of the client UI\'s "Archive". Stops the live process via the local daemon and marks the session inactive on the server. The session stays resumable. Cannot archive the current session from within itself.',
+      title: 'Archive Happy Session',
+      inputSchema: {
+        sessionId: z.string().describe('The Happy session id to archive.'),
+      },
+    },
+    async (args) => {
+      try {
+        const client = await ensureHttpClient();
+        return await client.callTool({ name: 'archive_session', arguments: args }) as any;
+      } catch (error) {
+        return {
+          content: [
+            { type: 'text', text: `Failed to archive session: ${error instanceof Error ? error.message : String(error)}` },
           ],
           isError: true,
         };

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -682,7 +682,7 @@ export async function runCodex(opts: {
     });
 
     // Start Happy MCP server (HTTP) and prepare STDIO bridge config for Codex
-    const happyServer = await startHappyServer(session, { api });
+    const happyServer = await startHappyServer(session, { api, archiveAndExit: handleKillSession });
     // Launch the bridge via `node <path>` (rather than relying on the .mjs shebang)
     // so it works on Windows, where Windows can't execute shebang scripts directly.
     // codex would otherwise fail to start the MCP server, the change_title tool would

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -682,7 +682,7 @@ export async function runCodex(opts: {
     });
 
     // Start Happy MCP server (HTTP) and prepare STDIO bridge config for Codex
-    const happyServer = await startHappyServer(session);
+    const happyServer = await startHappyServer(session, { api });
     // Launch the bridge via `node <path>` (rather than relying on the .mjs shebang)
     // so it works on Windows, where Windows can't execute shebang scripts directly.
     // codex would otherwise fail to start the MCP server, the change_title tool would

--- a/packages/happy-cli/src/daemon/controlClient.ts
+++ b/packages/happy-cli/src/daemon/controlClient.ts
@@ -100,8 +100,20 @@ export async function stopDaemonSession(sessionId: string): Promise<boolean> {
   return result.success || false;
 }
 
-export async function spawnDaemonSession(directory: string, sessionId?: string): Promise<any> {
-  const result = await daemonPost('/spawn-session', { directory, sessionId });
+export async function spawnDaemonSession(
+  directory: string,
+  sessionId?: string,
+  options?: {
+    agent?: 'claude' | 'codex' | 'gemini' | 'openclaw';
+    environmentVariables?: Record<string, string>;
+  }
+): Promise<any> {
+  const result = await daemonPost('/spawn-session', {
+    directory,
+    sessionId,
+    agent: options?.agent,
+    environmentVariables: options?.environmentVariables,
+  });
   return result;
 }
 

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -502,7 +502,7 @@ export async function runGemini(opts: {
   // Start Happy MCP server and create Gemini backend
   //
 
-  const happyServer = await startHappyServer(session);
+  const happyServer = await startHappyServer(session, { api });
   const bridgeCommand = join(projectPath(), 'bin', 'happy-mcp.mjs');
   const mcpServers = {
     happy: {

--- a/packages/happy-cli/src/gemini/runGemini.ts
+++ b/packages/happy-cli/src/gemini/runGemini.ts
@@ -502,7 +502,7 @@ export async function runGemini(opts: {
   // Start Happy MCP server and create Gemini backend
   //
 
-  const happyServer = await startHappyServer(session, { api });
+  const happyServer = await startHappyServer(session, { api, archiveAndExit: handleKillSession });
   const bridgeCommand = join(projectPath(), 'bin', 'happy-mcp.mjs');
   const mcpServers = {
     happy: {

--- a/packages/happy-cli/src/utils/createWorktree.test.ts
+++ b/packages/happy-cli/src/utils/createWorktree.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createWorktree } from './createWorktree';
+
+describe('createWorktree', () => {
+    const created: string[] = [];
+
+    afterEach(() => {
+        for (const dir of created) {
+            try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+        }
+        created.length = 0;
+    });
+
+    function makeRepo(): string {
+        const dir = mkdtempSync(join(tmpdir(), 'happy-wt-test-'));
+        created.push(dir);
+        execFileSync('git', ['-C', dir, 'init', '-q']);
+        execFileSync('git', ['-C', dir, 'config', 'user.email', 'test@happy.dev']);
+        execFileSync('git', ['-C', dir, 'config', 'user.name', 'happy-test']);
+        // worktree add -b requires at least one commit (no unborn HEAD)
+        execFileSync('git', ['-C', dir, 'commit', '--allow-empty', '-q', '-m', 'init']);
+        return dir;
+    }
+
+    it('creates a worktree under .dev/worktree with a matching branch', async () => {
+        const repo = makeRepo();
+        const result = await createWorktree(repo);
+
+        expect(result.worktreePath).toContain('/.dev/worktree/');
+        expect(result.worktreePath.endsWith(result.branchName)).toBe(true);
+        expect(existsSync(result.worktreePath)).toBe(true);
+
+        const branches = execFileSync('git', ['-C', repo, 'branch', '--list', result.branchName]).toString();
+        expect(branches).toContain(result.branchName);
+
+        const worktrees = execFileSync('git', ['-C', repo, 'worktree', 'list']).toString();
+        expect(worktrees).toContain(result.worktreePath);
+    });
+
+    it('creates distinct worktrees on repeated calls', async () => {
+        const repo = makeRepo();
+        const a = await createWorktree(repo);
+        const b = await createWorktree(repo);
+        expect(a.worktreePath).not.toBe(b.worktreePath);
+        expect(a.branchName).not.toBe(b.branchName);
+    });
+
+    it('throws for a non-git directory', async () => {
+        const dir = mkdtempSync(join(tmpdir(), 'happy-nongit-'));
+        created.push(dir);
+        await expect(createWorktree(dir)).rejects.toThrow();
+    });
+});

--- a/packages/happy-cli/src/utils/createWorktree.ts
+++ b/packages/happy-cli/src/utils/createWorktree.ts
@@ -1,0 +1,68 @@
+/**
+ * Git worktree creation for new isolated Happy sessions.
+ *
+ * Mirrors the mobile app's convention (`<repo>/.dev/worktree/<name>`, see
+ * packages/happy-app/sources/utils/worktree.ts WORKTREE_PATH_MARKER) so that
+ * the app's worktree detection and cleanup recognise sessions opened from the
+ * CLI's `open_session` MCP tool. The CLI runs on the same machine as the repo,
+ * so it shells out to git directly rather than going through the app's
+ * machineBash RPC.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { logger } from '@/ui/logger';
+
+const execFileAsync = promisify(execFile);
+
+/** Must match packages/happy-app/sources/utils/worktree.ts WORKTREE_DIR. */
+const WORKTREE_DIR = '.dev/worktree';
+
+const ADJECTIVES = [
+    'amber', 'brave', 'calm', 'clever', 'cosmic', 'crimson', 'eager', 'gentle',
+    'golden', 'jolly', 'lucid', 'mellow', 'nimble', 'quiet', 'rapid', 'sharp',
+    'silent', 'smooth', 'solar', 'swift', 'teal', 'vivid', 'witty', 'zesty',
+];
+const NOUNS = [
+    'archer', 'badger', 'canyon', 'cedar', 'comet', 'delta', 'ember', 'falcon',
+    'forest', 'harbor', 'island', 'lagoon', 'meadow', 'nebula', 'ocean', 'orbit',
+    'pixel', 'quartz', 'ridge', 'river', 'summit', 'thicket', 'valley', 'willow',
+];
+
+function randomWorktreeName(): string {
+    const adjective = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+    const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)];
+    return `${adjective}-${noun}`;
+}
+
+export interface CreateWorktreeResult {
+    /** Absolute path to the new worktree directory. */
+    worktreePath: string;
+    /** Name of the branch created for the worktree (same as the directory name). */
+    branchName: string;
+}
+
+/**
+ * Create a git worktree under `<repoRoot>/.dev/worktree/<adjective-noun>` with a
+ * fresh branch of the same name. `repoDirectory` must be inside a git repo.
+ * Retries with new random names on collision; throws if no name succeeds.
+ */
+export async function createWorktree(repoDirectory: string): Promise<CreateWorktreeResult> {
+    const { stdout } = await execFileAsync('git', ['-C', repoDirectory, 'rev-parse', '--show-toplevel']);
+    const repoRoot = stdout.trim();
+
+    const maxAttempts = 5;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const name = randomWorktreeName();
+        const relativePath = `${WORKTREE_DIR}/${name}`;
+        try {
+            await execFileAsync('git', ['-C', repoRoot, 'worktree', 'add', '-b', name, relativePath]);
+            return { worktreePath: `${repoRoot}/${relativePath}`, branchName: name };
+        } catch (error) {
+            lastError = error;
+            logger.debug(`[createWorktree] attempt ${attempt}/${maxAttempts} failed for '${name}': ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+    throw new Error(`Failed to create worktree after ${maxAttempts} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+}


### PR DESCRIPTION
The per-session Happy MCP server (`mcp__happy__*`) previously exposed a single tool, `change_title`. This PR adds three session-control tools — **`open_session`**, **`archive_session`**, and **`archive_self`** — so a running agent can do programmatically what the client UI does: open a new session (optionally in a fresh git worktree), archive another session, and retire itself.

### Tools

- **`open_session`** — opens a new session on this machine via the daemon control API (`POST /spawn-session`). Args: `directory` (defaults to the current session's cwd), `agent` (`claude`/`codex`/`gemini`/`openclaw`), and `worktree: true` which first creates a git worktree under `<repo>/.dev/worktree/<name>` (mirroring the app's `WORKTREE_PATH_MARKER` convention so the app recognises and can clean it up) and opens the session there. Stamps `HAPPY_FORKED_FROM_SESSION_ID` so the new session records its parent for lineage. Returns the new session id.
- **`archive_session`** — archives a session by id: stops its process via the daemon (`POST /stop-session`) so the archive sticks past the session keepalive, then marks it inactive on the server (`POST /v1/sessions/:id/archive`). The session stays resumable. Refuses to archive the *current* session from within itself (its keepalive would immediately re-activate it).
- **`archive_self`** — archives the *current* session and exits: the self-archive that `archive_session` deliberately refuses. A live session can't make its own `POST /archive` stick — its ~2s keepalive re-activates it. Instead this triggers the same graceful path the app's "Archive" button uses (`registerKillSessionHandler` → the runner's kill handler): stamp `lifecycleState='archived'`, stop the keepalive, then exit the process, so the archive sticks. Takes no args. The archive+exit is deferred briefly so the tool's response reaches the client before the process terminates. The session stays resumable.

### Wiring

- `startHappyServer(client, { api })` now takes an optional `ApiClient` (used by `archive_session`); threaded through all four agent entrypoints (claude/codex/gemini/acp).
- `HappyServerDeps` also gains an optional `archiveAndExit` callback, wired by each entrypoint to its existing kill-session handler (claude `cleanup({ archive: true })`, codex/gemini `handleKillSession`, acp's handler extracted to a named const) — so `archive_self` reuses the proven app-"Archive" teardown rather than reimplementing it.
- `spawnDaemonSession` gains optional `agent` + `environmentVariables` passthrough.
- New `createWorktree` CLI helper (shells out to `git` directly, since the CLI runs on the same machine as the repo).
- The Codex stdio bridge mirrors all three new tools (forwarding to the HTTP server), so Codex gets them too.

Scoped out of this PR: worktree-cleanup-on-archive (the app's `maybeCleanupWorktree`) — the CLI can't fetch an arbitrary session's path locally — and cross-machine kill (the local daemon control client only reaches the local daemon).

## Proof

Unit + integration tests (happy-cli suite: **559 passing**, incl. 8 new):
- `createWorktree` against a real git repo (creates `.dev/worktree/<name>` + branch, retries on collision, throws on non-git).
- MCP server tool registration + `change_title` regression + `archive_session` self-archive guard, exercised via a live in-process MCP client.
- `archive_self`: responds with success **before** the deferred archive+exit fires (so the client receives the goodbye before the process would terminate); reports unavailable when no `archiveAndExit` is wired.

Live end-to-end against a throwaway standalone `happy-server` (PGlite) + a paired `happy-cli` daemon built from this branch — an MCP client called the tools and observed real daemon/server state changes:

```
[open_session]      → "Opened new claude session cmqkz39z5… in <repo>"
                      daemon /list:  []  →  [cmqkz39z5…]      (real session spawned)
[archive_session]   → "process stopped via daemon; marked inactive on server"
                      daemon /list:  [cmqkz39z5…]  →  []      (process stopped)
                      server /v1/sessions: active = false      (archive landed)
[open_session worktree:true]
                    → "Opened … in <repo>/.dev/worktree/brave-ridge (new worktree on branch 'brave-ridge')"
                      worktree dir created: .dev/worktree/brave-ridge
[archive_session <self>]
                    → refused: "Cannot archive the current session from within itself …"
```

`archive_self` exits the host process by design (it's the "retire this session" tool), so it's verified by the unit tests above rather than the shared live harness; it reuses the exact `cleanup({ archive: true })` / `handleKillSession` path the app's Archive button already exercises in production.

`pnpm typecheck` clean.
