### PR TITLE
feat(cli): render agent tool-result images inline in the app

### DIFF
--- a/packages/happy-cli/src/api/apiSession.test.ts
+++ b/packages/happy-cli/src/api/apiSession.test.ts
@@ -542,6 +542,99 @@ describe('ApiSessionClient v3 messages API migration', () => {
         expect(decryptBlob(new Uint8Array(uploadBody), blobKey)).toEqual(pngBytes);
     });
 
+    it('uploads image blocks nested inside tool results as file events', async () => {
+        const client = new ApiSessionClient('fake-token', session);
+        const pngBytes = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 4, 5, 6]);
+
+        mockAxiosPost.mockImplementation(async (url: string, payload: any) => {
+            if (url.endsWith('/attachments/request-upload')) {
+                expect(payload).toMatchObject({
+                    filename: 'tool-image-1.png',
+                });
+                expect(payload.size).toBeGreaterThan(pngBytes.length);
+                return {
+                    data: {
+                        ref: 'sessions/test-session-id/attachments/tool-image.enc',
+                        uploadUrl: 'https://server.test/v1/sessions/test-session-id/attachments/tool-image.enc',
+                        method: 'PUT',
+                    },
+                };
+            }
+
+            return {
+                data: {
+                    messages: payload.messages.map((_message: unknown, index: number) => ({
+                        id: `msg-${index + 1}`,
+                        seq: index + 1,
+                        localId: `local-${index + 1}`,
+                        createdAt: 1,
+                        updatedAt: 1,
+                    })),
+                },
+            };
+        });
+        mockAxiosPut.mockResolvedValueOnce({ data: { ok: true } });
+
+        client.sendClaudeSessionMessage({
+            type: 'user',
+            uuid: 'u-tool-1',
+            isSidechain: false,
+            isMeta: false,
+            message: {
+                role: 'user',
+                content: [
+                    {
+                        type: 'tool_result',
+                        tool_use_id: 'toolu_screenshot_1',
+                        content: [
+                            { type: 'text', text: 'Screenshot captured: 1152x648' },
+                            {
+                                type: 'image',
+                                source: {
+                                    type: 'base64',
+                                    media_type: 'image/png',
+                                    data: Buffer.from(pngBytes).toString('base64'),
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        } as any);
+
+        await waitForCheck(() => {
+            expect(mockAxiosPut).toHaveBeenCalledTimes(1);
+        });
+
+        const uploadBody = mockAxiosPut.mock.calls[0][1];
+        const blobKey = await client.getBlobKey();
+        expect(decryptBlob(new Uint8Array(uploadBody), blobKey)).toEqual(pngBytes);
+
+        const fileMessage = mockAxiosPost.mock.calls
+            .filter(([url]) => url === 'https://server.test/v3/sessions/test-session-id/messages')
+            .flatMap(([, payload]) => payload.messages as { content: string }[])
+            .map((message) => decrypt(
+                session.encryptionKey,
+                session.encryptionVariant,
+                decodeBase64(message.content),
+            ))
+            .find((decrypted: any) => decrypted?.content?.ev?.t === 'file');
+
+        expect(fileMessage).toMatchObject({
+            role: 'session',
+            content: {
+                role: 'user',
+                ev: {
+                    t: 'file',
+                    ref: 'sessions/test-session-id/attachments/tool-image.enc',
+                    name: 'tool-image-1.png',
+                    size: pngBytes.length,
+                    mimeType: 'image/png',
+                },
+            },
+        });
+    });
+
     it('sends session protocol messages through enqueueMessage with session envelope', async () => {
         const client = new ApiSessionClient('fake-token', session);
         mockAxiosPost.mockResolvedValueOnce({

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -105,6 +105,69 @@ function extensionForImageMime(mimeType: string): string {
     }
 }
 
+type ToolResultImage = {
+    toolUseId: string;
+    attachments: LocalImageAttachment[];
+};
+
+/**
+ * Extract base64 image blocks nested inside tool_result content.
+ * These are agent-generated images (e.g. screenshots from MCP tools) that
+ * should be forwarded to the app as encrypted blob attachments so they
+ * render inline in the conversation.
+ */
+function extractToolResultImages(body: RawJSONLines): ToolResultImage[] {
+    if (body.type !== 'user' || body.isMeta) {
+        return [];
+    }
+
+    const content = (body as { message?: { content?: unknown } }).message?.content;
+    if (!Array.isArray(content)) {
+        return [];
+    }
+
+    const results: ToolResultImage[] = [];
+    for (const block of content) {
+        if (!isRecord(block) || block.type !== 'tool_result' || typeof block.tool_use_id !== 'string') {
+            continue;
+        }
+        const innerContent = block.content;
+        if (!Array.isArray(innerContent)) {
+            continue;
+        }
+
+        const attachments: LocalImageAttachment[] = [];
+        for (const inner of innerContent) {
+            if (!isRecord(inner) || inner.type !== 'image') {
+                continue;
+            }
+            const source = inner.source;
+            if (!isRecord(source) || source.type !== 'base64' || typeof source.data !== 'string') {
+                continue;
+            }
+            const data = decodeBase64(source.data);
+            if (data.length === 0) {
+                continue;
+            }
+            const mimeType = typeof source.media_type === 'string' && source.media_type.startsWith('image/')
+                ? source.media_type
+                : 'image/png';
+            const index = attachments.length + 1;
+            attachments.push({
+                data,
+                mimeType,
+                name: `tool-image-${index}.${extensionForImageMime(mimeType)}`,
+            });
+        }
+
+        if (attachments.length > 0) {
+            results.push({ toolUseId: block.tool_use_id as string, attachments });
+        }
+    }
+
+    return results;
+}
+
 function extractLocalTranscriptImageAttachments(body: RawJSONLines): LocalImageAttachment[] {
     if (body.type !== 'user' || body.isMeta || body.isSidechain) {
         return [];
@@ -115,8 +178,8 @@ function extractLocalTranscriptImageAttachments(body: RawJSONLines): LocalImageA
         return [];
     }
 
-    // Tool results are user-role messages from Claude's protocol, but they
-    // represent agent tool lifecycle, not human multimodal input.
+    // Tool results are user-role messages from Claude's protocol — handled
+    // separately by extractToolResultImages, not as user multimodal input.
     if (content.some((block) => isRecord(block) && block.type === 'tool_result')) {
         return [];
     }
@@ -712,10 +775,40 @@ export class ApiSessionClient extends EventEmitter {
     }
 
     /**
+     * Upload base64 images from tool results as encrypted blobs and enqueue
+     * them as file events so the app renders them inline in the conversation.
+     */
+    private async uploadAndEnqueueToolResultImages(toolResultImages: ToolResultImage[]): Promise<void> {
+        for (const { attachments } of toolResultImages) {
+            for (const attachment of attachments) {
+                try {
+                    const envelope = await this.uploadLocalImageAttachmentEnvelope(attachment);
+                    this.enqueueSessionProtocolEnvelope(envelope);
+                } catch (error) {
+                    logger.debug('[API] Failed to upload tool result image attachment', {
+                        sessionId: this.sessionId,
+                        name: attachment.name,
+                        errorName: error instanceof Error ? error.name : typeof error,
+                    });
+                }
+            }
+        }
+    }
+
+    /**
      * Send message to session
      * @param body - Message body (can be MessageContent or raw content for agent messages)
      */
     sendClaudeSessionMessage(body: RawJSONLines) {
+        const toolResultImages = extractToolResultImages(body);
+        if (toolResultImages.length > 0) {
+            void this.uploadAndEnqueueToolResultImages(toolResultImages).catch((error) => {
+                logger.debug('[API] Unexpected error uploading tool result images', {
+                    sessionId: this.sessionId,
+                    errorName: error instanceof Error ? error.name : typeof error,
+                });
+            });
+        }
         const mapped = mapClaudeLogMessageToSessionEnvelopes(body, this.claudeSessionProtocolState);
         this.claudeSessionProtocolState.currentTurnId = mapped.currentTurnId;
         this.enqueueSessionProtocolEnvelopes(mapped.envelopes);

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -105,10 +105,35 @@ function extensionForImageMime(mimeType: string): string {
     }
 }
 
-type ToolResultImage = {
-    toolUseId: string;
-    attachments: LocalImageAttachment[];
-};
+/**
+ * Decode a single base64 `image` content block into an attachment, or null
+ * if the block is not a base64 image. `makeName` receives the resolved file
+ * extension so callers can label the attachment (e.g. `tool-image-1.png`).
+ */
+function decodeBase64ImageBlock(
+    block: unknown,
+    makeName: (extension: string) => string,
+): LocalImageAttachment | null {
+    if (!isRecord(block) || block.type !== 'image') {
+        return null;
+    }
+    const source = block.source;
+    if (!isRecord(source) || source.type !== 'base64' || typeof source.data !== 'string') {
+        return null;
+    }
+    const data = decodeBase64(source.data);
+    if (data.length === 0) {
+        return null;
+    }
+    const mimeType = typeof source.media_type === 'string' && source.media_type.startsWith('image/')
+        ? source.media_type
+        : 'image/png';
+    return {
+        data,
+        mimeType,
+        name: makeName(extensionForImageMime(mimeType)),
+    };
+}
 
 /**
  * Extract base64 image blocks nested inside tool_result content.
@@ -116,8 +141,8 @@ type ToolResultImage = {
  * should be forwarded to the app as encrypted blob attachments so they
  * render inline in the conversation.
  */
-function extractToolResultImages(body: RawJSONLines): ToolResultImage[] {
-    if (body.type !== 'user' || body.isMeta) {
+function extractToolResultImages(body: RawJSONLines): LocalImageAttachment[] {
+    if (body.type !== 'user' || body.isMeta || body.isSidechain) {
         return [];
     }
 
@@ -126,46 +151,20 @@ function extractToolResultImages(body: RawJSONLines): ToolResultImage[] {
         return [];
     }
 
-    const results: ToolResultImage[] = [];
+    const attachments: LocalImageAttachment[] = [];
     for (const block of content) {
-        if (!isRecord(block) || block.type !== 'tool_result' || typeof block.tool_use_id !== 'string') {
+        if (!isRecord(block) || block.type !== 'tool_result' || !Array.isArray(block.content)) {
             continue;
         }
-        const innerContent = block.content;
-        if (!Array.isArray(innerContent)) {
-            continue;
-        }
-
-        const attachments: LocalImageAttachment[] = [];
-        for (const inner of innerContent) {
-            if (!isRecord(inner) || inner.type !== 'image') {
-                continue;
+        for (const inner of block.content) {
+            const attachment = decodeBase64ImageBlock(inner, (ext) => `tool-image-${attachments.length + 1}.${ext}`);
+            if (attachment) {
+                attachments.push(attachment);
             }
-            const source = inner.source;
-            if (!isRecord(source) || source.type !== 'base64' || typeof source.data !== 'string') {
-                continue;
-            }
-            const data = decodeBase64(source.data);
-            if (data.length === 0) {
-                continue;
-            }
-            const mimeType = typeof source.media_type === 'string' && source.media_type.startsWith('image/')
-                ? source.media_type
-                : 'image/png';
-            const index = attachments.length + 1;
-            attachments.push({
-                data,
-                mimeType,
-                name: `tool-image-${index}.${extensionForImageMime(mimeType)}`,
-            });
-        }
-
-        if (attachments.length > 0) {
-            results.push({ toolUseId: block.tool_use_id as string, attachments });
         }
     }
 
-    return results;
+    return attachments;
 }
 
 function extractLocalTranscriptImageAttachments(body: RawJSONLines): LocalImageAttachment[] {
@@ -186,28 +185,10 @@ function extractLocalTranscriptImageAttachments(body: RawJSONLines): LocalImageA
 
     const attachments: LocalImageAttachment[] = [];
     for (const block of content) {
-        if (!isRecord(block) || block.type !== 'image') {
-            continue;
+        const attachment = decodeBase64ImageBlock(block, (ext) => `claude-image-${attachments.length + 1}.${ext}`);
+        if (attachment) {
+            attachments.push(attachment);
         }
-        const source = block.source;
-        if (!isRecord(source) || source.type !== 'base64' || typeof source.data !== 'string') {
-            continue;
-        }
-
-        const data = decodeBase64(source.data);
-        if (data.length === 0) {
-            continue;
-        }
-
-        const mimeType = typeof source.media_type === 'string' && source.media_type.startsWith('image/')
-            ? source.media_type
-            : 'image/png';
-        const index = attachments.length + 1;
-        attachments.push({
-            data,
-            mimeType,
-            name: `claude-image-${index}.${extensionForImageMime(mimeType)}`,
-        });
     }
 
     return attachments;
@@ -778,19 +759,17 @@ export class ApiSessionClient extends EventEmitter {
      * Upload base64 images from tool results as encrypted blobs and enqueue
      * them as file events so the app renders them inline in the conversation.
      */
-    private async uploadAndEnqueueToolResultImages(toolResultImages: ToolResultImage[]): Promise<void> {
-        for (const { attachments } of toolResultImages) {
-            for (const attachment of attachments) {
-                try {
-                    const envelope = await this.uploadLocalImageAttachmentEnvelope(attachment);
-                    this.enqueueSessionProtocolEnvelope(envelope);
-                } catch (error) {
-                    logger.debug('[API] Failed to upload tool result image attachment', {
-                        sessionId: this.sessionId,
-                        name: attachment.name,
-                        errorName: error instanceof Error ? error.name : typeof error,
-                    });
-                }
+    private async uploadAndEnqueueToolResultImages(attachments: LocalImageAttachment[]): Promise<void> {
+        for (const attachment of attachments) {
+            try {
+                const envelope = await this.uploadLocalImageAttachmentEnvelope(attachment);
+                this.enqueueSessionProtocolEnvelope(envelope);
+            } catch (error) {
+                logger.debug('[API] Failed to upload tool result image attachment', {
+                    sessionId: this.sessionId,
+                    name: attachment.name,
+                    errorName: error instanceof Error ? error.name : typeof error,
+                });
             }
         }
     }


### PR DESCRIPTION
## Author note

I have been wanting this feature myself for a while and wondered why it wasn't working. So I was browsing with Claude through the open issues and tried to work backwards to find out what was missing. That's how we got to the solution presented in this PR. I admit I don't actually know TypeScript, but I did run a code-review, tested locally, and am happy to discuss any changes or concerns!

Tool results returned by the agent can contain base64 `image` content blocks — for example screenshots captured by MCP tools (Godot capture, browser automation, data-viz renderers). Previously these images never appeared in the app: the session protocol mapper emitted only a `tool-call-end` event for `tool_result` blocks and dropped any nested image content, so no `file` event was ever produced.

This adds support for surfacing those images inline in the conversation, which is exactly what folks have been asking for in #128 (and the "I want to see UI-test screenshots on mobile" comment there).

## Changes

All in `packages/happy-cli/src/api/apiSession.ts`:

- `extractToolResultImages()` — walks `tool_result` content and pulls out base64 `image` blocks (mirrors the existing `extractLocalTranscriptImageAttachments` helper).
- `uploadAndEnqueueToolResultImages()` — uploads each image as an encrypted attachment blob via the existing `uploadLocalImageAttachmentEnvelope` path and enqueues a `file` event.
- `sendClaudeSessionMessage()` — fires the upload as fire-and-forget when a message carries tool-result images, then proceeds through the unchanged synchronous mapper path. No changes to the mapper or to any callers.

The images ride the same end-to-end-encrypted blob pipeline already used for user→agent uploads, so no new server or crypto surface is introduced. Because the upload is async, a file event lands just after its `tool-call-end` rather than nested inside the tool result.

## Testing

- `tsc --noEmit` passes.
- Added a unit test in `apiSession.test.ts` that drives `sendClaudeSessionMessage` with a `tool_result` containing a base64 PNG and asserts the encrypted blob is uploaded and a `file` envelope with the right ref/name/size/mimeType is enqueued.
- Verified live: ran a Godot screenshot through a locally-linked build and confirmed the image renders inline in the app on device.

## Minor Notes

Display is not gated by `expImageUpload` — that flag only covers user→agent uploads. If gating agent→user images is desired, happy to add a flag check.

Closes #128