### PR TITLE
feat(cli): auto-resume interrupted sessions after daemon restart

### DIFF
--- a/packages/happy-cli/src/daemon/autoResume.test.ts
+++ b/packages/happy-cli/src/daemon/autoResume.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Metadata } from '@/api/types';
+import type { PersistedSession } from '@/persistence';
+
+import {
+    selectAutoResumeCandidates,
+    type SelectAutoResumeCandidatesOptions,
+} from './autoResume';
+
+const NOW = 1_800_000_000_000;
+
+function makeMetadata(overrides: Partial<Metadata> = {}): Metadata {
+    return {
+        path: '/home/user/project',
+        host: 'test-host',
+        startedFromDaemon: true,
+        hostPid: 4242,
+        ...overrides,
+    } as Metadata;
+}
+
+function makeSession(overrides: Partial<PersistedSession> = {}): PersistedSession {
+    return {
+        encryptionKey: 'a2V5',
+        encryptionVariant: 'dataKey',
+        seq: 0,
+        metadataVersion: 1,
+        agentStateVersion: 1,
+        metadata: makeMetadata(),
+        savedAt: NOW - 60_000,
+        ...overrides,
+    };
+}
+
+function makeOptions(overrides: Partial<SelectAutoResumeCandidatesOptions> = {}): SelectAutoResumeCandidatesOptions {
+    return {
+        isPidAlive: () => false,
+        now: NOW,
+        maxSessions: 10,
+        maxAgeMs: 7 * 24 * 60 * 60 * 1000,
+        ...overrides,
+    };
+}
+
+describe('selectAutoResumeCandidates', () => {
+    it('selects daemon-spawned sessions that never exited and whose process is gone', () => {
+        const candidates = selectAutoResumeCandidates(
+            { 'session-1': makeSession() },
+            makeOptions(),
+        );
+        expect(candidates.map((c) => c.sessionId)).toEqual(['session-1']);
+    });
+
+    it('skips sessions that exited under daemon supervision', () => {
+        const candidates = selectAutoResumeCandidates(
+            { 'session-1': makeSession({ exitedAt: NOW - 30_000 }) },
+            makeOptions(),
+        );
+        expect(candidates).toEqual([]);
+    });
+
+    it('skips sessions that were not spawned by the daemon', () => {
+        const candidates = selectAutoResumeCandidates(
+            { 'session-1': makeSession({ metadata: makeMetadata({ startedFromDaemon: false }) }) },
+            makeOptions(),
+        );
+        expect(candidates).toEqual([]);
+    });
+
+    it('skips sessions whose process is still alive', () => {
+        const candidates = selectAutoResumeCandidates(
+            { 'session-1': makeSession() },
+            makeOptions({ isPidAlive: (pid) => pid === 4242 }),
+        );
+        expect(candidates).toEqual([]);
+    });
+
+    it('skips sessions persisted longer ago than maxAgeMs', () => {
+        const candidates = selectAutoResumeCandidates(
+            { 'session-1': makeSession({ savedAt: NOW - 8 * 24 * 60 * 60 * 1000 }) },
+            makeOptions(),
+        );
+        expect(candidates).toEqual([]);
+    });
+
+    it('skips sessions without metadata', () => {
+        const candidates = selectAutoResumeCandidates(
+            { 'session-1': makeSession({ metadata: undefined as unknown as Metadata }) },
+            makeOptions(),
+        );
+        expect(candidates).toEqual([]);
+    });
+
+    it('orders by most recently persisted and applies the cap', () => {
+        const sessions: Record<string, PersistedSession> = {
+            'session-old': makeSession({ savedAt: NOW - 3_000 }),
+            'session-new': makeSession({ savedAt: NOW - 1_000 }),
+            'session-mid': makeSession({ savedAt: NOW - 2_000 }),
+        };
+        const candidates = selectAutoResumeCandidates(sessions, makeOptions({ maxSessions: 2 }));
+        expect(candidates.map((c) => c.sessionId)).toEqual(['session-new', 'session-mid']);
+    });
+
+    it('sessions without hostPid are treated as not alive', () => {
+        const candidates = selectAutoResumeCandidates(
+            { 'session-1': makeSession({ metadata: makeMetadata({ hostPid: undefined }) }) },
+            makeOptions({ isPidAlive: () => true }),
+        );
+        expect(candidates.map((c) => c.sessionId)).toEqual(['session-1']);
+    });
+});

