### PR TITLE
feat(app): nest forked sessions under their parent in the session list

### DIFF
--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -12,6 +12,7 @@ import { useAllMachines, useSessionGitStatus } from '@/sync/storage';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { t } from '@/text';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
+import { ForkLineageConnector, forkIndentPadding } from './ForkLineageConnector';
 import { useHappyAction } from '@/hooks/useHappyAction';
 import { HappyError } from '@/utils/errors';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
@@ -302,11 +303,13 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
             style={[
                 styles.sessionRow,
                 showBorder && styles.sessionRowWithBorder,
-                selected && styles.sessionRowSelected
+                selected && styles.sessionRowSelected,
+                { paddingLeft: forkIndentPadding(session.forkDepth, 16) },
             ]}
             onPress={handlePress}
             {...menuProps}
         >
+            <ForkLineageConnector forkDepth={session.forkDepth} rowHeight={56} basePadding={16} />
             <View style={styles.sessionContent}>
                 <View style={styles.sessionTitleRow}>
                     <Text

--- a/packages/happy-app/sources/components/ForkLineageConnector.tsx
+++ b/packages/happy-app/sources/components/ForkLineageConnector.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+import { FORK_INDENT_SIZE, FORK_MAX_VISUAL_DEPTH, forkIndentPadding } from '@/utils/forkLineage';
+
+// Re-exported so renderer components can pull the indent helper alongside the
+// connector from one place. The ordering/indent math lives in the pure,
+// unit-tested `@/utils/forkLineage` module.
+export { forkIndentPadding };
+
+/**
+ * An "└" tree connector linking a forked child row to its parent row directly
+ * above it. Rendered absolutely inside the row, occupying the indent gap just
+ * left of the row's content. Returns null for root rows (forkDepth 0).
+ */
+export function ForkLineageConnector({ forkDepth, rowHeight, basePadding }: {
+    forkDepth: number;
+    rowHeight: number;
+    basePadding: number;
+}) {
+    if (forkDepth < 1) {
+        return null;
+    }
+    const visualDepth = Math.min(forkDepth, FORK_MAX_VISUAL_DEPTH);
+    const left = basePadding + (visualDepth - 1) * FORK_INDENT_SIZE + 4;
+    return (
+        <View
+            pointerEvents="none"
+            style={[
+                styles.connector,
+                { left, width: FORK_INDENT_SIZE - 6, height: Math.round(rowHeight / 2) },
+            ]}
+        />
+    );
+}
+
+const styles = StyleSheet.create((theme) => ({
+    connector: {
+        position: 'absolute',
+        top: 0,
+        borderLeftWidth: 1.5,
+        borderBottomWidth: 1.5,
+        borderColor: theme.colors.divider,
+        borderBottomLeftRadius: 5,
+    },
+}));

--- a/packages/happy-app/sources/components/ProjectGroup.tsx
+++ b/packages/happy-app/sources/components/ProjectGroup.tsx
@@ -7,6 +7,7 @@ import { Text } from '@/components/StyledText';
 import { Typography } from '@/constants/Typography';
 import { t } from '@/text';
 import { ProjectGroupData, ProjectWorkspaceGroup, useSessionGitStatus } from '@/sync/storage';
+import { orderSessionRowsByForkLineage } from '@/utils/forkLineage';
 import { CompactSessionRow } from './ActiveSessionsGroupCompact';
 import { Avatar } from './Avatar';
 import { requestHomeDockFocus } from './homeDockFocus';
@@ -65,6 +66,15 @@ const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId }: 
     // status the daemon reports, through the workspace's own name, down to the
     // "main" every repo has when nothing better is known.
     const gitStatus = useSessionGitStatus(firstSession?.id ?? '');
+
+    // Nesting runs here, not where the list data is built: the list is filtered
+    // after that (archive toggle, search box), and a depth stamped before the
+    // filter leaves a child indented under a parent that is no longer on screen.
+    // What this section receives is exactly what renders.
+    const sessions = React.useMemo(
+        () => orderSessionRowsByForkLineage(workspace.sessions),
+        [workspace.sessions],
+    );
     const branchName = worktreeName
         ?? gitStatus?.branch
         ?? 'main';
@@ -147,12 +157,12 @@ const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId }: 
             </View>
 
             <View style={styles.workspaceCard}>
