### PR TITLE
feat(app): support attachments in the new-session composer

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -42,6 +42,9 @@ import { resolveAbsolutePath } from '@/utils/pathUtils';
 import { formatPathRelativeToHome, formatLastSeen } from '@/utils/sessionUtils';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
+import { useImagePicker } from '@/hooks/useImagePicker';
+import { useWebImagePaste } from '@/hooks/useWebImagePaste';
+import { AgentInputAttachmentStrip } from '@/components/AgentInputAttachmentStrip';
 import { useShallow } from 'zustand/react/shallow';
 import type { MultiTextInputHandle } from '@/components/MultiTextInput';
 import { Modal } from '@/modal';
@@ -580,6 +583,34 @@ function NewSessionScreen() {
         setWorktreeKey: s.setWorktreeKey,
     })));
     const hasText = useNewSessionDraft((s) => s.input.trim().length > 0);
+
+    // Image/file attachments for the first message (expImageUpload feature).
+    // We reuse useImagePicker for the pick/camera/file/paste mechanics, then
+    // mirror its state into the persisted draft store so staged attachments
+    // survive navigating away from the screen (parity with the saved prompt).
+    const expImageUpload = useSetting('expImageUpload');
+    const {
+        selectedImages,
+        pickImages,
+        removeImage,
+        clearImages,
+        addImages,
+    } = useImagePicker();
+    // Seed the picker from the persisted draft exactly once on mount.
+    const attachmentsSeededRef = React.useRef(false);
+    React.useEffect(() => {
+        if (attachmentsSeededRef.current) return;
+        attachmentsSeededRef.current = true;
+        const persisted = useNewSessionDraft.getState().attachments;
+        if (persisted.length > 0) addImages(persisted);
+    }, [addImages]);
+    // Persist on every change (skip the initial seed pass).
+    React.useEffect(() => {
+        if (!attachmentsSeededRef.current) return;
+        useNewSessionDraft.getState().setAttachments(selectedImages);
+    }, [selectedImages]);
+    useWebImagePaste(expImageUpload ? addImages : undefined);
+
     const selectedAgent = draft.agentType;
     const setSelectedAgent = draft.setAgentType;
     const selectedMachineId = draft.selectedMachineId;