--- a/packages/happy-cli/src/daemon/autoResume.ts
+++ b/packages/happy-cli/src/daemon/autoResume.ts
@@ -1,0 +1,97 @@
+/**
+ * Auto-resume of interrupted sessions after a daemon restart.
+ *
+ * When the machine crashes, reboots, or the daemon is killed, previously
+ * running sessions die with it. Their encrypted state is already persisted in
+ * ~/.happy/sessions.json (see persistence.ts), and the daemon already knows
+ * how to resume a session in-place via `resumeSession` (reusing the same Happy
+ * session entity, so chat history and title are preserved).
+ *
+ * This module selects which persisted sessions should be automatically
+ * resumed when the daemon starts:
+ *
+ *   - only sessions spawned by the daemon (terminal sessions are managed by
+ *     the user and are intentionally left alone)
+ *   - only sessions that were still running when the daemon last died
+ *     (sessions that exited normally have `exitedAt` recorded)
+ *   - only sessions whose process is actually gone (if only the daemon was
+ *     restarted, the detached child may still be alive and will re-register
+ *     itself via webhook)
+ *   - only sessions that are resumable (they reported a claude session id or
+ *     codex thread id, directly or via flavor detection later)
+ *
+ * Selection is a pure function so it can be unit tested.
+ */
+
+import type { PersistedSession } from '@/persistence';
+
+export type AutoResumeCandidate = {
+    sessionId: string;
+    savedAt: number;
+};
+
+export type SelectAutoResumeCandidatesOptions = {
+    /** Returns true when the given PID belongs to a live process. */
+    isPidAlive: (pid: number) => boolean;
+    /** Current time in ms. */
+    now: number;
+    /** Do not resume more than this many sessions (most recent first). */
+    maxSessions: number;
+    /** Ignore sessions persisted longer ago than this. */
+    maxAgeMs: number;
+};
+
+export const AUTO_RESUME_DEFAULT_MAX_SESSIONS = 10;
+export const AUTO_RESUME_DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function selectAutoResumeCandidates(
+    sessions: Record<string, PersistedSession>,
+    options: SelectAutoResumeCandidatesOptions,
+): AutoResumeCandidate[] {
+    const candidates: AutoResumeCandidate[] = [];
+
+    for (const [sessionId, session] of Object.entries(sessions)) {
+        // Session exited under daemon supervision - not interrupted.
+        if (session.exitedAt) {
+            continue;
+        }
+
+        // Too old - user has most likely moved on.
+        if (options.now - session.savedAt > options.maxAgeMs) {
+            continue;
+        }
+
+        const metadata = session.metadata;
+        if (!metadata) {
+            continue;
+        }
+
+        // Only daemon-spawned sessions. Terminal sessions (started by the
+        // user, possibly inside tmux) are intentionally not auto-resumed.
+        if (!metadata.startedFromDaemon) {
+            continue;
+        }
+
+        // If the process is still alive the session survived the daemon
+        // restart. It will re-register itself - do not spawn a duplicate.
+        if (metadata.hostPid && options.isPidAlive(metadata.hostPid)) {
+            continue;
+        }
+
+        candidates.push({ sessionId, savedAt: session.savedAt });
+    }
+
+    // Most recently persisted sessions first, capped.
+    candidates.sort((a, b) => b.savedAt - a.savedAt);
+    return candidates.slice(0, options.maxSessions);
+}
+
+/** Signal-0 based liveness check, safe on all supported platforms. */
+export function isPidAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -14,8 +14,9 @@ import { startCaffeinate, stopCaffeinate } from '@/utils/caffeinate';
 import packageJson from '../../package.json';
 import { getEnvironmentInfo } from '@/ui/doctor';
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI';
-import { writeDaemonState, DaemonLocallyPersistedState, readDaemonState, acquireDaemonLock, releaseDaemonLock, readPersistedSessions, persistSession } from '@/persistence';
+import { writeDaemonState, DaemonLocallyPersistedState, readDaemonState, acquireDaemonLock, releaseDaemonLock, readPersistedSessions, persistSession, markSessionExited, readSettings } from '@/persistence';
 import type { PersistedSession } from '@/persistence';
+import { selectAutoResumeCandidates, isPidAlive, AUTO_RESUME_DEFAULT_MAX_SESSIONS, AUTO_RESUME_DEFAULT_MAX_AGE_MS } from './autoResume';
 
 import { cleanupDaemonState, isDaemonRunningCurrentlyInstalledHappyVersion, stopDaemon } from './controlClient';
 import { startDaemonControlServer } from './controlServer';
@@ -749,6 +750,9 @@ export async function startDaemon(): Promise<void> {
           }
 
           pidToTrackedSession.delete(pid);
+          if (session.happySessionId) {
+            markSessionExited(session.happySessionId);
+          }
           logger.debug(`[DAEMON RUN] Removed session ${sessionId} from tracking`);
           return true;
         }