-                {workspace.sessions.map((session, index) => (
+                {sessions.map((session, index) => (
                     <CompactSessionRow
                         key={session.id}
                         session={session}
                         selected={session.id === selectedSessionId}
-                        showBorder={index < workspace.sessions.length - 1}
+                        showBorder={index < sessions.length - 1}
                     />
                 ))}
             </View>

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -14,6 +14,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useHasArchivedSessions, useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
 import { Typography } from '@/constants/Typography';
 import { StatusDot } from './StatusDot';
+import { ForkLineageConnector, forkIndentPadding } from './ForkLineageConnector';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useIsTablet } from '@/utils/responsive';
 import { getHarnessName } from '@/utils/harnessCatalog';
@@ -669,11 +670,13 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
                 selected && styles.sessionItemSelected,
                 isSingle ? styles.sessionItemSingle :
                     isFirst ? styles.sessionItemFirst :
-                        isLast ? styles.sessionItemLast : {}
+                        isLast ? styles.sessionItemLast : {},
+                { paddingLeft: forkIndentPadding(session.forkDepth, 16) },
             ]}
             onPress={handlePress}
             {...menuProps}
         >
+            <ForkLineageConnector forkDepth={session.forkDepth} rowHeight={88} basePadding={16} />
             <View style={styles.avatarContainer}>
                 <Avatar id={session.avatarId} size={48} monochrome={!status.isConnected} flavor={session.flavor} clientId={session.clientId} imageUrl={session.projectAvatarUri} thumbhash={session.projectAvatarThumbhash} badgeLocation="sessionList" />
                 {session.hasDraft && (

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -157,6 +157,13 @@ export interface SessionRowData {
     // Private project art is already materialized as a local/data URI by sync.
     projectAvatarUri?: string | null;
     projectAvatarThumbhash?: string | null;
+    // Fork lineage: the Happy session this one was forked from (null if not a
+    // fork), and its nesting depth within the group it renders in (0 = root /
+    // not nested). forkDepth is stamped at render time — after the archive and
+    // search filters have run — so a child is never indented under a parent the
+    // filter removed.
+    parentSessionId: string | null;
+    forkDepth: number;
 }
 
 function buildSessionRowData(
@@ -218,6 +225,8 @@ function buildSessionRowData(
         workspaceName: session.metadata?.workspace?.name ?? null,
         projectAvatarUri: projectAvatar?.uri || null,
         projectAvatarThumbhash: projectAvatar?.thumbhash || null,
+        parentSessionId: session.metadata?.parentSessionId ?? null,
+        forkDepth: 0,
     };
 }
 

--- a/packages/happy-app/sources/utils/flatSessionList.test.ts
+++ b/packages/happy-app/sources/utils/flatSessionList.test.ts
@@ -34,6 +34,8 @@ function row(overrides: Partial<SessionRowData> & { id: string }): SessionRowDat
         projectName: null,
         workspaceId: null,
         workspaceName: null,
+        parentSessionId: null,
+        forkDepth: 0,
         ...overrides,
     };
 }

