### PR TITLE
fix(codex): preserve configured MCP servers

### DIFF
--- a/packages/happy-cli/src/codex/codexMcpConfig.test.ts
+++ b/packages/happy-cli/src/codex/codexMcpConfig.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { codexMcpListEntriesToThreadConfig } from './codexMcpConfig';
+
+describe('codexMcpListEntriesToThreadConfig', () => {
+    it('converts enabled HTTP MCP servers', () => {
+        expect(codexMcpListEntriesToThreadConfig([
+            {
+                name: 'paper',
+                enabled: true,
+                transport: {
+                    type: 'streamable_http',
+                    url: 'http://127.0.0.1:29979/mcp',
+                    bearer_token_env_var: null,
+                    http_headers: null,
+                    env_http_headers: null,
+                },
+                startup_timeout_sec: 3,
+                tool_timeout_sec: 30,
+            },
+        ])).toEqual({
+            paper: {
+                url: 'http://127.0.0.1:29979/mcp',
+                startup_timeout_sec: 3,
+                tool_timeout_sec: 30,
+            },
+        });
+    });
+
+    it('converts stdio MCP servers and skips disabled servers', () => {
+        expect(codexMcpListEntriesToThreadConfig([
+            {
+                name: 'local',
+                enabled: true,
+                transport: {
+                    type: 'stdio',
+                    command: 'node',
+                    args: ['server.mjs'],
+                    env: { TOKEN: 'x' },
+                },
+            },
+            {
+                name: 'off',
+                enabled: false,
+                transport: {
+                    type: 'stdio',
+                    command: 'node',
+                },
+            },
+        ])).toEqual({
+            local: {
+                command: 'node',
+                args: ['server.mjs'],
+                env: { TOKEN: 'x' },
+            },
+        });
+    });
+});

--- a/packages/happy-cli/src/codex/codexMcpConfig.ts
+++ b/packages/happy-cli/src/codex/codexMcpConfig.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from 'node:child_process';
+import { logger } from '@/ui/logger';
+
+type CodexMcpListEntry = {
+    name?: unknown;
+    enabled?: unknown;
+    transport?: unknown;
+    startup_timeout_sec?: unknown;
+    tool_timeout_sec?: unknown;
+};
+
+type CodexMcpTransport = Record<string, unknown>;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const items = value.filter((item): item is string => typeof item === 'string');
+    return items.length === value.length ? items : undefined;
+}
+
+function asStringRecord(value: unknown): Record<string, string> | undefined {
+    const record = asRecord(value);
+    if (!record) return undefined;
+
+    const entries = Object.entries(record).filter((entry): entry is [string, string] => (
+        typeof entry[1] === 'string'
+    ));
+    return entries.length === Object.keys(record).length ? Object.fromEntries(entries) : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function extractJsonArray(output: string): unknown {
+    const start = output.indexOf('[');
+    const end = output.lastIndexOf(']');
+    if (start < 0 || end < start) {
+        throw new Error('No JSON array found in `codex mcp list --json` output');
+    }
+    return JSON.parse(output.slice(start, end + 1));
+}
+
+export function codexMcpListEntriesToThreadConfig(entries: unknown): Record<string, unknown> {
+    if (!Array.isArray(entries)) return {};
+
+    const mcpServers: Record<string, unknown> = {};
+
+    for (const entry of entries as CodexMcpListEntry[]) {
+        const name = asString(entry.name);
+        if (!name || entry.enabled === false) continue;
+
+        const transport = asRecord(entry.transport);
+        const server = transport ? codexMcpTransportToThreadConfig(transport) : null;
+        if (!server) continue;
+
+        const startupTimeout = asNumber(entry.startup_timeout_sec);
+        if (startupTimeout !== undefined) {
+            server.startup_timeout_sec = startupTimeout;
+        }
+
+        const toolTimeout = asNumber(entry.tool_timeout_sec);
+        if (toolTimeout !== undefined) {
+            server.tool_timeout_sec = toolTimeout;
+        }
+
+        mcpServers[name] = server;
+    }
+
+    return mcpServers;
+}
+
+function codexMcpTransportToThreadConfig(transport: CodexMcpTransport): Record<string, unknown> | null {
+    const type = asString(transport.type);
+    const config: Record<string, unknown> = {};
+
+    if (type === 'stdio') {
+        const command = asString(transport.command);
+        if (!command) return null;
+
+        config.command = command;
+        const args = asStringArray(transport.args);
+        if (args) config.args = args;
+
+        const env = asStringRecord(transport.env);
+        if (env) config.env = env;
+
+        return config;
+    }
+
+    if (type === 'streamable_http' || type === 'sse') {
+        const url = asString(transport.url);
+        if (!url) return null;
+
+        config.url = url;
+
+        const bearerTokenEnvVar = asString(transport.bearer_token_env_var);
+        if (bearerTokenEnvVar) config.bearer_token_env_var = bearerTokenEnvVar;
+
+        const httpHeaders = asStringRecord(transport.http_headers);
+        if (httpHeaders) config.http_headers = httpHeaders;
+
+        const envHttpHeaders = asStringRecord(transport.env_http_headers);
+        if (envHttpHeaders) config.env_http_headers = envHttpHeaders;
+
+        return config;
+    }
+
+    return null;
+}
+
+export function readConfiguredCodexMcpServers(): Record<string, unknown> {
+    try {
+        const output = execFileSync('codex', ['mcp', 'list', '--json'], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true,
+        });
+        return codexMcpListEntriesToThreadConfig(extractJsonArray(output));
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        logger.debug(`[codex] Failed to read configured MCP servers: ${reason}`);
+        return {};
+    }
+}

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -54,6 +54,7 @@ import {
     parseCodexGoalCommand,
     type CodexGoalCommand,
 } from './codexGoalStatus';
+import { readConfiguredCodexMcpServers } from './codexMcpConfig';
 
 /**
  * Extracts a human-readable error from a codex task_complete/turn_aborted event.
@@ -792,6 +793,7 @@ export async function runCodex(opts: {
     // not be visible to the model, and the model would improvise with shell echoes.
     const bridgeEntrypoint = join(projectPath(), 'bin', 'happy-mcp.mjs');
     const mcpServers = {
+        ...readConfiguredCodexMcpServers(),
         happy: {
             command: process.execPath,
             args: ['--no-warnings', '--no-deprecation', bridgeEntrypoint, '--url', happyServer.url]


### PR DESCRIPTION
## Summary
- merge existing Codex MCP servers into Happy Codex thread config
- keep Happy's built-in MCP server registered as `happy`
- add conversion tests for HTTP and stdio MCP entries

## Tests
- pnpm --filter happy exec vitest run src/codex/codexMcpConfig.test.ts --project unit
- pnpm --filter happy typecheck
- pnpm --filter happy build