### PR TITLE
fix(app): stop session list jumping during multi-session streaming

### DIFF
--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -196,6 +196,23 @@ export function clearRegisteredPushToken() {
     mmkv.delete(REGISTERED_PUSH_TOKEN_KEY);
 }
 
+export function loadSessionLastMessageSentAt(): Record<string, number> {
+    const timestamps = mmkv.getString('session-last-message-sent-at');
+    if (timestamps) {
+        try {
+            return JSON.parse(timestamps);
+        } catch (e) {
+            console.error('Failed to parse session last message sent timestamps', e);
+            return {};
+        }
+    }
+    return {};
+}
+
+export function saveSessionLastMessageSentAt(timestamps: Record<string, number>) {
+    mmkv.set('session-last-message-sent-at', JSON.stringify(timestamps));
+}
+
 export function loadProfile(): Profile {
     const profile = mmkv.getString('profile');
     if (profile) {

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -1067,10 +1067,12 @@ export const storage = create<StorageState>()((set, get) => {
             saveSessionLastMessageSentAt(allTimestamps);
 
             // Rebuild list view data — this timestamp drives activity-based sort.
+            // Pass unreadSessionIds so other sessions keep their unread badges
+            // (omitting it drops every badge until the next rebuild).
             return {
                 ...state,
                 sessions: updatedSessions,
-                sessionListViewData: buildSessionListViewData(updatedSessions)
+                sessionListViewData: buildSessionListViewData(updatedSessions, state.unreadSessionIds)
             };
         }),
         getSessionPathKey: (sessionId: string): string | null => {

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -1173,14 +1173,19 @@ export const storage = create<StorageState>()((set, get) => {
             
             const { [sessionId]: _fileCache, ...remainingFileCache } = state.sessionFileCache;
 
-            // Clear drafts from persistent storage (permission / model / effort
+            // Clear local session data from persistent storage (permission / model / effort
             // picks live in synced session metadata, #1492)
             const drafts = loadSessionDrafts();
             delete drafts[sessionId];
             saveSessionDrafts(drafts);
-            
-            // Rebuild sessionListViewData without the deleted session
-            const sessionListViewData = buildSessionListViewData(remainingSessions);
+
+            const lastMessageSentAt = loadSessionLastMessageSentAt();
+            delete lastMessageSentAt[sessionId];
+            saveSessionLastMessageSentAt(lastMessageSentAt);
+
+            // Rebuild sessionListViewData without the deleted session.
+            // Pass unreadSessionIds so the remaining sessions keep their unread badges.
+            const sessionListViewData = buildSessionListViewData(remainingSessions, state.unreadSessionIds);
             
             return {
                 ...state,

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -24,6 +24,7 @@ import { Profile } from "./profile";
 import { UserProfile, RelationshipUpdatedEvent } from "./friendTypes";
 import { loadSettings, loadLocalSettings, saveLocalSettings, saveSettings, loadPurchases, savePurchases, loadProfile, saveProfile, loadSessionDrafts, saveSessionDrafts } from "./persistence";
 import { isAgentModePushPending } from "./agentModesPending";
+import { loadSessionLastMessageSentAt, saveSessionLastMessageSentAt } from "./persistence";
 import type { CustomerInfo } from './revenueCat/types';
 import React from "react";
 import { sync } from "./sync";
@@ -218,6 +219,7 @@ interface StorageState {
     getActiveSessions: () => Session[];
     updateSessionDraft: (sessionId: string, draft: string | null) => void;
     updateSessionAgentModes: (sessionId: string, patch: SessionAgentModesPatch) => void;
+    markSessionMessageSent: (sessionId: string) => void;
     // Artifact methods
     applyArtifacts: (artifacts: DecryptedArtifact[]) => void;
     addArtifact: (artifact: DecryptedArtifact) => void;
@@ -262,8 +264,11 @@ function buildSessionListViewData(
     });
 
     // Sort by last activity or creation date (newest first), per user setting — matches applySessions behavior
+    // Activity sort keys off the last user-sent message, not updatedAt: updatedAt
+    // bumps on every background agent update, which would make the list jump while
+    // several sessions stream at once. lastMessageSentAt only moves when the user acts.
     const sortKey = storage.getState().settings.sortSessionsByActivity
-        ? (s: Session) => s.updatedAt
+        ? (s: Session) => s.lastMessageSentAt ?? s.createdAt
         : (s: Session) => s.createdAt;
     activeSessions.sort((a, b) => sortKey(b) - sortKey(a));
     inactiveSessions.sort((a, b) => sortKey(b) - sortKey(a));
@@ -350,6 +355,7 @@ export const storage = create<StorageState>()((set, get) => {
     let purchases = loadPurchases();
     let profile = loadProfile();
     let sessionDrafts = loadSessionDrafts();
+    let sessionLastMessageSentAt = loadSessionLastMessageSentAt();
     return {
         settings,
         settingsVersion: version,
@@ -407,6 +413,7 @@ export const storage = create<StorageState>()((set, get) => {
             // Load drafts if sessions are empty (initial load)
             const isInitialLoad = Object.keys(state.sessions).length === 0;
             const savedDrafts = isInitialLoad ? sessionDrafts : {};
+            const savedLastMessageSentAt = isInitialLoad ? sessionLastMessageSentAt : {};
 
             // Merge new sessions with existing ones
             const mergedSessions: Record<string, Session> = indexSessionsById(Object.values(state.sessions));
@@ -440,6 +447,9 @@ export const storage = create<StorageState>()((set, get) => {
                 const resolvedModelMode = resolveModePick('modelMode');
                 const resolvedEffortLevel = resolveModePick('effortLevel');
 
+                // Local activity timestamp — preserve in-memory value, else restore from MMKV.
+                const resolvedLastMessageSentAt = state.sessions[session.id]?.lastMessageSentAt ?? savedLastMessageSentAt[session.id];
+
                 mergedSessions[session.id] = {
                     ...session,
                     presence,
@@ -447,6 +457,7 @@ export const storage = create<StorageState>()((set, get) => {
                     permissionMode: resolvedPermissionMode,
                     modelMode: resolvedModelMode,
                     effortLevel: resolvedEffortLevel,
+                    lastMessageSentAt: resolvedLastMessageSentAt,
                 };
             });
 
@@ -473,7 +484,7 @@ export const storage = create<StorageState>()((set, get) => {
 
             // Sort both arrays by last activity or creation date (newest first), per user setting
             const sortKey = get().settings.sortSessionsByActivity
-                ? (s: Session) => s.updatedAt
+                ? (s: Session) => s.lastMessageSentAt ?? s.createdAt
                 : (s: Session) => s.createdAt;
             activeSessions.sort((a, b) => sortKey(b) - sortKey(a));
             inactiveSessions.sort((a, b) => sortKey(b) - sortKey(a));
@@ -1032,6 +1043,34 @@ export const storage = create<StorageState>()((set, get) => {
                         ...(patch.effortLevel !== undefined && { effortLevel: patch.effortLevel }),
                     }
                 }
+            };
+        }),
+        markSessionMessageSent: (sessionId: string) => set((state) => {
+            const session = state.sessions[sessionId];
+            if (!session) return state;
+
+            const updatedSessions = {
+                ...state.sessions,
+                [sessionId]: {
+                    ...session,
+                    lastMessageSentAt: Date.now()
+                }
+            };
+
+            // Persist so activity ordering survives app restart.
+            const allTimestamps: Record<string, number> = {};
+            Object.entries(updatedSessions).forEach(([id, sess]) => {
+                if (sess.lastMessageSentAt) {
+                    allTimestamps[id] = sess.lastMessageSentAt;
+                }
+            });
+            saveSessionLastMessageSentAt(allTimestamps);
+
+            // Rebuild list view data — this timestamp drives activity-based sort.
+            return {
+                ...state,
+                sessions: updatedSessions,
+                sessionListViewData: buildSessionListViewData(updatedSessions)
             };
         }),
         getSessionPathKey: (sessionId: string): string | null => {

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -274,6 +274,7 @@ export interface Session {
     permissionMode?: string | null; // Permission pick; local mirror of synced metadata.permissionMode (#1492)
     modelMode?: string | null; // Model pick; local mirror of synced metadata.modelMode (#1492)
     effortLevel?: string | null; // Effort pick; local mirror of synced metadata.effortLevel (#1492)
+    lastMessageSentAt?: number; // Local timestamp of last user-sent message, not synced to server; used for activity-based sort
     // IMPORTANT: latestUsage is extracted from reducerState.latestUsage after message processing.
     // We store it directly on Session to ensure it's available immediately on load.
     // Do NOT store reducerState itself on Session - it's mutable and should only exist in SessionMessages.

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -749,6 +749,10 @@ class Sync {
         });
         trackMessageSent(source, session.metadata);
 
+        // Stamp local activity time so the (opt-in) activity sort bubbles this session
+        // up on user action only — not on background agent output.
+        storage.getState().markSessionMessageSent(sessionId);
+
         this.getSendSync(sessionId).invalidate();
         this.maybeStartBackgroundSendWatchdog();
     }


### PR DESCRIPTION
## Problem

Follow-up to #1440. That PR added an opt-in "sort sessions by activity" mode, but it sorts on `session.updatedAt` — which bumps on **every** background agent update. With several sessions streaming at once, the list reorders continuously and jumps under the user (the most active background session keeps stealing the top spot). It makes the sidebar unusable while multiple agents are running.

## Fix

Sort on **the last user-sent message time**, not `updatedAt`. Background output no longer reorders the list — a session only moves to the top when *you* act on it (send a message).

- New local-only `Session.lastMessageSentAt`, stamped in `sync.sendMessage` via a new `markSessionMessageSent` action.
- Both sort sites use `lastMessageSentAt ?? createdAt` when `sortSessionsByActivity` is on (falls back to creation order for sessions you haven't messaged yet).
- Persisted to MMKV (like drafts / model modes) so ordering survives an app restart.
- Not synced to the server; behavior stays behind the existing default-off `sortSessionsByActivity` setting.
- `deleteSession` now also clears the session's `lastMessageSentAt` from MMKV (matching how it already clears drafts / model modes / effort levels), and passes `unreadSessionIds` when rebuilding the list so remaining sessions keep their unread badges.

## Why `lastMessageSentAt` and not `updatedAt`

`updatedAt` reflects *any* change including streamed agent tokens, so it's inherently high-frequency and shared across all live sessions. "Most recently used" — which is what the sort is trying to express — is really "most recently *acted on* by the user", and that only changes on send. This keeps the list stable during heavy multi-session streaming.

## Testing

`pnpm --filter happy-app typecheck` passes; `pnpm --filter happy-app test` → 682 pass (1 unrelated pre-existing `settings.spec` snapshot failure on the base branch). Behavioral repro (list stops jumping while multiple sessions stream) is best seen live — happy to record a clip if useful.