@@ -968,11 +999,19 @@ function NewSessionScreen() {
                     // re-render the screen on every keystroke).
                     const draftState = useNewSessionDraft.getState();
                     const trimmedPrompt = draftState.input.trim();
+                    const stagedAttachments = expImageUpload ? draftState.attachments : [];
                     draftState.setInput('');
+                    draftState.setAttachments([]);
+                    clearImages();
 
-                    // Send initial message if provided
-                    if (trimmedPrompt) {
-                        await sync.sendMessage(result.sessionId, trimmedPrompt, { source: 'new_session' });
+                    // Send the initial message when there's text OR attachments.
+                    // The session already exists here, so sendMessage uploads the
+                    // attachments to it just like an in-session message.
+                    if (trimmedPrompt || stagedAttachments.length > 0) {
+                        await sync.sendMessage(result.sessionId, trimmedPrompt, {
+                            source: 'new_session',
+                            attachments: stagedAttachments.length > 0 ? stagedAttachments : undefined,
+                        });
                     }
 
                     router.back();
@@ -1001,7 +1040,7 @@ function NewSessionScreen() {
         } finally {
             setIsSpawning(false);
         }
-    }, [selectedMachineId, selectedMachine, selectedPath, selectedAgent, router, navigateToSession, currentPermission.key, currentModelKey, currentEffort?.key, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.effortLevel, worktreeKey]);
+    }, [selectedMachineId, selectedMachine, selectedPath, selectedAgent, router, navigateToSession, currentPermission.key, currentModelKey, currentEffort?.key, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.effortLevel, worktreeKey, expImageUpload, clearImages]);
 
     const canSend = selectedMachineId && selectedMachine && isMachineOnline(selectedMachine) && !isSpawning;
     const sidebarLayout = getNewSessionSidebarLayout({
@@ -1316,6 +1355,12 @@ function NewSessionScreen() {
 
     const composerNode = (
         <View style={styles.inputBox}>
+            {expImageUpload && selectedImages.length > 0 && (
+                <AgentInputAttachmentStrip
+                    images={selectedImages}
+                    onRemove={removeImage}
+                />
+            )}
             <View style={styles.inputField}>
                 <PromptInput
                     ref={composerInputRef}
@@ -1324,7 +1369,32 @@ function NewSessionScreen() {
                 />
             </View>
             <View style={styles.actionButtonsContainer}>
-                <View style={styles.actionButtonsLeft} />
+                <View style={styles.actionButtonsLeft}>
+                    {expImageUpload && (
+                        <Pressable
+                            onPress={pickImages}
+                            hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
+                            style={(p) => ({
+                                flexDirection: 'row',
+                                alignItems: 'center',
+                                borderRadius: Platform.select({ default: 16, android: 20 }),
+                                paddingHorizontal: 8,
+                                paddingVertical: 6,
+                                justifyContent: 'center',
+                                height: 32,
+                                opacity: p.pressed ? 0.7 : 1,
+                            })}
+                        >
+                            <Ionicons
+                                name="image-outline"
+                                size={16}
+                                color={selectedImages.length > 0
+                                    ? theme.colors.radio.active
+                                    : theme.colors.button.secondary.tint}
+                            />
+                        </Pressable>
+                    )}
+                </View>
                 <View style={[
                     styles.sendButton,
                     isSpawning ? styles.sendButtonActive :

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -4,7 +4,7 @@ import { View, Platform, useWindowDimensions, ViewStyle, Text, ActivityIndicator
 import { Image } from 'expo-image';
 import { AgentInputAttachmentStrip } from './AgentInputAttachmentStrip';
 import type { AttachmentPreview } from '@/sync/attachmentTypes';
-import { generateThumbhash } from '@/utils/thumbhash';
+import { useWebImagePaste } from '@/hooks/useWebImagePaste';
 import { layout } from './layout';
 import { MultiTextInput, KeyPressEvent } from './MultiTextInput';
 import { Typography } from '@/constants/Typography';
@@ -614,81 +614,8 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     React.useImperativeHandle(ref, () => inputRef.current!, []);
 
     // Web paste/drag — intercept image pastes and file drops for the
-    // attachment feature. Both handlers funnel through props.onAddImages.
-    React.useEffect(() => {
-        if (Platform.OS !== 'web' || !props.onAddImages) return;
-
-        const handlePaste = async (e: ClipboardEvent) => {
-            // Only handle pastes targeted at a focused text-editable element.
-            // The listener is attached to document, so without this guard a
-            // paste in the URL bar, another modal, or any focused-elsewhere
-            // input would steal images intended for somewhere else.
-            const active = document.activeElement;
-            const isEditableTarget = active instanceof HTMLInputElement
-                || active instanceof HTMLTextAreaElement
-                || (active instanceof HTMLElement && active.isContentEditable);
-            if (!isEditableTarget) return;
-
-            const { getImagesFromClipboard, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
-            const files = getImagesFromClipboard(e);
-            if (!files.length) return;
-            e.preventDefault();
-            const previews = (await Promise.all(
-                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
-            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
-            if (previews.length) {
-                props.onAddImages!(previews.map((p) => ({
-                    ...p,
-                    id: `paste_${Date.now()}_${Math.random().toString(36).slice(2)}`,
-                })));
-            }
-        };
-
-        // dragover must call preventDefault for drop to fire; we gate on
-        // `types.includes('Files')` so we don't hijack drag-text/HTML in the
-        // rest of the app.
-        const isFileDrag = (e: DragEvent) => {
-            const types = e.dataTransfer?.types;
-            if (!types) return false;
-            // DataTransferItemList vs DOMStringList — both expose .includes-ish.
-            for (let i = 0; i < types.length; i++) {
-                if (types[i] === 'Files') return true;
-            }
-            return false;
-        };
-
-        const handleDragOver = (e: DragEvent) => {
-            if (!isFileDrag(e)) return;
-            e.preventDefault();
-            if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
-        };
-
-        const handleDrop = async (e: DragEvent) => {
-            if (!isFileDrag(e)) return;
-            e.preventDefault();
-            const { getImagesFromDrop, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
-            const files = getImagesFromDrop(e);
-            if (!files.length) return;
-            const previews = (await Promise.all(
-                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
-            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
-            if (previews.length) {
-                props.onAddImages!(previews.map((p) => ({
-                    ...p,
-                    id: `drop_${Date.now()}_${Math.random().toString(36).slice(2)}`,
-                })));
-            }
-        };
-
-        document.addEventListener('paste', handlePaste as any);
-        document.addEventListener('dragover', handleDragOver);
-        document.addEventListener('drop', handleDrop);
-        return () => {
-            document.removeEventListener('paste', handlePaste as any);
-            document.removeEventListener('dragover', handleDragOver);
-            document.removeEventListener('drop', handleDrop);
-        };
-    }, [props.onAddImages]);
+    // attachment feature. Shared with the new-session composer.
+    useWebImagePaste(props.onAddImages);
 
     // Autocomplete state — text + selection. Updated via startTransition so
     // typing renders the character immediately and the autocomplete pipeline

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.ts
@@ -12,6 +12,7 @@ import {
     type NewSessionSessionType,
 } from '@/sync/persistence';
 import type { PermissionModeKey } from '@/components/PermissionModeSelector';
+import type { AttachmentPreview } from '@/sync/attachmentTypes';
 
 interface NewSessionDraftState {
     input: string;
@@ -22,6 +23,7 @@ interface NewSessionDraftState {
     modelMode: string;
     sessionType: NewSessionSessionType;
     worktreeKey: string | null;
+    attachments: AttachmentPreview[];
 
     setInput: (input: string) => void;
     setMachineId: (id: string | null) => void;
@@ -31,6 +33,7 @@ interface NewSessionDraftState {
     setModelMode: (mode: string) => void;
     setSessionType: (type: NewSessionSessionType) => void;
     setWorktreeKey: (key: string | null) => void;
+    setAttachments: (attachments: AttachmentPreview[]) => void;
 }
 
 function persist(state: NewSessionDraftState) {
@@ -43,6 +46,7 @@ function persist(state: NewSessionDraftState) {
         modelMode: state.modelMode,
         sessionType: state.sessionType,
         worktreeKey: state.worktreeKey,
+        attachments: state.attachments,
         updatedAt: Date.now(),
     });
 }
@@ -58,6 +62,7 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     modelMode: initial?.modelMode ?? 'default',
     sessionType: initial?.sessionType ?? 'simple',
     worktreeKey: initial?.worktreeKey ?? null,
+    attachments: initial?.attachments ?? [],
 
     setInput: (input) => { set({ input }); persist(get()); },
     setMachineId: (id) => { set({ selectedMachineId: id, selectedPath: null, worktreeKey: null }); persist(get()); },
@@ -67,4 +72,5 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     setModelMode: (mode) => { set({ modelMode: mode }); persist(get()); },
     setSessionType: (type) => { set({ sessionType: type }); persist(get()); },
     setWorktreeKey: (key) => { set({ worktreeKey: key }); persist(get()); },
+    setAttachments: (attachments) => { set({ attachments }); persist(get()); },
 }));

--- a/packages/happy-app/sources/hooks/useWebImagePaste.ts
+++ b/packages/happy-app/sources/hooks/useWebImagePaste.ts
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { generateThumbhash } from '@/utils/thumbhash';
+import type { AttachmentPreview } from '@/sync/attachmentTypes';
+
+/**
+ * Web-only: intercept image clipboard pastes and file drops anywhere in the
+ * document and funnel them into an attachment handler.
+ *
+ * Why a document-level listener (not an element handler): React Native Web's
+ * text input doesn't surface raw `paste`/`drop` clipboard files, so we listen
+ * on `document` and gate paste on a focused editable target — otherwise a paste
+ * in the URL bar or another input would steal images meant for elsewhere.
+ *
+ * Shared by AgentInput (in-session composer) and the new-session composer so
+ * both get identical paste/drag behavior. No-op on native and when no handler
+ * is provided.
+ */
+export function useWebImagePaste(onAddImages?: (images: AttachmentPreview[]) => void) {
+    React.useEffect(() => {
+        if (Platform.OS !== 'web' || !onAddImages) return;
+
+        const handlePaste = async (e: ClipboardEvent) => {
+            const active = document.activeElement;
+            const isEditableTarget = active instanceof HTMLInputElement
+                || active instanceof HTMLTextAreaElement
+                || (active instanceof HTMLElement && active.isContentEditable);
+            if (!isEditableTarget) return;
+
+            const { getImagesFromClipboard, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
+            const files = getImagesFromClipboard(e);
+            if (!files.length) return;
+            e.preventDefault();
+            const previews = (await Promise.all(
+                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
+            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
+            if (previews.length) {
+                onAddImages(previews.map((p) => ({
+                    ...p,
+                    id: `paste_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+                })));
+            }
+        };
+
+        // dragover must call preventDefault for drop to fire; we gate on
+        // `types.includes('Files')` so we don't hijack drag-text/HTML elsewhere.
+        const isFileDrag = (e: DragEvent) => {
+            const types = e.dataTransfer?.types;
+            if (!types) return false;
+            for (let i = 0; i < types.length; i++) {
+                if (types[i] === 'Files') return true;
+            }
+            return false;
+        };
+
+        const handleDragOver = (e: DragEvent) => {
+            if (!isFileDrag(e)) return;
+            e.preventDefault();
+            if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+        };
+
+        const handleDrop = async (e: DragEvent) => {
+            if (!isFileDrag(e)) return;
+            e.preventDefault();
+            const { getImagesFromDrop, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
+            const files = getImagesFromDrop(e);
+            if (!files.length) return;
+            const previews = (await Promise.all(
+                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
+            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
+            if (previews.length) {
+                onAddImages(previews.map((p) => ({
+                    ...p,
+                    id: `drop_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+                })));
+            }
+        };
+
+        document.addEventListener('paste', handlePaste as any);
+        document.addEventListener('dragover', handleDragOver);
+        document.addEventListener('drop', handleDrop);
+        return () => {
+            document.removeEventListener('paste', handlePaste as any);
+            document.removeEventListener('dragover', handleDragOver);
+            document.removeEventListener('drop', handleDrop);
+        };
+    }, [onAddImages]);
+}

--- a/packages/happy-app/sources/sync/attachmentDraft.test.ts
+++ b/packages/happy-app/sources/sync/attachmentDraft.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parsePersistedAttachments } from './attachmentDraft';
+import type { AttachmentPreview } from './attachmentTypes';
+
+const valid: AttachmentPreview = {
+    id: 'a1',
+    uri: 'file:///tmp/a.jpg',
+    width: 100,
+    height: 200,
+    mimeType: 'image/jpeg',
+    size: 1234,
+    name: 'a.jpg',
+    thumbhash: 'abc',
+};
+
+describe('parsePersistedAttachments', () => {
+    it('round-trips a well-formed attachment via JSON', () => {
+        const out = parsePersistedAttachments(JSON.parse(JSON.stringify([valid])));
+        expect(out).toEqual([valid]);
+    });
+
+    it('keeps a valid attachment without an optional thumbhash', () => {
+        const { thumbhash, ...noHash } = valid;
+        const out = parsePersistedAttachments([noHash]);
+        expect(out).toHaveLength(1);
+        expect(out[0]).not.toHaveProperty('thumbhash');
+        expect(out[0].id).toBe('a1');
+    });
+
+    it('drops a thumbhash that is not a string', () => {
+        const out = parsePersistedAttachments([{ ...valid, thumbhash: 42 }]);
+        expect(out[0]).not.toHaveProperty('thumbhash');
+    });
+
+    it('returns [] for non-array input', () => {
+        expect(parsePersistedAttachments(undefined)).toEqual([]);
+        expect(parsePersistedAttachments(null)).toEqual([]);
+        expect(parsePersistedAttachments('nope')).toEqual([]);
+        expect(parsePersistedAttachments({ id: 'x' })).toEqual([]);
+    });
+
+    it('filters out malformed entries but keeps valid ones', () => {
+        const out = parsePersistedAttachments([
+            valid,
+            null,
+            'string',
+            { id: 'missing-fields' },
+            { ...valid, id: 'b2', width: '100' }, // wrong type → dropped
+            { ...valid, id: 'b3' }, // valid
+        ]);
+        expect(out.map((a) => a.id)).toEqual(['a1', 'b3']);
+    });
+
+    it('returns a fresh array (not the input reference)', () => {
+        const input = [valid];
+        const out = parsePersistedAttachments(input);
+        expect(out).not.toBe(input);
+        expect(out[0]).not.toBe(valid);
+    });
+});

--- a/packages/happy-app/sources/sync/attachmentDraft.ts
+++ b/packages/happy-app/sources/sync/attachmentDraft.ts
@@ -1,0 +1,40 @@
+import type { AttachmentPreview } from '@/sync/attachmentTypes';
+
+/**
+ * Defensive parse for persisted new-session attachments. MMKV holds arbitrary
+ * prior-version JSON, so we drop anything that isn't a well-formed
+ * AttachmentPreview rather than trusting the blob. Returns a fresh array
+ * (never the input reference). Pure — no React Native deps — so it stays
+ * unit-testable in a plain Node test environment.
+ */
+export function parsePersistedAttachments(raw: unknown): AttachmentPreview[] {
+    if (!Array.isArray(raw)) {
+        return [];
+    }
+    const result: AttachmentPreview[] = [];
+    for (const item of raw) {
+        if (!item || typeof item !== 'object') continue;
+        const a = item as Record<string, unknown>;
+        if (
+            typeof a.id === 'string'
+            && typeof a.uri === 'string'
+            && typeof a.width === 'number'
+            && typeof a.height === 'number'
+            && typeof a.mimeType === 'string'
+            && typeof a.size === 'number'
+            && typeof a.name === 'string'
+        ) {
+            result.push({
+                id: a.id,
+                uri: a.uri,
+                width: a.width,
+                height: a.height,
+                mimeType: a.mimeType,
+                size: a.size,
+                name: a.name,
+                ...(typeof a.thumbhash === 'string' ? { thumbhash: a.thumbhash } : {}),
+            });
+        }
+    }
+    return result;
+}

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -4,6 +4,8 @@ import { LocalSettings, localSettingsDefaults, localSettingsParse } from './loca
 import { Purchases, purchasesDefaults, purchasesParse } from './purchases';
 import { Profile, profileDefaults, profileParse } from './profile';
 import type { PermissionModeKey } from '@/components/PermissionModeSelector';
+import type { AttachmentPreview } from '@/sync/attachmentTypes';
+import { parsePersistedAttachments } from '@/sync/attachmentDraft';
 
 const mmkv = new MMKV();
 const NEW_SESSION_DRAFT_KEY = 'new-session-draft-v1';
@@ -24,6 +26,8 @@ export interface NewSessionDraft {
     modelMode: string;
     sessionType: NewSessionSessionType;
     worktreeKey: string | null;
+    /** Image/file attachments staged for the first message (expImageUpload). */
+    attachments: AttachmentPreview[];
     updatedAt: number;
 }
 
@@ -154,6 +158,7 @@ export function loadNewSessionDraft(): NewSessionDraft | null {
         const modelMode: string = typeof parsed.modelMode === 'string' ? parsed.modelMode : 'default';
         const sessionType: NewSessionSessionType = parsed.sessionType === 'worktree' ? 'worktree' : 'simple';
         const worktreeKey = typeof parsed.worktreeKey === 'string' ? parsed.worktreeKey : null;
+        const attachments = parsePersistedAttachments(parsed.attachments);
         const updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now();
 
         return {
@@ -165,6 +170,7 @@ export function loadNewSessionDraft(): NewSessionDraft | null {
             modelMode,
             sessionType,
             worktreeKey,
+            attachments,
             updatedAt,
         };
     } catch (e) {


### PR DESCRIPTION
## Summary

The new-session screen's composer only accepted **text** — there was no way to attach an image to the very first message, unlike the in-session input (`AgentInput`) which already supports the `expImageUpload` attachment pipeline. Requested in #1319 / #1270 / #919 / #70 (those track attachments broadly; none of them call out the new-session composer specifically, which is a separate component from `AgentInput`).

This wires the same attachment flow into the new-session composer, matching the **in-session input's current capabilities** on `main` (gallery pick + web paste/drag — the camera/file chooser from the still-open #1387 is intentionally out of scope here).

## Changes

- **Picker button + preview strip** in the new-session composer action row, reusing `useImagePicker` and `AgentInputAttachmentStrip` (gated on the `expImageUpload` setting).
- **Persisted attachments** — staged attachments are stored in the new-session draft store so they survive navigating away from the screen, matching the already-persisted prompt text. The picker is seeded from the draft once on mount and mirrored back on every change.
- **Send path** — on spawn, the staged attachments are passed to `sync.sendMessage`. The session already exists at that point, so the existing upload→file-event→text path handles them exactly like an in-session message. Send now fires on **text OR attachments**.
- **Refactor** — `AgentInput`'s web paste/drag effect is extracted into a shared `useWebImagePaste` hook so both composers get identical clipboard-paste and file-drop behavior on web without duplication. `AgentInput` now calls the hook (no behavior change).
- **`parsePersistedAttachments`** — a pure, RN-free validator for the persisted draft blob (drops malformed/old-version entries), in its own module so it's unit-testable in Node.

## Tests

- `attachmentDraft.test.ts` — 6 cases: JSON round-trip, valid-without-thumbhash, non-string-thumbhash rejection, non-array input, malformed-entry filtering, fresh-array identity.
- `pnpm typecheck` clean.
- Full `happy-app` suite: **689 passed** (includes the `AgentInput` web-paste refactor regression surface).

## Test plan

- [x] Unit tests above
- [ ] Manual: new session → pick a gallery image → strip shows it → spawn → image arrives in the session as the first message
- [ ] Manual: stage an image → navigate away → return → image still staged (draft persistence)
- [ ] Manual (web): paste / drag-drop an image into the new-session screen → it stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)