### PR TITLE
fix(cli): forward resolved permission mode to local Claude spawn

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocal.test.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.test.ts
@@ -316,3 +316,135 @@ describe('claudeLocal --continue handling', () => {
         expect(spawnedArgs).not.toContain('--dangerously-skip-permissions');
     });
 });
+
+describe('claudeLocal permission mode forwarding', () => {
+    let onSessionFound: any;
+
+    beforeEach(() => {
+        mockSpawn.mockReturnValue({
+            stdio: [null, null, null, null],
+            on: vi.fn((event, callback) => {
+                if (event === 'exit') {
+                    process.nextTick(() => callback(0));
+                }
+            }),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            kill: vi.fn(),
+            stdout: { on: vi.fn() },
+            stderr: { on: vi.fn() },
+            stdin: { on: vi.fn(), end: vi.fn() },
+        });
+        onSessionFound = vi.fn();
+        vi.clearAllMocks();
+    });
+
+    const spawnedArgs = () => mockSpawn.mock.calls[0][1] as string[];
+
+    it('injects --dangerously-skip-permissions for the default yolo mode', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            permissionMode: 'yolo',
+        });
+        expect(spawnedArgs()).toContain('--dangerously-skip-permissions');
+    });
+
+    it('injects --dangerously-skip-permissions for bypassPermissions', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            permissionMode: 'bypassPermissions',
+        });
+        expect(spawnedArgs()).toContain('--dangerously-skip-permissions');
+    });
+
+    it('does not inject any permission flag for default mode', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            permissionMode: 'default',
+        });
+        expect(spawnedArgs()).not.toContain('--dangerously-skip-permissions');
+        expect(spawnedArgs()).not.toContain('--permission-mode');
+    });
+
+    it('injects --permission-mode for plan mode', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            permissionMode: 'plan',
+        });
+        const args = spawnedArgs();
+        expect(args).toContain('--permission-mode');
+        expect(args[args.indexOf('--permission-mode') + 1]).toBe('plan');
+        expect(args).not.toContain('--dangerously-skip-permissions');
+    });
+
+    it('does not duplicate the flag when claudeArgs already carries --dangerously-skip-permissions', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: ['--dangerously-skip-permissions'],
+            permissionMode: 'yolo',
+        });
+        const occurrences = spawnedArgs().filter((a) => a === '--dangerously-skip-permissions');
+        expect(occurrences).toHaveLength(1);
+    });
+
+    it('does not duplicate the bypass flag when sandbox is enabled', async () => {
+        mockInitializeSandbox.mockResolvedValue(mockSandboxCleanup);
+        mockWrapCommand.mockResolvedValue('wrapped claude command');
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            permissionMode: 'bypassPermissions',
+            sandboxConfig: {
+                enabled: true,
+                sessionIsolation: 'workspace',
+                customWritePaths: [],
+                denyReadPaths: [],
+                extraWritePaths: [],
+                denyWritePaths: [],
+                networkMode: 'allowed',
+                allowedDomains: [],
+                deniedDomains: [],
+                allowLocalBinding: true,
+            },
+        });
+        const wrappedCommand = mockWrapCommand.mock.calls[0][0] as string;
+        const occurrences = wrappedCommand.match(/--dangerously-skip-permissions/g) ?? [];
+        expect(occurrences).toHaveLength(1);
+    });
+
+    it('respects an explicit --permission-mode in claudeArgs and does not add bypass', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: ['--permission-mode', 'plan'],
+            permissionMode: 'yolo',
+        });
+        const args = spawnedArgs();
+        expect(args).not.toContain('--dangerously-skip-permissions');
+        expect(args[args.indexOf('--permission-mode') + 1]).toBe('plan');
+    });
+});

--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -12,7 +12,7 @@ import { projectPath } from "@/projectPath";
 import { systemPrompt } from "./utils/systemPrompt";
 import type { SandboxConfig } from "@/persistence";
 import type { PermissionMode } from "@/api/types";
