### PR TITLE
feat(cli): add a project-scoped Claude model pin

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { ApiClient } from '@/api/api';
 import { logger } from '@/ui/logger';
 import { loop } from '@/claude/loop';
+import { readForcedModel, resolveForcedModel } from '@/claude/utils/forceModel';
 import { AgentGoalStatus, AgentState, Metadata } from '@/api/types';
 import packageJson from '../../package.json';
 import { Credentials, readSettings } from '@/persistence';
@@ -74,6 +75,14 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     
     const workingDirectory = process.cwd();
     const sessionTag = randomUUID();
+
+    // A `.happy-force-model` marker in the working directory pins the Claude
+    // model for this session. Read once at startup; when set it wins at every
+    // model-resolution site below.
+    const forcedModel = readForcedModel(workingDirectory);
+    if (forcedModel) {
+        logger.debug(`[CLAUDE] .happy-force-model active: forcing model=${forcedModel} (app model choices ignored)`);
+    }
 
     // Log environment info at startup
     logger.debugLargeJson('[START] Happy process started', getEnvironmentInfo());
@@ -521,7 +530,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Forward messages to the queue
     // Permission modes: Use the unified 7-mode type, mapping happens at SDK boundary in claudeRemote.ts
     let currentPermissionMode: PermissionMode | undefined = initialPermissionMode;
-    let currentModel: string | undefined = options.model ?? DEFAULT_CLAUDE_MODEL; // Track current model state
+    let currentModel: string | undefined = resolveForcedModel(forcedModel, options.model ?? DEFAULT_CLAUDE_MODEL); // Track current model state
     let currentFallbackModel: string | undefined = undefined; // Track current fallback model
     let currentCustomSystemPrompt: string | undefined = undefined; // Track current custom system prompt
     let currentAppendSystemPrompt: string | undefined = undefined; // Track current append system prompt
@@ -531,7 +540,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
 
     const resetCurrentModeDefaults = () => {
         currentPermissionMode = initialPermissionMode;
-        currentModel = options.model ?? DEFAULT_CLAUDE_MODEL;
+        currentModel = resolveForcedModel(forcedModel, options.model ?? DEFAULT_CLAUDE_MODEL);
         currentFallbackModel = undefined;
         currentCustomSystemPrompt = undefined;
         currentAppendSystemPrompt = undefined;
@@ -674,9 +683,9 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
         // Resolve model - use message.meta.model if provided, otherwise use current model
         let messageModel = currentModel;
         if (message.meta?.hasOwnProperty('model')) {
-            messageModel = message.meta.model || undefined; // null becomes undefined
+            messageModel = resolveForcedModel(forcedModel, message.meta.model || undefined); // null becomes undefined
             currentModel = messageModel;
-            logger.debug(`[loop] Model updated from user message: ${messageModel || 'reset to default'}`);
+            logger.debug(`[loop] Model updated from user message: ${messageModel || 'reset to default'}${forcedModel ? ' (forced by .happy-force-model)' : ''}`);
         } else {
             logger.debug(`[loop] User message received with no model override, using current: ${currentModel || 'default'}`);
         }
@@ -920,7 +929,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Create claude loop
     const exitCode = await loop({
         path: workingDirectory,
-        model: options.model,
+        model: resolveForcedModel(forcedModel, options.model),
         permissionMode: initialPermissionMode,
         startingMode: options.startingMode,
         messageQueue,

--- a/packages/happy-cli/src/claude/utils/forceModel.test.ts
+++ b/packages/happy-cli/src/claude/utils/forceModel.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readForcedModel, resolveForcedModel, FORCE_MODEL_MARKER } from './forceModel';
+
+describe('forceModel', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'happy-force-model-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('returns undefined when no marker is present', () => {
+        expect(readForcedModel(dir)).toBeUndefined();
+    });
+
+    it('reads the model id from the marker file', () => {
+        writeFileSync(join(dir, FORCE_MODEL_MARKER), 'claude-sonnet-5\n');
+        expect(readForcedModel(dir)).toBe('claude-sonnet-5');
+    });
+
+    it('ignores comment and blank lines, taking the first meaningful line', () => {
+        writeFileSync(join(dir, FORCE_MODEL_MARKER), '# pin this lane to sonnet\n\n  sonnet  \n');
+        expect(readForcedModel(dir)).toBe('sonnet');
+    });
+
+    it('forced model overrides the app/picker choice', () => {
+        expect(resolveForcedModel('claude-sonnet-5', 'claude-opus-4-8')).toBe('claude-sonnet-5');
+    });
+
+    it('falls back to the requested model when nothing is forced', () => {
+        expect(resolveForcedModel(undefined, 'claude-opus-4-8')).toBe('claude-opus-4-8');
+    });
+});

