### PR TITLE
feat(app): add Fable 5 to the Claude model picker

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -78,6 +78,7 @@ export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
+        { key: 'fable', name: 'fable 5', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },
     ];


### PR DESCRIPTION
## Problem

Fable 5 shipped in Claude Code (v2.1.170+, selectable via `/model fable` or `--model fable`), but Happy's Claude model picker is hardcoded and doesn't list it. As a result, mobile and web users have no way to select Fable 5 — the picker only offers default / opus 4.8 / sonnet 4.6 / haiku 4.5. Expected: Fable 5 appears as a selectable option alongside the other Claude models.

## Change

One-line addition to `getClaudeModelModes()` in `packages/happy-app/sources/components/modelModeOptions.ts`, right after the `opus` entry:

```diff
     { key: 'opus', name: 'opus 4.8', description: null },
+    { key: 'fable', name: 'fable 5', description: null },
     { key: 'sonnet', name: 'sonnet 4.6', description: null },
```

## Why it's sufficient (no CLI change needed)

The `key: 'fable'` flows through to Claude unchanged. There is no Claude-side model allowlist in `happy-cli` — the only `Invalid model` validation lives in `packages/happy-cli/src/index.ts` and is scoped to the Gemini subcommand. For Claude sessions, `runClaude.ts` resolves the model from the session's `mode.model` and forwards it to the Claude Agent SDK as `claude --model <key>`. So a new picker entry is all that's required for it to work end to end.

## Testing

`claude --model fable` runs fine standalone on Claude Code v2.1.185. The change is a pure data addition to the picker list; a screenshot of the updated picker isn't attached yet — happy to add one on request.

Closes #1469
