### PR TITLE
fix(app): refresh open session messages on resume/reconnect

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -188,6 +188,20 @@ class Sync {
                 this.friendsSync.invalidate();
                 this.friendRequestsSync.invalidate();
                 this.feedSync.invalidate();
+
+                // Refresh the open chat's message log on resume. While the app is
+                // backgrounded the data socket is suspended/dropped, so any messages
+                // the agent produced while away arrive with no live `update` to apply
+                // them. The invalidations above only refresh the session LIST, not the
+                // viewing session's messages — without this the visible chat stays
+                // stale until the user leaves and re-enters it (it only re-fetches on a
+                // fresh SessionView mount). getMessagesSync does a bounded forward sync;
+                // if the socket hasn't reconnected yet, InvalidateSync's backoff retries
+                // until it has.
+                const resumeViewingSessionId = storage.getState().currentViewingSessionId;
+                if (resumeViewingSessionId) {
+                    this.onSessionVisible(resumeViewingSessionId);
+                }
             } else {
                 log.log(`📱 App state changed to: ${nextAppState}`);
                 this.maybeStartBackgroundSendWatchdog();
@@ -2098,9 +2112,20 @@ class Sync {
             this.friendsSync.invalidate();
             this.friendRequestsSync.invalidate();
             this.feedSync.invalidate();
-            // Messages are fetched lazily per-session via onSessionVisible (called by SessionView
-            // when realtimeStatus changes). Session metadata + agentState (including permission
-            // requests) are already refreshed by sessionsSync.invalidate() above.
+            // Refresh the open chat's message log. The socket dropped (foreground
+            // network blip, server restart, or returning from background), so any
+            // messages produced during the gap were missed — there was no live
+            // `update` to apply them, and `connect` fired with recovered=false so
+            // socket.io did not replay them. sessionsSync above only refreshes the
+            // session list/metadata, not the viewing session's messages. (This used
+            // to rely on SessionView calling onSessionVisible "when realtimeStatus
+            // changes", but realtimeStatus tracks the voice session, not this data
+            // socket — see useSocketStatus vs useRealtimeStatus — so that trigger
+            // never fired on reconnect.)
+            const reconnectViewingSessionId = storage.getState().currentViewingSessionId;
+            if (reconnectViewingSessionId) {
+                this.onSessionVisible(reconnectViewingSessionId);
+            }
             for (const sync of this.sendSync.values()) {
                 sync.invalidate();
             }


### PR DESCRIPTION
**Reported by 5 people** — issues #1208, #1308, #1432 (and #1056, adjacent). One user built his own client over it:

> "I'm getting notifications that Claude has responded but it's not updating any of the text" … "I started to work on my own internal version just because this has been a massive issue"
> — calvin00001, Discord, 2026-04-05

He also found the workaround that pins the diagnosis exactly — leaving the session and coming back is what forces the refetch:

> "Oh found a trick. I just send a keystroke, back out to my session list, then go back in. This is on mobile btw."
> — calvin00001, Discord, 2026-04-04

<details>
<summary>All reports</summary>

| Who | When | Where | Their words |
|---|---|---|---|
| calvin00001 | 2026-03-30 | Discord | "my phone doesn't seem to be displaying output of a session that my tablet is" |
| dudu1111685 | 2026-04-13 | #1056 | "Opening a session gets stuck on a loading spinner indefinitely … after sending any message to that session and waiting, it starts working" |
| karle102017 | 2026-05-02 | #1208 | "Long-running sessions stop syncing to Android" |
| pengjunfeng11 | 2026-05-19 | #1308 | "On foreground resume, the app refreshes sessions and related state, but did not explicitly invalidate the currently visible session's message sync" |
| DearMrJ | 2026-06-23 | #1432 | "mobile doesn't receive real-time updates until it sends a message first" |

</details>

---

Messages an agent produces while the Happy app is backgrounded don't appear when you return to the app — the open chat stays stale until you leave and re-enter the session. The cause is a misdirected refresh trigger: `SessionView`'s effect that re-fetches an open session's messages depends on `realtimeStatus`, but `realtimeStatus` tracks the **LiveKit voice session** (`storage.ts` `useRealtimeStatus`, written only by `RealtimeVoiceSession*`/`RealtimeSession`) — not the data socket, whose status lives in the separate `socketStatus`/`useSocketStatus`. So on app resume (or any socket reconnect), that effect never re-runs, and `sync.ts`'s `onReconnected` handler deliberately skipped refreshing the open session's messages, with a comment that relied on exactly this dead trigger (`onSessionVisible` "called by SessionView when realtimeStatus changes"). Re-entering the session works only because a fresh mount re-fetches. This fix refreshes the currently-viewing session's messages on both `AppState → 'active'` and the socket `onReconnected` path via `onSessionVisible(currentViewingSessionId)` (a bounded forward sync). It also covers a foreground network blip that reconnects with `recovered=false` (server connection-state recovery off), which had the same gap.

## Proof

Verified end-to-end on a throwaway standalone `happy-server` (PGlite) + Expo web + a paired `happy-cli` daemon, driven with Playwright. Two browser contexts on one account: context **A** opens a session then goes offline (simulating the app being backgrounded); context **B** (online) sends a marked message to that session; context **A** comes back online. The missed message now renders on A on reconnect **without a remount** (`onSessionVisible` → `fetchForwardSince`). Screenshots/GIF in the PR comment below — A shows "No messages yet" while offline, then the full conversation (including the message it missed) after reconnect. `pnpm typecheck` clean.

