### PR TITLE
feat: rename sessions from the app

### DIFF
--- a/packages/happy-app/sources/app/(app)/session/[id]/info.tsx
+++ b/packages/happy-app/sources/app/(app)/session/[id]/info.tsx
@@ -11,7 +11,7 @@ import { useSession, useIsDataReady } from '@/sync/storage';
 import { getSessionName, useSessionStatus, formatOSPlatform, formatPathRelativeToHome, getSessionAvatarId, getResumeCommand } from '@/utils/sessionUtils';
 import * as Clipboard from 'expo-clipboard';
 import { Modal } from '@/modal';
-import { sessionArchive, sessionKill, sessionDelete } from '@/sync/ops';
+import { sessionArchive, sessionKill, sessionDelete, sessionRename } from '@/sync/ops';
 import { maybeCleanupWorktree } from '@/hooks/useWorktreeCleanup';
 import { useUnistyles } from 'react-native-unistyles';
 import { layout } from '@/components/layout';
@@ -23,6 +23,7 @@ import { useHappyAction } from '@/hooks/useHappyAction';
 import { useSessionQuickActions } from '@/hooks/useSessionQuickActions';
 import { copySessionMetadataToClipboard, copySessionMetadataAndLogsToClipboard } from '@/utils/copySessionMetadataToClipboard';
 import { HappyError } from '@/utils/errors';
+import { resolveSessionRename } from '@/utils/sessionRename';
 
 // Animated status dot component
 function StatusDot({ color, isPulsing, size = 8 }: { color: string; isPulsing?: boolean; size?: number }) {
@@ -214,6 +215,37 @@ function SessionInfoContent({ session }: { session: Session }) {
         );
     }, [performDelete]);
 
+    // Rename the session. The new title is applied by the CLI, which writes it
+    // into the underlying Claude Code session, so it requires an online session.
+    // Note: a later agent-driven `change_title` can still overwrite a manual
+    // rename — the summary is a single shared field, by design.
+    const [renamingSession, performRename] = useHappyAction(async () => {
+        if (!sessionStatus.isConnected) {
+            Modal.alert(t('sessionInfo.renameSession'), t('sessionInfo.renameSessionOffline'));
+            return;
+        }
+        const currentTitle = session.metadata?.summary?.text ?? '';
+        const input = await Modal.prompt(
+            t('sessionInfo.renameSession'),
+            undefined,
+            {
+                defaultValue: currentTitle,
+                placeholder: t('sessionInfo.renameSessionPlaceholder'),
+                confirmText: t('common.save'),
+                cancelText: t('common.cancel'),
+            },
+        );
+        const title = resolveSessionRename(input, currentTitle);
+        if (title === null) {
+            return;
+        }
+        try {
+            await sessionRename(session.id, title);
+        } catch {
+            throw new HappyError(t('sessionInfo.renameSessionFailed'), false);
+        }
+    });
+
     const formatDate = useCallback((timestamp: number) => {
         return new Date(timestamp).toLocaleString();
     }, []);
