### PR TITLE
feat(app): fullscreen pinch-to-zoom viewer for Mermaid diagrams

### DIFF
--- a/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
+++ b/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
-import { View, Platform, Text } from 'react-native';
+import { View, Platform, Text, Pressable } from 'react-native';
 import { WebView } from 'react-native-webview';
+import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Typography } from '@/constants/Typography';
 import { t } from '@/text';
+import { Modal } from '@/modal';
+import { MermaidViewer } from './MermaidViewer';
 
 // Tall diagrams scroll inside a capped container instead of taking over the chat
 const MAX_DIAGRAM_HEIGHT = 600;
@@ -17,6 +20,21 @@ const webStyle = (backgroundColor: string): any => ({
     overflow: 'auto',
 });
 
+// Tap target to open the diagram in the fullscreen zoomable viewer.
+function ExpandButton({ onPress }: { onPress: () => void }) {
+    return (
+        <Pressable
+            onPress={onPress}
+            hitSlop={8}
+            style={style.expandBtn}
+            accessibilityRole="button"
+            accessibilityLabel="Expand diagram"
+        >
+            <Ionicons name="expand" size={16} color="#fff" />
+        </Pressable>
+    );
+}
+
 // Mermaid render component that works on all platforms
 export const MermaidRenderer = React.memo((props: {
     content: string;
@@ -29,6 +47,10 @@ export const MermaidRenderer = React.memo((props: {
         const { width } = event.nativeEvent.layout;
         setDimensions(prev => ({ ...prev, width }));
     }, []);
+
+    const openViewer = React.useCallback(() => {
+        Modal.show({ component: MermaidViewer, props: { content: props.content } } as any);
+    }, [props.content]);
 
     // Web platform uses direct SVG rendering for better performance and native DOM integration
     if (Platform.OS === 'web') {
@@ -103,6 +125,7 @@ export const MermaidRenderer = React.memo((props: {
                     style={webStyle(theme.colors.surfaceHighest)}
                     dangerouslySetInnerHTML={{ __html: svgContent }}
                 />
+                <ExpandButton onPress={openViewer} />
             </View>
         );
     }
@@ -200,6 +223,7 @@ export const MermaidRenderer = React.memo((props: {
                     }}
                 />
             </View>
+            <ExpandButton onPress={openViewer} />
         </View>
     );
 });
@@ -208,6 +232,17 @@ const style = StyleSheet.create((theme) => ({
     container: {
         marginVertical: 8,
         width: '100%',
+    },
+    expandBtn: {
+        position: 'absolute',
+        top: 12,
+        right: 12,
+        width: 30,
+        height: 30,
+        borderRadius: 15,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0,0,0,0.45)',
     },
     innerContainer: {
         width: '100%',

--- a/packages/happy-app/sources/components/markdown/MermaidViewer.tsx
+++ b/packages/happy-app/sources/components/markdown/MermaidViewer.tsx
@@ -1,0 +1,111 @@
+/**
+ * Fullscreen, zoomable Mermaid diagram viewer (native: iOS / Android).
+ *
+ * Opened via `Modal.show({ component: MermaidViewer, props: { content } })` from
+ * the expand button on an inline diagram. Re-renders the diagram in a fullscreen
+ * WebView and zooms by CSS-transforming the SVG *inside* the WebView — the SVG
+ * is vector, so it stays crisp, unlike scaling the WebView itself from RN (which
+ * upscales a raster snapshot and blurs). Pinch / pan / double-tap are handled by
+ * injected JS, so there's no `svg-pan-zoom` dependency.
+ *
+ * Web has a separate implementation in `MermaidViewer.web.tsx`.
+ */
+import * as React from 'react';
+import { View, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+interface MermaidViewerProps {
+    content: string;
+    onClose: () => void;
+}
+
+export function MermaidViewer({ content, onClose }: MermaidViewerProps) {
+    const { width, height } = useWindowDimensions();
+    const insets = useSafeAreaInsets();
+    const mermaidContent = JSON.stringify(content);
+
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<style>
+  html,body{margin:0;height:100%;background:#000;overflow:hidden;}
+  #wrap{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;touch-action:none;}
+  #stage{transform-origin:center center;will-change:transform;}
+  #stage svg{max-width:100vw;max-height:100vh;height:auto;}
+  .error{color:#ff6b6b;font-family:monospace;white-space:pre-wrap;padding:16px;}
+</style>
+</head>
+<body>
+<div id="wrap"><div id="stage"></div></div>
+<script>
+(async function(){
+  var stage=document.getElementById('stage'), wrap=document.getElementById('wrap');
+  try{
+    mermaid.initialize({startOnLoad:false,theme:'dark'});
+    var r=await mermaid.render('m',${mermaidContent});
+    stage.innerHTML=r.svg;
+  }catch(e){ stage.innerHTML='<div class="error">'+String((e&&e.message)||e).replace(/</g,'&lt;')+'</div>'; }
+
+  var scale=1,tx=0,ty=0,sx=0,sy=0,sd=0,ss=1,pan=false,last=0;
+  function apply(){ stage.style.transform='translate('+tx+'px,'+ty+'px) scale('+scale+')'; }
+  function dist(t){ return Math.hypot(t[0].clientX-t[1].clientX, t[0].clientY-t[1].clientY); }
+  wrap.addEventListener('touchstart',function(e){
+    if(e.touches.length===2){ sd=dist(e.touches); ss=scale; pan=false; }
+    else if(e.touches.length===1){
+      var now=Date.now();
+      if(now-last<300){ if(scale>1){scale=1;tx=0;ty=0;}else{scale=2.5;} apply(); pan=false; }
+      else { pan=true; sx=e.touches[0].clientX-tx; sy=e.touches[0].clientY-ty; }
+      last=now;
+    }
+  },{passive:false});
+  wrap.addEventListener('touchmove',function(e){
+    e.preventDefault();
+    if(e.touches.length===2){ scale=Math.min(8,Math.max(1, ss*dist(e.touches)/sd)); apply(); }
+    else if(e.touches.length===1 && pan){ tx=e.touches[0].clientX-sx; ty=e.touches[0].clientY-sy; apply(); }
+  },{passive:false});
+  wrap.addEventListener('touchend',function(e){ if(e.touches.length===0){ pan=false; if(scale<=1){tx=0;ty=0;apply();} } });
+})();
+</script>
+</body>
+</html>`;
+
+    return (
+        <View style={[styles.root, { width, height }]}>
+            <WebView
+                source={{ html }}
+                style={styles.webview}
+                scrollEnabled={false}
+                originWhitelist={['*']}
+            />
+            <Pressable
+                onPress={onClose}
+                hitSlop={16}
+                style={[styles.close, { top: Math.max(insets.top, 12) + 4 }]}
+                accessibilityRole="button"
+                accessibilityLabel="Close diagram"
+            >
+                <Ionicons name="close" size={26} color="#fff" />
+            </Pressable>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    root: { backgroundColor: '#000' },
+    webview: { flex: 1, backgroundColor: '#000' },
+    close: {
+        position: 'absolute',
+        right: 12,
+        width: 40,
+        height: 40,
+        borderRadius: 20,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+    },
+});

--- a/packages/happy-app/sources/components/markdown/MermaidViewer.tsx
+++ b/packages/happy-app/sources/components/markdown/MermaidViewer.tsx
@@ -1,0 +1,221 @@
+/**
+ * Fullscreen, zoomable Mermaid diagram viewer (native: iOS / Android).
+ *
+ * Opened via `Modal.show({ component: MermaidViewer, props: { content } })` from
+ * the expand button on an inline diagram. Re-renders the diagram in a fullscreen
+ * WebView and zooms the SVG *inside* the WebView. Pinch / pan / double-tap are
+ * handled by injected JS, so there's no `svg-pan-zoom` dependency.
+ *
+ * Zooming is two-phase, and that is the whole point of this file. A CSS
+ * `transform: scale()` does not re-render an SVG — Chromium rasterizes the layer
+ * once and the compositor stretches that bitmap, and `will-change: transform`
+ * pins the raster scale so it never catches up. Measured in Chrome at
+ * devicePixelRatio 3 by capturing compositor frames (an ordinary screenshot
+ * re-rasterizes on capture and hides the problem entirely): at 8x zoom a glyph
+ * edge spanned 12.1 px with `will-change` present versus 2.0 px once the SVG is
+ * genuinely re-rendered. The blur grew in proportion to the zoom factor, which
+ * is the signature of a 1x bitmap being upscaled.
+ *
+ * So: while fingers are down we keep the cheap composited transform (smooth),
+ * and the moment they lift we *commit* — the SVG's own width/height are set to
+ * the zoomed size, the transform scale returns to 1, and `will-change` is
+ * released. At rest the diagram is then laid out at its true size and painted at
+ * the device's full pixel density at any zoom level, instead of depending on
+ * Chromium deciding to re-rasterize a scaled layer.
+ *
+ * Web has a separate implementation in `MermaidViewer.web.tsx`; it never sets
+ * `will-change`, and was measured crisp under the same test.
+ */
+import * as React from 'react';
+import { View, StyleSheet, Pressable, useWindowDimensions } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+interface MermaidViewerProps {
+    content: string;
+    onClose: () => void;
+}
+
+export function MermaidViewer({ content, onClose }: MermaidViewerProps) {
+    const { width, height } = useWindowDimensions();
+    const insets = useSafeAreaInsets();
+    const mermaidContent = JSON.stringify(content);
+
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11.12.2/dist/mermaid.min.js"></script>
+<style>
+  html,body{margin:0;height:100%;background:#000;overflow:hidden;}
+  #wrap{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;touch-action:none;}
+  /* No resting will-change: it would pin the layer's raster scale and every
+     zoom level would then be an upscaled 1x bitmap. It is switched on only for
+     the duration of a gesture (see beginGesture/commit below). */
+  #stage{transform-origin:center center;}
+  /* display:block removes the inline-baseline strut under the svg. Left inline,
+     that few-px gap belongs to the stage box and scales with the gesture, so the
+     diagram jumped vertically the moment the zoom was committed. */
+  #stage svg{display:block;max-width:100vw;max-height:100vh;height:auto;}
+  .error{color:#ff6b6b;font-family:monospace;white-space:pre-wrap;padding:16px;}
+</style>
+</head>
+<body>
+<div id="wrap"><div id="stage"></div></div>
+<script>
+(async function(){
+  var stage=document.getElementById('stage'), wrap=document.getElementById('wrap');
+  try{
+    mermaid.initialize({startOnLoad:false,theme:'dark'});
+    var r=await mermaid.render('m',${mermaidContent});
+    stage.innerHTML=r.svg;
+  }catch(e){ stage.innerHTML='<div class="error">'+String((e&&e.message)||e).replace(/</g,'&lt;')+'</div>'; }
+
+  var scale=1,tx=0,ty=0,sx=0,sy=0,sd=0,ss=1,pan=false,last=0;
+  // committed = the zoom factor already baked into the SVG's own width/height.
+  // The CSS transform only ever carries the part not yet baked in.
+  var committed=1, base=null, baseStyle='', commitTimer=null;
+
+  function svgEl(){ return stage.querySelector('svg'); }
+
+  function measureBase(){
+    var s=svgEl(); if(!s) return;
+    var r=s.getBoundingClientRect();
+    // The fitted 1x size, measured with mermaid's own inline max-width and the
+    // stylesheet's 100vw/100vh still in force. Every zoom level multiplies this.
+    if(r.width>0&&r.height>0){ base={w:r.width,h:r.height}; }
+  }
+
+  function apply(){
+    stage.style.transform='translate('+tx+'px,'+ty+'px) scale('+(scale/committed)+')';
+  }
+
+  function beginGesture(){
+    if(commitTimer){ clearTimeout(commitTimer); commitTimer=null; }
+    // Retake the reference while the transform is still identity: getBoundingClientRect
+    // reports the *transformed* box, so this is the only safe moment, and it closes the
+    // window where a pinch within the first 200ms would bake a multiple of a
+    // pre-font-settle size.
+    if(committed===1&&scale===1){ measureBase(); }
+    // Promote for the duration of the gesture so per-frame scaling stays cheap.
+    stage.style.willChange='transform';
+  }
+
+  function commit(){
+    commitTimer=null;
+    var s=svgEl();
+    if(!s||!base) return;
+    committed=scale;
+    if(committed===1){
+      // Back to the fitted state: restore mermaid's original inline style rather
+      // than clearing it, or the svg's width="100%" would stretch a small
+      // diagram to the full viewport.
+      s.setAttribute('style', baseStyle);
+    } else {
+      // Inline wins over both the stylesheet rule and mermaid's own max-width.
+      s.style.maxWidth='none';
+      s.style.maxHeight='none';
+      s.style.width=(base.w*committed)+'px';
+      s.style.height=(base.h*committed)+'px';
+    }
+    // The stage is centred in the wrapper, so growing its box is geometrically
+    // identical to scaling about its centre — the pan offset carries over as is.
+    stage.style.transform='translate('+tx+'px,'+ty+'px) scale(1)';
+    // Releasing the hint is what lets the compositor rasterize at the new size.
+    stage.style.willChange='auto';
+  }
+
+  function endGesture(){
+    if(commitTimer) clearTimeout(commitTimer);
+    commitTimer=setTimeout(commit,90);
+  }
+
+  function dist(t){ return Math.hypot(t[0].clientX-t[1].clientX, t[0].clientY-t[1].clientY); }
+
+  wrap.addEventListener('touchstart',function(e){
+    beginGesture();
+    if(e.touches.length===2){ sd=dist(e.touches); ss=scale; pan=false; }
+    else if(e.touches.length===1){
+      var now=Date.now();
+      if(now-last<300){ if(scale>1){scale=1;tx=0;ty=0;}else{scale=2.5;} apply(); pan=false; endGesture(); }
+      else { pan=true; sx=e.touches[0].clientX-tx; sy=e.touches[0].clientY-ty; }
+      last=now;
+    }
+  },{passive:false});
+  wrap.addEventListener('touchmove',function(e){
+    e.preventDefault();
+    if(e.touches.length===2){ scale=Math.min(8,Math.max(1, ss*dist(e.touches)/sd)); apply(); }
+    else if(e.touches.length===1 && pan){ tx=e.touches[0].clientX-sx; ty=e.touches[0].clientY-sy; apply(); }
+  },{passive:false});
+  function settle(e){
+    // touchcancel (notification shade, incoming call, edge-swipe) never reports the
+    // remaining touches, and it is the one path that would otherwise skip commit() and
+    // leave will-change pinned — i.e. blurry at that zoom until the viewer is reopened.
+    if(e.type==='touchend'&&e.touches.length>0) return;
+    pan=false;
+    if(scale<=1){scale=1;tx=0;ty=0;apply();}
+    endGesture();
+  }
+  wrap.addEventListener('touchend',settle);
+  wrap.addEventListener('touchcancel',settle);
+
+  // Mermaid settles its layout asynchronously (web fonts, foreignObject labels),
+  // so take the reference size again shortly after the first frame.
+  requestAnimationFrame(function(){
+    var s=svgEl(); if(s){ baseStyle=s.getAttribute('style')||''; }
+    measureBase();
+    setTimeout(function(){ if(committed===1&&scale===1){ measureBase(); } },200);
+  });
+
+  // A rotation changes the fitted reference, so drop back to 1x and re-measure
+  // instead of scaling a stale one.
+  window.addEventListener('resize',function(){
+    var s=svgEl(); if(!s) return;
+    scale=1; committed=1; tx=0; ty=0;
+    s.setAttribute('style', baseStyle);
+    stage.style.transform='';
+    stage.style.willChange='auto';
+    measureBase();
+  });
+})();
+</script>
+</body>
+</html>`;
+
+    return (
+        <View style={[styles.root, { width, height }]}>
+            <WebView
+                source={{ html }}
+                style={styles.webview}
+                scrollEnabled={false}
+                originWhitelist={['*']}
+            />
+            <Pressable
+                onPress={onClose}
+                hitSlop={16}
+                style={[styles.close, { top: Math.max(insets.top, 12) + 4 }]}
+                accessibilityRole="button"
+                accessibilityLabel="Close diagram"
+            >
+                <Ionicons name="close" size={26} color="#fff" />
+            </Pressable>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    root: { backgroundColor: '#000' },
+    webview: { flex: 1, backgroundColor: '#000' },
+    close: {
+        position: 'absolute',
+        right: 12,
+        width: 40,
+        height: 40,
+        borderRadius: 20,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+    },
+});

--- a/packages/happy-app/sources/components/markdown/MermaidViewer.web.tsx
+++ b/packages/happy-app/sources/components/markdown/MermaidViewer.web.tsx
@@ -1,0 +1,164 @@
+/**
+ * Fullscreen, zoomable Mermaid diagram viewer (web).
+ *
+ * Renders the diagram to SVG (same as MermaidRenderer's web path) and zooms by
+ * CSS-transforming the SVG wrapper — wheel-zoom toward the cursor, drag-to-pan
+ * when zoomed, double-click toggle, Esc / × to close. The SVG is vector, so it
+ * stays crisp. Metro resolves this over `MermaidViewer.tsx` on web.
+ */
+import * as React from 'react';
+import { useWindowDimensions } from 'react-native';
+
+const MAX_SCALE = 8;
+const DOUBLE_CLICK_SCALE = 2.5;
+
+interface MermaidViewerProps {
+    content: string;
+    onClose: () => void;
+}
+
+export function MermaidViewer({ content, onClose }: MermaidViewerProps) {
+    const { width, height } = useWindowDimensions();
+    const [svg, setSvg] = React.useState<string | null>(null);
+    const [err, setErr] = React.useState(false);
+    const [scale, setScale] = React.useState(1);
+    const [tx, setTx] = React.useState(0);
+    const [ty, setTy] = React.useState(0);
+
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const dragRef = React.useRef<{ x: number; y: number; tx: number; ty: number } | null>(null);
+    const stateRef = React.useRef({ scale, tx, ty });
+    stateRef.current = { scale, tx, ty };
+
+    React.useEffect(() => {
+        let mounted = true;
+        (async () => {
+            try {
+                const mod: any = await import('mermaid');
+                const mermaid = mod.default || mod;
+                mermaid.initialize?.({ startOnLoad: false, theme: 'dark' });
+                const rendered = await mermaid.render(`mv-${Date.now()}`, content);
+                if (mounted) setSvg(rendered.svg);
+            } catch {
+                if (mounted) setErr(true);
+            }
+        })();
+        return () => { mounted = false; };
+    }, [content]);
+
+    const applyZoom = React.useCallback((nextScale: number, cx: number, cy: number) => {
+        const { scale: s, tx: curTx, ty: curTy } = stateRef.current;
+        const s2 = Math.min(MAX_SCALE, Math.max(1, nextScale));
+        const px = cx - width / 2;
+        const py = cy - height / 2;
+        let nTx = px - (px - curTx) * (s2 / s);
+        let nTy = py - (py - curTy) * (s2 / s);
+        if (s2 <= 1) { nTx = 0; nTy = 0; }
+        setScale(s2);
+        setTx(nTx);
+        setTy(nTy);
+    }, [width, height]);
+
+    React.useEffect(() => {
+        const el = containerRef.current;
+        if (!el) return;
+        const onWheel = (e: WheelEvent) => {
+            e.preventDefault();
+            const rect = el.getBoundingClientRect();
+            const factor = Math.exp(-e.deltaY * 0.0015);
+            applyZoom(stateRef.current.scale * factor, e.clientX - rect.left, e.clientY - rect.top);
+        };
+        el.addEventListener('wheel', onWheel, { passive: false });
+        return () => el.removeEventListener('wheel', onWheel);
+    }, [applyZoom, svg]);
+
+    React.useEffect(() => {
+        const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onClose]);
+
+    const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+        if (stateRef.current.scale <= 1) return;
+        dragRef.current = { x: e.clientX, y: e.clientY, tx: stateRef.current.tx, ty: stateRef.current.ty };
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+    };
+    const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+        const d = dragRef.current;
+        if (!d) return;
+        setTx(d.tx + (e.clientX - d.x));
+        setTy(d.ty + (e.clientY - d.y));
+    };
+    const onPointerUp = () => { dragRef.current = null; };
+
+    const onDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        const rect = containerRef.current?.getBoundingClientRect();
+        const cx = rect ? e.clientX - rect.left : width / 2;
+        const cy = rect ? e.clientY - rect.top : height / 2;
+        applyZoom(stateRef.current.scale > 1 ? 1 : DOUBLE_CLICK_SCALE, cx, cy);
+    };
+
+    return (
+        <div
+            ref={containerRef}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerLeave={onPointerUp}
+            onDoubleClick={onDoubleClick}
+            style={{
+                width,
+                height,
+                background: '#000',
+                overflow: 'hidden',
+                position: 'relative',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                touchAction: 'none',
+                cursor: scale > 1 ? 'grab' : 'default',
+            }}
+        >
+            {err ? (
+                <div style={{ color: '#ff6b6b', fontFamily: 'monospace', whiteSpace: 'pre-wrap', padding: 16 }}>
+                    Mermaid diagram syntax error
+                </div>
+            ) : svg ? (
+                <div
+                    style={{
+                        transform: `translate(${tx}px, ${ty}px) scale(${scale})`,
+                        transformOrigin: 'center center',
+                        maxWidth: '100%',
+                        maxHeight: '100%',
+                    }}
+                    dangerouslySetInnerHTML={{ __html: svg }}
+                />
+            ) : (
+                <div style={{ color: '#888' }}>…</div>
+            )}
+            <button
+                onClick={onClose}
+                onPointerDown={(e) => e.stopPropagation()}
+                aria-label="Close diagram"
+                style={{
+                    position: 'absolute',
+                    top: 12,
+                    right: 12,
+                    width: 40,
+                    height: 40,
+                    borderRadius: 20,
+                    border: 'none',
+                    background: 'rgba(0,0,0,0.45)',
+                    color: '#fff',
+                    fontSize: 24,
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                }}
+            >
+                ×
+            </button>
+        </div>
+    );
+}


### PR DESCRIPTION
Inline Mermaid diagrams render small, and a tall diagram gets clipped, with no way to zoom in. An expand button on each diagram now opens a fullscreen viewer.

- **Native (iOS/Android):** the diagram re-renders in a fullscreen WebView and zoom is applied inside that WebView. Pinch / pan / double-tap are handled by injected JS.
- **Web (`MermaidViewer.web.tsx`):** wheel-zoom toward the cursor, drag-to-pan when zoomed, double-click to toggle, Esc / × to close.

No new dependencies (no `svg-pan-zoom` — the pan/zoom is a few lines of transform math).

## Why the native zoom is two-phase

A CSS `transform: scale()` does not re-render an SVG. Chromium rasterizes the layer once and the compositor stretches that bitmap, and `will-change: transform` makes it permanent: `MinimumRasterContentsScaleForWillChangeTransform` pins the raster scale to devicePixelRatio and `ShouldAdjustRasterScale` then declines every later increase ([`cc/layers/picture_layer_impl.cc`](https://chromium.googlesource.com/chromium/src/+/main/cc/layers/picture_layer_impl.cc)). The hint propagates to descendants (`node_or_ancestors_will_change_transform`), so the child SVG cannot escape it. Chrome 53+ would otherwise [re-raster a script-driven scale change](https://developer.chrome.com/blog/re-rastering-composite) crisply — the hint is exactly the opt-out.

So while fingers are down the composited transform carries the scale and the gesture stays cheap; on lift the zoom is **committed** into the SVG's own `width`/`height`, the transform scale returns to 1, and the hint is released. At rest the diagram is laid out at its true size and painted at full device density at any zoom level, rather than depending on the compositor's raster policy.

## Proof

**Feature end-to-end**, captured on the web build (standalone server + Expo web, driven with Playwright). Sequence: inline diagram with its expand button → tap → fullscreen viewer → wheel-zoom in → drag-pan → × closes back to the chat.

![mermaid fullscreen zoom](https://github.com/chphch/happy/releases/download/pr-proofs/mermaid-fullscreen-zoom.gif)

**Zoom fidelity**, measured on the injected HTML this file ships. A script extracts the template literal from `MermaidViewer.tsx` verbatim, loads it in Chrome at `deviceScaleFactor: 3`, and drives a real two-finger pinch via CDP `Input.dispatchTouchEvent`. The frames below come from `Page.startScreencast`, i.e. the composited surface — an ordinary screenshot re-rasterizes on capture and hides the effect entirely, which is why the first attempt at this measurement showed no difference at all.

![zoom crispness before and after](https://github.com/chphch/happy/releases/download/pr-proofs/pr1427-mermaid-zoom-crispness.png)

| | glyph-edge blur, 3x | glyph-edge blur, 8x |
|---|---|---|
| composited `transform: scale()` with `will-change` | 7.0 px | 12.1 px |
| committed into the SVG | 2.0 px | 2.0 px |

The blur growing in proportion to the zoom factor is the signature of a 1x bitmap being upscaled.

Also checked on the same rig: re-pinching from an already-committed 8x keeps identical sharpness (no re-promotion flicker), a gesture ended by `touchcancel` still commits, a 35-node diagram baked to 8x (6751 × 419 CSS px) still paints rather than dropping tiles, and the geometry during the gesture and after the commit is pixel-identical — `display: block` on the SVG is load-bearing for that last one, because the inline baseline strut otherwise belongs to the stage box, scales with the gesture, and makes the diagram jump 16.3 px the instant the zoom is committed.

## Not exercised

- **A real iOS/Android device.** The measurement above runs the shipped injected HTML in desktop Chrome, which is the same Blink/cc compositor as the Android System WebView but not the same build; the mechanism is cited from Chromium source rather than assumed.
- **iOS specifically.** The commit path is plain layout, so it does not depend on a raster policy, but it has not been run on WKWebView.

`pnpm typecheck` clean; `vitest run` 1114 passed.