-import { mapToClaudeMode } from "./utils/permissionMode";
+import { resolveLocalPermissionModeArgs } from "./utils/permissionMode";
 import { initializeSandbox, wrapCommand } from "@/sandbox/manager";
 
 /**
@@ -249,28 +249,9 @@ export async function claudeLocal(opts: {
                 args.push(...opts.claudeArgs)
             }
 
-            // Translate the resolved permission mode into a Claude CLI flag. The
-            // remote/SDK path does this via the SDK's permissionMode option (which
-            // emits --permission-mode); the local spawn must mirror it, otherwise a
-            // session Happy resolved to bypass/plan/acceptEdits silently runs in
-            // Claude's default mode (slopus/happy local bypass bug). Skip when the
-            // user already carries an explicit permission flag in claudeArgs. Bypass
-            // uses --dangerously-skip-permissions to match the interactive sandbox
-            // branch below and `claude --dangerously-skip-permissions` directly.
-            if (opts.permissionMode) {
-                const claudeMode = mapToClaudeMode(opts.permissionMode);
-                const hasPermissionFlag =
-                    args.includes('--permission-mode') ||
-                    args.some((arg) => arg.startsWith('--permission-mode=')) ||
-                    args.includes('--dangerously-skip-permissions');
-                if (!hasPermissionFlag) {
-                    if (claudeMode === 'bypassPermissions') {
-                        args.push('--dangerously-skip-permissions');
-                    } else if (claudeMode !== 'default') {
-                        args.push('--permission-mode', claudeMode);
-                    }
-                }
-            }
+            // Mirror the resolved permission mode into a Claude CLI flag so the local
+            // spawn enters the same mode the remote/SDK path already applies.
+            args.push(...resolveLocalPermissionModeArgs(opts.permissionMode, args));
 
             // Add hook settings for session tracking (when available)
             if (opts.hookSettingsPath) {

--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -11,6 +11,8 @@ import { getProjectPath } from "./utils/path";
 import { projectPath } from "@/projectPath";
 import { systemPrompt } from "./utils/systemPrompt";
 import type { SandboxConfig } from "@/persistence";
+import type { PermissionMode } from "@/api/types";
+import { mapToClaudeMode } from "./utils/permissionMode";
 import { initializeSandbox, wrapCommand } from "@/sandbox/manager";
 
 /**
@@ -44,6 +46,9 @@ export async function claudeLocal(opts: {
     claudeEnvVars?: Record<string, string>,
     claudeArgs?: string[],
     allowedTools?: string[],
+    /** Resolved permission mode for this session (default = yolo/bypass). Mirrors the
+     * remote/SDK path so the local interactive spawn actually enters that mode. */
+    permissionMode?: PermissionMode,
     /** Path to temporary settings file with SessionStart hook (optional - for session tracking) */
     hookSettingsPath?: string,
     sandboxConfig?: SandboxConfig,
@@ -242,6 +247,29 @@ export async function claudeLocal(opts: {
             // Add custom Claude arguments
             if (opts.claudeArgs) {
                 args.push(...opts.claudeArgs)
+            }
+
+            // Translate the resolved permission mode into a Claude CLI flag. The
+            // remote/SDK path does this via the SDK's permissionMode option (which
+            // emits --permission-mode); the local spawn must mirror it, otherwise a
+            // session Happy resolved to bypass/plan/acceptEdits silently runs in
+            // Claude's default mode (slopus/happy local bypass bug). Skip when the
+            // user already carries an explicit permission flag in claudeArgs. Bypass
+            // uses --dangerously-skip-permissions to match the interactive sandbox
+            // branch below and `claude --dangerously-skip-permissions` directly.
+            if (opts.permissionMode) {
+                const claudeMode = mapToClaudeMode(opts.permissionMode);
+                const hasPermissionFlag =
+                    args.includes('--permission-mode') ||
+                    args.some((arg) => arg.startsWith('--permission-mode=')) ||
+                    args.includes('--dangerously-skip-permissions');
+                if (!hasPermissionFlag) {
+                    if (claudeMode === 'bypassPermissions') {
+                        args.push('--dangerously-skip-permissions');
+                    } else if (claudeMode !== 'default') {
+                        args.push('--permission-mode', claudeMode);
+                    }
+                }
             }
 
             // Add hook settings for session tracking (when available)

--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -119,6 +119,7 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
                     claudeArgs: session.claudeArgs,
                     mcpServers: session.mcpServers,
                     allowedTools: session.allowedTools,
+                    permissionMode: session.permissionMode,
                     hookSettingsPath: session.hookSettingsPath,
                     sandboxConfig: session.sandboxConfig,
                 });