@@ -348,6 +380,13 @@ function SessionInfoContent({ session }: { session: Session }) {
 
                 {/* Quick Actions */}
                 <ItemGroup title={t('sessionInfo.quickActions')}>
+                    <Item
+                        title={t('sessionInfo.renameSession')}
+                        subtitle={t('sessionInfo.renameSessionSubtitle')}
+                        icon={<Ionicons name="create-outline" size={29} color="#007AFF" />}
+                        onPress={performRename}
+                        loading={renamingSession}
+                    />
                     {session.metadata?.machineId && (
                         <Item
                             title={t('sessionInfo.viewMachine')}

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -30,6 +30,16 @@ interface SessionGoalActionRequest {
     objective?: string;
 }
 
+// Rename (title) operation types
+interface SessionChangeTitleRequest {
+    title: string;
+}
+
+interface SessionChangeTitleResponse {
+    success: boolean;
+    error?: string;
+}
+
 // Bash operation types
 interface SessionBashRequest {
     command: string;
@@ -603,6 +613,25 @@ export async function sessionGoalAction(
         action,
         ...(objective !== undefined ? { objective } : {}),
     } satisfies SessionGoalActionRequest);
+}
+
+/**
+ * Rename a session by changing its title.
+ *
+ * The rename is applied by the CLI, which writes it into the underlying Claude
+ * Code session (the `summary` record) and propagates it back as the session's
+ * metadata summary — the same value {@link getSessionName} renders. Requires the
+ * session to be online; throws if it is offline or the CLI rejects the title.
+ */
+export async function sessionRename(sessionId: string, title: string): Promise<void> {
+    const response = await apiSocket.sessionRPC<SessionChangeTitleResponse, SessionChangeTitleRequest>(
+        sessionId,
+        'changeTitle',
+        { title },
+    );
+    if (!response.success) {
+        throw new Error(response.error || 'Failed to rename session');
+    }
 }
 
 /**

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -403,6 +403,11 @@ export const en = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Version ${currentVersion} installed. Update to ${requiredVersion} or later`,
         updateCliInstructions: 'Please run npm install -g happy@latest',
+        renameSession: 'Rename Session',
+        renameSessionSubtitle: 'Change the chat title',
+        renameSessionPlaceholder: 'Enter a title',
+        renameSessionOffline: 'Connect to this session to rename it',
+        renameSessionFailed: 'Failed to rename session',
         deleteSession: 'Delete Session',
         deleteSessionSubtitle: 'Permanently remove this session',
         deleteSessionConfirm: 'Delete Session Permanently?',

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -389,6 +389,11 @@ export const ca: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Versió ${currentVersion} instal·lada. Actualitzeu a ${requiredVersion} o posterior`,
         updateCliInstructions: 'Si us plau executeu npm install -g happy@latest',
+        renameSession: 'Reanomena la sessió',
+        renameSessionSubtitle: 'Canvia el títol del xat',
+        renameSessionPlaceholder: 'Introdueix un títol',
+        renameSessionOffline: 'Connecta\'t a aquesta sessió per reanomenar-la',
+        renameSessionFailed: 'Ha fallat reanomenar la sessió',
         deleteSession: 'Elimina la sessió',
         deleteSessionSubtitle: 'Elimina permanentment aquesta sessió',
         deleteSessionConfirm: 'Eliminar la sessió permanentment?',

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -403,6 +403,11 @@ export const en: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Version ${currentVersion} installed. Update to ${requiredVersion} or later`,
         updateCliInstructions: 'Please run npm install -g happy@latest',
+        renameSession: 'Rename Session',
+        renameSessionSubtitle: 'Change the chat title',
+        renameSessionPlaceholder: 'Enter a title',
+        renameSessionOffline: 'Connect to this session to rename it',
+        renameSessionFailed: 'Failed to rename session',
         deleteSession: 'Delete Session',
         deleteSessionSubtitle: 'Permanently remove this session',
         deleteSessionConfirm: 'Delete Session Permanently?',

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -389,6 +389,11 @@ export const es: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Versión ${currentVersion} instalada. Actualice a ${requiredVersion} o posterior`,
         updateCliInstructions: 'Por favor ejecute npm install -g happy@latest',
+        renameSession: 'Renombrar sesión',
+        renameSessionSubtitle: 'Cambiar el título del chat',
+        renameSessionPlaceholder: 'Escribe un título',
+        renameSessionOffline: 'Conéctate a esta sesión para renombrarla',
+        renameSessionFailed: 'Error al renombrar la sesión',
         deleteSession: 'Eliminar sesión',
         deleteSessionSubtitle: 'Eliminar permanentemente esta sesión',
         deleteSessionConfirm: '¿Eliminar sesión permanentemente?',

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -387,6 +387,11 @@ export const it: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Versione ${currentVersion} installata. Aggiorna a ${requiredVersion} o successiva`,
         updateCliInstructions: 'Esegui npm install -g happy@latest',
+        renameSession: 'Rinomina sessione',
+        renameSessionSubtitle: 'Cambia il titolo della chat',
+        renameSessionPlaceholder: 'Inserisci un titolo',
+        renameSessionOffline: 'Connettiti a questa sessione per rinominarla',
+        renameSessionFailed: 'Impossibile rinominare la sessione',
         deleteSession: 'Elimina sessione',
         deleteSessionSubtitle: 'Rimuovi definitivamente questa sessione',
         deleteSessionConfirm: 'Eliminare definitivamente la sessione?',

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -390,6 +390,11 @@ export const ja: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `バージョン ${currentVersion} がインストールされています。${requiredVersion} 以降に更新してください`,
         updateCliInstructions: 'npm install -g happy@latest を実行してください',
+        renameSession: 'セッションの名前を変更',
+        renameSessionSubtitle: 'チャットのタイトルを変更',
+        renameSessionPlaceholder: 'タイトルを入力',
+        renameSessionOffline: '名前を変更するにはこのセッションに接続してください',
+        renameSessionFailed: 'セッションの名前の変更に失敗しました',
         deleteSession: 'セッションを削除',
         deleteSessionSubtitle: 'このセッションを完全に削除',
         deleteSessionConfirm: 'セッションを完全に削除しますか？',

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -406,6 +406,11 @@ export const pl: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Zainstalowana wersja ${currentVersion}. Zaktualizuj do ${requiredVersion} lub nowszej`,
         updateCliInstructions: 'Proszę uruchomić npm install -g happy@latest',
+        renameSession: 'Zmień nazwę sesji',
+        renameSessionSubtitle: 'Zmień tytuł czatu',
+        renameSessionPlaceholder: 'Wprowadź tytuł',
+        renameSessionOffline: 'Połącz się z tą sesją, aby zmienić jej nazwę',
+        renameSessionFailed: 'Nie udało się zmienić nazwy sesji',
         deleteSession: 'Usuń sesję',
         deleteSessionSubtitle: 'Trwale usuń tę sesję',
         deleteSessionConfirm: 'Usunąć sesję na stałe?',

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -388,6 +388,11 @@ export const pt: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Versão ${currentVersion} instalada. Atualize para ${requiredVersion} ou posterior`,
         updateCliInstructions: 'Por favor execute npm install -g happy@latest',
+        renameSession: 'Renomear sessão',
+        renameSessionSubtitle: 'Alterar o título do chat',
+        renameSessionPlaceholder: 'Digite um título',
+        renameSessionOffline: 'Conecte-se a esta sessão para renomeá-la',
+        renameSessionFailed: 'Falha ao renomear sessão',
         deleteSession: 'Excluir sessão',
         deleteSessionSubtitle: 'Remover permanentemente esta sessão',
         deleteSessionConfirm: 'Excluir sessão permanentemente?',

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -347,6 +347,11 @@ export const ru: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `Установлена версия ${currentVersion}. Обновите до ${requiredVersion} или новее`,
         updateCliInstructions: 'Пожалуйста, выполните npm install -g happy@latest',
+        renameSession: 'Переименовать сессию',
+        renameSessionSubtitle: 'Изменить название чата',
+        renameSessionPlaceholder: 'Введите название',
+        renameSessionOffline: 'Подключитесь к этой сессии, чтобы переименовать её',
+        renameSessionFailed: 'Не удалось переименовать сессию',
         deleteSession: 'Удалить сессию',
         deleteSessionSubtitle: 'Удалить эту сессию навсегда',
         deleteSessionConfirm: 'Удалить сессию навсегда?',

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -390,6 +390,11 @@ export const zhHans: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `已安装版本 ${currentVersion}。请更新到 ${requiredVersion} 或更高版本`,
         updateCliInstructions: '请运行 npm install -g happy@latest',
+        renameSession: '重命名会话',
+        renameSessionSubtitle: '更改聊天标题',
+        renameSessionPlaceholder: '输入标题',
+        renameSessionOffline: '请连接到此会话后再重命名',
+        renameSessionFailed: '重命名会话失败',
         deleteSession: '删除会话',
         deleteSessionSubtitle: '永久删除此会话',
         deleteSessionConfirm: '永久删除会话？',

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -389,6 +389,11 @@ export const zhHant: TranslationStructure = {
         cliVersionOutdatedMessage: ({ currentVersion, requiredVersion }: { currentVersion: string; requiredVersion: string }) =>
             `已安裝版本 ${currentVersion}。請更新到 ${requiredVersion} 或更高版本`,
         updateCliInstructions: '請執行 npm install -g happy@latest',
+        renameSession: '重新命名工作階段',
+        renameSessionSubtitle: '變更聊天標題',
+        renameSessionPlaceholder: '輸入標題',
+        renameSessionOffline: '請連線到此工作階段以重新命名',
+        renameSessionFailed: '重新命名工作階段失敗',
         deleteSession: '刪除工作階段',
         deleteSessionSubtitle: '永久刪除此工作階段',
         deleteSessionConfirm: '永久刪除工作階段？',

--- a/packages/happy-app/sources/utils/sessionRename.test.ts
+++ b/packages/happy-app/sources/utils/sessionRename.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSessionRename } from './sessionRename';
+
+describe('resolveSessionRename', () => {
+    it('returns null when the prompt was cancelled', () => {
+        expect(resolveSessionRename(null, 'Old title')).toBeNull();
+    });
+
+    it('returns null for empty or whitespace-only input', () => {
+        expect(resolveSessionRename('', 'Old title')).toBeNull();
+        expect(resolveSessionRename('   ', 'Old title')).toBeNull();
+    });
+
+    it('returns null when the trimmed title is unchanged', () => {
+        expect(resolveSessionRename('Old title', 'Old title')).toBeNull();
+        expect(resolveSessionRename('  Old title  ', 'Old title')).toBeNull();
+    });
+
+    it('returns the trimmed title when it differs', () => {
+        expect(resolveSessionRename('  New title  ', 'Old title')).toBe('New title');
+        expect(resolveSessionRename('New title', '')).toBe('New title');
+    });
+});

--- a/packages/happy-app/sources/utils/sessionRename.ts
+++ b/packages/happy-app/sources/utils/sessionRename.ts
@@ -1,0 +1,18 @@
+/**
+ * Decides what to do with the raw text a user entered in the rename prompt.
+ *
+ * Returns the trimmed title to apply, or `null` when the rename should be
+ * skipped: the prompt was cancelled (`input === null`), the input was empty /
+ * whitespace-only, or it is unchanged from the current title. Keeping this pure
+ * lets the UI stay thin and makes the rename decision easy to unit test.
+ */
+export function resolveSessionRename(input: string | null, currentTitle: string): string | null {
+    if (input === null) {
+        return null; // prompt cancelled
+    }
+    const trimmed = input.trim();
+    if (trimmed.length === 0 || trimmed === currentTitle.trim()) {
+        return null; // empty or unchanged
+    }
+    return trimmed;
+}

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -10,6 +10,7 @@ import { randomUUID } from 'node:crypto';
 import { AsyncLock } from '@/utils/lock';
 import { deriveKey } from '@/utils/deriveKey';
 import { RpcHandlerManager } from './rpc/RpcHandlerManager';
+import { registerChangeTitleHandler } from './rpc/registerChangeTitleHandler';
 import { registerCommonHandlers } from '../modules/common/registerCommonHandlers';
 import { calculateCost } from '@/utils/pricing';
 import { shouldReconnect } from '@/utils/lidState';
@@ -250,6 +251,7 @@ export class ApiSessionClient extends EventEmitter {
             logger: (msg, data) => logger.debug(msg, data)
         });
         registerCommonHandlers(this.rpcHandlerManager, this.metadata.path);
+        registerChangeTitleHandler(this.rpcHandlerManager, (title) => this.changeTitle(title));
 
         //
         // Create socket
@@ -709,6 +711,22 @@ export class ApiSessionClient extends EventEmitter {
                 }
             }));
         }
