### PR TITLE
feat(app): fullscreen pinch-to-zoom viewer for images

### DIFF
--- a/packages/happy-app/sources/components/ImageViewer.tsx
+++ b/packages/happy-app/sources/components/ImageViewer.tsx
@@ -1,0 +1,152 @@
+/**
+ * Fullscreen, pinch-to-zoom image viewer (native: iOS / Android).
+ *
+ * Opened via `Modal.show({ component: ImageViewer, props: { uri } })`. Because
+ * it is presented inside React Native's `<Modal>` (via BaseModal), gestures
+ * only work if the content is wrapped in its OWN `GestureHandlerRootView` — the
+ * app-root one does not extend into the modal's separate native hierarchy.
+ *
+ * Web has a separate implementation in `ImageViewer.web.tsx` (wheel + drag).
+ */
+import * as React from 'react';
+import { StyleSheet, useWindowDimensions, Pressable, Platform } from 'react-native';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { GestureHandlerRootView, GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const MAX_SCALE = 6;
+const DOUBLE_TAP_SCALE = 2.5;
+
+interface ImageViewerProps {
+    uri: string;
+    onClose: () => void;
+}
+
+export function ImageViewer({ uri, onClose }: ImageViewerProps) {
+    const { width, height } = useWindowDimensions();
+    const insets = useSafeAreaInsets();
+
+    const scale = useSharedValue(1);
+    const savedScale = useSharedValue(1);
+    const tx = useSharedValue(0);
+    const ty = useSharedValue(0);
+    const savedTx = useSharedValue(0);
+    const savedTy = useSharedValue(0);
+
+    // Keep the image from being panned entirely off-screen: at scale S the
+    // image overflows the viewport by (S-1) on each axis, so allow half of
+    // that overflow as translation in each direction.
+    const clamp = (val: number, scaleVal: number, dim: number) => {
+        'worklet';
+        const max = (dim * (scaleVal - 1)) / 2;
+        return Math.min(max, Math.max(-max, val));
+    };
+
+    const pinch = Gesture.Pinch()
+        .onUpdate((e) => {
+            scale.value = Math.min(MAX_SCALE, Math.max(0.8, savedScale.value * e.scale));
+        })
+        .onEnd(() => {
+            if (scale.value <= 1) {
+                scale.value = withTiming(1);
+                tx.value = withTiming(0);
+                ty.value = withTiming(0);
+                savedScale.value = 1;
+                savedTx.value = 0;
+                savedTy.value = 0;
+            } else {
+                savedScale.value = scale.value;
+                tx.value = clamp(tx.value, scale.value, width);
+                ty.value = clamp(ty.value, scale.value, height);
+                savedTx.value = tx.value;
+                savedTy.value = ty.value;
+            }
+        });
+
+    const pan = Gesture.Pan()
+        .onUpdate((e) => {
+            if (savedScale.value <= 1) return; // pan only when zoomed in
+            tx.value = clamp(savedTx.value + e.translationX, savedScale.value, width);
+            ty.value = clamp(savedTy.value + e.translationY, savedScale.value, height);
+        })
+        .onEnd(() => {
+            savedTx.value = tx.value;
+            savedTy.value = ty.value;
+        });
+
+    const doubleTap = Gesture.Tap()
+        .numberOfTaps(2)
+        .onEnd(() => {
+            if (scale.value > 1) {
+                scale.value = withTiming(1);
+                tx.value = withTiming(0);
+                ty.value = withTiming(0);
+                savedScale.value = 1;
+                savedTx.value = 0;
+                savedTy.value = 0;
+            } else {
+                scale.value = withTiming(DOUBLE_TAP_SCALE);
+                savedScale.value = DOUBLE_TAP_SCALE;
+            }
+        });
+
+    // Race so pan/pinch activate immediately on movement (no double-tap delay);
+    // a real double-tap has no movement so it wins the race instead.
+    const gesture = Gesture.Race(doubleTap, Gesture.Simultaneous(pinch, pan));
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        transform: [
+            { translateX: tx.value },
+            { translateY: ty.value },
+            { scale: scale.value },
+        ],
+    }));
+
+    return (
+        <GestureHandlerRootView style={[styles.root, { width, height }]}>
+            <GestureDetector gesture={gesture}>
+                <Animated.View style={[styles.imageWrap, animatedStyle, { width, height }]}>
+                    <Image
+                        source={{ uri }}
+                        style={{ width, height }}
+                        contentFit="contain"
+                        transition={Platform.OS === 'android' ? 0 : 120}
+                    />
+                </Animated.View>
+            </GestureDetector>
+            <Pressable
+                onPress={onClose}
+                hitSlop={16}
+                style={[styles.close, { top: Math.max(insets.top, 12) + 4 }]}
+                accessibilityRole="button"
+                accessibilityLabel="Close image"
+            >
+                <Ionicons name="close" size={26} color="#fff" />
+            </Pressable>
+        </GestureHandlerRootView>
+    );
+}
+
+const styles = StyleSheet.create({
+    root: {
+        backgroundColor: '#000',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    imageWrap: {
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    close: {
+        position: 'absolute',
+        right: 12,
+        width: 40,
+        height: 40,
+        borderRadius: 20,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+    },
+});

--- a/packages/happy-app/sources/components/ImageViewer.web.tsx
+++ b/packages/happy-app/sources/components/ImageViewer.web.tsx
@@ -1,0 +1,164 @@
+/**
+ * Fullscreen, zoomable image viewer (web).
+ *
+ * Native gesture-handler/reanimated pinch doesn't map cleanly to mouse/trackpad,
+ * so the web build uses DOM directly: wheel-zoom toward the cursor, drag-to-pan
+ * when zoomed, double-click to toggle zoom, Esc / × to close. Metro resolves this
+ * file in place of `ImageViewer.tsx` on web.
+ */
+import * as React from 'react';
+import { useWindowDimensions } from 'react-native';
+
+const MAX_SCALE = 6;
+const DOUBLE_CLICK_SCALE = 2.5;
+
+interface ImageViewerProps {
+    uri: string;
+    onClose: () => void;
+}
+
+export function ImageViewer({ uri, onClose }: ImageViewerProps) {
+    const { width, height } = useWindowDimensions();
+    const [scale, setScale] = React.useState(1);
+    const [tx, setTx] = React.useState(0);
+    const [ty, setTy] = React.useState(0);
+
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const dragRef = React.useRef<{ x: number; y: number; tx: number; ty: number } | null>(null);
+    // Mirror live state for the imperative wheel listener (registered once).
+    const stateRef = React.useRef({ scale, tx, ty });
+    stateRef.current = { scale, tx, ty };
+
+    const clampT = React.useCallback((v: number, s: number, dim: number) => {
+        const max = (dim * (s - 1)) / 2;
+        return Math.min(max, Math.max(-max, v));
+    }, []);
+
+    // Zoom to `nextScale` keeping the point (cx, cy) — container-relative px —
+    // anchored under the cursor.
+    const applyZoom = React.useCallback((nextScale: number, cx: number, cy: number) => {
+        const { scale: s, tx: curTx, ty: curTy } = stateRef.current;
+        const s2 = Math.min(MAX_SCALE, Math.max(1, nextScale));
+        const px = cx - width / 2;
+        const py = cy - height / 2;
+        let nTx = px - (px - curTx) * (s2 / s);
+        let nTy = py - (py - curTy) * (s2 / s);
+        if (s2 <= 1) {
+            nTx = 0;
+            nTy = 0;
+        } else {
+            nTx = clampT(nTx, s2, width);
+            nTy = clampT(nTy, s2, height);
+        }
+        setScale(s2);
+        setTx(nTx);
+        setTy(nTy);
+    }, [width, height, clampT]);
+
+    // Non-passive wheel listener so preventDefault() actually stops page scroll.
+    React.useEffect(() => {
+        const el = containerRef.current;
+        if (!el) return;
+        const onWheel = (e: WheelEvent) => {
+            e.preventDefault();
+            const rect = el.getBoundingClientRect();
+            const factor = Math.exp(-e.deltaY * 0.0015);
+            applyZoom(stateRef.current.scale * factor, e.clientX - rect.left, e.clientY - rect.top);
+        };
+        el.addEventListener('wheel', onWheel, { passive: false });
+        return () => el.removeEventListener('wheel', onWheel);
+    }, [applyZoom]);
+
+    React.useEffect(() => {
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onClose]);
+
+    const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+        if (stateRef.current.scale <= 1) return;
+        dragRef.current = { x: e.clientX, y: e.clientY, tx: stateRef.current.tx, ty: stateRef.current.ty };
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+    };
+    const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+        const drag = dragRef.current;
+        if (!drag) return;
+        const s = stateRef.current.scale;
+        setTx(clampT(drag.tx + (e.clientX - drag.x), s, width));
+        setTy(clampT(drag.ty + (e.clientY - drag.y), s, height));
+    };
+    const onPointerUp = () => {
+        dragRef.current = null;
+    };
+
+    const onDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        const rect = containerRef.current?.getBoundingClientRect();
+        const cx = rect ? e.clientX - rect.left : width / 2;
+        const cy = rect ? e.clientY - rect.top : height / 2;
+        applyZoom(stateRef.current.scale > 1 ? 1 : DOUBLE_CLICK_SCALE, cx, cy);
+    };
+
+    return (
+        <div
+            ref={containerRef}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerLeave={onPointerUp}
+            onDoubleClick={onDoubleClick}
+            style={{
+                width,
+                height,
+                background: '#000',
+                overflow: 'hidden',
+                position: 'relative',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                touchAction: 'none',
+                cursor: scale > 1 ? (dragRef.current ? 'grabbing' : 'grab') : 'default',
+            }}
+        >
+            <img
+                src={uri}
+                draggable={false}
+                style={{
+                    maxWidth: '100%',
+                    maxHeight: '100%',
+                    objectFit: 'contain',
+                    transform: `translate(${tx}px, ${ty}px) scale(${scale})`,
+                    transformOrigin: 'center center',
+                    userSelect: 'none',
+                }}
+            />
+            <button
+                onClick={onClose}
+                // Stop the container's pan/pointer-capture from hijacking the
+                // click while zoomed in (otherwise × does nothing at scale > 1).
+                onPointerDown={(e) => e.stopPropagation()}
+                aria-label="Close image"
+                style={{
+                    position: 'absolute',
+                    top: 12,
+                    right: 12,
+                    width: 40,
+                    height: 40,
+                    borderRadius: 20,
+                    border: 'none',
+                    background: 'rgba(0,0,0,0.45)',
+                    color: '#fff',
+                    fontSize: 24,
+                    lineHeight: '24px',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                ×
+            </button>
+        </div>
+    );
+}

--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'expo-router';
 import * as Clipboard from 'expo-clipboard';
 import * as WebBrowser from 'expo-web-browser';
 import { MermaidRenderer } from './MermaidRenderer';
+import { ImageViewer } from '@/components/ImageViewer';
 import { t } from '@/text';
 import { isHttpMarkdownLink } from './linkUtils';
 import { openExternalUrl } from '@/utils/openExternalUrl';
@@ -215,14 +216,20 @@ function RenderCodeBlock(props: { content: string, language: string | null, firs
 function RenderImageBlock(props: { url: string, alt: string, first: boolean, last: boolean }) {
     const accessibleLabel = props.alt || 'Markdown image';
 
+    const openViewer = React.useCallback(() => {
+        Modal.show({ component: ImageViewer, props: { uri: props.url } } as any);
+    }, [props.url]);
+
     return (
         <View style={[style.imageBlock, props.first && style.first, props.last && style.last]}>
-            <Image
-                source={{ uri: props.url }}
-                style={style.image}
-                accessibilityLabel={accessibleLabel}
-                resizeMode="contain"
-            />
+            <Pressable onPress={openViewer} accessibilityRole="imagebutton">
+                <Image
+                    source={{ uri: props.url }}
+                    style={style.image}
+                    accessibilityLabel={accessibleLabel}
+                    resizeMode="contain"
+                />
+            </Pressable>
             {props.alt ? (
                 <Text style={style.imageCaption}>{props.alt}</Text>
             ) : null}

--- a/packages/happy-app/sources/components/tools/views/FileView.tsx
+++ b/packages/happy-app/sources/components/tools/views/FileView.tsx
@@ -8,7 +8,7 @@
  * ratio is used until the actual image lands and contentFit shows it.
  */
 import * as React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
@@ -16,6 +16,8 @@ import { ToolViewProps } from './_all';
 import { z } from 'zod';
 import { useAttachmentImage } from '@/hooks/useAttachmentImage';
 import { thumbhashToDataUri } from '@/utils/thumbhash';
+import { Modal } from '@/modal';
+import { ImageViewer } from '@/components/ImageViewer';
 
 const fileInputSchema = z.object({
     ref: z.string(),
@@ -64,9 +66,18 @@ export const FileView = React.memo<ToolViewProps>(({ tool, sessionId }) => {
         displayW = displayH * aspect;
     }
 
+    const openViewer = React.useCallback(() => {
+        if (!uri) return;
+        Modal.show({ component: ImageViewer, props: { uri } } as any);
+    }, [uri]);
+
     return (
         <View style={styles.inlineContainer}>
-            <View style={[styles.inlineWrapper, { borderColor: theme.colors.divider }]}>
+            <Pressable
+                onPress={openViewer}
+                disabled={!uri}
+                style={[styles.inlineWrapper, { borderColor: theme.colors.divider }]}
+            >
                 <Image
                     source={uri ? { uri } : undefined}
                     placeholder={placeholder}
@@ -79,7 +90,7 @@ export const FileView = React.memo<ToolViewProps>(({ tool, sessionId }) => {
                         <Ionicons name="alert-circle-outline" size={20} color={theme.colors.textSecondary} />
                     </View>
                 )}
-            </View>
+            </Pressable>
             <Text style={[styles.filename, { color: theme.colors.textSecondary }]} numberOfLines={1}>{name}</Text>
         </View>
     );


### PR DESCRIPTION
Image attachments and markdown images in chat were completely inert — you couldn't even tap to enlarge them, let alone zoom, on any platform. Tapping one now opens a fullscreen viewer.

- **Native (iOS/Android):** pinch-to-zoom, pan when zoomed, and double-tap to toggle zoom, via `react-native-gesture-handler` + `react-native-reanimated`. The viewer wraps its content in its own `GestureHandlerRootView` — the app-root one does not extend into the React Native `<Modal>` hierarchy, so gestures would otherwise be dead inside the modal.
- **Web (`ImageViewer.web.tsx`):** wheel-zoom toward the cursor, drag-to-pan when zoomed, double-click to toggle, Esc / × to close.

Wired into both image surfaces — `FileView` (attachments) and the markdown image block — through the existing `Modal.show()` stack. No new dependencies (all three libraries are already in `package.json`).

## Proof

Captured on the web build (standalone server + Expo web, driven with Playwright). Sequence: small inline thumbnail with unreadable fine print → tap → fullscreen viewer (fit) → wheel-zoom in (fine print now crisp) → drag-pan → × closes back to the chat.

![image fullscreen zoom](https://github.com/chphch/happy/releases/download/pr-proofs/image-fullscreen-zoom.gif)

## Not exercised by the web GIF

- **Native touch gestures (iOS/Android)** — the web build uses mouse wheel + drag, so Playwright can't drive the pinch / double-tap path in `ImageViewer.tsx`. Verified by code review of the gesture composition (`Gesture.Race(doubleTap, Gesture.Simultaneous(pinch, pan))`) and the `GestureHandlerRootView`-inside-`Modal` requirement.

`pnpm typecheck` clean.
