### PR TITLE
perf(app): coalesce streaming message application to keep input responsive

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -69,6 +69,15 @@ type V3GetSessionMessagesResponse = {
 // within int4 while still being effectively "infinite" for any session.
 const SEQ_BACKWARD_INITIAL_SENTINEL = 2_147_483_647;
 
+// Coalescing window for applying incoming messages. Streaming agents emit many
+// tokens per second; applying each one individually re-sorts the entire message
+// map and re-renders the chat list per token, saturating the main thread and
+// making text input feel laggy. Batching arrivals within one ~frame collapses
+// those storms into a single update. The trade-off is that a message appears
+// at most ~one frame later than today (e.g. the local echo of a just-sent
+// message), which is well worth removing the per-token re-render storms.
+const MESSAGE_COALESCE_MS = 24;
+
 type V3PostSessionMessagesResponse = {
     messages: Array<{
         id: string;
@@ -339,23 +348,27 @@ class Sync {
         }
 
         this.sessionQueueProcessing.add(sessionId);
-        const lock = this.getSessionMessageLock(sessionId);
-        void lock.inLock(() => {
-            while (true) {
+        // Coalesce bursts OUTSIDE the per-session lock: let tokens that arrive
+        // within one frame accumulate, then apply them in a single batch. The
+        // wait must not hold the lock — fetchMessages/loadOlderMessages share it,
+        // and a continuous stream would otherwise starve gap recovery and
+        // scroll-up history loading for as long as the agent keeps talking.
+        setTimeout(() => {
+            const lock = this.getSessionMessageLock(sessionId);
+            void lock.inLock(() => {
                 const pending = this.sessionMessageQueue.get(sessionId);
-                if (!pending || pending.length === 0) {
-                    break;
+                if (pending && pending.length > 0) {
+                    const batch = pending.splice(0, pending.length);
+                    this.applyMessages(sessionId, batch);
                 }
-                const batch = pending.splice(0, pending.length);
-                this.applyMessages(sessionId, batch);
-            }
-        }).finally(() => {
-            this.sessionQueueProcessing.delete(sessionId);
-            const pending = this.sessionMessageQueue.get(sessionId);
-            if (pending && pending.length > 0) {
-                this.scheduleQueuedMessagesProcessing(sessionId);
-            }
-        });
+            }).finally(() => {
+                this.sessionQueueProcessing.delete(sessionId);
+                const pending = this.sessionMessageQueue.get(sessionId);
+                if (pending && pending.length > 0) {
+                    this.scheduleQueuedMessagesProcessing(sessionId);
+                }
+            });
+        }, MESSAGE_COALESCE_MS);
     }
 
     private hasPendingOutboxMessages() {


### PR DESCRIPTION
## Problem

When an agent streams a response, each token arrives as a separate message update. `scheduleQueuedMessagesProcessing` drains the queue immediately, so on web every token triggers a full `applyMessages` — rebuilding and re-sorting the entire message map (`Object.values(map).sort()`) and re-rendering the chat list. At dozens of tokens/second this saturates the main thread; even though the composer textarea is uncontrolled, the browser can't paint promptly and typing feels laggy while the agent is streaming.

## Change

Coalesce message application within one ~frame (`MESSAGE_COALESCE_MS = 24`): tokens that arrive within the window are applied as a single batch instead of one-at-a-time. The wait is placed **outside** the per-session `AsyncLock` so it never starves `fetchMessages` / `loadOlderMessages` (which share that lock) — only the synchronous splice+apply runs under the lock.

The queue stays FIFO and `splice(0, len)` preserves order, so no messages are dropped or reordered.

**Trade-off:** a message can appear up to ~one frame (~24 ms) later than before, including the local echo of a just-sent message. In practice this is imperceptible, and well worth removing the per-token re-sort/re-render storms.

## Testing

- `tsc --noEmit` passes.
- Verified a long streaming response no longer blocks composer input on web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)