+    }
+
+    /**
+     * Rename the session by writing a Claude `summary` record.
+     *
+     * Single source of truth for session titles: the `change_title` MCP tool
+     * (agent-driven) and the `changeTitle` RPC (user-driven rename from the app)
+     * both call this, so the Happy metadata summary and the underlying Claude
+     * Code session name stay in sync.
+     */
+    changeTitle(title: string) {
+        this.sendClaudeSessionMessage({
+            type: 'summary',
+            summary: title,
+            leafUuid: randomUUID()
+        });
     }
 
     /**

--- a/packages/happy-cli/src/api/rpc/registerChangeTitleHandler.test.ts
+++ b/packages/happy-cli/src/api/rpc/registerChangeTitleHandler.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerChangeTitleHandler } from './registerChangeTitleHandler';
+import type { RpcHandlerManager } from './RpcHandlerManager';
+
+function setup() {
+    const handlers = new Map<string, (params: any) => Promise<any>>();
+    const rpcHandlerManager = {
+        registerHandler: vi.fn((method: string, handler: (params: any) => Promise<any>) => {
+            handlers.set(method, handler);
+        }),
+    } as unknown as RpcHandlerManager;
+    const changeTitle = vi.fn();
+    registerChangeTitleHandler(rpcHandlerManager, changeTitle);
+    const handler = handlers.get('changeTitle');
+    if (!handler) {
+        throw new Error('changeTitle handler not registered');
+    }
+    return { handler, changeTitle };
+}
+
+describe('registerChangeTitleHandler', () => {
+    it('registers a changeTitle handler', () => {
+        const { handler } = setup();
+        expect(handler).toBeTypeOf('function');
+    });
+
+    it('trims the title and forwards it to changeTitle', async () => {
+        const { handler, changeTitle } = setup();
+        const result = await handler({ title: '  New name  ' });
+        expect(changeTitle).toHaveBeenCalledWith('New name');
+        expect(result).toEqual({ success: true });
+    });
+
+    it('rejects an empty or whitespace-only title without calling changeTitle', async () => {
+        const { handler, changeTitle } = setup();
+        for (const title of ['', '   ']) {
+            const result = await handler({ title });
+            expect(result.success).toBe(false);
+            expect(result.error).toBeTruthy();
+        }
+        expect(changeTitle).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing or non-string title', async () => {
+        const { handler, changeTitle } = setup();
+        expect((await handler({})).success).toBe(false);
+        expect((await handler({ title: 42 })).success).toBe(false);
+        expect(changeTitle).not.toHaveBeenCalled();
+    });
+});

--- a/packages/happy-cli/src/api/rpc/registerChangeTitleHandler.ts
+++ b/packages/happy-cli/src/api/rpc/registerChangeTitleHandler.ts
@@ -1,0 +1,37 @@
+import { RpcHandlerManager } from './RpcHandlerManager';
+import { logger } from '@/ui/logger';
+
+interface ChangeTitleRequest {
+    title: string;
+}
+
+interface ChangeTitleResponse {
+    success: boolean;
+    error?: string;
+}
+
+/**
+ * Registers the `changeTitle` session RPC used by the app to rename a chat.
+ *
+ * The rename is written through the same Claude `summary` record used by the
+ * `change_title` MCP tool (see {@link ApiSessionClient.changeTitle}), so a
+ * user-driven rename updates the underlying Claude Code session name and
+ * propagates to the Happy session metadata exactly like an agent-driven title
+ * change. Registered for every session flavor because a `summary` message only
+ * updates `metadata.summary` and produces no Claude-specific protocol messages.
+ */
+export function registerChangeTitleHandler(
+    rpcHandlerManager: RpcHandlerManager,
+    changeTitle: (title: string) => void,
+) {
+    rpcHandlerManager.registerHandler<ChangeTitleRequest, ChangeTitleResponse>('changeTitle', async (request) => {
+        const title = typeof request?.title === 'string' ? request.title.trim() : '';
+        if (!title) {
+            return { success: false, error: 'Title must be a non-empty string' };
+        }
+
+        logger.debug('[changeTitle] Renaming session to:', title);
+        changeTitle(title);
+        return { success: true };
+    });
+}

