### PR TITLE
fix(cli): honor HAPPY_CLAUDE_PATH in SDK-driven sessions

### DIFF
--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -3,6 +3,7 @@
  * Maps internal QueryOptions to official SDK Options
  */
 
+import { existsSync } from 'node:fs'
 import { query as sdkQuery, type Options, type Query } from '@anthropic-ai/claude-agent-sdk'
 import type { QueryOptions, QueryPrompt, SDKMessage } from './types'
 import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
@@ -44,6 +45,16 @@ export function query(params: { prompt: QueryPrompt; options?: QueryOptions }): 
         strictMcpConfig: opts?.strictMcpConfig,
         sessionId: undefined,
         effort: opts?.effort,
+    }
+
+    // Respect the explicit Claude Code binary override. The local and remote
+    // launchers already honor HAPPY_CLAUDE_PATH (see
+    // scripts/claude_version_utils.cjs); without this, SDK-driven sessions
+    // always run the SDK's bundled executable, which can be older than the
+    // user's installed Claude Code and out of sync with local sessions.
+    const claudePathOverride = process.env.HAPPY_CLAUDE_PATH
+    if (claudePathOverride && existsSync(claudePathOverride)) {
+        sdkOptions.pathToClaudeCodeExecutable = claudePathOverride
     }
 
     // Map abort signal -> AbortController


### PR DESCRIPTION
## Problem

The local and remote launchers resolve the Claude Code binary through `getClaudeCliPath()`, which respects the `HAPPY_CLAUDE_PATH` override (`scripts/claude_version_utils.cjs`, priority: `HAPPY_CLAUDE_PATH` > PATH > npm > Bun > Homebrew > Native).

SDK-driven sessions, however, go through `src/claude/sdk/query.ts`, which calls the agent SDK `query()` without `pathToClaudeCodeExecutable` — so they always run the SDK's **bundled** executable and silently ignore `HAPPY_CLAUDE_PATH`.

When the bundled executable lags behind the user's installed Claude Code, sessions spawned through the SDK behave differently from local sessions on the same machine. Concrete example I hit while self-hosting: local (tmux) sessions ran my installed Claude Code just fine, while SDK-spawned sessions rejected a newer model alias with `400 The provided model identifier is invalid`, because the bundled binary was older. There was no supported way to point the SDK path at the right binary.

## Fix

In the `QueryOptions -> Options` mapping, pass `HAPPY_CLAUDE_PATH` through as `pathToClaudeCodeExecutable` when it points to an existing file — matching launcher behavior. No behavior change when the env var is unset.

## Testing

- `pnpm --filter happy typecheck` — clean
- `pnpm --filter happy build` — clean
- `npx vitest run src/claude/claudeRemote.test.ts` — 2/2 passed
- Manually verified on a self-hosted setup that setting `HAPPY_CLAUDE_PATH` makes SDK sessions spawn the overridden binary (previously bundled one).