### PR TITLE
fix(app): widen user message bubble on native (CJK 1-char-column collapse)

### DIFF
--- a/packages/happy-app/sources/components/MessageView.tsx
+++ b/packages/happy-app/sources/components/MessageView.tsx
@@ -275,9 +275,8 @@ const styles = StyleSheet.create((theme) => ({
     overflow: 'hidden',
   },
   userMessageContainer: {
-    maxWidth: '100%',
-    flexDirection: 'column',
-    alignItems: 'flex-end',
+    width: '100%',
+    flexDirection: 'row',
     justifyContent: 'flex-end',
     paddingHorizontal: 16,
   },
@@ -287,7 +286,14 @@ const styles = StyleSheet.create((theme) => ({
     paddingVertical: 4,
     borderRadius: 12,
     marginBottom: 12,
-    maxWidth: '100%',
+    // Right-aligned bubble sized to content but capped. Laid out as a row item
+    // (justifyContent: 'flex-end' on the container) so Yoga sizes it from the
+    // content's max-content width clamped to maxWidth — NOT the cross-axis
+    // content-fit of `alignItems: 'flex-end'`, which on native collapses to the
+    // min-content width (1 glyph for space-less CJK text), producing a tall
+    // 1-char-wide column on iOS/Android. flexShrink lets it yield to the cap.
+    maxWidth: '85%',
+    flexShrink: 1,
   },
   goalMessageBubble: {
     marginBottom: 6,


### PR DESCRIPTION
On iOS/Android, a multiline **user** message — most visibly space-less CJK text (Korean/Japanese/Chinese) — collapses into a tall, ~1-character-wide vertical column against the right edge. A numbered list, for example, renders as just the `1.` / `2.` markers stacked down a thin sliver.

The user-message bubble is content-fit via `alignItems: 'flex-end'` on `userMessageContainer` (column cross-axis), while `MarkdownView` wraps its content in `<View style={{ width: '100%' }}>`. A `width: '100%'` child inside a shrink-wrapped parent is circular, so Yoga sizes the bubble from the content's **min-content** width — and for space-less CJK every glyph is a valid break point, so min-content is one glyph wide. Browsers lay text out differently, so this only reproduces on native (iOS + Android), not web.

This lays the bubble out as a **row** item (`justifyContent: 'flex-end'` on the container) so Yoga sizes it from max-content clamped to `maxWidth: '85%'` (+ `flexShrink: 1`) — the standard chat-bubble pattern. Agent bubbles (a stretch container) were already fine; web is unaffected and now also caps at 85%.

## Proof

Reproduced and verified fixed on a real Android device (self-hosted build): a Korean numbered-list message that rendered as a 1-glyph-wide column (only the list markers visible) now wraps to the normal bubble width (≤ 85%). `pnpm typecheck` passes. This is a native-only Yoga layout bug, so the web test harness can't surface it (browser text layout doesn't collapse to CJK min-content).