--- a/packages/happy-cli/src/claude/utils/startHappyServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHappyServer.ts
@@ -13,7 +13,6 @@ import { AddressInfo } from "node:net";
 import { z } from "zod";
 import { logger } from "@/ui/logger";
 import { ApiSessionClient } from "@/api/apiSession";
-import { randomUUID } from "node:crypto";
 
 function createMcpServer(handler: (title: string) => Promise<{ success: boolean; error?: string }>): McpServer {
     const mcp = new McpServer({
@@ -63,11 +62,7 @@ export async function startHappyServer(client: ApiSessionClient) {
     const handler = async (title: string) => {
         logger.debug('[happyMCP] Changing title to:', title);
         try {
-            client.sendClaudeSessionMessage({
-                type: 'summary',
-                summary: title,
-                leafUuid: randomUUID()
-            });
+            client.changeTitle(title);
             return { success: true };
         } catch (error) {
             return { success: false, error: String(error) };


### PR DESCRIPTION
## What

Adds a user-facing **Rename Session** action to the session info screen, closing the gap in #894 ("Nameing" — *"is there no way to grab the name of the terminal … I have so many I have to click on them all!"*). Users can now give a chat a memorable name instead of scanning through many look‑alike sessions.

The rename **is** the Claude Code session summary — the same `type:'summary'` record shown by `claude --resume` and rendered by `getSessionName()` (`metadata.summary.text`). No new custom‑name field is introduced.

## How

A rename flows through the exact path the agent's `mcp__happy__change_title` tool already uses, so a manual rename updates the underlying Claude Code session name and propagates back to Happy metadata identically:

**happy-cli**
- New `changeTitle` session RPC (`registerChangeTitleHandler`), registered on **every** `ApiSessionClient` — so it works for all agent flavors (Claude, Codex, Gemini, OpenClaw). A `summary` message maps to zero session‑protocol envelopes; it only updates `metadata.summary`, so this is flavor‑agnostic and safe.
- New `ApiSessionClient.changeTitle()` is now the single source of truth; the `change_title` MCP tool calls it too (no behavior change for agents).

**happy-app**
- `sessionRename()` op → `apiSocket.sessionRPC(sessionId, 'changeTitle', { title })`.
- Rename row in **Quick Actions** using `Modal.prompt`, prefilled with the current title. `getSessionName` keeps rendering `metadata.summary.text`.
- `resolveSessionRename()` pure helper for the cancel / empty / unchanged cases.
- Strings added to all 10 languages.

**Server:** no changes.

## Explicit decisions (per the two edge cases)

**(a) Offline sessions.** Renaming is applied by the CLI (it writes the summary record), so it requires the session to be online. The UI guards on connection state and shows *"Connect to this session to rename it"* when offline, rather than silently no‑op'ing or desyncing with a local‑only edit. The op also throws as a backstop if the RPC is unavailable.

**(b) A later agent `change_title` can overwrite a manual rename.** **Accepted by design, and documented in‑code.** The title is a single shared `summary` field (issue and existing code treat the Happy name and the Claude summary as the same thing). Guarding a manual rename would require a separate "locked name" field, which contradicts keeping the name == the Claude summary. Agents only re‑title when the task changes dramatically, so this is rare in practice; if maintainers prefer a lock later, it's an additive change.

## Tests
- `registerChangeTitleHandler.test.ts` — trims valid titles, forwards them, rejects empty/whitespace/missing/non‑string.
- `resolveSessionRename.test.ts` — cancel/empty/unchanged → skip; trimmed change → apply.
- `pnpm typecheck` passes in both `happy-cli` and `happy-app`.
- `happy-cli` unit suite passes. `happy-app` suite: all pass except one **pre‑existing, unrelated** failure in `sources/sync/settings.spec.ts` (its `settingsDefaults` expectation was not updated when `sortSessionsByActivity` was added in 55faebc8; that file is untouched by this PR).
- No new dependencies.

Refs #894
