### PR TITLE
fix(app): allow partial text selection on the markdown copy screen

### DIFF
--- a/packages/happy-app/sources/app/(app)/text-selection.tsx
+++ b/packages/happy-app/sources/app/(app)/text-selection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, View, Text, ScrollView, TextInput, Pressable } from 'react-native';
+import { Platform, View, Text, ScrollView, Pressable } from 'react-native';
 import { useRouter, useLocalSearchParams, useNavigation } from 'expo-router';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -97,17 +97,19 @@ export default function TextSelectionScreen() {
                     { paddingBottom: insets.bottom + 16 }
                 ]}
             >
-                <TextInput
-                    style={[styles.textInput, { 
-                        color: theme.colors.text,
-                        backgroundColor: 'transparent'
-                    }]}
-                    value={fullText}
-                    multiline={true}
-                    editable={false}
-                    selectTextOnFocus={false}
-                    scrollEnabled={false}
-                />
+                {/*
+                    Render as a selectable <Text>, not a read-only <TextInput>.
+                    On Android a TextInput with editable={false} cannot be
+                    selected at all, so the only way to copy was the "Copy All"
+                    header button. A selectable <Text> brings up the native
+                    selection handles + copy toolbar, enabling partial copy.
+                */}
+                <Text
+                    selectable={true}
+                    style={[styles.sourceText, { color: theme.colors.text }]}
+                >
+                    {fullText}
+                </Text>
             </ScrollView>
             </MobileGlassSurface>
         </View>
@@ -141,17 +143,11 @@ const styles = StyleSheet.create((theme) => ({
     scrollContent: {
         flexGrow: 1,
     },
-    textInput: {
+    sourceText: {
         ...Typography.mono(),
         fontSize: 14,
         lineHeight: 20,
         color: theme.colors.text,
-        minHeight: 200,
-        textAlignVertical: 'top',
-        backgroundColor: 'transparent',
-        borderWidth: 0,
-        paddingHorizontal: 0,
-        paddingVertical: 0,
     },
     copyButton: {
         padding: 8,


### PR DESCRIPTION
**Reported by 7 people over 6 months** — issues #311, #532, #841 (open, 3 👍), #919, #1386, plus two in Discord. #841 and #1386 name this exact screen:

> "There's no way to copy a specific paragraph, a single code block, or any partial selection — it's all or nothing. This is a basic usability gap."
> — Thoroslives, #841, 2026-03-10

<details>
<summary>All 7 reports</summary>

| Who | When | Where | Their words |
|---|---|---|---|
| beckot | 2025-12-30 | #311 | "chat message text cannot currently be selected or copied … Even partial selection would already be a clear improvement" |
| sherkevin | 2026-02-04 | #532 | "I hope the responses generated by Happy Code can be copied. Currently, the copy function is not working" |
| miohtama | 2026-02-12 | Discord | "I would like to make the chat text selectable and copyable" |
| Thoroslives | 2026-03-10 | #841 (open) | see above |
| WhymustIhaveaname | 2026-03-26 | #919 | "it seems impossible to copy text from the conversation on mobile" |
| b.r.z. | 2026-03-30 | Discord | "Copy is broken … Also no way to copy from within the in line code sections as far as I can see" (one of his top-3 iOS complaints) |
| venkuht1997 | 2026-06-11 | #1386 | "it randomly copies a portion of the output that I want, it doesn't let me select the text I want to copy" |

</details>

---

The long-press "copy markdown" screen (`text-selection.tsx`) rendered the raw markdown in a read-only `<TextInput editable={false}>`. On Android a non-editable `TextInput` is not selectable at all, so the only copy path was the "Copy All" header button — there was no way to grab just a paragraph or a single line. This swaps it for a selectable `<Text>`, which brings up the native selection handles + copy toolbar on Android and iOS, so the markdown source is now partially selectable and copyable. The "Copy All" header button is unchanged.

This addresses the most acute part of #841 ("markdownCopyV2 only copies entire response"): once you're on the text-selection page you can now copy a portion instead of all-or-nothing. The broader ask in #841 — inline arbitrary selection directly on the rendered message and touch-visible per-block copy buttons — is left to a follow-up, since `markdownCopyV2` intentionally disables inline span selection (so the native copy menu doesn't race the long-press gesture).

### Verification
This is Android/iOS-native selection behaviour — the broken state (a non-editable `TextInput` being unselectable) only manifests on a touch device; on web the text is always selectable, so the web test harness can't exercise it. Checked: `pnpm typecheck` clean, and the change is the documented RN pattern for selectable read-only text (`<Text selectable>`). On-device repro: long-press a message → "copy markdown" screen → drag the selection handles over part of the text → native **Copy**.
