### PR TITLE
Fix pairing link crash when no account exists and make auth polling survive transient errors

### DIFF
--- a/packages/happy-app/sources/app/(app)/terminal/connect.tsx
+++ b/packages/happy-app/sources/app/(app)/terminal/connect.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { View, Platform } from 'react-native';
 import { Text } from '@/components/StyledText';
-import { useRouter } from 'expo-router';
+import { Redirect, useRouter } from 'expo-router';
 import { Typography } from '@/constants/Typography';
 import { RoundButton } from '@/components/RoundButton';
 import { useConnectTerminal } from '@/hooks/useConnectTerminal';
+import { useAuth } from '@/auth/AuthContext';
 import { Ionicons } from '@expo/vector-icons';
 import { ItemList } from '@/components/ItemList';
 import { ItemGroup } from '@/components/ItemGroup';
@@ -13,6 +14,7 @@ import { t } from '@/text';
 
 export default function TerminalConnectScreen() {
     const router = useRouter();
+    const auth = useAuth();
     const [publicKey, setPublicKey] = useState<string | null>(null);
     const [hashProcessed, setHashProcessed] = useState(false);
     const { processAuthUrl, isLoading } = useConnectTerminal({
@@ -23,7 +25,7 @@ export default function TerminalConnectScreen() {
 
     // Extract key from hash on web platform
     useEffect(() => {
-        if (Platform.OS === 'web' && typeof window !== 'undefined' && !hashProcessed) {
+        if (Platform.OS === 'web' && typeof window !== 'undefined' && !hashProcessed && auth.isAuthenticated) {
             const hash = window.location.hash;
             if (hash.startsWith('#key=')) {
                 const key = hash.substring(5); // Remove '#key='
@@ -36,7 +38,7 @@ export default function TerminalConnectScreen() {
                 setHashProcessed(true);
             }
         }
-    }, [hashProcessed]);
+    }, [hashProcessed, auth.isAuthenticated]);
 
     const handleConnect = async () => {
         if (publicKey) {
@@ -49,6 +51,15 @@ export default function TerminalConnectScreen() {
     const handleReject = () => {
         router.back();
     };
+
+    // Approving a connection needs account credentials, so a visitor
+    // without an account would crash below. Send them to the welcome
+    // screen to create or restore an account first. The URL hash is
+    // intentionally not cleared in this case so the pairing link still
+    // works when it is opened again after the account exists.
+    if (!auth.isAuthenticated) {
+        return <Redirect href="/" />;
+    }
 
     // Show placeholder for mobile platforms
     if (Platform.OS !== 'web') {

--- a/packages/happy-cli/src/ui/auth.ts
+++ b/packages/happy-cli/src/ui/auth.ts
@@ -146,6 +146,7 @@ async function waitForAuthentication(keypair: tweetnacl.BoxKeyPair): Promise<Cre
     process.stdout.write('Waiting for authentication');
     let dots = 0;
     let cancelled = false;
+    let consecutiveFailures = 0;
 
     // Handle Ctrl-C during waiting
     const handleInterrupt = () => {
@@ -167,6 +168,7 @@ async function waitForAuthentication(keypair: tweetnacl.BoxKeyPair): Promise<Cre
                         'X-Happy-Client': `cli/${configuration.currentCliVersion}`
                     }
                 });
+                consecutiveFailures = 0;
                 if (response.data.state === 'authorized') {
                     let token = response.data.token as string;
                     let r = decodeBase64(response.data.response);
@@ -214,8 +216,15 @@ async function waitForAuthentication(keypair: tweetnacl.BoxKeyPair): Promise<Cre
                     }
                 }
             } catch (error) {
-                console.log('\n\nFailed to check authentication status. Please try again.');
-                return null;
+                // A single failed poll is almost always a transient network
+                // problem, not a reason to abandon a pairing that is still
+                // valid. Only give up after the server has been unreachable
+                // for about half a minute.
+                consecutiveFailures++;
+                if (consecutiveFailures >= 30) {
+                    console.log('\n\nFailed to check authentication status. Please try again.');
+                    return null;
+                }
             }
 
             // Animate waiting dots


### PR DESCRIPTION
While pairing a new machine today through the web flow I hit two bugs, one in the app and one in the CLI. Both fixes are small and scoped.

**Crash when opening a pairing link without an account**

The CLI opens the terminal connect page directly in the browser. A brand new user has no account yet, but the page still renders the Accept button. Pressing it throws inside the connect hook because credentials are null, and the only feedback is a generic failure dialog. Every retry fails the same way, so a first time user gets stuck. This is what the browser console shows

```
TypeError: Cannot read properties of null (reading 'secret')
```

The fix redirects the connect screen to the welcome screen when there is no account. The user can create or restore an account there and then open the pairing link again. The URL hash is intentionally left untouched in that case, so the link keeps working on the second visit. No new translation strings are needed.

**One failed poll aborts the whole auth flow**

While waiting for approval the CLI polls the auth request endpoint once per second. Any single network error made waitForAuthentication give up and the process exited with an authentication error, even though the pairing was still valid. That is exactly how my first pairing attempt died. The fix counts consecutive failures and only gives up after thirty in a row, which is about half a minute of sustained unreachability. A successful poll resets the counter.

**How this was verified**

Reproduced both bugs on Windows 11 with CLI version 1.1.10 against the production web app. Once an account existed, the same pairing link connected without problems, which confirms the null credentials diagnosis. The polling change keeps the existing failure message and matches the style of the surrounding code.