### PR TITLE
fix(app): show app-sent slash commands typed mid-message

### DIFF
--- a/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.spec.ts
@@ -128,8 +128,8 @@ describe('isUserSlashCommandEcho', () => {
         expect(isUserSlashCommandEcho('/compact', false)).toBe(false);
     });
 
-    it('detects a trailing command echo with a localId', () => {
-        expect(isUserSlashCommandEcho('привет давай /maintain', true)).toBe(true);
+    it('does not suppress a mid-message command echo (no SDK wrapper replaces it)', () => {
+        expect(isUserSlashCommandEcho('привет давай /maintain', true)).toBe(false);
     });
 
     it('does not treat the SDK wrapper itself as a raw echo', () => {

--- a/packages/happy-app/sources/components/parseLocalCommandMessage.ts
+++ b/packages/happy-app/sources/components/parseLocalCommandMessage.ts
@@ -141,6 +141,16 @@ export function parseLocalCommandMessage(text: string): LocalCommandMessage {
  * the raw echo and let the wrapper chip stand in — matching how the
  * Claude Code terminal renders slash commands.
  *
+ * Only a LEADING slash command is echoed this way. Claude Code recognizes
+ * a command solely as the first token of a message
+ * (https://code.claude.com/docs/en/commands — "A command is only
+ * recognized at the start of your message"), so a mid-message slash is
+ * ordinary text that produces no `<command-*>` wrapper. Suppressing that
+ * echo would hide the message with nothing to replace it, so we gate on
+ * the start-anchored RAW_SLASH_COMMAND_RE rather than the looser
+ * `rawSlashCommand` (which also matches mid-message tokens for chip
+ * rendering — those stay visible).
+ *
  * Gated on `hasLocalId` so we only ever hide a message the user actually
  * sent from Happy, never an agent/SDK-originated one.
  */
@@ -149,7 +159,7 @@ export function isUserSlashCommandEcho(text: string, hasLocalId: boolean): boole
         return false;
     }
     const trimmed = text.trim();
-    if (!rawSlashCommand(trimmed)) {
+    if (!RAW_SLASH_COMMAND_RE.test(trimmed)) {
         return false;
     }
     // Guard: a real wrapper message also contains <command-name>; never


### PR DESCRIPTION
## Summary

A slash command sent from the app disappears from the chat when the `/` is not the first token of the message (e.g. `please /deploy now`) — no bubble, no chip, the message is simply gone.

## Root cause

`isUserSlashCommandEcho` hides the user's optimistic echo on the assumption the Claude Agent SDK re-emits it as a canonical `<command-*>` wrapper chip that stands in for it.

But Claude Code only recognizes a command at the **start** of a message — [docs](https://code.claude.com/docs/en/commands): *"A command is only recognized at the start of your message."* A mid-message slash is ordinary text and produces **no** wrapper, so suppressing its echo leaves nothing to replace it and the message is lost.

The suppression gated on `rawSlashCommand`, which matches a slash **anywhere** in the message (it also powers mid-message chip rendering in `parseLocalCommandMessage`). That is too broad for the echo-suppression decision.

The regression became visible once #1410 started propagating the real `localId` onto rendered user messages (`convertReducerMessageToMessage` previously hard-coded `localId: null`), which activated the otherwise-inert suppression path.

## Fix

Gate the suppression on the start-anchored `RAW_SLASH_COMMAND_RE` instead of the broader `rawSlashCommand`:

- **Leading commands** (`/foo args`) — still suppressed; the SDK wrapper renders the chip + args. Unchanged, no duplicate.
- **Mid-message commands** (`text /foo`) — no longer suppressed; they render via `parseLocalCommandMessage` exactly as before, so they stay visible instead of vanishing.

Only the echo-suppression condition is narrowed; `MessageView` and `parseLocalCommandMessage` behavior are otherwise unchanged.

## Test Plan

- [x] `pnpm --filter happy-app run typecheck`
- [x] `pnpm --filter happy-app exec vitest run sources/components/parseLocalCommandMessage.spec.ts` (22 passed)
- [x] Device (iOS): leading `/cmd args` shows once (chip + args); mid-message `foo /cmd bar` is visible again; neither path duplicates
