### PR TITLE
fix(app): re-pin chat to bottom on send so option taps don't jump up on Android

### DIFF
--- a/packages/happy-app/sources/components/ChatList.tsx
+++ b/packages/happy-app/sources/components/ChatList.tsx
@@ -186,6 +186,26 @@ const ChatListInternal = React.memo((props: {
                 }
                 return next;
             });
+            // A new latest user-text id only appears on the user's OWN send —
+            // typed, or via tapping an <options>/AskUserQuestion chip. Agent
+            // tokens are agent-text/tool-call and never change latestUserMsgId.
+            // Sending is always an intent to be at the newest message, so
+            // deliberately re-pin the inverted list to the visual bottom
+            // (offset 0). This counteracts the upward viewport drift caused by
+            // maintainVisibleContentPosition (minIndexForVisible: 1): the new
+            // index-0 insert re-anchors MVCP onto a different row and the
+            // collapseCurrentTurn re-group lands a large height change above the
+            // anchor in the same commit. Option taps expose it because they
+            // happen with the keyboard closed (viewport not pinned within the
+            // autoscroll threshold), unlike typed sends. This runs per-send, NOT
+            // per-token, so it does not reintroduce the per-token scrollToOffset
+            // "fight" removed above (see the maintainVisibleContentPosition
+            // comment). rAF defers it until after the collapse/insert commit's
+            // layout settles (Android timing).
+            const raf = requestAnimationFrame(() => {
+                flatListRef.current?.scrollToOffset({ offset: 0, animated: false });
+            });
+            return () => cancelAnimationFrame(raf);
         }
     }, [latestUserMsgId]);
 


### PR DESCRIPTION
Tapping an `<options>` / `AskUserQuestion` chip on Android makes the chat viewport jump upward toward older messages instead of staying on the newest one. The chat is an inverted `FlatList` with `maintainVisibleContentPosition={{ minIndexForVisible: 1, autoscrollToTopThreshold: 50 }}` and no deliberate re-pin to the bottom on send (the per-token `scrollToOffset` was intentionally removed to avoid fighting MVCP). When a message is sent, a new user-text is inserted at index 0 so MVCP re-anchors onto a physically different row, and `collapseCurrentTurn` flips as the agent starts responding — re-grouping the just-finished turn and landing a large content-height change *above* the anchor in the same commit. The net drift only surfaces on **option taps** because they happen with the keyboard closed (viewport not pinned within the autoscroll threshold), unlike typed sends which keep the keyboard open and stay pinned; and only on **Android**, where `AgentContentView.tsx` drives the list height via layout `paddingBottom` while iOS uses a layout-neutral transform. The fix: on the discrete new-user-message event (typed or chip tap — agent tokens never change `latestUserMsgId`), deliberately re-pin the inverted list to offset 0 via a single `requestAnimationFrame`. It runs per-send, not per-token, so it does not reintroduce the streaming "fight," does not affect stick-to-bottom while reading history, and the same path serves both typed and option sends.

## Proof

Verified on a self-hosted Android build (OTA to a real device):

- **Before:** scroll up mid-history, then tap an `<options>` chip → the viewport jumps up toward older messages.
- **After:** same steps → the viewport stays pinned to the newest message.

This is an Android-native `maintainVisibleContentPosition` timing behavior, so a web (react-native-web) capture does not reproduce it — happy to add an Android-emulator screen recording if that's preferred for review.
