### PR TITLE
fix(app): kill processes inside a worktree before removing it

### DIFF
--- a/packages/happy-app/sources/utils/worktree.ts
+++ b/packages/happy-app/sources/utils/worktree.ts
@@ -151,6 +151,43 @@ export async function listWorktrees(
     return worktrees;
 }
 
+/**
+ * Kill any process whose working directory is inside the worktree.
+ *
+ * `git worktree remove --force` deletes the directory even while a process is
+ * still cwd'd into it — most often a happy session that got orphaned when its
+ * daemon restarted. That orphan then lives on inside a now-deleted directory,
+ * holding its server socket open and re-reporting the session as `active`
+ * forever, so the session can never be archived from the app. We therefore
+ * stop those processes *before* removing the directory.
+ *
+ * Portable across the machine's OS: Linux reads /proc/<pid>/cwd, macOS falls
+ * back to lsof (resolved by absolute path so a stripped PATH still finds it).
+ * The worktree path is canonicalised (pwd -P) so a symlinked parent still
+ * matches, and the match is anchored to the worktree dir or a subdir of it —
+ * never a sibling that merely shares a name prefix. SIGTERM lets the happy CLI
+ * shut its session down cleanly. Entirely best-effort: a failure here must
+ * never block the worktree removal itself.
+ */
+async function killProcessesInWorktree(
+    machineId: string,
+    worktreePath: string,
+    cwd: string
+): Promise<void> {
+    const script = [
+        `WT='${worktreePath}'`,
+        `WT=$(cd "$WT" 2>/dev/null && pwd -P || printf %s "$WT")`,
+        `if [ -d /proc ]; then`,
+        `  for d in /proc/[0-9]*; do c=$(readlink "$d/cwd" 2>/dev/null) || continue; case "$c" in "$WT"|"$WT"/*) kill "$(basename "$d")" 2>/dev/null || true;; esac; done`,
+        `else`,
+        `  L=$(command -v lsof || echo /usr/sbin/lsof)`,
+        `  "$L" -d cwd -Fpn 2>/dev/null | awk -v wt="$WT" '/^p/{pid=substr($0,2)} /^n/{p=substr($0,2); if(p==wt||index(p,wt"/")==1)print pid}' | while read -r pid; do kill "$pid" 2>/dev/null || true; done`,
+        `fi`,
+        `true`,
+    ].join('\n');
+    await machineBash(machineId, script, cwd).catch(() => {});
+}
+
 export async function removeWorktree(
     machineId: string,
     worktreePath: string
@@ -160,6 +197,10 @@ export async function removeWorktree(
         return { success: false, error: 'Not a worktree path' };
     }
     const basePath = worktreePath.slice(0, idx);
+
+    // Stop processes still running inside the worktree before --force deletes
+    // it out from under them (see killProcessesInWorktree).
+    await killProcessesInWorktree(machineId, worktreePath, basePath);
 
     const result = await machineBash(
         machineId,


### PR DESCRIPTION
Removing a git worktree from the app (`removeWorktree` in `sources/utils/worktree.ts`) ran `git worktree remove --force` while a happy session could still be cwd'd inside that worktree — most often a session that got orphaned when its daemon restarted, so the daemon-driven stop never reached it. `--force` then deleted the directory out from under the live process, which kept its server socket open and re-reported the session as `active` on every heartbeat. The session became impossible to archive from the app: each `active: false` was instantly overwritten by the orphan's next heartbeat. This change stops any process whose working directory is inside the worktree (SIGTERM, best-effort) **before** the directory is removed.

The new `killProcessesInWorktree` is portable across the host OS (Linux reads `/proc/<pid>/cwd`, macOS falls back to `lsof`), canonicalises the worktree path (`pwd -P`) so a symlinked parent still matches, and anchors the match to the worktree dir or a subdir of it so a sibling that merely shares a name prefix is never touched. It resolves `lsof` by absolute path so a stripped `PATH` still finds it, and never blocks the removal if anything goes wrong.

## Proof

Ran the exact `killProcessesInWorktree` shell — the macOS/`lsof` branch — verbatim against a real process tree, handing it a **symlinked** worktree path to exercise canonicalisation:

![worktree-orphan-kill](https://github.com/chphch/happy/releases/download/pr-proofs/worktree-orphan-kill.png)

- process **inside** the worktree → killed
- process in a **subdirectory** of the worktree → killed
- process in a **prefix-sibling** dir (`wt-sibling`) → **spared** (anchoring — a shared name prefix is not a match)
- the symlinked path `…/link/wt` was canonicalised to `…/real/wt`, so `lsof`'s physical paths matched
- `lsof` was not on `PATH`, so the `/usr/sbin/lsof` fallback was exercised

`removeWorktree` calls this immediately before `git worktree remove --force` (see the diff), so the orphaned session is shut down cleanly and can be archived from the app as expected.
