### PR TITLE
fix(app): keep user-selection UI (<options>, AskUserQuestion) visible — never fold it into collapsed work groups

### DIFF
--- a/packages/happy-app/sources/hooks/useGroupedMessages.test.ts
+++ b/packages/happy-app/sources/hooks/useGroupedMessages.test.ts
@@ -400,6 +400,191 @@ describe('useGroupedMessages', () => {
         expect(items.map((item) => item.id)).toEqual(['agent-final', 'user']);
     });
 
+    it('keeps an <options> block visible instead of folding it into the work group', () => {
+        const messages: Message[] = [
+            {
+                kind: 'agent-text',
+                id: 'agent-final',
+                localId: null,
+                createdAt: 4,
+                text: 'done',
+            },
+            {
+                kind: 'agent-text',
+                id: 'agent-options',
+                localId: null,
+                createdAt: 3,
+                text: 'Pick one:\n<options>\n    <option>A</option>\n    <option>B</option>\n</options>',
+            },
+            toolMessage('tool-earliest', 2),
+            {
+                kind: 'user-text',
+                id: 'user',
+                localId: null,
+                createdAt: 1,
+                text: 'run tools',
+            },
+        ];
+
+        const items = groupMessagesForDisplay(messages, true);
+
+        // The options message renders standalone; only the older tool folds.
+        expect(items.map((item) => ({ type: item.type, id: item.id }))).toEqual([
+            { type: 'message', id: 'agent-final' },
+            { type: 'message', id: 'agent-options' },
+            { type: 'agent-work-group', id: 'work-tool-earliest' },
+            { type: 'message', id: 'user' },
+        ]);
+        const workGroup = items.find((item) => item.type === 'agent-work-group');
+        if (workGroup?.type !== 'agent-work-group') {
+            throw new Error('Expected an agent work group');
+        }
+        expect(workGroup.messages.map((message) => message.id)).toEqual([
+            'tool-earliest',
+        ]);
+    });
+
+    it('splits the fold around an interleaved selection so chronology is preserved', () => {
+        // Chronological: user → tool-old → <options> → tool-new → final.
+        // The selection card must render BETWEEN the two work groups, not be
+        // pushed to one side of a single merged group.
+        const messages: Message[] = [
+            {
+                kind: 'agent-text',
+                id: 'agent-final',
+                localId: null,
+                createdAt: 5,
+                text: 'done',
+            },
+            toolMessage('tool-new', 4),
+            {
+                kind: 'agent-text',
+                id: 'agent-options',
+                localId: null,
+                createdAt: 3,
+                text: '<options>\n    <option>A</option>\n</options>',
+            },
+            toolMessage('tool-old', 2),
+            {
+                kind: 'user-text',
+                id: 'user',
+                localId: null,
+                createdAt: 1,
+                text: 'run tools',
+            },
+        ];
+
+        const items = groupMessagesForDisplay(messages, true);
+
+        expect(items.map((item) => ({ type: item.type, id: item.id }))).toEqual([
+            { type: 'message', id: 'agent-final' },
+            { type: 'agent-work-group', id: 'work-tool-new' },
+            { type: 'message', id: 'agent-options' },
+            { type: 'agent-work-group', id: 'work-tool-old' },
+            { type: 'message', id: 'user' },
+        ]);
+    });
+
+    it('does not treat an inline "<options>" mention in prose as a selection block', () => {
+        const messages: Message[] = [
+            {
+                kind: 'agent-text',
+                id: 'agent-final',
+                localId: null,
+                createdAt: 4,
+                text: 'done',
+            },
+            {
+                kind: 'agent-text',
+                id: 'agent-mentions-options',
+                localId: null,
+                createdAt: 3,
+                text: 'I parsed the `<options>` tag in the code.',
+            },
+            toolMessage('tool-earliest', 2),
+            {
+                kind: 'user-text',
+                id: 'user',
+                localId: null,
+                createdAt: 1,
+                text: 'explain',
+            },
+        ];
+
+        const items = groupMessagesForDisplay(messages, true);
+
+        // The prose mention is ordinary agent work and still folds.
+        const workGroup = items.find((item) => item.type === 'agent-work-group');
+        if (workGroup?.type !== 'agent-work-group') {
+            throw new Error('Expected an agent work group');
+        }
+        expect(workGroup.messages.map((message) => message.id)).toEqual([
+            'agent-mentions-options',
+            'tool-earliest',
+        ]);
+    });
+
+    it('keeps an AskUserQuestion card visible instead of folding it into the work group', () => {
+        const messages: Message[] = [
+            {
+                kind: 'agent-text',
+                id: 'agent-final',
+                localId: null,
+                createdAt: 5,
+                text: 'done',
+            },
+            namedToolMessage('ask', 'AskUserQuestion', 4),
+            {
+                kind: 'agent-text',
+                id: 'agent-intro',
+                localId: null,
+                createdAt: 3,
+                text: 'one question',
+            },
+            toolMessage('tool-earliest', 2),
+            {
+                kind: 'user-text',
+                id: 'user',
+                localId: null,
+                createdAt: 1,
+                text: 'go',
+            },
+        ];
+
+        const items = groupMessagesForDisplay(messages, true);
+
+        expect(items.map((item) => ({ type: item.type, id: item.id }))).toEqual([
+            { type: 'message', id: 'agent-final' },
+            { type: 'message', id: 'ask' },
+            { type: 'agent-work-group', id: 'work-tool-earliest' },
+            { type: 'message', id: 'user' },
+        ]);
+    });
+
+    it('does not bury a waiting AskUserQuestion inside a collapsed tool group', () => {
+        const messages: Message[] = [
+            namedToolMessage('ask', 'AskUserQuestion', 4),
+            toolMessage('tool-b', 3),
+            toolMessage('tool-a', 2),
+            {
+                kind: 'user-text',
+                id: 'user',
+                localId: null,
+                createdAt: 1,
+                text: 'go',
+            },
+        ];
+
+        const items = groupMessagesForDisplay(messages, true);
+
+        // The preceding tools fold; the question stands alone and tappable.
+        expect(items.map((item) => ({ type: item.type, id: item.id }))).toEqual([
+            { type: 'message', id: 'ask' },
+            { type: 'tool-group', id: 'group-tool-a' },
+            { type: 'message', id: 'user' },
+        ]);
+    });
+
     it('can collapse single standalone tool calls for nested work details', () => {
         const messages: Message[] = [
             toolMessage('tool-only', 2),

--- a/packages/happy-app/sources/hooks/useGroupedMessages.ts
+++ b/packages/happy-app/sources/hooks/useGroupedMessages.ts
@@ -80,6 +80,7 @@ export function groupMessagesForDisplay(
         if (!collapseCurrentTurn && turnOf[index] === 0) return false;
         if (hiddenWorkIndexes.has(index)) return false;
         if (isInvisibleMessage(msg) || isUserAttachment(msg)) return false;
+        if (isUserSelectionMessage(msg)) return false;
         return msg.kind === 'tool-call' && !isInteractiveQuestionToolName(msg.tool.name);
     };
 
@@ -150,6 +151,7 @@ export function groupToolCallsForDisplay(
     const toolRuns = collectToolRuns(messages, (msg) => {
         if (msg.kind !== 'tool-call' || isInteractiveQuestionToolName(msg.tool.name)) return false;
         if (isInvisibleMessage(msg) || isUserAttachment(msg)) return false;
+        if (isUserSelectionMessage(msg)) return false;
         return true;
     });
 
@@ -281,27 +283,53 @@ function collectAgentWorkGroups(messages: Message[], turnOf: number[], collapseC
         const finalTextIndex = visibleAgentIndexes.find((index) => messages[index].kind === 'agent-text');
         if (finalTextIndex === undefined) continue;
 
-        const hiddenIndexes = visibleAgentIndexes.filter((index) => index > finalTextIndex);
-        if (hiddenIndexes.length === 0) continue;
+        // Every agent message older than the turn's final text is foldable —
+        // EXCEPT user-selection elements (an <options> block, an AskUserQuestion
+        // card), which must stay visible and tappable. A selection element that
+        // sits *between* tool calls splits the fold into separate runs so the
+        // card renders in its true chronological place instead of being pushed
+        // to one side of a single merged group. Walk newest-first; each maximal
+        // run of foldable messages becomes its own work group.
+        const candidates = visibleAgentIndexes.filter((index) => index > finalTextIndex);
 
-        const oldestIdx = Math.max(...hiddenIndexes);
-        const hiddenMessages = hiddenIndexes.map((index) => messages[index]);
-        const startedAt = Math.min(...hiddenMessages.map((msg) => msg.createdAt));
-        const completedAt = messages[finalTextIndex].createdAt;
+        let run: number[] = [];
+        // The newest run completes at the final text; each older run completes at
+        // the selection card that split it off (drives the "Worked for…" label).
+        let boundaryCreatedAt = messages[finalTextIndex].createdAt;
 
-        groups.push({
-            hiddenIndexes,
-            oldestIdx,
-            item: {
-                type: 'agent-work-group',
-                id: `work-${messages[oldestIdx].id}`,
-                messages: hiddenMessages,
-                hasRunning: false,
-                hasPendingPermission: hasPendingPermission(hiddenMessages),
-                startedAt,
-                completedAt,
-            },
-        });
+        const flushRun = () => {
+            if (run.length === 0) return;
+            const runIndexes = run;
+            run = [];
+            const oldestIdx = Math.max(...runIndexes);
+            const runMessages = runIndexes.map((index) => messages[index]);
+            const startedAt = Math.min(...runMessages.map((msg) => msg.createdAt));
+            const hasRunning = runMessages.some((msg) => msg.kind === 'tool-call' && msg.tool.state === 'running');
+
+            groups.push({
+                hiddenIndexes: runIndexes,
+                oldestIdx,
+                item: {
+                    type: 'agent-work-group',
+                    id: `work-${messages[oldestIdx].id}`,
+                    messages: runMessages,
+                    hasRunning,
+                    hasPendingPermission: hasPendingPermission(runMessages),
+                    startedAt,
+                    completedAt: boundaryCreatedAt,
+                },
+            });
+        };
+
+        for (const index of candidates) {
+            if (isUserSelectionMessage(messages[index])) {
+                flushRun();
+                boundaryCreatedAt = messages[index].createdAt;
+                continue;
+            }
+            run.push(index);
+        }
+        flushRun();
     }
 
     return groups;
@@ -325,6 +353,29 @@ function isInvisibleMessage(msg: Message): boolean {
 /** User-sent file/image attachments should never be collapsed into a group */
 function isUserAttachment(msg: Message): boolean {
     return msg.kind === 'tool-call' && msg.tool.name === 'file';
+}
+
+// Matches a line that begins (after any leading same-line whitespace) with the
+// <options> tag — mirroring the per-line `line.trim().startsWith('<options>')`
+// trigger parseMarkdownBlock uses to render the interactive options block, so
+// inline mentions of "<options>" in prose don't match. `[^\S\n]` is "whitespace
+// except newline", matching trim()'s reach (spaces, tabs, \r, \f, \v, NBSP).
+const OPTIONS_BLOCK_RE = /(?:^|\n)[^\S\n]*<options>/i;
+
+/**
+ * Messages that present a user choice — the markdown <options> block (carried in
+ * an agent-text message) or the AskUserQuestion tool card. These are interactive
+ * and must never be folded into a collapsed work/tool group, or the user can't
+ * see or tap the choice.
+ */
+function isUserSelectionMessage(msg: Message): boolean {
+    if (msg.kind === 'agent-text') {
+        return OPTIONS_BLOCK_RE.test(msg.text);
+    }
+    if (msg.kind === 'tool-call') {
+        return msg.tool.name === 'AskUserQuestion';
+    }
+    return false;
 }
 
 function hasPendingPermission(messages: Message[]): boolean {


### PR DESCRIPTION
> **Rewritten 2026-09-14 against current `main`.** The original implementation hooked into `visibleForToolGrouping` and `groupToolCallsForDisplay`, both of which `main` has since removed. It is also smaller now: `main` already keeps the `AskUserQuestion` card out of the fold, so only the `<options>` half and the chronological split remain.

A turn's intermediate agent work is folded into a collapsed-by-default "Worked for…" group. That also swallows the markdown `<options>` block — an `agent-text` message the chat renders as tappable chips — so the prompt ends up hidden behind a tap-to-expand header and the user cannot see or answer it.

`main` already excludes the `AskUserQuestion` tool card from the foldable set (`collectAgentWorkGroups`, the `isInteractiveQuestionToolName` line). An `<options>` block is not a tool call, so nothing excludes it.

### Fix

`isUserSelectionMessage()` recognizes a user-selection element — an `agent-text` whose line starts with `<options>` (mirroring `parseMarkdownBlock`'s trigger), or a tool call the existing `isInteractiveQuestionToolName` already names. `collectAgentWorkGroups` then walks the foldable candidates and **splits the fold at each selection element** rather than dropping it into the group:

- the selection element itself is never a member of a group, so it renders standalone and tappable;
- work on either side of it becomes its own group, so a selection answered mid-turn stays in its true chronological position instead of being pushed to one side of a single merged group. Each group's "Worked for…" label ends at the boundary that split it.

### Behaviour

| Before | After |
| --- | --- |
| `<options>` older than the turn's final text → folded into the collapsed group, hidden until tapped | rendered standalone, always visible and tappable |
| selection element between two runs of tool work → both runs merged into one group, the element pushed to one side | fold split at the element; chronological order preserved |

### Testing

`packages/happy-app` — `pnpm typecheck` clean; `useGroupedMessages.test.ts` 13/13. Four cases are new: an `<options>` block kept visible, the interleaved split, an `AskUserQuestion` card kept visible, and a false-positive guard so an inline `` `<options>` `` mentioned in prose still folds.
