### PR TITLE
feat(agent-input): !-prefix bash command mode

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -829,7 +829,18 @@ export function SessionViewLoaded({
     // need to re-create on every keystroke.
     const handleSend = React.useCallback(() => {
         const liveMessage = composerHandleRef.current?.getMessage() ?? '';
-        if (liveMessage.trim() || selectedImages.length > 0) {
+        // !-prefix bash mode: a message starting with `!` runs as a one-off
+        // shell command in the session's cwd instead of being sent to the agent.
+        const trimmed = liveMessage.trim();
+        if (trimmed.startsWith('!')) {
+            const command = trimmed.slice(1).trim();
+            if (command) {
+                composerHandleRef.current?.clearMessage();
+                sync.runBashCommand(sessionId, command);
+                return;
+            }
+        }
+        if (trimmed || selectedImages.length > 0) {
             const attachments = selectedImages.length > 0 ? selectedImages : undefined;
             const communicationsToDismiss = [...pendingCommunications];
             composerHandleRef.current?.clearMessage();

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -123,6 +123,24 @@ function avatarDescriptorKey(descriptor: NonNullable<DecryptedProjectRecord['ava
     return `${descriptor.ref}:${descriptor.version}`;
 }
 
+/**
+ * Format a `!`-bash command result as chat markdown: stdout+stderr inside a
+ * fenced code block, with a trailing note for a non-zero exit code.
+ */
+function formatBashResult(result: { success: boolean; stdout: string; stderr: string; exitCode: number; error?: string }): string {
+    const stripTrailing = (s: string | undefined) => (s ?? '').replace(/\s+$/, '');
+    const out = stripTrailing(result.stdout);
+    const err = stripTrailing(result.stderr);
+    const body = [out, err].filter(Boolean).join('\n');
+    const footer = result.exitCode && result.exitCode !== 0
+        ? `\n\n\`${t('bashMode.exitCode', { code: result.exitCode })}\``
+        : '';
+    if (!body) {
+        return `_${t('bashMode.noOutput')}_${footer}`;
+    }
+    return '```sh\n' + body + '\n```' + footer;
+}
+
 class Sync {
     private static readonly BACKGROUND_SEND_TIMEOUT_MS = 30_000;
     encryption!: Encryption;
@@ -821,6 +839,55 @@ class Sync {
             this.getSendSync(sessionId).invalidate();
         }
         this.maybeStartBackgroundSendWatchdog();
+    }
+
+    /**
+     * Run a one-off shell command for a session — the `!`-prefix bash mode.
+     *
+     * The command runs on the session's own daemon process via the
+     * session-scoped `bash` RPC, so it executes in (and is sandboxed to) the
+     * session's working directory — the same handler that powers directory
+     * autocomplete. Nothing reaches the agent or the server: both the echoed
+     * command and its output are injected as local-only messages (no
+     * `pendingOutbox` push), so they render in the chat but never sync.
+     */
+    async runBashCommand(sessionId: string, command: string) {
+        const session = storage.getState().sessions[sessionId];
+        const cwd = session?.metadata?.path;
+
+        // Echo the command as a local user message so the chat shows what ran.
+        const echoId = randomUUID();
+        this.enqueueMessages(sessionId, [{
+            id: echoId,
+            localId: echoId,
+            createdAt: Date.now(),
+            role: 'user',
+            isSidechain: false,
+            content: { type: 'text', text: `!${command}` },
+        }]);
+
+        let outputText: string;
+        try {
+            const result = await apiSocket.sessionRPC<
+                { success: boolean; stdout: string; stderr: string; exitCode: number; error?: string },
+                { command: string; cwd?: string }
+            >(sessionId, 'bash', { command, cwd });
+            outputText = formatBashResult(result);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            outputText = t('bashMode.failed', { error: message });
+        }
+
+        // Inject the output as a local agent message (markdown code block).
+        const outputId = randomUUID();
+        this.enqueueMessages(sessionId, [{
+            id: outputId,
+            localId: null,
+            createdAt: Date.now(),
+            role: 'agent',
+            isSidechain: false,
+            content: [{ type: 'text', text: outputText, uuid: outputId, parentUUID: null }],
+        }]);
     }
 
     /** Server sent us settings — merge any pending local changes on top, then apply as one update. */

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -252,6 +252,13 @@ export const en = {
         notSupportedMessage: 'This agent does not support image attachments. Images were not sent.',
     },
 
+    bashMode: {
+        // !-prefix bash command mode in the chat input
+        noOutput: 'no output',
+        exitCode: ({ code }: { code: number }) => `exited with code ${code}`,
+        failed: ({ error }: { error: string }) => `Could not run command: ${error}`,
+    },
+
     errors: {
         networkError: 'Network error occurred',
         serverError: 'Server error occurred',

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -239,6 +239,12 @@ export const ca: TranslationStructure = {
         groupToolCallsSubtitle: 'Replega les crides consecutives a eines en un sol contenidor',
     },
 
+    bashMode: {
+        noOutput: 'sense sortida',
+        exitCode: ({ code }: { code: number }) => `ha finalitzat amb el codi ${code}`,
+        failed: ({ error }: { error: string }) => `No s'ha pogut executar la comanda: ${error}`,
+    },
+
     errors: {
         networkError: 'Error de connexió',
         serverError: 'Error del servidor',

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -253,6 +253,13 @@ export const en: TranslationStructure = {
         groupToolCallsSubtitle: 'Collapse consecutive tool calls into one container',
     },
 
+    bashMode: {
+        // !-prefix bash command mode in the chat input
+        noOutput: 'no output',
+        exitCode: ({ code }: { code: number }) => `exited with code ${code}`,
+        failed: ({ error }: { error: string }) => `Could not run command: ${error}`,
+    },
+
     errors: {
         networkError: 'Network error occurred',
         serverError: 'Server error occurred',

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -239,6 +239,12 @@ export const es: TranslationStructure = {
         groupToolCallsSubtitle: 'Contrae las llamadas consecutivas a herramientas en un solo contenedor',
     },
 
+    bashMode: {
+        noOutput: 'sin salida',
+        exitCode: ({ code }: { code: number }) => `terminó con el código ${code}`,
+        failed: ({ error }: { error: string }) => `No se pudo ejecutar el comando: ${error}`,
+    },
+
     errors: {
         networkError: 'Error de conexión',
         serverError: 'Error del servidor',

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -237,6 +237,12 @@ export const it: TranslationStructure = {
         groupToolCallsSubtitle: 'Comprimi le chiamate consecutive agli strumenti in un unico contenitore',
     },
 
+    bashMode: {
+        noOutput: 'nessun output',
+        exitCode: ({ code }: { code: number }) => `uscito con codice ${code}`,
+        failed: ({ error }: { error: string }) => `Impossibile eseguire il comando: ${error}`,
+    },
+
     errors: {
         networkError: 'Si è verificato un errore di rete',
         serverError: 'Si è verificato un errore del server',

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -240,6 +240,12 @@ export const ja: TranslationStructure = {
         groupToolCallsSubtitle: '連続するツール呼び出しを1つのコンテナにまとめる',
     },
 
+    bashMode: {
+        noOutput: '出力なし',
+        exitCode: ({ code }: { code: number }) => `コード ${code} で終了しました`,
+        failed: ({ error }: { error: string }) => `コマンドを実行できませんでした: ${error}`,
+    },
+
     errors: {
         networkError: 'ネットワークエラーが発生しました',
         serverError: 'サーバーエラーが発生しました',

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -256,6 +256,12 @@ export const pl: TranslationStructure = {
         groupToolCallsSubtitle: 'Zwijaj kolejne wywołania narzędzi w jeden kontener',
     },
 
+    bashMode: {
+        noOutput: 'brak danych wyjściowych',
+        exitCode: ({ code }: { code: number }) => `zakończono z kodem ${code}`,
+        failed: ({ error }: { error: string }) => `Nie można uruchomić polecenia: ${error}`,
+    },
+
     errors: {
         networkError: 'Wystąpił błąd sieci',
         serverError: 'Wystąpił błąd serwera',

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -238,6 +238,12 @@ export const pt: TranslationStructure = {
         groupToolCallsSubtitle: 'Recolher chamadas consecutivas de ferramentas em um único contêiner',
     },
 
+    bashMode: {
+        noOutput: 'sem saída',
+        exitCode: ({ code }: { code: number }) => `encerrado com o código ${code}`,
+        failed: ({ error }: { error: string }) => `Não foi possível executar o comando: ${error}`,
+    },
+
     errors: {
         networkError: 'Ocorreu um erro de rede',
         serverError: 'Ocorreu um erro do servidor',

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -224,6 +224,12 @@ export const ru: TranslationStructure = {
         groupToolCallsSubtitle: 'Сворачивать подряд идущие вызовы инструментов в один блок',
     },
 
+    bashMode: {
+        noOutput: 'нет вывода',
+        exitCode: ({ code }: { code: number }) => `завершено с кодом ${code}`,
+        failed: ({ error }: { error: string }) => `Не удалось выполнить команду: ${error}`,
+    },
+
     errors: {
         networkError: 'Произошла ошибка сети',
         serverError: 'Произошла ошибка сервера',

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -240,6 +240,12 @@ export const zhHans: TranslationStructure = {
         groupToolCallsSubtitle: '将连续的工具调用折叠到一个容器中',
     },
 
+    bashMode: {
+        noOutput: '无输出',
+        exitCode: ({ code }: { code: number }) => `已退出，退出码 ${code}`,
+        failed: ({ error }: { error: string }) => `无法运行命令：${error}`,
+    },
+
     errors: {
         networkError: '发生网络错误',
         serverError: '发生服务器错误',

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -239,6 +239,12 @@ export const zhHant: TranslationStructure = {
         groupToolCallsSubtitle: '將連續的工具呼叫摺疊到單一容器中',
     },
 
+    bashMode: {
+        noOutput: '無輸出',
+        exitCode: ({ code }: { code: number }) => `結束，退出碼為 ${code}`,
+        failed: ({ error }: { error: string }) => `無法執行命令：${error}`,
+    },
+
     errors: {
         networkError: '發生網路錯誤',
         serverError: '發生伺服器錯誤',


### PR DESCRIPTION
Adds a `!`-prefix bash command mode to the chat input, mirroring the Claude Code CLI: a message that starts with `!` runs as a one-off shell command in the session's working directory instead of being sent to the agent, and its output renders inline. It's per-message only — there's no persistent mode toggle. The command runs over the existing **session-scoped `bash` RPC** (the same handler that powers directory autocomplete and Windows `cmd` support), so it executes in and is sandboxed to the session cwd; the echoed command and its output are injected as **local-only messages** (no server round-trip, the agent is never involved), with output shown in a fenced code block.

## Proof

Captured locally via a standalone `happy-server` (PGlite) + Expo web + a paired `happy-cli` daemon, authenticated through the `getDevWebQueryCredentials()` dev URL bypass and driven headlessly with Playwright (live e2e — real daemon, real session). Typing `!pwd` and `!echo BASHMODE_OK_4242` runs each as a shell command and renders the output in a `sh` code block; the agent is never invoked.

![!-bash mode running pwd and echo in a real session](https://github.com/chphch/happy/releases/download/pr-proofs/bashmode-after.png)

Verification: `tsc --noEmit` clean, and the new strings are added to all 10 locale files. No new message kind and no reducer changes — the output reuses the existing agent-text markdown rendering.


Related: addresses #568 (run shell commands from mobile without burning tokens). #597 proposes the same capability with a `$` prefix; this uses `!` to mirror the Claude Code CLI's bash mode.