### PR TITLE
fix(cli): transcode HEIC attachments before Claude upload

### DIFF
--- a/packages/happy-cli/package.json
+++ b/packages/happy-cli/package.json
@@ -93,6 +93,7 @@
     "expo-server-sdk": "^3.15.0",
     "fastify": "^5.6.2",
     "fastify-type-provider-zod": "^6.1.0",
+    "heic-convert": "2.1.0",
     "http-proxy": "^1.18.1",
     "http-proxy-middleware": "^3.0.5",
     "ink": "^6.5.1",
@@ -110,6 +111,7 @@
   },
   "devDependencies": {
     "@eslint/compat": "^1",
+    "@types/heic-convert": "^2.1.1",
     "@types/inquirer": "^9.0.9",
     "@types/node": ">=20",
     "@types/ws": "^8.18.1",

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -1,6 +1,7 @@
 import { render } from "ink";
 import { Session } from "./session";
 import { MessageBuffer } from "@/ui/ink/messageBuffer";
+import { isHeicOrHeif, transcodeHeicToJpeg } from "@/claude/utils/heicTranscode";
 import { RemoteModeDisplay } from "@/ui/ink/RemoteModeDisplay";
 import React from "react";
 import { claudeRemote } from "./claudeRemote";
@@ -354,7 +355,21 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                                     // strict enum validation error. If the bytes look like one
                                     // of the four formats Claude accepts, send that label —
                                     // otherwise skip the attachment with a debug log.
-                                    const detected = detectClaudeImageMime(att.data);
+                                    // HEIC/HEIF is not accepted by Claude's media_type
+                                    // enum. Transcode it to JPEG instead of dropping the
+                                    // photo. A failed transcode falls through to the skip
+                                    // below rather than crashing.
+                                    let imageData = att.data;
+                                    let detected = detectClaudeImageMime(imageData);
+                                    if (!detected && isHeicOrHeif(imageData)) {
+                                        try {
+                                            imageData = await transcodeHeicToJpeg(imageData);
+                                            detected = detectClaudeImageMime(imageData) ?? 'image/jpeg';
+                                            logger.debug(`[remote] Transcoded HEIC/HEIF attachment ${att.name} to JPEG (${imageData.length} bytes)`);
+                                        } catch (err) {
+                                            logger.debug(`[remote] HEIC transcode failed for ${att.name}: ${err instanceof Error ? err.message : err}`);
+                                        }
+                                    }
                                     if (!detected) {
                                         logger.debug(`[remote] Skipping unsupported attachment (no magic-byte match): ${att.name}, claimed mimeType=${att.mimeType}`);
                                         continue;
@@ -364,7 +379,7 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                                         source: {
                                             type: 'base64' as const,
                                             media_type: detected,
-                                            data: Buffer.from(att.data).toString('base64'),
+                                            data: Buffer.from(imageData).toString('base64'),
                                         },
                                     });
                                 }

--- a/packages/happy-cli/src/claude/utils/heicTranscode.test.ts
+++ b/packages/happy-cli/src/claude/utils/heicTranscode.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { isHeicOrHeif, transcodeHeicToJpeg } from './heicTranscode';
+
+/** Build a minimal ISO-BMFF ftyp box: [size]['ftyp'][major][minor][...compat]. */
+function ftyp(major: string, compatible: string[] = []): Uint8Array {
+    const brands = [major, '\0\0\0\0', ...compatible];
+    const size = 8 + brands.length * 4; // 4 size + 4 'ftyp' + brands
+    const bytes = new Uint8Array(size);
+    bytes[0] = (size >> 24) & 0xff;
+    bytes[1] = (size >> 16) & 0xff;
+    bytes[2] = (size >> 8) & 0xff;
+    bytes[3] = size & 0xff;
+    bytes.set([0x66, 0x74, 0x79, 0x70], 4); // 'ftyp'
+    let off = 8;
+    for (const b of brands) {
+        for (let i = 0; i < 4; i++) bytes[off + i] = b.charCodeAt(i) || 0;
+        off += 4;
+    }
+    return bytes;
+}
+
+describe('isHeicOrHeif', () => {
+    it('detects a HEIC major brand', () => {
+        expect(isHeicOrHeif(ftyp('heic', ['mif1', 'heic']))).toBe(true);
+    });
+
+    it('detects HEIF via a compatible brand when the major brand is generic', () => {
+        // iOS often writes major brand 'mif1' with 'heic'/'heix' in compatibles.
+        expect(isHeicOrHeif(ftyp('mif1', ['heix']))).toBe(true);
+    });
+
+    it('detects a HEIF image sequence (msf1)', () => {
+        expect(isHeicOrHeif(ftyp('msf1', ['hevc']))).toBe(true);
+    });
+
+    it('rejects a plain MP4 (isom), which is not HEIF', () => {
+        expect(isHeicOrHeif(ftyp('isom', ['mp41', 'iso2']))).toBe(false);
+    });
+
+    it('rejects PNG and JPEG magic bytes', () => {
+        expect(isHeicOrHeif(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0, 0, 0, 0, 0, 0, 0, 0]))).toBe(false);
+        expect(isHeicOrHeif(new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0]))).toBe(false);
+    });
+
+    it('rejects a too-short buffer', () => {
+        expect(isHeicOrHeif(new Uint8Array([0x66, 0x74, 0x79, 0x70]))).toBe(false);
+    });
+});
+
+describe('transcodeHeicToJpeg', () => {
+    it('rejects non-HEIC input (so the launcher try/catch skips instead of crashing)', async () => {
+        await expect(transcodeHeicToJpeg(new Uint8Array([0x89, 0x50, 0x4e, 0x47]))).rejects.toBeDefined();
+    });
+});

