### PR TITLE
fix(android): allow cleartext HTTP in dev/preview for self-host parity with iOS

### DIFF
--- a/packages/happy-app/app.config.js
+++ b/packages/happy-app/app.config.js
@@ -134,6 +134,23 @@ export default {
         plugins: [
             require("./plugins/withEinkCompatibility.js"),
             [
+                // Mirror iOS NSAllowsLocalNetworking + NSAllowsArbitraryLoads
+                // (see ios.infoPlist.NSAppTransportSecurity above): in dev/preview,
+                // allow http:// fetches to LAN / mesh addresses (e.g. a self-hosted
+                // Happy Server at http://192.168.x.y or http://100.64.x.y) without
+                // forcing TLS. Production keeps Android's default cleartext block.
+                // Without this, Android 9+ throws CleartextNotPermittedException at
+                // the OkHttp layer before any request leaves the device, so the
+                // server never sees the connection — the iOS path was carefully
+                // configured for self-host, the Android equivalent was missing.
+                "expo-build-properties",
+                {
+                    android: {
+                        usesCleartextTraffic: variant !== "production"
+                    }
+                }
+            ],
+            [
                 "expo-router",
                 {
                     root: "./sources/app"

--- a/packages/happy-app/package.json
+++ b/packages/happy-app/package.json
@@ -101,6 +101,7 @@
     "expo": "~55.0.8",
     "expo-application": "~55.0.0",
     "expo-asset": "~55.0.0",
+    "expo-build-properties": "~55.0.0",
     "expo-audio": "~55.0.0",
     "expo-battery": "~55.0.0",
     "expo-blur": "~55.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.143
-        version: 0.3.167(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.179(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/claude-code':
         specifier: 2.1.143
         version: 2.1.143
@@ -569,6 +569,9 @@ importers:
       expo-brightness:
         specifier: ~55.0.0
         version: 55.0.9(expo@55.0.8)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0))
+      expo-build-properties:
+        specifier: ~55.0.0
+        version: 55.0.15(expo@55.0.8)
       expo-calendar:
         specifier: ~55.0.0
         version: 55.0.10(expo@55.0.8)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0))
@@ -1274,19 +1277,9 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.167':
-    resolution: {integrity: sha512-lRdC0lWpRQmoo3geCia/9M0/72BraWwZLxyIQrwWhUCvvlGwqvPLRlPd7Ls20W3py1U4qe2UHt8/NlKMMmoq2g==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.179':
     resolution: {integrity: sha512-2QoEl7p+RTkF4ARZ40N9OWWi+at8Iy9ZZg3UeP6sWoGrM0GL6NJSv8pbYUdoSRySbNeZshqWar5DF41265J5Sg==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.167':
-    resolution: {integrity: sha512-24WCqqXc9SBliROFQz+JhO8+u9DARqhmMGWAZwT+/fs9RDJtHd2SZ7o8rWPAVnUicKQCMsjxdhtp/vFWELGenA==}
-    cpu: [x64]
     os: [darwin]
 
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.179':
@@ -1294,18 +1287,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.167':
-    resolution: {integrity: sha512-g9KB5JIDvcLENitm6+QLnY3YC40FvJroWz65C0etK6ri07SALFxfahSPHQqlbHlAo8a/+ZibSihwjqkvOXQtfg==}
-    cpu: [arm64]
-    os: [linux]
-
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.179':
     resolution: {integrity: sha512-ehqWR9bV0dJONkoKleKg/LJIGDVevLGLPVIQpol+Bqrgyv05DE1hx68g6mBnfp9IEKo2BMZCba3aHKhkHlZvnQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.167':
-    resolution: {integrity: sha512-f6269JZ8KngRIHDK9tmQMFWHg8XhOyJww6pbTVHqlUnf70pJPEP7hsmg6OQErRIvqQzHQWBiakQA8VIdRrOrjw==}
     cpu: [arm64]
     os: [linux]
 
@@ -1314,18 +1297,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.167':
-    resolution: {integrity: sha512-VA+0oQS8jTl2vyeMt4vjFiHf14F0mOxQbNJ6PLdy4etelYxC0lipPtSxVHbdzrgd0cF91uqUDhUMexNkVqS4MQ==}
-    cpu: [x64]
-    os: [linux]
-
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.179':
     resolution: {integrity: sha512-Q+clijh01m+Gg/tSNjHQWfPFRvXSVMIQJZqu6v28vFduaucL7ZL+p6o6VOSdlgLjhqtIFFjOO37aL+VkvEu9MQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.167':
-    resolution: {integrity: sha512-ecxQI20+Fr+PexMgmHlG9/WrUOUi9uQT9n1laUDn4bQAcQX3xDqgZbiH7RErCuTJW+mBSauSh4X68b4jmf64Bg==}
     cpu: [x64]
     os: [linux]
 
@@ -1334,33 +1307,15 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.167':
-    resolution: {integrity: sha512-uB2E9w0bReXONBbaGM27S60F1h+NI/P2HyYoDy+eJsFhMv1lVbko9NG2Wm3kT5qOooBGRlSE5GgiCAK80xBcTA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.179':
     resolution: {integrity: sha512-7wc4j3vDE/TiuiCEPV024U/TDNKXUJ89V0N9WteYJ57YrIUm0RA51WiKCrEmSxSqstQ7Slq26e0gWGHRf7ljDQ==}
     cpu: [arm64]
-    os: [win32]
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.167':
-    resolution: {integrity: sha512-r2IzO8ADzu4uRorXSs07baXee0LtTUIVDXP2ubYW32oTcAr98eip2VfkxwL9xm0tHXN63rp4fporU0eAy9fLPA==}
-    cpu: [x64]
     os: [win32]
 
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.179':
     resolution: {integrity: sha512-gFad1AVUZOXbEyS9lf3Pr0LDXrLuO6limZoZoUZQmjhjy0LnudnTU8P/VbCY0AHmT46YMZ/ieisFzeq8X5jTcg==}
     cpu: [x64]
     os: [win32]
-
-  '@anthropic-ai/claude-agent-sdk@0.3.167':
-    resolution: {integrity: sha512-FTwjBkfcJlqDugBp/kR2GtQ7wPE1ekU4IJzIuUni0pVikdrOVmAPel3EE9LMSJ0WVqFVnHvoYIuj4U9z4gC+5w==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@anthropic-ai/sdk': '>=0.93.0'
-      '@modelcontextprotocol/sdk': ^1.29.0
-      zod: ^4.0.0
 
   '@anthropic-ai/claude-agent-sdk@0.3.179':
     resolution: {integrity: sha512-BlZULVW61ZCcho6mb026QoOQbGZnfxbsEtcoNaW5lF0sIEu7D+/nnQjHSMK8buS/h7HVmIx2RtGbHVX1y4V0uQ==}
@@ -2873,6 +2828,9 @@ packages:
 
   '@expo/schema-utils@55.0.2':
     resolution: {integrity: sha512-QZ5WKbJOWkCrMq0/kfhV9ry8te/OaS34YgLVpG8u9y2gix96TlpRTbxM/YATjNcUR2s4fiQmPCOxkGtog4i37g==}
+
+  '@expo/schema-utils@55.0.4':
+    resolution: {integrity: sha512-65IdeeE8dAZR3n3J5Eq7LYiQ8BFGeEYCWPBCzycvafL7PkskbCyIclTQarRwf/HXFoRvezKCjaLwy/8v9Prk6g==}
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
@@ -7435,6 +7393,11 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-build-properties@55.0.15:
+    resolution: {integrity: sha512-mLCtpn/nBEg4lm7tQUhh/yT5l+8gqwHU/ONqs/zbeeqnNbvryjTuGE0krluueB7Tol4/epfgjiKL4hVEW2VAvA==}
+    peerDependencies:
+      expo: '*'
+
   expo-calendar@55.0.10:
     resolution: {integrity: sha512-UvETOHoUbXwNNT6sV61URbKhxgqHzyvtcUNTdnBo4ndLMx5Drd3KARK9YHG0wKCacBo43D/aCl8d7E2g6ngngQ==}
     peerDependencies:
@@ -10630,6 +10593,9 @@ packages:
 
   react-native-enriched@0.1.6:
     resolution: {integrity: sha512-UMNmwbcURb+/CdQv6bNMryvMqZRxKRNvO0C4XAZKe9d/fkif+mAjAe6o/eTBx6ior42464V8L2zBCbkVXERHig==}
+    deprecated: |-
+      react-native-enriched has been renamed to react-native-enriched-html.
+      This package will not receive any further updates. Migrate with no breaking changes to https://github.com/software-mansion/react-native-enriched-html/releases/tag/v1.0.0
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -11864,6 +11830,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -12716,68 +12683,29 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.0.2
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.167':
-    optional: true
-
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.179':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.167':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.179':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.167':
-    optional: true
-
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.179':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.167':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.179':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.167':
-    optional: true
-
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.179':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.167':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.179':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.167':
-    optional: true
-
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.179':
-    optional: true
-
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.167':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.179':
     optional: true
-
-  '@anthropic-ai/claude-agent-sdk@0.3.167(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.96.0(zod@4.4.3)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      zod: 4.4.3
-    optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.167
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.167
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.167
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.167
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.167
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.167
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.167
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.167
 
   '@anthropic-ai/claude-agent-sdk@0.3.179(@anthropic-ai/sdk@0.96.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
@@ -14481,6 +14409,8 @@ snapshots:
       - supports-color
 
   '@expo/schema-utils@55.0.2': {}
+
+  '@expo/schema-utils@55.0.4': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
 
@@ -19760,6 +19690,13 @@ snapshots:
     dependencies:
       expo: 55.0.8(@babel/core@7.28.6)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.15.0(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0))(react@19.2.0))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react-native: 0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0)
+
+  expo-build-properties@55.0.15(expo@55.0.8):
+    dependencies:
+      '@expo/schema-utils': 55.0.4
+      expo: 55.0.8(@babel/core@7.28.6)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.15.0(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0))(react@19.2.0))(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      resolve-from: 5.0.0
+      semver: 7.7.3
 
   expo-calendar@55.0.10(expo@55.0.8)(react-native@0.83.1(@babel/core@7.28.6)(@types/react@19.1.17)(react@19.2.0)):
     dependencies:


### PR DESCRIPTION
## Summary

A self-hosted Happy Server (`pnpm --filter happy-server standalone:dev`) is reachable from the phone's browser but invisible to the Happy Android app — `fetch` and `Socket.IO` both error immediately with no traffic ever reaching the server. iOS already configures `NSAllowsLocalNetworking` (+ `NSAllowsArbitraryLoads` for dev/preview) for exactly this case at `app.config.js:86-88`; Android had no equivalent, so Android 9+ blocks cleartext HTTP at the OkHttp layer. This PR adds the missing `expo-build-properties` plugin with `usesCleartextTraffic` enabled for dev/preview builds only, mirroring the iOS pattern. Production stays locked down.

## Repro

1. Self-host Happy Server on a LAN or mesh address, e.g. `http://192.168.1.50:3005` (or via Tailscale at `http://100.64.0.2:3005`).
2. In the production Android app, set the custom API endpoint to that URL via Dev Tools.
3. Try to pair. Observe `● disconnected` on the Settings header, `Failed to connect terminal`, and verbose logs spamming `[warn] {}` interleaved with `📰 Fetching feed: <url>` lines — but the server's access log never shows any of those requests landing.

The browser on the same phone reaches the same URL fine, which is the tell that this is an app-layer (manifest) policy, not network.

## Root cause

Android 9+ blocks cleartext HTTP traffic at the OkHttp layer unless explicitly opted in via the manifest. `fetch('http://...')` throws `CleartextNotPermittedException` _before the packet leaves the device_; the exception serializes to `{}` when caught (`utils/time.ts:41`'s `console.warn(e)` in the backoff `onError` is what produces the opaque `[warn] {}` flood). The iOS guard at `app.config.js:86-88` already handles this for Apple platforms with a clear inline comment about LAN self-host. Android just needs parity.

## Fix

Add the `expo-build-properties` plugin with `android.usesCleartextTraffic = (variant !== "production")`. One plugin, one flag, no logic changes. Production builds are unaffected — cleartext stays blocked there, matching iOS production's `NSAllowsLocalNetworking`-only config.

## Test plan

Built a `preview` variant via EAS Build, sideloaded to a physical Android 16 device, and paired against a self-hosted Happy Server over a Headscale mesh.

**Before — unmodified production build, same network, same flow:**

`Happy ● disconnected` on the home header. Verbose logs confirm `📰 Fetching feed: http://100.64.0.2:3005/v1/feed?limit=100` but server access log shows zero requests from the phone.

![Screenshot_20260625_192421_Happy.jpg](https://github.com/user-attachments/assets/2dd6cfd5-2031-4866-b997-4c14df653b73)



**After — this PR's preview variant, identical server URL and flow:**

`Settings ● connected` (green). Build commit `390511a` visible in the footer. Server access log shows the patched build completing `/v1/auth/account/request` → `/v1/auth/account/response` and entering the Socket.IO `connected` state, while the unpatched production build with the identical server URL never reaches the server at all.

![Screenshot_20260625_224812_Happy (preview).jpg](https://github.com/user-attachments/assets/c9434bd6-4c05-4160-b69e-51bedf453241)



## Notes

- Production builds are unchanged: cleartext stays blocked, matching iOS production's `NSAllowsLocalNetworking`-only config.
- Setup-flow gotcha I hit during testing (out of scope here but worth a follow-up): on the welcome screen, tap the server icon (top right) to set the custom API endpoint _before_ tapping "Create account". Otherwise the account is auto-created against the default `cluster-fluster` server and you're left with credentials the self-hosted server can't validate (every subsequent request 401s, the Settings header reads `disconnected`, and there's no in-app path to clear and re-pair short of "Clear storage" at the OS level). Might be worth a follow-up PR to have `setServerUrl()` clear `TokenStorage` credentials on change.

---

Co-authored with Claude Code (Opus 4.8) — diagnosis and patch authoring; build, sideload, end-to-end verification, and the Headscale-meshed self-host setup all on my end.
