### PR TITLE
fix(cli): filter stale reconnect env from child spawns

### DIFF
--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
@@ -47,7 +47,11 @@ describe('ensureDaemonRunning', () => {
 
   it('starts the daemon and waits for readiness when the installed version is not running', async () => {
     const mockUnref = vi.fn()
+    const originalReconnectSessionId = process.env.HAPPY_RECONNECT_SESSION_ID
+    const originalReconnectEncryptionKey = process.env.HAPPY_RECONNECT_ENCRYPTION_KEY
     mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(false)
+    process.env.HAPPY_RECONNECT_SESSION_ID = 'stale-session'
+    process.env.HAPPY_RECONNECT_ENCRYPTION_KEY = 'stale-key'
     mocks.mockSpawnHappyCLI.mockReturnValue({
       unref: mockUnref,
     })
@@ -55,16 +59,34 @@ describe('ensureDaemonRunning', () => {
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(true)
 
-    await ensureDaemonRunning()
+    try {
+      await ensureDaemonRunning()
 
-    expect(mocks.mockSpawnHappyCLI).toHaveBeenCalledWith(['daemon', 'start-sync'], {
-      detached: true,
-      stdio: 'ignore',
-      env: process.env,
-    })
-    expect(mockUnref).toHaveBeenCalled()
-    expect(mocks.mockCheckIfDaemonRunningAndCleanupStaleState).toHaveBeenCalledTimes(2)
-    expect(mocks.mockLoggerDebug).toHaveBeenCalledWith('Starting Happy background service...')
-    expect(mocks.mockLoggerDebug).toHaveBeenCalledWith('Happy background service is ready')
+      expect(mocks.mockSpawnHappyCLI).toHaveBeenCalledWith(['daemon', 'start-sync'], expect.objectContaining({
+        detached: true,
+        stdio: 'ignore',
+        env: expect.objectContaining({
+          PATH: process.env.PATH,
+        }),
+      }))
+      const spawnOptions = mocks.mockSpawnHappyCLI.mock.calls[0][1]
+      expect(spawnOptions.env).not.toHaveProperty('HAPPY_RECONNECT_SESSION_ID')
+      expect(spawnOptions.env).not.toHaveProperty('HAPPY_RECONNECT_ENCRYPTION_KEY')
+      expect(mockUnref).toHaveBeenCalled()
+      expect(mocks.mockCheckIfDaemonRunningAndCleanupStaleState).toHaveBeenCalledTimes(2)
+      expect(mocks.mockLoggerDebug).toHaveBeenCalledWith('Starting Happy background service...')
+      expect(mocks.mockLoggerDebug).toHaveBeenCalledWith('Happy background service is ready')
+    } finally {
+      if (originalReconnectSessionId === undefined) {
+        delete process.env.HAPPY_RECONNECT_SESSION_ID
+      } else {
+        process.env.HAPPY_RECONNECT_SESSION_ID = originalReconnectSessionId
+      }
+      if (originalReconnectEncryptionKey === undefined) {
+        delete process.env.HAPPY_RECONNECT_ENCRYPTION_KEY
+      } else {
+        process.env.HAPPY_RECONNECT_ENCRYPTION_KEY = originalReconnectEncryptionKey
+      }
+    }
   })
 })

--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/ui/logger'
 import { checkIfDaemonRunningAndCleanupStaleState, isDaemonRunningCurrentlyInstalledHappyVersion } from './controlClient'
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI'
+import { createHappyChildEnv } from '@/utils/happyReconnectEnv'
 
 const DAEMON_READY_TIMEOUT_MS = 5000
 const DAEMON_READY_POLL_INTERVAL_MS = 100
@@ -17,7 +18,7 @@ export async function ensureDaemonRunning(): Promise<void> {
   const daemonProcess = spawnHappyCLI(['daemon', 'start-sync'], {
     detached: true,
     stdio: 'ignore',
-    env: process.env,
+    env: createHappyChildEnv(),
   })
   daemonProcess.unref()
 

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -28,6 +28,7 @@ import { detectCLIAvailability } from '@/utils/detectCLI';
 import { buildResumeLaunch } from '@/resume/handleResumeCommand';
 import { detectResumeSupport } from '@/resume/localHappyAgentAuth';
 import { encodeBase64, decodeBase64, decrypt } from '@/api/encryption';
+import { createHappyChildEnv, createHappyTmuxChildEnv } from '@/utils/happyReconnectEnv';
 
 /** Shell-escape a string for safe interpolation into tmux commands. */
 function shellescape(s: string): string {
@@ -412,22 +413,15 @@ export async function startDaemon(): Promise<void> {
           const fullCommand = `node --no-warnings --no-deprecation ${cliPath} ${agent} --happy-starting-mode remote --started-by daemon${resumeFragment}`;
 
           // Spawn in tmux with environment variables
-          // IMPORTANT: Pass complete environment (process.env + extraEnv) because:
+          // IMPORTANT: Pass complete non-reconnect environment (process.env + extraEnv) because:
           // 1. tmux sessions need daemon's expanded auth variables (e.g., ANTHROPIC_AUTH_TOKEN)
-          // 2. Regular spawn uses env: { ...process.env, ...extraEnv }
+          // 2. Regular spawn uses the same sanitized env base
           // 3. tmux needs explicit environment via -e flags to ensure all variables are available
           const windowName = `happy-${Date.now()}-${agent}`;
-          const tmuxEnv: Record<string, string> = {};
-
-          // Add all daemon environment variables (filtering out undefined)
-          for (const [key, value] of Object.entries(process.env)) {
-            if (value !== undefined) {
-              tmuxEnv[key] = value;
-            }
-          }
-
-          // Add extra environment variables (these should already be filtered)
-          Object.assign(tmuxEnv, extraEnv);
+          const tmuxEnv = createHappyTmuxChildEnv({
+            ...process.env,
+            ...extraEnv,
+          });
 
           const tmuxResult = await tmux.spawnInTmux([fullCommand], {
             sessionName: tmuxSessionName,
@@ -533,10 +527,10 @@ export async function startDaemon(): Promise<void> {
           return spawnTrackedHappyProcess({
             args,
             cwd: directory,
-            env: {
+            env: createHappyChildEnv({
               ...process.env,
-              ...extraEnv
-            },
+              ...extraEnv,
+            }),
             directoryCreated,
             message: directoryCreated ? `The path '${directory}' did not exist. We created a new folder and spawned a new session there.` : undefined,
           });
@@ -703,7 +697,7 @@ export async function startDaemon(): Promise<void> {
           args: launch.args,
           cwd: launch.cwd,
           env: {
-            ...process.env,
+            ...createHappyChildEnv(),
             HAPPY_RECONNECT_SESSION_ID: happySessionId,
             HAPPY_RECONNECT_ENCRYPTION_KEY: encodeBase64(tracked.encryption.encryptionKey),
             HAPPY_RECONNECT_ENCRYPTION_VARIANT: tracked.encryption.encryptionVariant,
@@ -901,7 +895,8 @@ export async function startDaemon(): Promise<void> {
         try {
           spawnHappyCLI(['daemon', 'start'], {
             detached: true,
-            stdio: 'ignore'
+            stdio: 'ignore',
+            env: createHappyChildEnv(),
           });
         } catch (error) {
           logger.debug('[DAEMON RUN] Failed to spawn new daemon, this is quite likely to happen during integration tests as we are cleaning out dist/ directory', error);

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -34,6 +34,7 @@ import { extractNoSandboxFlag } from './utils/sandboxFlags'
 import { handleResumeCommand } from '@/resume/handleResumeCommand'
 import { ensureDaemonRunning } from './daemon/ensureDaemonRunning'
 import { handleCodexCommand } from './commands/codexCommand'
+import { createHappyChildEnv } from '@/utils/happyReconnectEnv'
 
 
 (async () => {
@@ -503,7 +504,7 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       const child = spawnHappyCLI(['daemon', 'start-sync'], {
         detached: true,
         stdio: 'ignore',
-        env: process.env
+        env: createHappyChildEnv()
       });
       child.unref();
 

--- a/packages/happy-cli/src/resume/handleResumeCommand.ts
+++ b/packages/happy-cli/src/resume/handleResumeCommand.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 
 import type { Metadata } from '@/api/types';
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI';
+import { createHappyChildEnv } from '@/utils/happyReconnectEnv';
 
 import { resolveHappySession, type ResumableHappySession } from './resolveHappySession';
 
@@ -105,7 +106,7 @@ function spawnResumeChild(launch: ResumeLaunch): Promise<number | null> {
     return new Promise((resolve, reject) => {
         const child = spawnHappyCLI(launch.args, {
             cwd: launch.cwd,
-            env: process.env,
+            env: createHappyChildEnv(),
             stdio: 'inherit',
         });
 

--- a/packages/happy-cli/src/utils/happyReconnectEnv.test.ts
+++ b/packages/happy-cli/src/utils/happyReconnectEnv.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHappyChildEnv, createHappyTmuxChildEnv, HAPPY_RECONNECT_ENV_KEYS } from './happyReconnectEnv';
+
+describe('createHappyChildEnv', () => {
+  it('removes stale Happy reconnect variables while preserving ordinary env vars', () => {
+    expect(createHappyChildEnv({
+      PATH: '/usr/bin',
+      HAPPY_HOME_DIR: '/tmp/happy',
+      HAPPY_RECONNECT_SESSION_ID: 'old-session',
+      HAPPY_RECONNECT_ENCRYPTION_KEY: 'old-key',
+      HAPPY_RECONNECT_FUTURE_FIELD: 'old-value',
+      UNDEFINED_VALUE: undefined,
+    })).toEqual({
+      PATH: '/usr/bin',
+      HAPPY_HOME_DIR: '/tmp/happy',
+    });
+  });
+
+  it('neutralizes known reconnect variables for tmux windows', () => {
+    const env = createHappyTmuxChildEnv({
+      PATH: '/usr/bin',
+      HAPPY_RECONNECT_SESSION_ID: 'old-session',
+      HAPPY_RECONNECT_ENCRYPTION_KEY: 'old-key',
+      HAPPY_RECONNECT_FUTURE_FIELD: 'old-value',
+    });
+
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env).not.toHaveProperty('HAPPY_RECONNECT_FUTURE_FIELD');
+    for (const key of HAPPY_RECONNECT_ENV_KEYS) {
+      expect(env[key]).toBe('');
+    }
+  });
+});

--- a/packages/happy-cli/src/utils/happyReconnectEnv.ts
+++ b/packages/happy-cli/src/utils/happyReconnectEnv.ts
@@ -1,0 +1,33 @@
+const HAPPY_RECONNECT_ENV_PREFIX = 'HAPPY_RECONNECT_';
+
+export const HAPPY_RECONNECT_ENV_KEYS = [
+  'HAPPY_RECONNECT_SESSION_ID',
+  'HAPPY_RECONNECT_ENCRYPTION_KEY',
+  'HAPPY_RECONNECT_ENCRYPTION_VARIANT',
+  'HAPPY_RECONNECT_SEQ',
+  'HAPPY_RECONNECT_METADATA_VERSION',
+  'HAPPY_RECONNECT_AGENT_STATE_VERSION',
+] as const;
+
+export function createHappyChildEnv(baseEnv: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const childEnv: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (value === undefined || key.startsWith(HAPPY_RECONNECT_ENV_PREFIX)) {
+      continue;
+    }
+    childEnv[key] = value;
+  }
+
+  return childEnv;
+}
+
+export function createHappyTmuxChildEnv(baseEnv: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const childEnv = createHappyChildEnv(baseEnv);
+
+  for (const key of HAPPY_RECONNECT_ENV_KEYS) {
+    childEnv[key] = '';
+  }
+
+  return childEnv;
+}

--- a/packages/happy-cli/src/utils/tmux.test.ts
+++ b/packages/happy-cli/src/utils/tmux.test.ts
@@ -420,6 +420,45 @@ describe('TmuxUtilities.detectTmuxEnvironment', () => {
     });
 });
 
+describe('TmuxUtilities.spawnInTmux', () => {
+    it('passes empty environment variables to tmux without quoted empty strings', async () => {
+        const utils = new TmuxUtilities('happy');
+        const commands: string[][] = [];
+
+        (utils as any).ensureSessionExists = async () => undefined;
+        (utils as any).executeTmuxCommand = async (args: string[]) => {
+            commands.push(args);
+            if (args[0] === 'list-sessions' && args[1] === '-F') {
+                return { returncode: 0, stdout: 'happy\n', stderr: '', command: args };
+            }
+            if (args[0] === 'new-window') {
+                return { returncode: 0, stdout: '12345\n', stderr: '', command: args };
+            }
+            return { returncode: 0, stdout: '', stderr: '', command: args };
+        };
+
+        const result = await utils.spawnInTmux(
+            ['node', 'dist/index.mjs'],
+            { windowName: 'happy-test', cwd: '/tmp/project' },
+            {
+                HAPPY_RECONNECT_SESSION_ID: '',
+                PATH: '/usr/bin',
+            },
+        );
+
+        expect(result).toEqual({
+            success: true,
+            sessionId: 'happy:happy-test',
+            pid: 12345,
+        });
+
+        const newWindowArgs = commands.find((args) => args[0] === 'new-window');
+        expect(newWindowArgs).toContain('HAPPY_RECONNECT_SESSION_ID=');
+        expect(newWindowArgs).not.toContain('HAPPY_RECONNECT_SESSION_ID=""');
+        expect(newWindowArgs).toContain('PATH="/usr/bin"');
+    });
+});
+
 describe('Round-trip consistency', () => {
     it('should parse and format consistently for session-only', () => {
         const original = 'my-session';

--- a/packages/happy-cli/src/utils/tmux.ts
+++ b/packages/happy-cli/src/utils/tmux.ts
@@ -820,7 +820,7 @@ export class TmuxUtilities {
                         .replace(/\$/g, '\\$')    // Dollar signs
                         .replace(/`/g, '\\`');    // Backticks
 
-                    createWindowArgs.push('-e', `${key}="${escapedValue}"`);
+                    createWindowArgs.push('-e', value === '' ? `${key}=` : `${key}="${escapedValue}"`);
                 }
                 logger.debug(`[TMUX] Setting ${Object.keys(env).length} environment variables in tmux window`);
             }


### PR DESCRIPTION
## Summary

Daemon-spawned Happy CLI children could inherit stale `HAPPY_RECONNECT_*` variables from the daemon, causing ordinary new sessions to reconnect to an old Happy session instead of creating a fresh one. This PR centralizes child-process environment sanitization so normal child spawns drop stale reconnect tuples, while the daemon resume path still explicitly injects the current reconnect tuple.

## What changed

- Added a shared `happyReconnectEnv` utility that removes stale `HAPPY_RECONNECT_*` values from child environments.
- Applied the sanitized environment to daemon startup paths, daemon self-restart, daemon regular child spawns, and direct `happy resume`.
- Kept daemon resume-in-place behavior by explicitly adding the fresh reconnect tuple after sanitizing the base environment.
- Hardened tmux spawns by setting known reconnect keys to empty values, and fixed tmux `-e` serialization so empty values are passed as `KEY=` instead of a literal quoted string.
- Added focused unit coverage for reconnect env filtering, tmux empty env serialization, and daemon startup sanitization.

Fixes #1444.

## Test Plan

- [x] `PATH=/Users/haoqian/Documents/Codex/2026-06-26/https-linear-app-dark-legion-issue-18/work/bin:$PATH CI=true corepack pnpm --filter happy typecheck`
- [x] `PATH=/Users/haoqian/Documents/Codex/2026-06-26/https-linear-app-dark-legion-issue-18/work/bin:$PATH CI=true corepack pnpm --filter happy exec vitest run --project unit src/utils/happyReconnectEnv.test.ts src/utils/tmux.test.ts src/daemon/ensureDaemonRunning.test.ts src/resume/handleResumeCommand.test.ts`
- [x] `PATH=/Users/haoqian/Documents/Codex/2026-06-26/https-linear-app-dark-legion-issue-18/work/bin:$PATH CI=true corepack pnpm --filter happy exec vitest run --project unit`
- [x] `git diff --check`
