### PR TITLE
fix(server): don't count CLI coding sessions as user presence for push

### DIFF
--- a/packages/happy-server/sources/app/events/eventRouter.spec.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import type { Server } from 'socket.io';
+import { eventRouter } from './eventRouter';
+
+// hasActiveNonMachineSocket only touches `io.in(room).fetchSockets()`, so a tiny
+// stub is enough — it ignores the room and returns the provided sockets.
+function stubIo(sockets: Array<{ data: Record<string, unknown> }>): Server {
+    return { in: () => ({ fetchSockets: async () => sockets }) } as unknown as Server;
+}
+
+function socket(clientType: string, appState?: string): { data: Record<string, unknown> } {
+    return { data: appState === undefined ? { clientType } : { clientType, appState } };
+}
+
+describe('EventRouter.hasActiveNonMachineSocket', () => {
+    it('ignores session-scoped (CLI agent) sockets, even without app-state', async () => {
+        // A running coding session is always connected as session-scoped and never
+        // sends app-state. It is the agent, not the user viewing Happy, so it must
+        // not count as presence — otherwise a session suppresses its own push.
+        eventRouter.init(stubIo([socket('session-scoped'), socket('session-scoped')]));
+        expect(await eventRouter.hasActiveNonMachineSocket('u1')).toBe(false);
+    });
+
+    it('ignores the machine-scoped daemon socket', async () => {
+        eventRouter.init(stubIo([socket('machine-scoped')]));
+        expect(await eventRouter.hasActiveNonMachineSocket('u1')).toBe(false);
+    });
+
+    it('is active when a user-scoped client is foreground or has not reported app-state', async () => {
+        eventRouter.init(stubIo([socket('user-scoped', 'active')]));
+        expect(await eventRouter.hasActiveNonMachineSocket('u1')).toBe(true);
+
+        eventRouter.init(stubIo([socket('user-scoped')]));
+        expect(await eventRouter.hasActiveNonMachineSocket('u1')).toBe(true);
+    });
+
+    it('is not active when the only user-scoped client is backgrounded, despite session sockets', async () => {
+        // The exact regression: phone backgrounded but CLI sessions still connected.
+        eventRouter.init(stubIo([
+            socket('session-scoped'),
+            socket('session-scoped'),
+            socket('user-scoped', 'background'),
+        ]));
+        expect(await eventRouter.hasActiveNonMachineSocket('u1')).toBe(false);
+    });
+});

--- a/packages/happy-server/sources/app/events/eventRouter.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.ts
@@ -281,17 +281,30 @@ class EventRouter {
     // === PRESENCE QUERIES ===
 
     /**
-     * Returns true if the user has any non-machine socket that hasn't
-     * reported `app-state: background`.  Old clients that never send
-     * `app-state` are treated as active (connected = present).
+     * Returns true if the user is actively viewing Happy on one of their own
+     * clients (mobile / web / desktop), used to suppress redundant push
+     * notifications.
+     *
+     * Only `user-scoped` connections count. `session-scoped` sockets belong to
+     * CLI coding sessions (the agent, not the user) and are always connected
+     * while a session runs; `machine-scoped` is the daemon. A viewing client is
+     * "active" unless it has reported `app-state: background`; a client that has
+     * not sent `app-state` yet is treated as active (present).
      *
      * Uses fetchSockets() which works cross-replica via Redis streams adapter.
      */
     async hasActiveNonMachineSocket(userId: string): Promise<boolean> {
         const sockets = await this.io.in(`user:${userId}`).fetchSockets();
         return sockets.some(s => {
-            if (s.data.clientType === 'machine-scoped') return false;
-            // No app-state yet → old client or just connected; assume active
+            // Only the user's own viewing clients (mobile / web / desktop, which
+            // connect `user-scoped`) represent presence. A `session-scoped` socket
+            // is a CLI coding session — the agent, not the user looking at Happy —
+            // and is always connected while that session runs; `machine-scoped` is
+            // the daemon. Counting either meant a session's own "done"/permission
+            // push was suppressed by that session's own socket, so mobile push
+            // never fired while any session was active.
+            if (s.data.clientType !== 'user-scoped') return false;
+            // A viewing client that hasn't reported app-state yet is assumed active.
             const appState = s.data.appState as string | undefined;
             return appState !== 'background';
         });


### PR DESCRIPTION
## Problem

Session-event push notifications (agent finished, permission request, question) are suppressed whenever a coding session is connected — which is essentially always — so mobile devices receive no push notifications.

`EventRouter.hasActiveNonMachineSocket()` decides whether to skip a push because the user is already looking at Happy. It treated **every non-`machine-scoped` socket** as presence, which includes `session-scoped` sockets. But a `session-scoped` socket is a CLI coding session (the agent, not the user), and it stays connected for the entire life of the session. So the very session dispatching a "done" push is itself counted as active presence and suppresses its own notification.

## Fix

Count only `user-scoped` connections (the user's mobile / web / desktop clients) as presence. `session-scoped` (agent) and `machine-scoped` (daemon) sockets are excluded. A `user-scoped` client is still treated as active unless it has reported `app-state: background`.

## How it was found / verified

On a live server, with the old logic the phone reported `app-state: background` yet the push was still `Suppressed … user active`, because ~10 `session-scoped` (`cli-coding-session`) sockets with no `app-state` counted as presence. With the fix, the same push is delivered.

Added `eventRouter.spec.ts` covering: session-scoped and machine-scoped sockets are ignored; a user-scoped client counts when foreground or before it reports state; and — the exact regression — a backgrounded user-scoped client is not active even with session sockets present.