--- a/packages/happy-app/sources/utils/forkLineage.test.ts
+++ b/packages/happy-app/sources/utils/forkLineage.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+    orderSessionRowsByForkLineage,
+    forkIndentPadding,
+    FORK_INDENT_SIZE,
+    FORK_MAX_VISUAL_DEPTH,
+} from './forkLineage';
+
+type Row = { id: string; parentSessionId: string | null; forkDepth: number };
+const row = (id: string, parentSessionId: string | null = null): Row => ({ id, parentSessionId, forkDepth: 0 });
+const ids = (rows: Row[]) => rows.map(r => r.id);
+const depths = (rows: Row[]) => rows.map(r => r.forkDepth);
+
+describe('orderSessionRowsByForkLineage', () => {
+    it('leaves a fork-free list in original order at depth 0', () => {
+        const out = orderSessionRowsByForkLineage([row('a'), row('b'), row('c')]);
+        expect(ids(out)).toEqual(['a', 'b', 'c']);
+        expect(depths(out)).toEqual([0, 0, 0]);
+    });
+
+    it('nests a child directly under its parent at depth 1', () => {
+        // Input is newest-first: forked child 'b' sorts above its parent 'a'.
+        const out = orderSessionRowsByForkLineage([row('b', 'a'), row('a'), row('c')]);
+        expect(ids(out)).toEqual(['a', 'b', 'c']);
+        expect(depths(out)).toEqual([0, 1, 0]);
+    });
+
+    it('nests a multi-level fork chain with increasing depth', () => {
+        const out = orderSessionRowsByForkLineage([row('c', 'b'), row('b', 'a'), row('a')]);
+        expect(ids(out)).toEqual(['a', 'b', 'c']);
+        expect(depths(out)).toEqual([0, 1, 2]);
+    });
+
+    it('keeps a child at depth 0 when its parent is not in the same section', () => {
+        const out = orderSessionRowsByForkLineage([row('b', 'parent-in-another-group'), row('c')]);
+        expect(ids(out)).toEqual(['b', 'c']);
+        expect(depths(out)).toEqual([0, 0]);
+    });
+
+    it('places multiple children under one parent, preserving their order', () => {
+        const out = orderSessionRowsByForkLineage([row('c1', 'p'), row('c2', 'p'), row('p')]);
+        expect(ids(out)).toEqual(['p', 'c1', 'c2']);
+        expect(depths(out)).toEqual([0, 1, 1]);
+    });
+
+    it('does not loop or drop rows on a parent cycle', () => {
+        // a -> b -> a, both present (pathological metadata).
+        const out = orderSessionRowsByForkLineage([row('a', 'b'), row('b', 'a')]);
+        expect(out).toHaveLength(2);
+        expect(ids(out).sort()).toEqual(['a', 'b']);
+    });
+
+    it('returns the same row reference when depth is unchanged (deep-equal stability)', () => {
+        const a = row('a');
+        const b = row('b');
+        const out = orderSessionRowsByForkLineage([a, b]);
+        expect(out[0]).toBe(a);
+        expect(out[1]).toBe(b);
+    });
+});
+
+describe('forkIndentPadding', () => {
+    it('adds no indent at depth 0', () => {
+        expect(forkIndentPadding(0, 16)).toBe(16);
+    });
+
+    it('adds one indent step per level', () => {
+        expect(forkIndentPadding(1, 16)).toBe(16 + FORK_INDENT_SIZE);
+        expect(forkIndentPadding(2, 16)).toBe(16 + 2 * FORK_INDENT_SIZE);
+    });
+
+    it('caps the visual indent at FORK_MAX_VISUAL_DEPTH', () => {
+        expect(forkIndentPadding(99, 16)).toBe(16 + FORK_MAX_VISUAL_DEPTH * FORK_INDENT_SIZE);
+    });
+});

--- a/packages/happy-app/sources/utils/forkLineage.ts
+++ b/packages/happy-app/sources/utils/forkLineage.ts
@@ -1,0 +1,92 @@
+// Pure helpers for nesting forked sessions in the session list.
+//
+// Kept free of React / React-Native imports so the ordering logic stays
+// unit-testable (storage.ts and the renderer components both pull in RN and
+// cannot be loaded under vitest).
+
+export const FORK_INDENT_SIZE = 20;
+export const FORK_MAX_VISUAL_DEPTH = 4;
+
+/** Minimal shape the fork ordering needs from a session row. */
+export interface ForkLineageRow {
+    id: string;
+    parentSessionId: string | null;
+    forkDepth: number;
+}
+
+/** Left padding for a row at `forkDepth`, added on top of the row's base padding. */
+export function forkIndentPadding(forkDepth: number, basePadding: number): number {
+    const visualDepth = Math.min(Math.max(forkDepth, 0), FORK_MAX_VISUAL_DEPTH);
+    return basePadding + visualDepth * FORK_INDENT_SIZE;
+}
+
+/**
+ * Reorder a flat array of session rows so that forked children appear
+ * immediately after their parent (depth-first) and stamp each row's `forkDepth`
+ * (0 = root within this array). A row whose parent is NOT present in the same
+ * array is treated as a root at depth 0 — nesting therefore happens only within
+ * a single rendered section (a date group, or an active project group), never
+ * across section boundaries. New row objects are returned when a row's depth
+ * changes so deep-equality still detects the update. O(n).
+ */
+export function orderSessionRowsByForkLineage<T extends ForkLineageRow>(rows: T[]): T[] {
+    const atRoot = (r: T): T => (r.forkDepth === 0 ? r : { ...r, forkDepth: 0 } as T);
+    if (rows.length < 2) {
+        return rows.map(atRoot);
+    }
+
+    const present = new Set(rows.map(r => r.id));
+    const childrenByParent = new Map<string, T[]>();
+    const roots: T[] = [];
+
+    for (const row of rows) {
+        const parentId = row.parentSessionId;
+        if (parentId && parentId !== row.id && present.has(parentId)) {
+            const siblings = childrenByParent.get(parentId);
+            if (siblings) {
+                siblings.push(row);
+            } else {
+                childrenByParent.set(parentId, [row]);
+            }
+        } else {
+            roots.push(row);
+        }
+    }
+
+    // No fork relationships within this array — keep original order at depth 0.
+    if (childrenByParent.size === 0) {
+        return rows.map(atRoot);
+    }
+
+    const ordered: T[] = [];
+    const visited = new Set<string>();
+
+    const emit = (row: T, depth: number) => {
+        if (visited.has(row.id)) {
+            return; // guard against pathological parent cycles
+        }
+        visited.add(row.id);
+        ordered.push(row.forkDepth === depth ? row : { ...row, forkDepth: depth } as T);
+        const children = childrenByParent.get(row.id);
+        if (children) {
+            for (const child of children) {
+                emit(child, depth + 1);
+            }
+        }
+    };
+
+    for (const root of roots) {
+        emit(root, 0);
+    }
+
+    // Safety net: emit any rows skipped by a cycle, at depth 0, preserving order.
+    if (ordered.length !== rows.length) {
+        for (const row of rows) {
+            if (!visited.has(row.id)) {
+                ordered.push(atRoot(row));
+            }
+        }
+    }
+
+    return ordered;
+}

