### PR TITLE
fix(app,cli): forward new-session permission mode and effort to daemon

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -941,6 +941,11 @@ function NewSessionScreen() {
                 directory: spawnDirectory,
                 approvedNewDirectoryCreation,
                 agent: selectedAgent,
+                // Forward the picker values so the daemon-spawned Claude
+                // session starts in the chosen mode + effort instead of the
+                // CLI's hardcoded 'yolo' + 'medium' defaults.
+                permissionMode: currentPermission?.key,
+                effort: currentEffort?.key,
             });
 
             switch (result.type) {

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -160,6 +160,18 @@ export interface SpawnSessionOptions {
     parentSessionId?: string;
     /** Happy message id used as the rewind point (only set for "duplicate"). */
     forkedFromMessageId?: string;
+    /**
+     * Initial permission mode chosen in the new-session UI. Forwarded to the
+     * daemon so the spawned Claude session starts in this mode instead of the
+     * daemon's hardcoded 'yolo' default.
+     */
+    permissionMode?: string;
+    /**
+     * Initial thinking effort chosen in the new-session UI (low | medium | high
+     * | xhigh | max). Forwarded to the daemon so the spawned Claude session
+     * starts at this effort instead of the daemon's hardcoded 'medium' default.
+     */
+    effort?: string;
 }
 
 // Options for forking a Claude session on a machine
@@ -219,7 +231,7 @@ export interface ResumeSessionOptions {
  */
 export async function machineSpawnNewSession(options: SpawnSessionOptions): Promise<SpawnSessionResult> {
 
-    const { machineId, directory, approvedNewDirectoryCreation = false, token, agent, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId } = options;
+    const { machineId, directory, approvedNewDirectoryCreation = false, token, agent, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, permissionMode, effort } = options;
 
     try {
         const result = await apiSocket.machineRPC<SpawnSessionResult, {
@@ -232,10 +244,12 @@ export async function machineSpawnNewSession(options: SpawnSessionOptions): Prom
             resumeCodexThreadId?: string,
             parentSessionId?: string,
             forkedFromMessageId?: string,
+            permissionMode?: string,
+            effort?: string,
         }>(
             machineId,
             'spawn-happy-session',
-            { type: 'spawn-in-directory', directory, approvedNewDirectoryCreation, token, agent, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId }
+            { type: 'spawn-in-directory', directory, approvedNewDirectoryCreation, token, agent, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, permissionMode, effort }
         );
         return result;
     } catch (error) {

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -146,14 +146,14 @@ export class ApiMachineClient {
 
         // Register spawn session handler
         this.rpcHandlerManager.registerHandler('spawn-happy-session', async (params: any) => {
-            const { directory, sessionId, machineId, approvedNewDirectoryCreation, agent, environmentVariables, token, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId } = params || {};
+            const { directory, sessionId, machineId, approvedNewDirectoryCreation, agent, environmentVariables, token, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, permissionMode, effort } = params || {};
             logger.debug(`[API MACHINE] Spawning session with params: ${JSON.stringify(params)}`);
 
             if (!directory) {
                 throw new Error('Directory is required');
             }
 
-            const result = await spawnSession({ directory, sessionId, machineId, approvedNewDirectoryCreation, agent, environmentVariables, token, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId });
+            const result = await spawnSession({ directory, sessionId, machineId, approvedNewDirectoryCreation, agent, environmentVariables, token, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, permissionMode, effort });
 
             switch (result.type) {
                 case 'success':

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -46,6 +46,11 @@ export type JsRuntime = 'node' | 'bun'
 export interface StartOptions {
     model?: string
     permissionMode?: PermissionMode
+    /**
+     * Initial Claude thinking effort. When set, seeds `currentEffort` at
+     * session start; otherwise falls back to DEFAULT_CLAUDE_EFFORT.
+     */
+    effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max'
     startingMode?: 'local' | 'remote'
     shouldStartDaemon?: boolean
     claudeEnvVars?: Record<string, string>
@@ -526,7 +531,11 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     let currentAppendSystemPrompt: string | undefined = undefined; // Track current append system prompt
     let currentAllowedTools: string[] | undefined = undefined; // Track current allowed tools
     let currentDisallowedTools: string[] | undefined = undefined; // Track current disallowed tools
-    let currentEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined = DEFAULT_CLAUDE_EFFORT; // Track current Claude effort (thinking depth)
+    // Initial effort: prefer the value the daemon forwarded from the app's
+    // new-session picker; only fall back to the hardcoded default when nothing
+    // was passed.
+    const initialEffort = options.effort ?? DEFAULT_CLAUDE_EFFORT;
+    let currentEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined = initialEffort; // Track current Claude effort (thinking depth)
 
     const resetCurrentModeDefaults = () => {
         currentPermissionMode = initialPermissionMode;
@@ -536,7 +545,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         currentAppendSystemPrompt = undefined;
         currentAllowedTools = undefined;
         currentDisallowedTools = undefined;
-        currentEffort = DEFAULT_CLAUDE_EFFORT;
+        currentEffort = initialEffort;
         logger.debug('[loop] Reset current mode defaults after abort');
     };
     const currentEnhancedMode = (): EnhancedMode => ({

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -409,7 +409,16 @@ export async function startDaemon(): Promise<void> {
           const resumeFragment = resumeId
             ? ` --resume ${shellescape(resumeId)}`
             : '';
-          const fullCommand = `node --no-warnings --no-deprecation ${cliPath} ${agent} --happy-starting-mode remote --started-by daemon${resumeFragment}`;
+          // App-chosen initial mode + effort. Without these, the spawned CLI
+          // falls back to runClaude's hardcoded 'yolo' + 'medium' defaults
+          // regardless of what the user picked in the new-session UI.
+          const permissionModeFragment = options.permissionMode
+            ? ` --permission-mode ${shellescape(options.permissionMode)}`
+            : '';
+          const effortFragment = options.effort
+            ? ` --effort ${shellescape(options.effort)}`
+            : '';
+          const fullCommand = `node --no-warnings --no-deprecation ${cliPath} ${agent} --happy-starting-mode remote --started-by daemon${resumeFragment}${permissionModeFragment}${effortFragment}`;
 
           // Spawn in tmux with environment variables
           // IMPORTANT: Pass complete environment (process.env + extraEnv) because:
@@ -526,6 +535,13 @@ export async function startDaemon(): Promise<void> {
           }
           if (options.resumeCodexThreadId && agentCommand === 'codex') {
             args.push('--resume', options.resumeCodexThreadId);
+          }
+          // Same app-chosen mode + effort forwarding as the tmux command above.
+          if (options.permissionMode) {
+            args.push('--permission-mode', options.permissionMode);
+          }
+          if (options.effort) {
+            args.push('--effort', options.effort);
           }
 
           // TODO: In future, sessionId could be used with --resume to continue existing sessions

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -611,6 +611,17 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
         unknownArgs.push('--dangerously-skip-permissions')
       } else if (arg === '--model') {
         options.model = args[++i]
+      } else if (arg === '--effort') {
+        // Initial Claude thinking effort (low | medium | high | xhigh | max).
+        // Passed by the daemon when the app spawns a session so runClaude
+        // doesn't fall back to its hardcoded 'medium' default.
+        const value = args[++i]
+        if (value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh' || value === 'max') {
+          options.effort = value
+        } else {
+          console.error(chalk.red(`Invalid --effort value: ${value}. Must be one of low, medium, high, xhigh, max`))
+          process.exit(1)
+        }
       } else if (arg === '--started-by') {
         options.startedBy = args[++i] as 'daemon' | 'terminal'
       } else if (arg === '--js-runtime') {

--- a/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
+++ b/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
@@ -140,6 +140,17 @@ export interface SpawnSessionOptions {
     parentSessionId?: string;
     /** Happy message id used as the rewind point (only set for "duplicate"). */
     forkedFromMessageId?: string;
+    /**
+     * Initial permission mode for the spawned Claude session (e.g. 'acceptEdits',
+     * 'plan', 'yolo'). When set, the daemon forwards it via --permission-mode so
+     * runClaude doesn't fall back to its hardcoded 'yolo' default.
+     */
+    permissionMode?: string;
+    /**
+     * Initial Claude thinking effort ('low' | 'medium' | 'high' | 'xhigh' | 'max').
+     * Forwarded via --effort; overrides runClaude's hardcoded 'medium' default.
+     */
+    effort?: string;
 }
 
 export type SpawnSessionResult =


### PR DESCRIPTION
## Summary
Sessions started from the app's new-session screen let the user pick a permission
mode and thinking effort, but daemon-spawned (remote) sessions ignored both — the
daemon always launched the CLI with its hardcoded `yolo` mode and `medium` effort,
so the picker had no effect on remotely-spawned sessions. This forwards the picker
values end-to-end.

## What changed
- App forwards `permissionMode` + `effort` through the spawn op
  (`sync/ops.ts`, `app/(app)/new/index.tsx`).
- Daemon threads them into both spawn paths and emits `--permission-mode` /
  `--effort` (`daemon/run.ts`, `modules/common/registerCommonHandlers.ts`,
  `api/apiMachine.ts`).
- CLI parses `--effort` (validated) and seeds `currentEffort`; `--permission-mode`
  is resolved by the existing `extractPermissionModeFromClaudeArgs` path
  (`index.ts`, `claude/runClaude.ts`).
- Both are omitted when unset, so behaviour is unchanged for callers that don't
  supply them.

## Test plan
- [x] `pnpm --filter happy run typecheck`
- [x] `pnpm --filter happy-app run typecheck`
- [x] `pnpm --filter happy exec vitest run src/claude/utils/permissionMode.test.ts src/claude/runClaude.test.ts src/api/apiMachine.test.ts` — 35 passed
- [x] Manual: spawn a remote session with no default overrides set — starts at the app defaults
- [x] Manual: spawn a remote session with agent defaults overridden — starts in the overridden mode/effort
- [x] Manual: spawn a remote session, then change effort/permissions from the in-session menu — per-session override takes effect
