### PR TITLE
fix(app): call SessionsList hooks before the early return (Rules of Hooks)

### DIFF
--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -420,13 +420,6 @@ export function SessionsList({
         return [...hierarchy, ...legacyItems, ...archiveToggle, ...archivedRows];
     }, [flatSessionList, hasArchivedSessions, hideArchivedSessions, machines, sourceData]);
 
-    // Early return if no data yet
-    if (!data) {
-        return (
-            <View style={[styles.container, flatSessionList && styles.containerFlat]} />
-        );
-    }
-
     const keyExtractor = React.useCallback((item: SessionListDisplayItem, index: number) => {
         switch (item.type) {
             case 'machine-header': return `machine-header-${JSON.stringify(item.machineId)}`;
@@ -528,9 +521,12 @@ export function SessionsList({
                 );
 
             case 'session':
-                // Determine card styling based on position within date group
-                const prevItem = index > 0 ? data[index - 1] : null;
-                const nextItem = index < data.length - 1 ? data[index + 1] : null;
+                // Determine card styling based on position within date group.
+                // `data` is only non-null when FlatList renders (guarded below),
+                // but it's typed nullable here since renderItem is now defined
+                // above the early return — guard the lookups accordingly.
+                const prevItem = data && index > 0 ? data[index - 1] : null;
+                const nextItem = data && index < data.length - 1 ? data[index + 1] : null;
 
                 const isFirst = prevItem?.type === 'header';
                 const isLast = nextItem?.type === 'header' || nextItem == null || nextItem?.type === 'active-sessions';
@@ -564,6 +560,17 @@ export function SessionsList({
     }, [styles.phoneUpdateBanner, styles.phoneUpdateBannerHeader, topContentInset]);
 
     // Footer removed - all sessions now shown inline
+
+    // Early return if no data yet — placed AFTER all hooks so the hook order is
+    // identical on every render (Rules of Hooks). Returning before the
+    // useCallback hooks above would change the hook count when `data` flips from
+    // null to a populated array on a mounted instance ("Rendered more hooks than
+    // during the previous render").
+    if (!data) {
+        return (
+            <View style={[styles.container, flatSessionList && styles.containerFlat]} />
+        );
+    }
 
     return (
         <View style={[styles.container, flatSessionList && styles.containerFlat]}>


### PR DESCRIPTION
`SessionsList` defines three `useCallback` hooks (`keyExtractor`, `renderItem`, `HeaderComponent`) **after** its early `if (!data) return`, which violates the Rules of Hooks: when a mounted instance's `data` (the memoized `sessionListViewData`) flips from `null` to a populated array, the render goes from fewer hooks to more and React throws `Rendered more hooks than during the previous render`, dropping the whole screen to the error boundary. In normal use the store has already settled `sessionListViewData` to `[]` (non-null) before the component mounts, so the early-return path is effectively dead and the bug stays latent — but any code path that mounts the list while the store is still empty and then populates it hits the crash. This moves the early return below all hooks so the hook order is identical on every render, and null-guards `renderItem`'s `data` lookups (it's now typed nullable above the narrowing, though FlatList only invokes it once `data` is non-null). No behavior change otherwise.

## Proof

Reproduced on Expo web by mounting `<SessionsList/>` while `sessionListViewData === null`, then injecting sessions on the next tick (the null → array transition). Left = current `main` (error boundary: "Rendered more hooks than during the previous render"); right = with this fix (the list renders normally).

![SessionsList hook-order before/after](https://github.com/chphch/happy/releases/download/pr-proofs/hookorder-before-after.png)

`pnpm typecheck` is clean.