--- a/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
+++ b/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
@@ -44,6 +44,8 @@ function session(
         projectName: null,
         workspaceId: null,
         workspaceName: null,
+        parentSessionId: null,
+        forkDepth: 0,
     };
 }
 

--- a/packages/happy-app/sources/utils/sessionDisplayOrder.ts
+++ b/packages/happy-app/sources/utils/sessionDisplayOrder.ts
@@ -1,4 +1,5 @@
 import type { SessionListViewItem, SessionRowData } from '@/sync/storage';
+import { orderSessionRowsByForkLineage } from '@/utils/forkLineage';
 
 type SessionProjectListItem = Extract<SessionListViewItem, { type: 'project' }>;
 
@@ -78,6 +79,8 @@ export function buildActiveSessionDisplayGroups(
     byMachine.forEach((machineGroup) => {
         machineGroup.projects.forEach((projectGroup) => {
             projectGroup.sessions.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+            // Nest forked children under their parent within this project group.
+            projectGroup.sessions = orderSessionRowsByForkLineage(projectGroup.sessions);
         });
     });
 
@@ -142,7 +145,8 @@ export function getSessionShortcutIdsInDisplayOrder(
     projectGroups.forEach((machineGroup) => {
         machineGroup.projects.forEach((item) => {
             item.project.workspaces.forEach((workspace) => {
-                workspace.sessions.forEach((session) => sessionIds.push(session.id));
+                orderSessionRowsByForkLineage(workspace.sessions)
+                    .forEach((session) => sessionIds.push(session.id));
             });
         });
     });


### PR DESCRIPTION
Forked sessions already persist `parentSessionId` in their (encrypted) metadata — it's set on every fork path (the **Fork** quick-action, **duplicate-from-message**, and the MCP `open_session` tool) and already surfaced as the "Forked From" link on the session info screen — but the session list ignored it, so a fork showed up as an unrelated row sorted only by recency and you couldn't tell at a glance what was branched from what.

This renders forked children directly under their parent within each list section (the active-sessions project group, and each project card's workspace section), indented by fork depth with a `└` tree connector. A child whose parent isn't in the same section falls back to depth 0 so nesting never crosses section boundaries, and the visual indent caps at a max depth so deep chains never march off-screen (the underlying depth stays accurate).

## Shape of the change

- **`utils/forkLineage.ts` (new)** — the pure reorder + indent math, dependency-free and unit-tested.
- **`components/ForkLineageConnector.tsx` (new)** — the `└` connector, drawn in the indent gap just left of a child row.
- **`sync/storage.ts`** — `SessionRowData` gains `parentSessionId` and `forkDepth`.
- **`utils/sessionDisplayOrder.ts` / `components/ProjectGroup.tsx`** — apply the lineage ordering at render time, after the archive and search filters have run, so a child is never indented under a parent the filter removed.
- **Renderers** — both session row renderers consume `forkDepth` for their indent padding and draw the connector.

## Proof

Synthetic parent → two children → grandchild sessions rendered through the real `SessionsList` on Expo web (standalone server, `dev_token` URL bypass, driven with Playwright). Left = the layout before this change (forks scattered by recency, lineage invisible); right = after (children nested under their parent with a `└` connector; the grandchild sits one level deeper).

![fork lineage before/after](https://github.com/chphch/happy/releases/download/pr-proofs/fork-lineage-before-after.png)

## Verification

`pnpm typecheck` clean; app suite green. `utils/forkLineage.test.ts` covers the ordering — multi-level chains, multiple children of one parent, the parent-not-in-section fallback, a parent-cycle guard, and deep-equal reference stability.