### PR TITLE
fix(agy): surface empty print failures

### DIFF
--- a/packages/happy-cli/src/agy/AgyBackend.test.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { writeFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AgyBackend, type SpawnFn } from './AgyBackend';
@@ -82,6 +83,55 @@ describe('AgyBackend', () => {
     expect(messages.at(-1)).toMatchObject({ type: 'status', status: 'error' });
   });
 
+  it('rejects an exit-0 turn that produced no stdout and surfaces agy quota logs', async () => {
+    const { child } = makeFakeChild();
+    let logFile = '';
+    const spawnFn = vi.fn((_bin: string, args: string[]) => {
+      const idx = args.indexOf('--log-file');
+      logFile = args[idx + 1];
+      return child;
+    }) as unknown as SpawnFn;
+
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      spawnFn,
+      resolveConversationId: () => null,
+    });
+    const messages: AgentMessage[] = [];
+    backend.onMessage((m) => messages.push(m));
+
+    await backend.startSession();
+    const turn = backend.sendPrompt('/work', 'hi');
+    writeFileSync(logFile, 'agent executor error: RESOURCE_EXHAUSTED (code 429): Individual quota reached.\n');
+    child.emit('close', 0);
+
+    await expect(turn).rejects.toThrow(/RESOURCE_EXHAUSTED/);
+    expect(messages.at(-1)).toMatchObject({
+      type: 'status',
+      status: 'error',
+      detail: expect.stringContaining('RESOURCE_EXHAUSTED'),
+    });
+  });
+
+  it('rejects an exit-0 turn that produced no stdout even without a classified agy log error', async () => {
+    const { child } = makeFakeChild();
+    const spawnFn = vi.fn(() => child) as unknown as SpawnFn;
+
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      spawnFn,
+      resolveConversationId: () => null,
+    });
+
+    await backend.startSession();
+    const turn = backend.sendPrompt('/work', 'hi');
+    child.emit('close', 0);
+
+    await expect(turn).rejects.toThrow(/produced no output/);
+  });
+
   it('resumes the captured conversation id on the next turn', async () => {
     const spawnCalls: string[][] = [];
     let current = makeFakeChild();
@@ -104,6 +154,7 @@ describe('AgyBackend', () => {
     // First turn: fresh (no --conversation), then a conversation id appears.
     const t1 = backend.sendPrompt('/work', 'first');
     recorded = 'cid-xyz';
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t1;
 
@@ -112,6 +163,7 @@ describe('AgyBackend', () => {
     // Second turn: resumes the captured id.
     current = makeFakeChild();
     const t2 = backend.sendPrompt('/work', 'second');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t2;
 
@@ -139,6 +191,7 @@ describe('AgyBackend', () => {
     await backend.startSession();
 
     const t1 = backend.sendPrompt('/work', 'first');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t1;
     expect(spawnCalls[0]).not.toContain('--conversation');
@@ -146,6 +199,7 @@ describe('AgyBackend', () => {
     // The cache entry never changed, so it was not ours to adopt.
     current = makeFakeChild();
     const t2 = backend.sendPrompt('/work', 'second');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t2;
     expect(spawnCalls[1]).not.toContain('--conversation');
@@ -171,12 +225,14 @@ describe('AgyBackend', () => {
 
     const t1 = backend.sendPrompt('/work', 'first');
     recorded = 'fresh-1'; // our turn created a new conversation
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t1;
     expect(spawnCalls[0]).not.toContain('--conversation');
 
     current = makeFakeChild();
     const t2 = backend.sendPrompt('/work', 'second');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t2;
     const idx = spawnCalls[1].indexOf('--conversation');
@@ -204,6 +260,7 @@ describe('AgyBackend', () => {
 
     // Turn 1: cache stays at the stale value → nothing to adopt.
     const t1 = backend.sendPrompt('/work', 'first');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t1;
 
@@ -213,11 +270,13 @@ describe('AgyBackend', () => {
 
     current = makeFakeChild();
     const t2 = backend.sendPrompt('/work', 'second');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t2;
 
     current = makeFakeChild();
     const t3 = backend.sendPrompt('/work', 'third');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t3;
 
@@ -246,6 +305,7 @@ describe('AgyBackend', () => {
 
     const t1 = backend.sendPrompt('/work', 'first');
     recorded = 'mine';
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t1;
 
@@ -254,11 +314,13 @@ describe('AgyBackend', () => {
 
     current = makeFakeChild();
     const t2 = backend.sendPrompt('/work', 'second');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t2;
 
     current = makeFakeChild();
     const t3 = backend.sendPrompt('/work', 'third');
+    current.stdout.emit('data', 'ok');
     current.child.emit('close', 0);
     await t3;
 

--- a/packages/happy-cli/src/agy/AgyBackend.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.ts
@@ -16,6 +16,9 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { PermissionMode } from '@/api/types';
 import type {
   AgentBackend,
@@ -99,6 +102,7 @@ export class AgyBackend implements AgentBackend {
   }
 
   async sendPrompt(_sessionId: SessionId, prompt: string): Promise<void> {
+    const logFile = join(tmpdir(), `happy-agy-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
     const args = buildAgyArgs({
       prompt,
       model: this.model,
@@ -106,6 +110,7 @@ export class AgyBackend implements AgentBackend {
       permissionMode: this.permissionMode,
       addDirs: [this.cwd],
       printTimeout: this.printTimeout,
+      logFile,
     });
 
     this.emit({ type: 'status', status: 'running' });
@@ -127,6 +132,8 @@ export class AgyBackend implements AgentBackend {
         stdio: ['ignore', 'pipe', 'pipe'],
       });
       this.child = child;
+      let sawModelOutput = false;
+      let stderrText = '';
 
       // Node can fire both 'error' and 'close' on spawn failure; act on the first only.
       let settled = false;
@@ -144,6 +151,9 @@ export class AgyBackend implements AgentBackend {
       child.stdout?.setEncoding('utf8');
       child.stdout?.on('data', (chunk: string) => {
         if (chunk) {
+          if (chunk.trim().length > 0) {
+            sawModelOutput = true;
+          }
           this.emit({ type: 'model-output', textDelta: chunk });
         }
       });
@@ -152,6 +162,7 @@ export class AgyBackend implements AgentBackend {
       child.stderr?.on('data', (chunk: string) => {
         const text = chunk.trimEnd();
         if (text) {
+          stderrText += `${text}\n`;
           this.log(`stderr: ${text}`);
         }
       });
@@ -191,6 +202,12 @@ export class AgyBackend implements AgentBackend {
         }
 
         if (code === 0) {
+          if (!sawModelOutput) {
+            const detail = this.describeEmptyOutput(logFile, stderrText);
+            this.emit({ type: 'status', status: 'error', detail });
+            reject(new Error(detail));
+            return;
+          }
           this.emit({ type: 'status', status: 'idle' });
           resolve();
         } else {
@@ -200,6 +217,27 @@ export class AgyBackend implements AgentBackend {
         }
       });
     });
+  }
+
+  private describeEmptyOutput(logFile: string, stderrText: string): string {
+    const logText = existsSync(logFile) ? readFileSync(logFile, 'utf8') : '';
+    const hay = `${stderrText}\n${logText}`;
+    const lower = hay.toLowerCase();
+    const resourceExhausted = hay.match(/RESOURCE_EXHAUSTED[^\n]*/);
+    if (resourceExhausted) {
+      return `agy produced no output: ${resourceExhausted[0]}`;
+    }
+    const quota = hay.match(/(?:quota|usage limit|rate limit|too many requests|429)[^\n]*/i);
+    if (quota) {
+      return `agy produced no output: ${quota[0]}`;
+    }
+    if (lower.includes('not logged into antigravity') || lower.includes('failed to get oauth token')) {
+      return 'agy produced no output: not logged into Antigravity';
+    }
+    if (lower.includes('auth') && lower.includes('failed')) {
+      return 'agy produced no output: Antigravity authentication failed';
+    }
+    return 'agy exited successfully but produced no output';
   }
 
   async cancel(_sessionId?: SessionId): Promise<void> {

--- a/packages/happy-cli/src/agy/cliArgs.test.ts
+++ b/packages/happy-cli/src/agy/cliArgs.test.ts
@@ -51,4 +51,11 @@ describe('buildAgyArgs', () => {
     expect(idx).toBeGreaterThanOrEqual(0);
     expect(args[idx + 1]).toBe('10m');
   });
+
+  it('passes --log-file when provided', () => {
+    const args = buildAgyArgs({ prompt: 'p', permissionMode: 'default', logFile: '/tmp/agy.log' });
+    const idx = args.indexOf('--log-file');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(args[idx + 1]).toBe('/tmp/agy.log');
+  });
 });

--- a/packages/happy-cli/src/agy/cliArgs.ts
+++ b/packages/happy-cli/src/agy/cliArgs.ts
@@ -34,6 +34,8 @@ export interface BuildAgyArgsOptions {
   addDirs?: string[];
   /** Value for `--print-timeout` (e.g. "10m"). */
   printTimeout?: string;
+  /** Path for agy's per-turn log file. */
+  logFile?: string;
 }
 
 /**
@@ -59,6 +61,9 @@ export function buildAgyArgs(opts: BuildAgyArgsOptions): string[] {
   }
   if (opts.printTimeout) {
     args.push('--print-timeout', opts.printTimeout);
+  }
+  if (opts.logFile) {
+    args.push('--log-file', opts.logFile);
   }
 
   args.push('--print', opts.prompt);

--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -239,6 +239,7 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         log(`Turn ended: ${msg}`);
+        sendEnvelopes(sessionManager.mapMessage({ type: 'model-output', textDelta: `Error: ${msg}` }));
         sendEnvelopes(sessionManager.endTurn('failed'));
       }
       thinking = false;


### PR DESCRIPTION
## Summary

`agy --print` can exit with code 0 while producing no stdout when Antigravity fails internally (observed with `RESOURCE_EXHAUSTED` quota errors), and Happy currently maps that to an empty completed turn; this PR treats exit 0 + empty output as a failed agy turn, reads the per-turn agy log for useful diagnostics, and sends the error text into the session before `turn-end failed` so the app does not show a silent success.

## What changed

- Pass a per-turn `--log-file` to `agy --print`.
- Track whether stdout produced any non-whitespace model output.
- Reject exit 0 + empty stdout instead of emitting `status: idle`.
- Extract common diagnostics from the agy log, especially `RESOURCE_EXHAUSTED`, quota/rate limit, and auth failures.
- Emit the failure detail as session text before ending the turn as failed.
- Add unit coverage for the empty stdout / quota-log path and the new `--log-file` arg.

## Proof

Real exhausted-account smoke test before this patch produced a silent completed turn:

```text
user message
turn-start
turn-end completed
ready
```

With this patch, the same `agy --print` failure is visible and failed:

```text
user message
turn-start
text: Error: agy produced no output: RESOURCE_EXHAUSTED (code 429): Individual quota reached...
turn-end failed
ready
```

Actual history excerpt from the patched build:

```json
{
  "ev": {
    "t": "text",
    "text": "Error: agy produced no output: RESOURCE_EXHAUSTED (code 429): Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 161h36m45s."
  }
}
{
  "ev": {
    "t": "turn-end",
    "status": "failed"
  }
}
```

## Existing issues

I did not find an existing issue for the empty-output / `RESOURCE_EXHAUSTED` case. This is a follow-up to the agy backend work in #1429 / #1430.

## Test plan

Ran against the same patch in my self-host fork before opening this PR:

```bash
pnpm --dir . --filter happy test -- agy/AgyBackend.test.ts agy/cliArgs.test.ts api/apiMachine.test.ts --run
pnpm --dir packages/happy-app typecheck
```

The first command ran the happy CLI unit suite and passed: 79 test files / 744 tests.

I also applied this PR branch to a clean upstream checkout; the patch is now limited to `packages/happy-cli/src/agy/*` and applies cleanly. I did not rerun tests in that temporary checkout because dependencies were not installed there (`shx: command not found`).
