### PR TITLE
fix(app): stop pending-settings loader from re-injecting schema defaults

### DIFF
--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -50,7 +50,15 @@ export function loadPendingSettings(): Partial<Settings> {
     if (pending) {
         try {
             const parsed = JSON.parse(pending);
-            return SettingsSchema.partial().parse(parsed);
+            const validated = SettingsSchema.partial().parse(parsed);
+            // partial().parse() re-injects .default() fields (e.g. a blank agentDefaultOverrides) that were never pending and would clobber synced values — keep only persisted keys.
+            const result: Partial<Settings> = {};
+            Object.keys(parsed).forEach(key => {
+                if (key in validated) {
+                    (result as any)[key] = (validated as any)[key];
+                }
+            });
+            return result;
         } catch (e) {
             console.error('Failed to parse pending settings', e);
             return {};


### PR DESCRIPTION
## Problem

Agent defaults set on **Settings → Agents** (`agentDefaultOverrides` — permission/model/effort per agent) get silently wiped back to code defaults on any cold start, most visibly after an app update. The value is intact on disk and on the server, yet the app overwrites the server copy with `{}`, which every device then pulls.

Related to #1450 (consolidates #648, #625): new sessions seed their defaults from `agentDefaultOverrides`, so wiping it is one root cause there.

## Root cause

`loadPendingSettings()` returns `SettingsSchema.partial().parse(parsed)`. `partial()` makes fields optional but doesn't strip their Zod `.default()`, so the parse **re-injects** defaulted fields (`schemaVersion`, `agentDefaultOverrides`, `dismissedCLIWarnings`) that were never pending. The blank `{}` re-enters the pending queue every launch; the next write applies it over the real value, `settingsToSyncPayload` strips the emptied field, and the POST replaces the server blob without it — wiping it everywhere.

## Fix

Keep only the keys actually present in the stored pending blob:

```diff
-            return SettingsSchema.partial().parse(parsed);
+            const validated = SettingsSchema.partial().parse(parsed);
+            // partial().parse() re-injects .default() fields (e.g. a blank agentDefaultOverrides) that were never pending and would clobber synced values — keep only persisted keys.
+            const result: Partial<Settings> = {};
+            Object.keys(parsed).forEach(key => {
+                if (key in validated) {
+                    (result as any)[key] = (validated as any)[key];
+                }
+            });
+            return result;
```

A genuine change (including "Clear Overrides", which stores `{}`) is preserved, since that key is present.

## Test Plan

- `pnpm --dir packages/happy-app typecheck`
- Device build: defaults survive repeated cold starts (previously wiped each time).
