### PR TITLE
fix(server): exclude coding sessions from push suppression

### DIFF
--- a/packages/happy-server/sources/app/events/eventRouter.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.ts
@@ -281,16 +281,26 @@ class EventRouter {
     // === PRESENCE QUERIES ===
 
     /**
-     * Returns true if the user has any non-machine socket that hasn't
-     * reported `app-state: background`.  Old clients that never send
-     * `app-state` are treated as active (connected = present).
+     * Returns true if the user has any *UI* client (mobile app / web) that
+     * hasn't reported `app-state: background` — i.e. someone is looking at a
+     * Happy client right now, so a push would be redundant.
+     *
+     * Only `user-scoped` sockets count. `machine-scoped` (CLI daemon) and
+     * `session-scoped` (CLI coding sessions) are background processes that
+     * never surface notifications, so they must NOT suppress push — otherwise
+     * simply having a coding session running silently blocks every mobile
+     * push for the user. Old UI clients that never send `app-state` are
+     * treated as active (connected = present) for backwards compatibility.
      *
      * Uses fetchSockets() which works cross-replica via Redis streams adapter.
      */
-    async hasActiveNonMachineSocket(userId: string): Promise<boolean> {
+    async hasActiveUiClient(userId: string): Promise<boolean> {
         const sockets = await this.io.in(`user:${userId}`).fetchSockets();
         return sockets.some(s => {
-            if (s.data.clientType === 'machine-scoped') return false;
+            // Only interactive UI clients count toward "active". The daemon
+            // (machine-scoped) and coding sessions (session-scoped) are not
+            // notification surfaces and must not suppress mobile pushes.
+            if (s.data.clientType !== 'user-scoped') return false;
             // No app-state yet → old client or just connected; assume active
             const appState = s.data.appState as string | undefined;
             return appState !== 'background';

--- a/packages/happy-server/sources/app/push/focusTracker.ts
+++ b/packages/happy-server/sources/app/push/focusTracker.ts
@@ -1,9 +1,11 @@
 /**
- * Checks whether a user is actively looking at any Happy client.
+ * Checks whether a user is actively looking at any Happy UI client
+ * (mobile app / web).
  *
- * "Active" means a non-machine socket is connected AND has not reported
- * `app-state: background`. Old clients that never send `app-state` are
- * treated as active (connected = present) for backwards compatibility.
+ * "Active" means a `user-scoped` socket is connected AND has not reported
+ * `app-state: background`. The daemon (machine-scoped) and CLI coding
+ * sessions (session-scoped) do NOT count — they are background processes
+ * that never display notifications, so they must not suppress push.
  *
  * State lives on `socket.data.appState` — set by the `app-state` socket
  * event in socket.ts. No external storage (Redis, Maps) needed: when a
@@ -13,5 +15,5 @@
 import { eventRouter } from "@/app/events/eventRouter";
 
 export async function isUserActive(userId: string): Promise<boolean> {
-    return eventRouter.hasActiveNonMachineSocket(userId);
+    return eventRouter.hasActiveUiClient(userId);
 }


### PR DESCRIPTION
## Summary

Mobile push notifications for `done` (task finished), permission, and question events were silently suppressed whenever a CLI coding session was running. The server's presence check counted any non-machine socket as "user is looking at a client"; but a running coding session opens a `session-scoped` socket that never reports `app-state`, so the `undefined → active` fallback marked it permanently active and blocked every mobile push for that user. This narrows the check to `user-scoped` sockets (mobile app / web) only.

## Proof it works

Self-hosted server, same repro: a `happy` coding session running in a terminal, phone backgrounded, trigger a task completion.

**Before** — server log:
```
Suppressed session-event push for user cmr... session cmr...: user active
```
Phone receives nothing. Daemon log confirms it was sent: `[PUSH] sendSessionNotification dispatched via server (kind=done)`.

**After** — server log (same repro):
```
Push sent for user cmr...: 1 token(s)
```
Phone receives the push.

## Root cause

`hasActiveNonMachineSocket` only excluded `machine-scoped` (daemon) sockets. A `session-scoped` coding-session socket combined with the `appState === undefined → active` fallback meant any running coding session read as a permanently-active UI client, suppressing all session-event pushes. Manual `happy notify` worked because it bypasses `dispatchSessionEventPush`.

## Changes

- `packages/happy-server/sources/app/events/eventRouter.ts`: `hasActiveNonMachineSocket` → `hasActiveUiClient`; only `user-scoped` sockets now count toward active.
- `packages/happy-server/sources/app/push/focusTracker.ts`: updated caller + doc comment.

## Notes

- This is a server change, which `contributing.md` asks to discuss first — that discussion happened in #1464 and #1383 (root-cause analysis posted there before opening this PR).
- Refs #1464, #1383. Not using `Fixes` so the reporters (on the hosted server) can still verify once this is deployed.
