### PR TITLE
Retry RevenueCat offering fetch before paywall

### DIFF
--- a/packages/happy-app/sources/sync/revenueCat/revenueCat.ts
+++ b/packages/happy-app/sources/sync/revenueCat/revenueCat.ts
@@ -5,6 +5,7 @@ import Purchases, {
     LOG_LEVEL
 } from 'react-native-purchases';
 import RevenueCatUI, { PAYWALL_RESULT, CustomVariableValue } from 'react-native-purchases-ui';
+import { delay } from '@/utils/time';
 import { 
     RevenueCatInterface, 
     CustomerInfo, 
@@ -76,11 +77,24 @@ class RevenueCatNative implements RevenueCatInterface {
 
     async presentPaywall(options?: PaywallOptions): Promise<PaywallResult> {
         try {
+            let nativeOfferings;
+            try {
+                nativeOfferings = await Purchases.getOfferings();
+            } catch (error) {
+                console.warn('Failed to fetch RevenueCat offerings, retrying:', error);
+                await delay(500);
+                nativeOfferings = await Purchases.getOfferings();
+            }
+
             // If offering is provided, we need to get the native offering object
-            let nativeOffering = undefined;
+            let nativeOffering = nativeOfferings.current;
             if (options?.offering) {
-                const nativeOfferings = await Purchases.getOfferings();
                 nativeOffering = nativeOfferings.all[options.offering.identifier];
+            }
+
+            if (!nativeOffering) {
+                console.error('RevenueCat current offering is unavailable');
+                return PaywallResult.ERROR;
             }
 
             // Convert custom variables to RevenueCat format
@@ -91,7 +105,7 @@ class RevenueCatNative implements RevenueCatInterface {
                 : undefined;
 
             const nativeResult = await RevenueCatUI.presentPaywall({
-                ...(nativeOffering && { offering: nativeOffering }),
+                offering: nativeOffering,
                 ...(nativeCustomVars && { customVariables: nativeCustomVars }),
             });
 


### PR DESCRIPTION
## Summary

- fetch the current RevenueCat offering before presenting the native paywall
- retry the offering fetch once after a short delay
- avoid mounting RevenueCatUI when no offering is available

## User-facing error

<img src="https://github.com/tomascupr/happy/releases/download/pr-1509-assets/46f6e075-d7d2-4950-b285-d77f363f9d85.jpg" alt="RevenueCat Error 23 shown in Happy on iOS" width="400">

## Root cause

RevenueCatUI fetched the current offering internally. When StoreKit transiently returned no products, the native UI surfaced RevenueCat configuration error 23 directly to users. Happy had no opportunity to retry or handle the failure gracefully.

Passing a successfully fetched offering into RevenueCatUI keeps transient StoreKit failures in Happy's error-handling path and prevents the raw SDK alert from being shown.

## Validation

- `pnpm --filter happy-app typecheck`
- `pnpm --filter happy-app test -- --run` (58 files, 706 tests passed)
