### PR TITLE
feat(cli): env overrides for new-session Claude defaults (effort, permission mode, model)

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -33,6 +33,7 @@ import {
 } from '@/claude/claudeGoalStatus';
 import { Session } from './session';
 import { applySandboxPermissionPolicy, resolveInitialClaudePermissionMode, resolveRemoteClaudePermissionMode } from './utils/permissionMode';
+import { defaultClaudeEffort, defaultClaudeModel, defaultClaudePermissionMode } from './utils/startupDefaults';
 import { decodeBase64, encodeBase64 } from '@/api/encryption';
 import type { Session as ApiSession } from '@/api/types';
 import { getProjectPath } from './utils/path';
@@ -56,9 +57,9 @@ export interface StartOptions {
     jsRuntime?: JsRuntime
 }
 
-const DEFAULT_CLAUDE_PERMISSION_MODE: PermissionMode = 'yolo';
-const DEFAULT_CLAUDE_MODEL = 'opus';
-const DEFAULT_CLAUDE_EFFORT: 'low' | 'medium' | 'high' | 'xhigh' | 'max' = 'medium';
+const DEFAULT_CLAUDE_PERMISSION_MODE: PermissionMode = defaultClaudePermissionMode();
+const DEFAULT_CLAUDE_MODEL = defaultClaudeModel();
+const DEFAULT_CLAUDE_EFFORT: 'low' | 'medium' | 'high' | 'xhigh' | 'max' = defaultClaudeEffort();
 type ClaudeGoalCommand = NonNullable<ReturnType<typeof parseClaudeGoalActionParams>>;
 type PendingClaudeGoalAction = {
     command: ClaudeGoalCommand;

--- a/packages/happy-cli/src/claude/utils/startupDefaults.test.ts
+++ b/packages/happy-cli/src/claude/utils/startupDefaults.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultClaudeEffort, defaultClaudeModel, defaultClaudePermissionMode } from './startupDefaults';
+
+describe('defaultClaudeEffort', () => {
+    it('returns medium when HAPPY_CLAUDE_EFFORT is not set', () => {
+        expect(defaultClaudeEffort({})).toBe('medium');
+    });
+
+    it.each(['low', 'medium', 'high', 'xhigh', 'max'] as const)('honors HAPPY_CLAUDE_EFFORT=%s', (effort) => {
+        expect(defaultClaudeEffort({ HAPPY_CLAUDE_EFFORT: effort })).toBe(effort);
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(defaultClaudeEffort({ HAPPY_CLAUDE_EFFORT: ' xhigh ' })).toBe('xhigh');
+    });
+
+    it('falls back to medium on invalid values', () => {
+        expect(defaultClaudeEffort({ HAPPY_CLAUDE_EFFORT: 'turbo' })).toBe('medium');
+        expect(defaultClaudeEffort({ HAPPY_CLAUDE_EFFORT: 'XHIGH' })).toBe('medium');
+        expect(defaultClaudeEffort({ HAPPY_CLAUDE_EFFORT: '' })).toBe('medium');
+    });
+});
+
+describe('defaultClaudePermissionMode', () => {
+    it('returns yolo when HAPPY_CLAUDE_PERMISSION_MODE is not set', () => {
+        expect(defaultClaudePermissionMode({})).toBe('yolo');
+    });
+
+    it('honors a valid mode', () => {
+        expect(defaultClaudePermissionMode({ HAPPY_CLAUDE_PERMISSION_MODE: 'plan' })).toBe('plan');
+        expect(defaultClaudePermissionMode({ HAPPY_CLAUDE_PERMISSION_MODE: 'safe-yolo' })).toBe('safe-yolo');
+    });
+
+    it('falls back to yolo on invalid values', () => {
+        expect(defaultClaudePermissionMode({ HAPPY_CLAUDE_PERMISSION_MODE: 'YOLO' })).toBe('yolo');
+        expect(defaultClaudePermissionMode({ HAPPY_CLAUDE_PERMISSION_MODE: 'nonsense' })).toBe('yolo');
+    });
+});
+
+describe('defaultClaudeModel', () => {
+    it('returns opus when HAPPY_CLAUDE_MODEL is not set', () => {
+        expect(defaultClaudeModel({})).toBe('opus');
+    });
+
+    it('passes through any non-empty model name', () => {
+        expect(defaultClaudeModel({ HAPPY_CLAUDE_MODEL: 'claude-fable-5' })).toBe('claude-fable-5');
+        expect(defaultClaudeModel({ HAPPY_CLAUDE_MODEL: ' sonnet ' })).toBe('sonnet');
+    });
+
+    it('falls back to opus on empty or whitespace-only values', () => {
+        expect(defaultClaudeModel({ HAPPY_CLAUDE_MODEL: '' })).toBe('opus');
+        expect(defaultClaudeModel({ HAPPY_CLAUDE_MODEL: '   ' })).toBe('opus');
+    });
+});