--- a/packages/happy-cli/src/claude/utils/heicTranscode.ts
+++ b/packages/happy-cli/src/claude/utils/heicTranscode.ts
@@ -1,0 +1,64 @@
+import convert from 'heic-convert';
+
+/**
+ * HEIC/HEIF upload support for Claude image blocks.
+ *
+ * iPhone/iPad photos are HEIC, which the Anthropic API's strict
+ * `image.source.base64.media_type` enum does NOT accept -- so the magic-byte
+ * detector drops them and the photo silently vanishes from the message. Here we
+ * (a) recognise HEIC/HEIF by its ISO base-media-file-format `ftyp` box, and
+ * (b) transcode it to JPEG (which the API does accept) before the image block is
+ * built.
+ */
+
+// HEIF/HEIC major or compatible brands seen in the ftyp box.
+const HEIF_BRANDS = new Set([
+    'heic', 'heix', 'heim', 'heis', 'hevc', 'hevx',
+    'heif', 'mif1', 'msf1', 'miaf', 'mira',
+]);
+
+function brandAt(bytes: Uint8Array, offset: number): string {
+    return String.fromCharCode(
+        bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3],
+    ).toLowerCase();
+}
+
+/**
+ * True when the blob is an ISO-BMFF HEIF/HEIC file: a `ftyp` box (bytes 4..8)
+ * whose major brand, or one of its compatible brands, is a known HEIF brand.
+ */
+export function isHeicOrHeif(bytes: Uint8Array): boolean {
+    if (bytes.length < 12) {
+        return false;
+    }
+    // Bytes 4..8 must spell "ftyp".
+    if (bytes[4] !== 0x66 || bytes[5] !== 0x74 || bytes[6] !== 0x79 || bytes[7] !== 0x70) {
+        return false;
+    }
+    // Major brand at bytes 8..12.
+    if (HEIF_BRANDS.has(brandAt(bytes, 8))) {
+        return true;
+    }
+    // Compatible brands follow, 4 bytes each, up to the declared box size.
+    const declaredSize = (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3];
+    const end = Math.min(declaredSize > 0 ? declaredSize : bytes.length, bytes.length);
+    for (let i = 16; i + 4 <= end; i += 4) {
+        if (HEIF_BRANDS.has(brandAt(bytes, i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Transcode HEIC/HEIF bytes to JPEG bytes. Delegates to heic-convert
+ * (libheif WASM), so it needs no native libheif on the host.
+ */
+export async function transcodeHeicToJpeg(bytes: Uint8Array): Promise<Uint8Array> {
+    const output = await convert({
+        buffer: Buffer.from(bytes),
+        format: 'JPEG',
+        quality: 0.92,
+    });
+    return new Uint8Array(output);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,6 +972,9 @@ importers:
       fastify-type-provider-zod:
         specifier: ^6.1.0
         version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.7.2)(openapi-types@12.1.3)(zod@4.4.3)
+      heic-convert:
+        specifier: 2.1.0
+        version: 2.1.0
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1(debug@4.4.3)
@@ -1018,6 +1021,9 @@ importers:
       '@eslint/compat':
         specifier: ^1
         version: 1.4.1(eslint@9.39.2(jiti@2.6.1))
+      '@types/heic-convert':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@types/inquirer':
         specifier: ^9.0.9
         version: 9.0.9
@@ -5532,6 +5538,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/heic-convert@2.1.1':
+    resolution: {integrity: sha512-+s14762Nf62z9zziIs7ItvAkSUCS3ls4Z5XPT9BlVve3Q3S4DAnf6qekffMTvEWycSUF+kulkGaSN65fK6eKvg==}
+
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
@@ -8310,6 +8319,14 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  heic-convert@2.1.0:
+    resolution: {integrity: sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==}
+    engines: {node: '>=12.0.0'}
+
+  heic-decode@2.1.0:
+    resolution: {integrity: sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==}
+    engines: {node: '>=8.0.0'}
+
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
@@ -8881,6 +8898,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -9013,6 +9033,10 @@ packages:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
     engines: {node: '>=16'}
     hasBin: true
+
+  libheif-js@1.19.8:
+    resolution: {integrity: sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==}
+    engines: {node: '>=8.0.0'}
 
   libsodium-sumo@0.7.16:
     resolution: {integrity: sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA==}
@@ -10245,6 +10269,10 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -17587,6 +17615,8 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/heic-convert@2.1.1': {}
+
   '@types/http-cache-semantics@4.2.0': {}
 
   '@types/http-errors@2.0.5': {}
@@ -20852,6 +20882,16 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  heic-convert@2.1.0:
+    dependencies:
+      heic-decode: 2.1.0
+      jpeg-js: 0.4.4
+      pngjs: 6.0.0
+
+  heic-decode@2.1.0:
+    dependencies:
+      libheif-js: 1.19.8
+
   help-me@5.0.0: {}
 
   hermes-compiler@0.14.0: {}
@@ -21445,6 +21485,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  jpeg-js@0.4.4: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -21586,6 +21628,8 @@ snapshots:
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
+
+  libheif-js@1.19.8: {}
 
   libsodium-sumo@0.7.16: {}
 
@@ -23284,6 +23328,8 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@5.0.0: {}
+
+  pngjs@6.0.0: {}
 
   points-on-curve@0.2.0: {}
 


### PR DESCRIPTION
Happy's Claude CLI path currently accepts only JPEG, PNG, GIF, and WebP magic bytes, so HEIC/HEIF blobs from iPhone/iPad or older clients are omitted. This detects ISO-BMFF HEIF brands and converts the decrypted bytes to JPEG before creating the Claude image block; conversion failure stays fail-soft and preserves the existing skip behavior.

## Live running proof

From this rebased contribution commit, I started a real Happy remote session against the production relay. I uploaded the pinned 718,114-byte libheif HEIC fixture through the same encrypted file envelope and attachment endpoints used by the app, followed by a real text turn. The running CLI log showed the full relay-to-agent path:

~~~text
[API] Received file event { size: 718114, hasMimeType: true }
[loop] File event received: hfork011-proof.heic (718114 bytes)
[loop] Attachment decrypted: hfork011-proof.heic (718114 bytes)
[remote] Transcoded HEIC/HEIF attachment hfork011-proof.heic to JPEG (558966 bytes)
[remote] Combined 1 image(s) with text message
result: HFORK_HEIC_E2E_OK
~~~

This exercises the production relay, encrypted blob upload/download, CLI decryption, HEIC conversion, Claude image-block construction, and a live GLM-4.6 response - not only the helper in isolation.

## Checks

- rebased onto upstream 5e2dd1ae; range-diff is identical to the original patch
- frozen workspace install passed
- focused HEIC suite: 7/7
- full Happy CLI unit suite: 748/748
- happy-wire build and full Happy CLI build passed
- standalone real fixture conversion: 718,114-byte HEIC to complete 558,966-byte JPEG
- lockfile delta contains only heic-convert, its types, and transitive dependencies

## Overlap

#1387 normalizes HEIC in the current app before upload; this is CLI-side defense in depth for older clients and already-uploaded HEIC blobs. #1387 also moves attachment routing into attachmentContentBlocks.ts. If it lands first, I will rebase this helper into that conversion boundary instead of retaining a competing launcher edit.

Refs bogdanbaciu21/dans-brain#10806 and bogdanbaciu21/dans-brain#15726.