### PR TITLE
fix(app): restore mobile session header icon

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -16,6 +16,7 @@ import { ChatHeaderView } from '@/components/ChatHeaderView';
 import { ChatList } from '@/components/ChatList';
 import { Deferred } from '@/components/Deferred';
 import { EmptyMessages } from '@/components/EmptyMessages';
+import { Avatar } from '@/components/Avatar';
 import { VoiceAssistantStatusBar } from '@/components/VoiceAssistantStatusBar';
 import { useDraft } from '@/hooks/useDraft';
 import { useImagePicker } from '@/hooks/useImagePicker';
@@ -39,7 +40,7 @@ import { FileViewPanel } from '@/components/FileViewPanel';
 import { prefetchPierreDiff } from '@/components/diff/PierreDiffView';
 import { GitFileStatus } from '@/sync/gitStatusFiles';
 import { useOverlayNav } from '@/-session/sessionOverlayNav';
-import { formatPathRelativeToHome, getResumeCommandBlock, getSessionName, useSessionStatus } from '@/utils/sessionUtils';
+import { formatPathRelativeToHome, getResumeCommandBlock, getSessionAvatarId, getSessionName, useSessionStatus } from '@/utils/sessionUtils';
 import { useSessionQuickActions } from '@/hooks/useSessionQuickActions';
 import { isVersionSupported, MINIMUM_CLI_VERSION } from '@/utils/versionUtils';
 import * as Clipboard from 'expo-clipboard';
@@ -196,6 +197,21 @@ export const SessionView = React.memo((props: { id: string }) => {
             isConnected,
         };
     }, [session, isDataReady]);
+    const headerRight = session && deviceType === 'phone' && Platform.OS !== 'web'
+        ? (
+            <Pressable
+                onPress={() => router.push(`/session/${sessionId}/info`)}
+                hitSlop={10}
+            >
+                <Avatar
+                    id={getSessionAvatarId(session)}
+                    size={28}
+                    monochrome={!headerProps.isConnected}
+                    flavor={session.metadata?.flavor}
+                />
+            </Pressable>
+        )
+        : null;
 
     const mainContent = (
         <>
@@ -234,7 +250,7 @@ export const SessionView = React.memo((props: { id: string }) => {
                         folderName={headerProps.folderName}
                         isConnected={headerProps.isConnected}
                         extraPathSegment={fileViewPath ?? undefined}
-                        rightSlot={(diffViewOpen || !!fileViewPath) ? headerRightSlot : null}
+                        rightSlot={(diffViewOpen || !!fileViewPath) ? headerRightSlot : headerRight}
                         onTitlePress={session ? () => router.push(`/session/${sessionId}/info`) : undefined}
                         onBackPress={() => router.back()}
                     />

--- a/packages/happy-app/sources/components/tools/ToolView.tsx
+++ b/packages/happy-app/sources/components/tools/ToolView.tsx
@@ -334,7 +334,7 @@ const styles = StyleSheet.create((theme) => ({
         flexDirection: 'row',
         alignItems: 'center',
         minHeight: 28,
-        paddingHorizontal: 4,
+        paddingHorizontal: 8,
         paddingVertical: 3,
         borderRadius: 4,
         backgroundColor: 'transparent',


### PR DESCRIPTION
## Context

Mobile session view lost the colorful session/provider icon in the header, and compact terminal tool rows were visually starting too far left compared with assistant text.

## What changed

- Restored a compact session avatar/provider icon in the mobile chat header.
- Kept diff/file overlay header slots unchanged.
- Aligned compact terminal tool rows with the normal assistant message inset.

## Test Plan

- pnpm --dir packages/happy-app typecheck
- git diff --check