@@ -763,6 +767,7 @@ export async function startDaemon(): Promise<void> {
       const session = pidToTrackedSession.get(pid);
       if (session?.happySessionId && session.encryption) {
         sessionIdToFinishedSession.set(session.happySessionId, session);
+        markSessionExited(session.happySessionId);
         logger.debug(`[DAEMON RUN] Process PID ${pid} exited, preserved session ${session.happySessionId} for resume`);
       } else {
         logger.debug(`[DAEMON RUN] Removing exited process PID ${pid} from tracking`);
@@ -839,6 +844,48 @@ export async function startDaemon(): Promise<void> {
     // Connect to server
     apiMachine.connect();
 
+    // Auto-resume sessions that were interrupted by a crash or reboot.
+    // Opt-in via settings.json `autoResumeSessions` or HAPPY_AUTO_RESUME_SESSIONS=1.
+    // Uses the same resume-in-place flow as the app-triggered `resumeSession`
+    // RPC, so sessions keep their identity (history, title, encryption).
+    const settings = await readSettings();
+    const autoResumeEnv = process.env.HAPPY_AUTO_RESUME_SESSIONS;
+    const autoResumeEnabled = autoResumeEnv !== undefined
+      ? autoResumeEnv === '1' || autoResumeEnv === 'true'
+      : settings.autoResumeSessions === true;
+    if (autoResumeEnabled) {
+      const candidates = selectAutoResumeCandidates(readPersistedSessions(), {
+        isPidAlive,
+        now: Date.now(),
+        maxSessions: AUTO_RESUME_DEFAULT_MAX_SESSIONS,
+        maxAgeMs: AUTO_RESUME_DEFAULT_MAX_AGE_MS,
+      });
+      if (candidates.length > 0) {
+        logger.debug(`[DAEMON RUN] Auto-resuming ${candidates.length} interrupted session(s): ${candidates.map(c => c.sessionId).join(', ')}`);
+        // Fire-and-forget: resuming sessions must not block daemon startup.
+        void (async () => {
+          // Give the machine socket a moment to settle before spawning children.
+          await new Promise(resolve => setTimeout(resolve, 3_000));
+          for (const candidate of candidates) {
+            try {
+              const result = await resumeSession(candidate.sessionId);
+              if (result.type === 'success') {
+                logger.debug(`[DAEMON RUN] Auto-resumed session ${candidate.sessionId}`);
+              } else {
+                logger.debug(`[DAEMON RUN] Auto-resume failed for session ${candidate.sessionId}: ${result.type === 'error' ? result.errorMessage : result.type}`);
+              }
+            } catch (error) {
+              logger.debug(`[DAEMON RUN] Auto-resume threw for session ${candidate.sessionId}:`, error);
+            }
+            // Stagger spawns to avoid a thundering herd after reboot.
+            await new Promise(resolve => setTimeout(resolve, 1_000));
+          }
+        })();
+      } else {
+        logger.debug('[DAEMON RUN] Auto-resume enabled, no interrupted sessions found');
+      }
+    }
+
     // Every 60 seconds:
     // 1. Prune stale sessions
     // 2. Check if daemon needs update
@@ -857,13 +904,18 @@ export async function startDaemon(): Promise<void> {
       }
 
       // Prune stale sessions
-      for (const [pid, _] of pidToTrackedSession.entries()) {
+      for (const [pid, session] of pidToTrackedSession.entries()) {
         try {
           // Check if process is still alive (signal 0 doesn't kill, just checks)
           process.kill(pid, 0);
         } catch (error) {
           // Process is dead, remove from tracking
           logger.debug(`[DAEMON RUN] Removing stale session with PID ${pid} (process no longer exists)`);
+          // The daemon observed the death while it was alive, so this was not
+          // an interruption (crash/reboot) - do not auto-resume it next start.
+          if (session.happySessionId) {
+            markSessionExited(session.happySessionId);
+          }
           pidToTrackedSession.delete(pid);
         }
       }

--- a/packages/happy-cli/src/persistence.ts
+++ b/packages/happy-cli/src/persistence.ts
@@ -45,6 +45,11 @@ interface Settings {
   sandboxConfig?: SandboxConfig
   serverUrl?: string
   webappUrl?: string
+  /**
+   * When enabled, the daemon automatically resumes daemon-spawned sessions
+   * that were interrupted by a crash or reboot (see daemon/autoResume.ts).
+   */
+  autoResumeSessions?: boolean
 }
 
 const defaultSettings: Settings = {
@@ -406,6 +411,12 @@ export type PersistedSession = {
   agentStateVersion: number;
   metadata: Metadata;
   savedAt: number;
+  /**
+   * Set when the daemon observed this session's process exit (or stopped it).
+   * Sessions without this field that are no longer running were interrupted
+   * (crash/reboot) and are eligible for auto-resume on daemon startup.
+   */
+  exitedAt?: number;
 };
 
 type SessionsFile = {
@@ -442,6 +453,21 @@ export function persistSession(sessionId: string, session: PersistedSession): vo
     renameSync(tmpFile, configuration.sessionsFile);
   } catch (error) {
     logger.debug(`[PERSISTENCE] Failed to persist session ${sessionId}:`, error);
+  }
+}
+
+/**
+ * Record that a session's process exited under daemon supervision.
+ * Sessions marked this way are not auto-resumed on the next daemon start.
+ */
+export function markSessionExited(sessionId: string, exitedAt: number = Date.now()): void {
+  try {
+    const existing = readPersistedSessions();
+    const session = existing[sessionId];
+    if (!session) return;
+    persistSession(sessionId, { ...session, exitedAt });
+  } catch (error) {
+    logger.debug(`[PERSISTENCE] Failed to mark session ${sessionId} as exited:`, error);
   }
 }
 


### PR DESCRIPTION
**Summary:** When the machine crashes, reboots, or the daemon is killed, daemon-spawned sessions die and never come back — the user opens the app and finds a list of dead sessions that must each be resumed by hand (or recreated, losing title/identity). The session's encrypted state already survives in `~/.happy/sessions.json` and the daemon already knows how to resume in-place (`resumeSession` RPC → `HAPPY_RECONNECT_*`), so this PR wires the two together: on startup the daemon detects sessions that were *interrupted* (never observed exiting) and resumes them into the **same Happy session entity**, preserving history, title, and encryption. Opt-in via `settings.json` `autoResumeSessions: true` or `HAPPY_AUTO_RESUME_SESSIONS=1`.

## What changed

- `persistence.ts`: record `exitedAt` on `PersistedSession` whenever the daemon *observes* a session end (child exit handler, `stopSession`, heartbeat stale-PID prune). Sessions without `exitedAt` whose process is gone were interrupted.
- `daemon/autoResume.ts` (new): pure, unit-tested candidate selection —
  - only daemon-spawned sessions (`metadata.startedFromDaemon`); terminal/tmux sessions belong to the user
  - only sessions with no recorded exit
  - only sessions whose `hostPid` is actually dead (if only the daemon restarted, detached children survive and re-register — no duplicates)
  - age-bounded (7 days) and capped (10, most recent first)
- `daemon/run.ts`: after machine registration, when enabled, resume candidates via the existing `resumeSession` flow (fire-and-forget, staggered 1s, does not block startup).

Default is **off** — no behavior change unless the user opts in.

## Evidence (real run, self-hosted server)

E2E on a live self-hosted deployment (Amazon Linux, node v22.23.1, claude 2.1.201). Full cycle — daemon + session with a real Claude conversation, `kill -9` both (simulated crash), daemon restart:

```
########## STEP 3: simulate crash (kill -9 daemon then session; no exit observed)
exitedAt: ABSENT - eligible for auto-resume

########## STEP 4: restart daemon - auto-resume
[01:30:40.427] [DAEMON RUN] Auto-resuming 1 interrupted session(s): cmr9z17gf1g5dqs1a1nf9o9dp
[01:30:44.312] [DAEMON RUN] Auto-resumed session cmr9z17gf1g5dqs1a1nf9o9dp

########## STEP 5: resumed process reconnects to SAME happy session entity
pid=86644 HAPPY_RECONNECT_SESSION_ID=cmr9z17gf1g5dqs1a1nf9o9dp <-- SAME ENTITY, title/history preserved

########## STEP 6: negative test - graceful exit is NOT auto-resumed
second session: cmr9z38iv1g5fqs1auvya0pag
exitedAt: 1783387869437
[01:31:15.928] [DAEMON RUN] Auto-resume enabled, no interrupted sessions found
```

The resumed child carries `HAPPY_RECONNECT_SESSION_ID` equal to the original Happy session id — it reattaches to the same session row (title/history preserved), not a new fork. The negative test shows a session stopped under daemon supervision gets `exitedAt` and is not resumed. The pid-alive guard was also exercised: the step-4 resumed session (still running, detached) was skipped on the step-6 daemon restart instead of being duplicated.

Also verified:
- `pnpm --filter happy typecheck` clean
- unit suite: 75 files / 689 tests passed, including 8 new tests for `selectAutoResumeCandidates`

## Design notes

- Reuses the existing resume-in-place machinery end-to-end; no protocol, server, or encryption changes.
- `exitedAt` is additive to `sessions.json`; old entries without it are still age-filtered (14d) as before, and auto-resume additionally bounds to 7d.
- Known edge: PID reuse after reboot could make a dead session look alive and skip its resume — conservative direction (skip rather than duplicate).

Motivation: self-hosting Happy on a small EC2 box; an OOM + reboot killed the daemon and every session. Everything needed to bring them back was already on disk — this makes it automatic.