--- a/packages/happy-cli/src/claude/utils/startupDefaults.ts
+++ b/packages/happy-cli/src/claude/utils/startupDefaults.ts
@@ -1,0 +1,58 @@
+import { logger } from '@/ui/logger';
+import type { PermissionMode } from '@/api/types';
+
+/**
+ * New-session defaults for Claude, overridable per machine via environment
+ * variables. This is the daemon/CLI-side counterpart to picking values in the
+ * app: headless machines (a daemon spawning sessions on a remote VM, CI, tmux)
+ * have no picker, so without these variables every session silently falls
+ * back to the hardcoded defaults.
+ *
+ * - HAPPY_CLAUDE_EFFORT: low | medium | high | xhigh | max
+ * - HAPPY_CLAUDE_PERMISSION_MODE: default | acceptEdits | bypassPermissions | plan | read-only | safe-yolo | yolo
+ * - HAPPY_CLAUDE_MODEL: any model name Claude accepts
+ *
+ * Invalid values are ignored with a debug log rather than failing startup.
+ */
+
+export type ClaudeEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+const CLAUDE_EFFORTS: readonly ClaudeEffort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+const PERMISSION_MODES: readonly PermissionMode[] = [
+    'default',
+    'acceptEdits',
+    'bypassPermissions',
+    'plan',
+    'read-only',
+    'safe-yolo',
+    'yolo',
+];
+
+function readEnvChoice<T extends string>(
+    name: string,
+    allowed: readonly T[],
+    fallback: T,
+    env: NodeJS.ProcessEnv,
+): T {
+    const raw = env[name]?.trim();
+    if (!raw) {
+        return fallback;
+    }
+    if ((allowed as readonly string[]).includes(raw)) {
+        return raw as T;
+    }
+    logger.debug(`[startupDefaults] Ignoring ${name}="${raw}" (expected one of: ${allowed.join(', ')})`);
+    return fallback;
+}
+
+export function defaultClaudeEffort(env: NodeJS.ProcessEnv = process.env): ClaudeEffort {
+    return readEnvChoice('HAPPY_CLAUDE_EFFORT', CLAUDE_EFFORTS, 'medium', env);
+}
+
+export function defaultClaudePermissionMode(env: NodeJS.ProcessEnv = process.env): PermissionMode {
+    return readEnvChoice('HAPPY_CLAUDE_PERMISSION_MODE', PERMISSION_MODES, 'yolo', env);
+}
+
+export function defaultClaudeModel(env: NodeJS.ProcessEnv = process.env): string {
+    return env.HAPPY_CLAUDE_MODEL?.trim() || 'opus';
+}


### PR DESCRIPTION
## Problem

`runClaude.ts` hardcodes the new-session defaults (`DEFAULT_CLAUDE_EFFORT = 'medium'`, `DEFAULT_CLAUDE_MODEL = 'opus'`, `DEFAULT_CLAUDE_PERMISSION_MODE = 'yolo'`). On machines where sessions are spawned by the daemon — a headless VM driven from the mobile app, tmux, CI — there is no picker in the loop at spawn time, so every session silently starts at `medium` effort regardless of what the user wants as their baseline (see #1450, including the daemon log `no effort override, using current: medium`). I've been patching the constant in `dist/` by hand and losing the patch on every `npm update`.

## Change

New-session defaults become overridable per machine via environment variables, following the existing `HAPPY_*` convention from `configuration.ts`:

- `HAPPY_CLAUDE_EFFORT` — `low | medium | high | xhigh | max`
- `HAPPY_CLAUDE_PERMISSION_MODE` — any `PermissionMode`
- `HAPPY_CLAUDE_MODEL` — passed through as-is

Resolution lives in a new `claude/utils/startupDefaults.ts` (mirroring `utils/permissionMode.ts`). Invalid values are ignored with a debug log and fall back to the previous hardcoded defaults, so nothing changes for anyone not setting the variables.

## Relation to existing work

This is the **daemon/CLI-side half** of #1450 and complements the app-side PRs (#1457, #1151, #1462), which persist and forward picker selections — none of them covers machines where no picker is involved at spawn. In-session behavior is untouched: the app can still change effort/model/permission mode per session exactly as before; only the *starting* value becomes configurable.

## Testing

- `startupDefaults.test.ts`: 14 unit tests (valid values, trimming, invalid → fallback, unset → previous defaults)
- Full `happy-cli` unit suite: 75 files / 695 tests pass
- `tsc --noEmit` clean

Fixes the effort part of #1450 for daemon-spawned sessions.