### PR TITLE
feat(cli): publish Codex model list to session metadata

### DIFF
--- a/packages/happy-cli/src/codex/codexAppServerClient.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.ts
@@ -31,6 +31,9 @@ import type {
     RollbackConversationResponse,
     InjectItemsParams,
     InjectItemsResponse,
+    CodexModel,
+    ListModelsParams,
+    ListModelsResponse,
     ThreadGoalSetParams,
     ThreadGoalSetResponse,
     ThreadGoalClearParams,
@@ -192,6 +195,9 @@ function normalizeRawFileChangeList(changes: unknown): LegacyPatchChanges | unde
 
     return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
+
+const MODEL_LIST_PAGE_SIZE = 100;
+const MODEL_LIST_MAX_PAGES = 10;
 
 export class CodexAppServerClient {
     private process: ChildProcess | null = null;
@@ -826,6 +832,32 @@ export class CodexAppServerClient {
             items: opts.items,
         };
         return await this.request('thread/inject_items', params) as InjectItemsResponse;
+    }
+
+    /**
+     * Enumerate the models this Codex backend offers, following pagination.
+     * Hidden models are excluded unless explicitly requested — they are the
+     * ones Codex itself keeps out of its picker.
+     */
+    async listModels(opts?: { includeHidden?: boolean }): Promise<CodexModel[]> {
+        const models: CodexModel[] = [];
+        let cursor: string | null | undefined = undefined;
+        // Bound the walk so a backend that always returns a cursor cannot hang startup.
+        for (let page = 0; page < MODEL_LIST_MAX_PAGES; page++) {
+            const params: ListModelsParams = {
+                includeHidden: opts?.includeHidden ?? false,
+                limit: MODEL_LIST_PAGE_SIZE,
+                ...(cursor ? { cursor } : {}),
+            };
+            const response = await this.request('model/list', params) as ListModelsResponse;
+            models.push(...response.data);
+            cursor = response.nextCursor;
+            if (!cursor) {
+                return models;
+            }
+        }
+        logger.debug(`[codex] model/list exceeded ${MODEL_LIST_MAX_PAGES} pages; returning ${models.length} models`);
+        return models;
     }
 
     async setGoal(opts: {

--- a/packages/happy-cli/src/codex/codexAppServerTypes.ts
+++ b/packages/happy-cli/src/codex/codexAppServerTypes.ts
@@ -296,3 +296,31 @@ export type JsonRpcResponse = {
     result?: unknown;
     error?: { code: number; message: string; data?: unknown };
 };
+
+//
+// model/list — enumerate the models the Codex backend currently offers.
+// Response shape mirrors codex-rs `ModelListResponse` (see
+// `codex app-server generate-json-schema`, v2/ModelListResponse.json).
+//
+
+export type CodexModel = {
+    id: string;
+    model: string;
+    displayName: string;
+    description: string;
+    hidden: boolean;
+    isDefault: boolean;
+    defaultReasoningEffort: string;
+    supportedReasoningEfforts: string[];
+};
+
+export type ListModelsParams = {
+    cursor?: string | null;
+    includeHidden?: boolean | null;
+    limit?: number | null;
+};
+
+export type ListModelsResponse = {
+    data: CodexModel[];
+    nextCursor?: string | null;
+};

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -4,6 +4,7 @@ import { ApiClient } from '@/api/api';
 import { CodexAppServerClient } from './codexAppServerClient';
 import type { ReasoningEffort } from './codexAppServerTypes';
 import { CodexPermissionHandler } from './utils/permissionHandler';
+import { toMetadataModels } from './utils/modelMetadata';
 import { ReasoningProcessor } from './utils/reasoningProcessor';
 import { DiffProcessor } from './utils/diffProcessor';
 import { randomUUID } from 'node:crypto';
@@ -70,9 +71,39 @@ function describeCodexFailure(msg: any): string | null {
     return 'Unknown error';
 }
 
+/**
+ * Fallback only. Used when the app sends no model override at all; a running
+ * backend advertises its real model list via `model/list` (see
+ * publishCodexModelMetadata) so the picker does not depend on this constant.
+ */
 const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 const DEFAULT_CODEX_EFFORT: ReasoningEffort = 'medium';
 const DEFAULT_CODEX_PERMISSION_MODE: PermissionMode = 'yolo';
+
+/**
+ * Ask the connected Codex backend which models it offers and publish them to
+ * session metadata, so the app renders a live picker instead of a hardcoded
+ * list that goes stale every time OpenAI ships a model.
+ *
+ * Best-effort: an older `codex` without `model/list` simply leaves
+ * `metadata.models` unset, and the app falls back to its hardcoded options.
+ */
+async function publishCodexModelMetadata(
+    client: CodexAppServerClient,
+    session: ApiSessionClient,
+): Promise<void> {
+    try {
+        const models = toMetadataModels(await client.listModels());
+        if (models.length === 0) {
+            logger.debug('[codex] model/list returned no visible models; keeping app defaults');
+            return;
+        }
+        session.updateMetadata((meta) => ({ ...meta, models }));
+        logger.debug(`[codex] published ${models.length} models to session metadata`);
+    } catch (error) {
+        logger.debug('[codex] model/list unavailable; app will fall back to hardcoded models', error);
+    }
+}
 
 /**
  * Main entry point for the codex command with ink UI
@@ -804,6 +835,8 @@ export async function runCodex(opts: {
         logger.debug('[codex]: client.connect begin');
         await client.connect();
         logger.debug('[codex]: client.connect done');
+
+        await publishCodexModelMetadata(client, session);
 
         if (opts.resumeThreadId) {
             await resumeExistingThread({

--- a/packages/happy-cli/src/codex/utils/modelMetadata.test.ts
+++ b/packages/happy-cli/src/codex/utils/modelMetadata.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CodexModel } from '../codexAppServerTypes';
+import { toMetadataModels } from './modelMetadata';
+
+function model(overrides: Partial<CodexModel> = {}): CodexModel {
+    return {
+        id: 'gpt-5.6-sol',
+        model: 'gpt-5.6-sol',
+        displayName: 'GPT-5.6-Sol',
+        description: 'Latest frontier agentic coding model.',
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: 'low',
+        supportedReasoningEfforts: ['low', 'medium', 'high'],
+        ...overrides,
+    };
+}
+
+describe('toMetadataModels', () => {
+    it('maps id/displayName/description onto the metadata option shape', () => {
+        expect(toMetadataModels([model()])).toEqual([
+            {
+                code: 'gpt-5.6-sol',
+                value: 'GPT-5.6-Sol',
+                description: 'Latest frontier agentic coding model.',
+            },
+        ]);
+    });
+
+    it('drops hidden models', () => {
+        const models = [
+            model({ id: 'gpt-5.6-sol' }),
+            model({ id: 'internal-preview', hidden: true }),
+        ];
+        expect(toMetadataModels(models).map((m) => m.code)).toEqual(['gpt-5.6-sol']);
+    });
+
+    it('never synthesises a `default` entry (the app adds its own)', () => {
+        const codes = toMetadataModels([model({ isDefault: true })]).map((m) => m.code);
+        expect(codes).not.toContain('default');
+    });
+
+    it('preserves backend ordering', () => {
+        const models = [
+            model({ id: 'gpt-5.6-sol' }),
+            model({ id: 'gpt-5.6-terra', isDefault: false }),
+            model({ id: 'gpt-5.5', isDefault: false }),
+        ];
+        expect(toMetadataModels(models).map((m) => m.code)).toEqual([
+            'gpt-5.6-sol',
+            'gpt-5.6-terra',
+            'gpt-5.5',
+        ]);
+    });
+
+    it('falls back to the id when displayName is empty, and nulls empty descriptions', () => {
+        const [mapped] = toMetadataModels([model({ displayName: '', description: '' })]);
+        expect(mapped).toEqual({
+            code: 'gpt-5.6-sol',
+            value: 'gpt-5.6-sol',
+            description: null,
+        });
+    });
+
+    it('returns an empty list when the backend reports no models', () => {
+        expect(toMetadataModels([])).toEqual([]);
+    });
+});

--- a/packages/happy-cli/src/codex/utils/modelMetadata.ts
+++ b/packages/happy-cli/src/codex/utils/modelMetadata.ts
@@ -1,0 +1,23 @@
+import type { Metadata } from '@/api/types';
+import type { CodexModel } from '../codexAppServerTypes';
+
+type MetadataModels = NonNullable<Metadata['models']>;
+
+/**
+ * Map Codex `model/list` entries onto the session metadata shape the mobile
+ * app consumes (`{ code, value, description }`).
+ *
+ * The app prepends its own `default` option for Codex sessions when metadata
+ * carries no `default` entry (see `getAvailableModels()` in
+ * `modelModeOptions.ts`), so we deliberately do not synthesise one here —
+ * `default` means "send no model override and let ~/.codex/config.toml decide".
+ */
+export function toMetadataModels(models: CodexModel[]): MetadataModels {
+    return models
+        .filter((model) => !model.hidden)
+        .map((model) => ({
+            code: model.id,
+            value: model.displayName || model.id,
+            description: model.description || null,
+        }));
+}


### PR DESCRIPTION
## Problem

The Codex model picker is a hardcoded array in `packages/happy-app/sources/components/modelModeOptions.ts`:

```ts
export function getCodexModelModes(): ModelMode[] {
    return [
        { key: 'default', name: 'default model', description: null },
        { key: 'gpt-5.5', name: 'gpt-5.5', description: null },
        { key: 'gpt-5.4', name: 'gpt-5.4', description: null },
        // ...
    ];
}
```

It tops out at `gpt-5.5`. Codex CLI 0.144.1 ships `gpt-5.6-sol`, `gpt-5.6-terra` and `gpt-5.6-luna`, and none of them are selectable from the app. Today the only workaround is to pick `default` and set `model` in `~/.codex/config.toml`.

Extending the array would fix it until the next model ships, and would need a client release to reach mobile users.

## What this does

`getAvailableModels()` already prefers backend-supplied `metadata.models[]` over the hardcoded array, and already re-adds a `default` option for Codex sessions:

```ts
const metadataModels = mapMetadataOptions(metadata?.models);
if (metadataModels.length > 0) {
    if (flavor === 'codex' && !metadataModels.some((model) => model.key === 'default')) {
        return [{ key: 'default', name: 'default model', description: null }, ...metadataModels];
    }
    return metadataModels;
}
return getHardcodedModelModes(flavor, translate);
```

Nothing was populating `metadata.models` on the Codex path — only the ACP path (`runAcp.ts`) does it, via `models_update`.

The Codex app-server protocol exposes a `model/list` RPC. This PR calls it once after `client.connect()` and publishes the result to session metadata. The picker then reflects whatever the installed `codex` actually supports — including models released after any given Happy version.

**This is CLI-only. No app change, no store release.**

## Changes

| File | Change |
|---|---|
| `src/codex/codexAppServerTypes.ts` | `CodexModel`, `ListModelsParams`, `ListModelsResponse` |
| `src/codex/codexAppServerClient.ts` | paginated `listModels()` (bounded at 10 pages) |
| `src/codex/utils/modelMetadata.ts` | `toMetadataModels()` — `{ id, displayName, description }` → `{ code, value, description }` |
| `src/codex/runCodex.ts` | `publishCodexModelMetadata()` after connect |
| `src/codex/utils/modelMetadata.test.ts` | 6 unit tests |

Design notes:

- **`default` is not synthesised.** The app adds it, and in Happy's Codex semantics it means "send no model override", which lets `~/.codex/config.toml` decide. Emitting a `default` entry here would change that.
- **`currentModelCode` is not set**, for the same reason — preselecting the backend's default model would turn a config-driven session into an explicit per-message override.
- **`hidden` models are filtered.** Those are the ones Codex itself keeps out of its picker.
- **Best-effort.** An older `codex` without `model/list` throws, we log at debug, `metadata.models` stays unset, and `getAvailableModels()` falls back to the hardcoded list. No regression for anyone.
- `DEFAULT_CODEX_MODEL` is left alone; it's still the fallback when the app sends no override at all.

## Verification

Against `codex-cli 0.144.1`, `model/list` returns 7 visible models:

```
id='gpt-5.6-sol'    displayName='GPT-5.6-Sol'    isDefault=True  hidden=False
id='gpt-5.6-terra'  displayName='GPT-5.6-Terra'  isDefault=False hidden=False
id='gpt-5.6-luna'   displayName='GPT-5.6-Luna'   isDefault=False hidden=False
id='gpt-5.5'        displayName='GPT-5.5'        isDefault=False hidden=False
id='gpt-5.4'        displayName='GPT-5.4'        isDefault=False hidden=False
id='gpt-5.4-mini'   displayName='GPT-5.4-Mini'   isDefault=False hidden=False
...
nextCursor: None
```

`id` and `model` are identical (both the slug); `id` is used as `code`.

- `tsc --noEmit` on `happy-cli`: clean (exit 0)
- `vitest run --project unit src/codex/`: **101 passed**, 17 files (6 new)

## Notes for reviewers

- The protocol types were derived from `codex app-server generate-json-schema` (`v2/ModelListResponse.json`), not hand-guessed.
- Pagination is implemented (`cursor` / `nextCursor`) and bounded at 10 pages so a misbehaving backend can't hang session startup.
- Related: #247 ("Android app hasn't been updated to see new models for codex"). This removes the need for an app release to surface *new* Codex models, so it addresses the model half of that report — but only for app builds that already contain the `getAvailableModels()` metadata path, and the MCP failures mentioned there are a separate problem.