--- a/packages/happy-cli/src/claude/utils/forceModel.ts
+++ b/packages/happy-cli/src/claude/utils/forceModel.ts
@@ -1,0 +1,45 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Project-scoped model override.
+ *
+ * A folder carrying a `.happy-force-model` file pins the Claude model for every
+ * session started in it, overriding model changes requested by a controller.
+ * The marker file's first non-empty, non-`#` line is the model id and is passed
+ * straight through to `claude --model`, so both aliases (`sonnet`, `opus`,
+ * `haiku`) and full ids work.
+ *
+ * Absent marker -> returns undefined and the app's choice is used unchanged.
+ */
+export const FORCE_MODEL_MARKER = '.happy-force-model';
+
+/** Read the forced model id from `<workingDirectory>/.happy-force-model`, or undefined. */
+export function readForcedModel(workingDirectory: string): string | undefined {
+    try {
+        const markerPath = join(workingDirectory, FORCE_MODEL_MARKER);
+        if (!existsSync(markerPath)) {
+            return undefined;
+        }
+        const firstMeaningful = readFileSync(markerPath, 'utf8')
+            .split('\n')
+            .map((line) => line.trim())
+            .find((line) => line.length > 0 && !line.startsWith('#'));
+        return firstMeaningful || undefined;
+    } catch {
+        // Never let a marker read break a session start.
+        return undefined;
+    }
+}
+
+/**
+ * Resolve the effective model: the forced model always wins when present,
+ * otherwise the requested (app/picker) model is used. Centralised so every
+ * model-resolution site in runClaude.ts applies the same rule.
+ */
+export function resolveForcedModel(
+    forced: string | undefined,
+    requested: string | undefined,
+): string | undefined {
+    return forced ?? requested;
+}


### PR DESCRIPTION
Happy currently lets app-supplied model changes override a session's startup model, so a project that must stay on one Claude model can drift when controlled remotely. This adds an optional .happy-force-model file in the working directory; its first non-comment line pins that session's model at startup and remains authoritative over later controller updates. With no marker, behavior is unchanged.

## Running proof

I started a real Happy CLI session from a directory containing claude-sonnet-5 while passing the conflicting startup choice claude-opus-4-8. The session answered HFORK_FORCE_OK, and the runtime log emitted:

~~~text
.happy-force-model active: forcing model=claude-sonnet-5 (app model choices ignored)
~~~

## Current-base validation

The single contribution commit is rebased onto upstream 5e2dd1ae. Its range-diff and stable patch ID are unchanged, while upstream effort handling, Agy support, and GPT-5.6 remain ancestors.

- frozen workspace install passed
- focused forceModel suite: 5/5
- full Happy CLI unit suite: 746/746
- happy-wire build and full Happy CLI build passed
- diff contains only runClaude.ts plus the forceModel helper and test
- git diff --check passed

## Overlap

This is related to #1500 but has different semantics: #1500 supplies machine-wide startup defaults, while this marker is project-scoped and deliberately pins the model for the whole session. I can adapt it onto #1500 if maintainers prefer one configuration surface.

Refs bogdanbaciu21/dans-brain#10806 and bogdanbaciu21/dans-brain#15726.