### PR TITLE
fix: reversed merge order in tool inputs, dead while loop in useHappyAction

### DIFF
--- a/packages/happy-app/sources/hooks/useHappyAction.ts
+++ b/packages/happy-app/sources/hooks/useHappyAction.ts
@@ -13,27 +13,12 @@ export function useHappyAction(action: () => Promise<void>) {
         setLoading(true);
         (async () => {
             try {
-                while (true) {
-                    try {
-                        await action();
-                        break;
-                    } catch (e) {
-                        if (e instanceof HappyError) {
-                            // if (e.canTryAgain) {
-                            //     Modal.alert('Error', e.message, [{ text: 'Try again' }, { text: 'Cancel', style: 'cancel' }]) 
-                            //         break;
-                            //     }
-                            // } else {
-                            //     await alert('Error', e.message, [{ text: 'OK', style: 'cancel' }]);
-                            //     break;
-                            // }
-                            Modal.alert('Error', e.message, [{ text: 'OK', style: 'cancel' }]);
-                            break;
-                        } else {
-                            Modal.alert('Error', 'Unknown error', [{ text: 'OK', style: 'cancel' }]);
-                            break;
-                        }
-                    }
+                await action();
+            } catch (e) {
+                if (e instanceof HappyError) {
+                    Modal.alert('Error', e.message, [{ text: 'OK', style: 'cancel' }]);
+                } else {
+                    Modal.alert('Error', 'Unknown error', [{ text: 'OK', style: 'cancel' }]);
                 }
             } finally {
                 loadingRef.current = false;

--- a/packages/happy-app/sources/sync/reducer/reducer.ts
+++ b/packages/happy-app/sources/sync/reducer/reducer.ts
@@ -188,7 +188,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function mergeToolInputs(existingInput: unknown, nextInput: unknown): unknown {
     if (isRecord(existingInput) && isRecord(nextInput)) {
-        return { ...nextInput, ...existingInput };
+        return { ...existingInput, ...nextInput };
     }
     return nextInput ?? existingInput;
 }


### PR DESCRIPTION
Two bugs:

- \`mergeToolInputs\` in the reducer had \`{ ...nextInput, ...existingInput }\` which means existing (old) values always overwrite the incoming update. Tool call arguments would display stale data whenever an update arrived with corrected parameters. Reversed to \`{ ...existingInput, ...nextInput }\` so new values win.

- \`useHappyAction\` had a \`while (true)\` loop wrapping the try-catch, but every code path (success, HappyError, unknown error) breaks immediately. The retry UI that was originally in there is commented out. Removed the dead loop to keep the code straightforward.