--- a/packages/happy-cli/src/claude/loop.ts
+++ b/packages/happy-cli/src/claude/loop.ts
@@ -65,6 +65,7 @@ export async function loop(opts: LoopOptions): Promise<number> {
         messageQueue: opts.messageQueue,
         allowedTools: opts.allowedTools,
         sandboxConfig: opts.sandboxConfig,
+        permissionMode: opts.permissionMode,
         onModeChange: opts.onModeChange,
         onAbort: opts.onAbort,
         hookSettingsPath: opts.hookSettingsPath,

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -240,6 +240,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
                 claudeArgs: options.claudeArgs,
                 mcpServers: {},
                 allowedTools: [],
+                permissionMode: initialPermissionMode,
                 sandboxConfig,
             });
         } finally {

--- a/packages/happy-cli/src/claude/session.ts
+++ b/packages/happy-cli/src/claude/session.ts
@@ -4,6 +4,7 @@ import { EnhancedMode } from "./loop";
 import { logger } from "@/ui/logger";
 import type { JsRuntime } from "./runClaude";
 import type { SandboxConfig } from "@/persistence";
+import type { PermissionMode } from "@/api/types";
 
 export class Session {
     readonly path: string;
@@ -16,6 +17,8 @@ export class Session {
     readonly mcpServers: Record<string, any>;
     readonly allowedTools?: string[];
     readonly sandboxConfig?: SandboxConfig;
+    /** Resolved initial permission mode, forwarded to the local claude spawn. */
+    readonly permissionMode?: PermissionMode;
     readonly _onModeChange: (mode: 'local' | 'remote') => void;
     readonly _onAbort?: () => void;
     /** Path to temporary settings file with SessionStart hook (required for session tracking) */
@@ -47,6 +50,7 @@ export class Session {
         onAbort?: () => void,
         allowedTools?: string[],
         sandboxConfig?: SandboxConfig,
+        permissionMode?: PermissionMode,
         /** Path to temporary settings file with SessionStart hook (required for session tracking) */
         hookSettingsPath: string,
         /** JavaScript runtime to use for spawning Claude Code (default: 'node') */
@@ -63,6 +67,7 @@ export class Session {
         this.mcpServers = opts.mcpServers;
         this.allowedTools = opts.allowedTools;
         this.sandboxConfig = opts.sandboxConfig;
+        this.permissionMode = opts.permissionMode;
         this._onModeChange = opts.onModeChange;
         this._onAbort = opts.onAbort;
         this.hookSettingsPath = opts.hookSettingsPath;

--- a/packages/happy-cli/src/claude/utils/permissionMode.test.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applySandboxPermissionPolicy, extractPermissionModeFromClaudeArgs, mapToClaudeMode, resolveInitialClaudePermissionMode, resolveRemoteClaudePermissionMode } from './permissionMode';
+import { applySandboxPermissionPolicy, extractPermissionModeFromClaudeArgs, mapToClaudeMode, resolveInitialClaudePermissionMode, resolveLocalPermissionModeArgs, resolveRemoteClaudePermissionMode } from './permissionMode';
 import type { PermissionMode } from '@/api/types';
 
 describe('mapToClaudeMode', () => {
@@ -77,6 +77,34 @@ describe('resolveInitialClaudePermissionMode', () => {
 
     it('falls back to option mode when claude args have no mode', () => {
         expect(resolveInitialClaudePermissionMode('bypassPermissions', ['--foo'])).toBe('bypassPermissions');
+    });
+});
+
+describe('resolveLocalPermissionModeArgs', () => {
+    it('injects --dangerously-skip-permissions for bypass-equivalent modes', () => {
+        expect(resolveLocalPermissionModeArgs('yolo', [])).toEqual(['--dangerously-skip-permissions']);
+        expect(resolveLocalPermissionModeArgs('bypassPermissions', [])).toEqual(['--dangerously-skip-permissions']);
+    });
+
+    it('injects --permission-mode for plan and acceptEdits', () => {
+        expect(resolveLocalPermissionModeArgs('plan', [])).toEqual(['--permission-mode', 'plan']);
+        expect(resolveLocalPermissionModeArgs('acceptEdits', [])).toEqual(['--permission-mode', 'acceptEdits']);
+    });
+
+    it('adds nothing for modes that map to Claude default', () => {
+        expect(resolveLocalPermissionModeArgs('default', [])).toEqual([]);
+        expect(resolveLocalPermissionModeArgs('safe-yolo', [])).toEqual([]);
+        expect(resolveLocalPermissionModeArgs('read-only', [])).toEqual([]);
+    });
+
+    it('adds nothing when no mode is resolved', () => {
+        expect(resolveLocalPermissionModeArgs(undefined, [])).toEqual([]);
+    });
+
+    it('does not override an explicit permission flag already in claudeArgs', () => {
+        expect(resolveLocalPermissionModeArgs('yolo', ['--permission-mode', 'plan'])).toEqual([]);
+        expect(resolveLocalPermissionModeArgs('yolo', ['--permission-mode=plan'])).toEqual([]);
+        expect(resolveLocalPermissionModeArgs('plan', ['--dangerously-skip-permissions'])).toEqual([]);
     });
 });
 

--- a/packages/happy-cli/src/claude/utils/permissionMode.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.ts
@@ -88,6 +88,41 @@ export function resolveInitialClaudePermissionMode(
 }
 
 /**
+ * Whether the user already supplied an explicit permission flag on the CLI.
+ * Any explicit flag (even an invalid `--permission-mode` value) means the user
+ * override wins and Happy must not inject its own.
+ */
+function hasExplicitClaudePermissionFlag(claudeArgs: string[]): boolean {
+    return claudeArgs.includes('--permission-mode') ||
+        claudeArgs.some((arg) => arg.startsWith('--permission-mode=')) ||
+        claudeArgs.includes('--dangerously-skip-permissions');
+}
+
+/**
+ * Build the Claude CLI permission flag for a locally spawned `claude` process,
+ * mirroring the SDK's `permissionMode` option on the remote path. Without it a
+ * session Happy resolved to bypass/plan/acceptEdits would silently run in Claude's
+ * default mode. Bypass maps to `--dangerously-skip-permissions` to match the
+ * sandbox branch; an explicit flag already in `claudeArgs` wins.
+ */
+export function resolveLocalPermissionModeArgs(
+    mode: PermissionMode | undefined,
+    claudeArgs: string[],
+): string[] {
+    if (!mode || hasExplicitClaudePermissionFlag(claudeArgs)) {
+        return [];
+    }
+    const claudeMode = mapToClaudeMode(mode);
+    if (claudeMode === 'bypassPermissions') {
+        return ['--dangerously-skip-permissions'];
+    }
+    if (claudeMode === 'default') {
+        return [];
+    }
+    return ['--permission-mode', claudeMode];
+}
+
+/**
  * Enforce sandbox permission policy for Claude.
  * When sandbox is enabled, we always force bypass permissions.
  */


### PR DESCRIPTION
## Summary

Local interactive sessions never entered the bypass permission mode that Happy resolved for them. The `claudeLocal` spawn builder forwarded `claudeArgs` verbatim but, unlike the remote/SDK path (`claudeRemote.ts`, which passes `permissionMode` to the SDK and gets `--permission-mode` emitted), it never translated the resolved mode into a Claude CLI flag. Since the default mode is `yolo` (bypass), a plain `happy` invocation started the local `claude` process in `default` - approval prompts still gated tool calls even though the session metadata (and the app UI) reported `dangerouslySkipPermissions: true`. This PR threads the resolved `permissionMode` down to the local spawn and injects the matching flag, so local sessions reach the same mode the remote path already does.

## Root cause

- `runClaude.ts` resolves `initialPermissionMode` (default `yolo` → bypass) and records `dangerouslySkipPermissions` in metadata.
- **Remote** path applies it first-class: `claudeRemote.ts` sets `permissionMode: mapToClaudeMode(...)` on the SDK, which emits `--permission-mode <mode>`.
- **Local** path (`claudeLocal.ts`) only did `args.push(...opts.claudeArgs)` and never emitted a permission flag from the resolved mode.
- The **sandbox** branch was unaffected only because it force-injects `--dangerously-skip-permissions`; plain non-sandbox local sessions hit the bug.

An explicit `--dangerously-skip-permissions` / `--permission-mode` typed on the CLI *did* survive (it rides `claudeArgs`), so the gap is every mode that comes from the default or `options.permissionMode` rather than an explicit CLI flag.

## Fix

Thread the resolved `permissionMode` through `Session → loop → claudeLocalLauncher → claudeLocal` (and the offline path in `runClaude`), then inject the matching flag in the spawn builder, next to the existing sandbox injection:

- `bypassPermissions` → `--dangerously-skip-permissions` (matches the sandbox branch and `claude --dangerously-skip-permissions` directly)
- `plan` / `acceptEdits` → `--permission-mode <mode>`
- `default` → nothing
- Skipped entirely when `claudeArgs` already carries an explicit permission flag (no duplicates, user override wins).

## Proof it works (real spawn)

Drove the real `claudeLocal` → real `cross-spawn` → real `claude_local_launcher.cjs` → a stub `claude` (via `HAPPY_CLAUDE_PATH`) that prints the argv it actually received - same evidence format as a `ps` on the live process.

**Before** (`happy@1.1.10`, plain local session) - no permission flag reached claude:
```
claude --append-system-prompt <happy title prompt> --mcp-config {...} --allowedTools mcp__happy__change_title --settings <hook>
```

**After** (this branch), real argv delivered to claude:

| Invocation | claude argv tail |
|---|---|
| plain `happy` (default `yolo`) | `… --dangerously-skip-permissions` |
| `permissionMode=bypassPermissions` | `… --dangerously-skip-permissions` |
| `permissionMode=plan` | `… --permission-mode plan` |
| `permissionMode=default` | *(no permission flag)* |
| `yolo` + explicit `--permission-mode plan` in args | `… --permission-mode plan` *(bypass not added - user override wins)* |

```
==== default happy (yolo) ====
STUB_CLAUDE_ARGV ["--session-id","…","--append-system-prompt","…","--dangerously-skip-permissions"]
==== plan mode ====
STUB_CLAUDE_ARGV ["--session-id","…","--append-system-prompt","…","--permission-mode","plan"]
==== default mode (no flag expected) ====
STUB_CLAUDE_ARGV ["--session-id","…","--append-system-prompt","…"]
==== yolo + explicit --permission-mode plan ====
STUB_CLAUDE_ARGV ["--session-id","…","--append-system-prompt","…","--permission-mode","plan"]
```

To reproduce interactively: `happy --yolo` (or plain `happy`), then in another terminal `ps -o args= -p <claude pid>` - the argv now carries `--dangerously-skip-permissions`.

## Testing

- `pnpm --filter happy test` - added 6 unit tests in `claudeLocal.test.ts` (inject bypass for yolo/bypass, `--permission-mode` for plan, no flag for default, no duplicate when a flag is already present, explicit-flag override). Full suite green.
- `tsc --noEmit` - clean.
- `pnpm --filter happy build` - passes.

## Scope

CLI-only, one focused bug fix. No sync engine / RPC / encryption / server changes.
