### PR TITLE
feat: spawn opencode (ACP) sessions from the daemon

### DIFF
--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -401,15 +401,17 @@ export async function startDaemon(): Promise<void> {
 
           // Construct command for the CLI
           const cliPath = join(projectPath(), 'dist', 'index.mjs');
-          // Determine agent command - support claude, codex, and gemini
-          const agent = options.agent === 'gemini' ? 'gemini' : (options.agent === 'codex' ? 'codex' : (options.agent === 'openclaw' ? 'openclaw' : 'claude'));
+          // Determine agent command - support claude, codex, gemini, openclaw, opencode
+          const agent = options.agent === 'gemini' ? 'gemini' : (options.agent === 'codex' ? 'codex' : (options.agent === 'openclaw' ? 'openclaw' : (options.agent === 'opencode' ? 'opencode' : 'claude')));
+          // opencode runs over ACP and is launched as `happy acp opencode`.
+          const agentCliCommand = agent === 'opencode' ? 'acp opencode' : agent;
           const resumeId = agent === 'claude'
             ? options.resumeClaudeSessionId
             : (agent === 'codex' ? options.resumeCodexThreadId : undefined);
           const resumeFragment = resumeId
             ? ` --resume ${shellescape(resumeId)}`
             : '';
-          const fullCommand = `node --no-warnings --no-deprecation ${cliPath} ${agent} --happy-starting-mode remote --started-by daemon${resumeFragment}`;
+          const fullCommand = `node --no-warnings --no-deprecation ${cliPath} ${agentCliCommand} --happy-starting-mode remote --started-by daemon${resumeFragment}`;
 
           // Spawn in tmux with environment variables
           // IMPORTANT: Pass complete environment (process.env + extraEnv) because:
@@ -491,7 +493,8 @@ export async function startDaemon(): Promise<void> {
         if (!useTmux) {
           logger.debug(`[DAEMON RUN] Using regular process spawning`);
 
-          // Construct arguments for the CLI - support claude, codex, and gemini
+          // Construct arguments for the CLI - support claude, codex, gemini,
+          // openclaw, and opencode (opencode runs over ACP: `happy acp opencode`).
           let agentCommand: string;
           switch (options.agent) {
             case 'claude':
@@ -507,6 +510,9 @@ export async function startDaemon(): Promise<void> {
             case 'openclaw':
               agentCommand = 'openclaw';
               break;
+            case 'opencode':
+              agentCommand = 'acp';
+              break;
             default:
               return {
                 type: 'error',
@@ -515,6 +521,8 @@ export async function startDaemon(): Promise<void> {
           }
           const args = [
             agentCommand,
+            // opencode is launched as the ACP sub-agent: `acp opencode`.
+            ...(options.agent === 'opencode' ? ['opencode'] : []),
             '--happy-starting-mode', 'remote',
             '--started-by', 'daemon'
           ];

--- a/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
+++ b/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
@@ -120,7 +120,7 @@ export interface SpawnSessionOptions {
     directory: string;
     sessionId?: string;
     approvedNewDirectoryCreation?: boolean;
-    agent?: 'claude' | 'codex' | 'gemini' | 'openclaw';
+    agent?: 'claude' | 'codex' | 'gemini' | 'openclaw' | 'opencode';
     environmentVariables?: Record<string, string>;
     token?: string;
     /**


### PR DESCRIPTION
Route agent 'opencode' through the ACP runner (acp opencode) in spawnSession on both the tmux and regular spawn paths, mirroring the openclaw precedent, and accept 'opencode' in SpawnSessionOptions.agent. Previously the daemon rejected opencode with "Unsupported agent type", so the desktop/app could not start opencode sessions remotely. runAcp already tags flavor:opencode, reads meta.model, and switches models.