### PR TITLE
fix(app): restore permission button selected-state legibility

### DIFF
--- a/packages/happy-app/sources/components/tools/PermissionFooter.tsx
+++ b/packages/happy-app/sources/components/tools/PermissionFooter.tsx
@@ -215,11 +215,11 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
         },
         buttonSelected: {
             backgroundColor: 'transparent',
-            borderColor: theme.colors.textSecondary,
+            borderColor: theme.colors.text,
             opacity: 1,
         },
         buttonInactive: {
-            opacity: 0.62,
+            opacity: 0.25,
         },
         buttonContent: {
             flexDirection: 'row',
@@ -250,7 +250,7 @@ export const PermissionFooter: React.FC<PermissionFooterProps> = ({ permission, 
         },
         buttonTextSelected: {
             color: theme.colors.text,
-            fontWeight: '500',
+            fontWeight: '700',
         },
         buttonForSession: {
             borderColor: theme.colors.textSecondary,


### PR DESCRIPTION
## Summary

A recent tool-card polish pass flattened the permission buttons, leaving the
selected and deselected states distinguished almost solely by a 0.62 → 1.0
opacity step. At a glance it's hard to tell which option registered after
tapping — you have to look closely to confirm the press was accepted. This
strengthens the existing cues while staying within the flat, monochrome
outline design.

## What changed

`PermissionFooter.tsx`, selected/inactive chip styles:

- Selected chip border → `theme.colors.text` (full contrast) instead of the
  faint `theme.colors.textSecondary`.
- Inactive chips fade further: opacity `0.62 → 0.25`, widening the gap from the
  selected chip's `1.0`.
- Selected label weight `500 → 700`.

Net effect: the chosen chip gains a crisp outline, full opacity, and heavier
text, while the others recede — so the decision reads instantly.

## Test plan

- [x] `pnpm --filter happy-app run typecheck`
- [x] Verified on a device build across Claude and Codex permission prompts
