### PR TITLE
fix(app): size context window for all 1M models + label Sonnet 5 (#910)

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -10,6 +10,7 @@ import { MultiTextInput, KeyPressEvent } from './MultiTextInput';
 import { Typography } from '@/constants/Typography';
 import { PermissionMode, ModelMode } from './PermissionModeSelector';
 import { EffortLevel } from './modelModeOptions';
+import { maxContextSizeForModel } from '@/utils/contextWindow';
 import { hapticsLight, hapticsError } from './haptics';
 import { Shaker, ShakeInstance } from './Shaker';
 import { StatusDot } from './StatusDot';
@@ -610,7 +611,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
     // Calculate context warning
     const contextWarning = props.usageData?.contextSize
-        ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme, props.usageData.contextWindow)
+        ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme, props.usageData.contextWindow ?? maxContextSizeForModel(props.modelMode?.key))
         : null;
 
     const agentInputEnterToSend = useSetting('agentInputEnterToSend');

--- a/packages/happy-app/sources/components/SessionStatusBar.tsx
+++ b/packages/happy-app/sources/components/SessionStatusBar.tsx
@@ -10,7 +10,7 @@ import {
     clampContextSize,
     getContextUsageLevel,
     getContextUsagePercentage,
-    SESSION_STATUS_CONTEXT_MAX,
+    resolveContextMaxValue,
 } from '@/utils/sessionStatusBar';
 
 type StatusIconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -39,9 +39,7 @@ export function SessionStatusBar(props: SessionStatusBarProps) {
     const availableEffortLevels = props.availableEffortLevels ?? [];
     const canSelectModel = availableModels.length > 0 && !!props.onModelModeChange;
     const canSelectEffort = availableEffortLevels.length > 0 && !!props.onEffortLevelChange;
-    const contextMaxValue = typeof props.contextWindow === 'number' && Number.isFinite(props.contextWindow) && props.contextWindow > 0
-        ? Math.trunc(props.contextWindow)
-        : SESSION_STATUS_CONTEXT_MAX;
+    const contextMaxValue = resolveContextMaxValue(props.contextWindow, props.modelMode?.key);
     const contextValue = clampContextSize(props.contextSize, contextMaxValue);
     const contextPercentage = getContextUsagePercentage(props.contextSize, contextMaxValue);
     const contextLevel = getContextUsageLevel(props.contextSize, contextMaxValue);

--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -65,6 +65,12 @@ describe('modelModeOptions', () => {
             name: 'fable 5',
             description: null,
         });
+        // Bare `sonnet` resolves to the latest Sonnet (Sonnet 5) — label must match.
+        expect(models.find((model) => model.key === 'sonnet')).toEqual({
+            key: 'sonnet',
+            name: 'sonnet 5',
+            description: null,
+        });
     });
 
     it('uses code defaults for agent defaults', () => {

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -79,7 +79,7 @@ export function getClaudeModelModes(): ModelMode[] {
         { key: 'default', name: 'default model', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
         { key: 'fable', name: 'fable 5', description: null },
-        { key: 'sonnet', name: 'sonnet 4.6', description: null },
+        { key: 'sonnet', name: 'sonnet 5', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },
     ];
 }

--- a/packages/happy-app/sources/utils/contextWindow.test.ts
+++ b/packages/happy-app/sources/utils/contextWindow.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import {
+    DEFAULT_MAX_CONTEXT_SIZE,
+    ONE_MILLION_CONTEXT_SIZE,
+    maxContextSizeForModel,
+} from './contextWindow';
+
+describe('maxContextSizeForModel', () => {
+    it('returns the 1M window for models tagged with the [1m] suffix', () => {
+        expect(maxContextSizeForModel('claude-opus-4-8[1m]')).toBe(ONE_MILLION_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('claude-sonnet-4-6[1m]')).toBe(1000000);
+    });
+
+    it('returns the default 190K window for standard models', () => {
+        expect(maxContextSizeForModel('claude-opus-4-8')).toBe(DEFAULT_MAX_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('claude-haiku-4-5-20251001')).toBe(190000);
+    });
+
+    it('falls back to the default window when the model id is unknown', () => {
+        expect(maxContextSizeForModel(undefined)).toBe(DEFAULT_MAX_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('')).toBe(DEFAULT_MAX_CONTEXT_SIZE);
+    });
+});

--- a/packages/happy-app/sources/utils/contextWindow.test.ts
+++ b/packages/happy-app/sources/utils/contextWindow.test.ts
@@ -11,9 +11,33 @@ describe('maxContextSizeForModel', () => {
         expect(maxContextSizeForModel('claude-sonnet-4-6[1m]')).toBe(1000000);
     });
 
-    it('returns the default 190K window for standard models', () => {
-        expect(maxContextSizeForModel('claude-opus-4-8')).toBe(DEFAULT_MAX_CONTEXT_SIZE);
+    it('returns the 1M window for Fable/Mythos (1M is their only window)', () => {
+        expect(maxContextSizeForModel('fable')).toBe(ONE_MILLION_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('claude-fable-5')).toBe(ONE_MILLION_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('claude-mythos-5')).toBe(ONE_MILLION_CONTEXT_SIZE);
+    });
+
+    it('returns the 1M window for the bare opus/sonnet aliases (latest = 1M)', () => {
+        expect(maxContextSizeForModel('opus')).toBe(ONE_MILLION_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('sonnet')).toBe(ONE_MILLION_CONTEXT_SIZE);
+    });
+
+    it('returns the 1M window for models that always run 1M on the Anthropic API', () => {
+        expect(maxContextSizeForModel('claude-opus-4-8')).toBe(ONE_MILLION_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('claude-opus-4-7')).toBe(ONE_MILLION_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('claude-sonnet-5')).toBe(ONE_MILLION_CONTEXT_SIZE);
+    });
+
+    it('returns the default 190K window for models that need the [1m] opt-in', () => {
+        // Older versions default to 200K and require the [1m] suffix for 1M.
+        expect(maxContextSizeForModel('claude-opus-4-6')).toBe(DEFAULT_MAX_CONTEXT_SIZE);
+        expect(maxContextSizeForModel('claude-sonnet-4-6')).toBe(DEFAULT_MAX_CONTEXT_SIZE);
+    });
+
+    it('returns the default 190K window for 200K-capped and unknown models', () => {
+        expect(maxContextSizeForModel('haiku')).toBe(DEFAULT_MAX_CONTEXT_SIZE);
         expect(maxContextSizeForModel('claude-haiku-4-5-20251001')).toBe(190000);
+        expect(maxContextSizeForModel('default')).toBe(DEFAULT_MAX_CONTEXT_SIZE);
     });
 
     it('falls back to the default window when the model id is unknown', () => {

--- a/packages/happy-app/sources/utils/contextWindow.ts
+++ b/packages/happy-app/sources/utils/contextWindow.ts
@@ -1,0 +1,18 @@
+// Context-window sizing for the input-bar usage indicator.
+//
+// Anthropic exposes a 1M-token context window on some models, surfaced in
+// Happy's model picker as a `[1m]` suffix on the selected model key
+// (e.g. `claude-opus-4-8[1m]`). The API response echoes only the base model id
+// (`claude-opus-4-8`), so the window must be sized from the selected model key.
+// The indicator used to assume a fixed 190K window, so on 1M models it clamped
+// to ~73% remaining on a fresh session and dropped fast (#910).
+
+export const DEFAULT_MAX_CONTEXT_SIZE = 190000;
+export const ONE_MILLION_CONTEXT_SIZE = 1000000;
+
+export function maxContextSizeForModel(model?: string): number {
+    if (model && model.includes('[1m]')) {
+        return ONE_MILLION_CONTEXT_SIZE;
+    }
+    return DEFAULT_MAX_CONTEXT_SIZE;
+}

--- a/packages/happy-app/sources/utils/contextWindow.ts
+++ b/packages/happy-app/sources/utils/contextWindow.ts
@@ -1,17 +1,48 @@
 // Context-window sizing for the input-bar usage indicator.
 //
-// Anthropic exposes a 1M-token context window on some models, surfaced in
-// Happy's model picker as a `[1m]` suffix on the selected model key
-// (e.g. `claude-opus-4-8[1m]`). The API response echoes only the base model id
-// (`claude-opus-4-8`), so the window must be sized from the selected model key.
-// The indicator used to assume a fixed 190K window, so on 1M models it clamped
-// to ~73% remaining on a fresh session and dropped fast (#910).
+// The Agent SDK never reports the real context window for a session (the usage
+// block carries token counts only, not a window size — see reducer.ts), so the
+// window must be inferred from the selected model key. The indicator used to
+// assume a fixed 190K window, so on 1M-token models it clamped to ~100% used on
+// a fresh session and pinned the gauge to "none left" (#910).
+//
+// Which models run the 1M window, per Claude Code's model-config:
+//   - Fable 5 / Mythos: 1M is the ONLY window (the max is also the default) —
+//     there is no 200K variant and no `[1m]` suffix to select.
+//   - Opus 4.8 / Opus 4.7 / Sonnet 5: always run 1M on the Anthropic API. The
+//     bare `opus`/`sonnet` picker aliases resolve to the latest of each
+//     (Opus 4.8 / Sonnet 5), so they are 1M too.
+//   - Older versions (Opus 4.6, Sonnet 4.6) and LLM-gateway deployments default
+//     to 200K and must carry the `[1m]` suffix to signal the 1M window — those
+//     fall through to the 190K default below.
+//   - Haiku is 200K-capped; unknown/`default` keys stay conservative at 190K.
 
 export const DEFAULT_MAX_CONTEXT_SIZE = 190000;
 export const ONE_MILLION_CONTEXT_SIZE = 1000000;
 
+// Model families/versions whose context window is 1M by default on the Anthropic
+// API, with no `[1m]` opt-in required. Matched as substrings of the model key so
+// both the raw ids (`claude-fable-5`, `claude-opus-4-8`) and any suffixed variant
+// resolve correctly. Opus 4.6 / Sonnet 4.6 are deliberately absent — they need
+// the `[1m]` suffix.
+const ALWAYS_ONE_MILLION_PATTERNS = ['fable', 'mythos', 'opus-4-8', 'opus-4-7', 'sonnet-5'];
+
 export function maxContextSizeForModel(model?: string): number {
-    if (model && model.includes('[1m]')) {
+    if (!model) {
+        return DEFAULT_MAX_CONTEXT_SIZE;
+    }
+    const key = model.toLowerCase();
+
+    // Explicit 1M opt-in suffix (older versions + gateway deployments).
+    if (key.includes('[1m]')) {
+        return ONE_MILLION_CONTEXT_SIZE;
+    }
+    // Bare picker aliases resolve to the latest model of the tier, which runs 1M.
+    if (key === 'opus' || key === 'sonnet') {
+        return ONE_MILLION_CONTEXT_SIZE;
+    }
+    // Model families/versions that always run the 1M window on the Anthropic API.
+    if (ALWAYS_ONE_MILLION_PATTERNS.some((pattern) => key.includes(pattern))) {
         return ONE_MILLION_CONTEXT_SIZE;
     }
     return DEFAULT_MAX_CONTEXT_SIZE;

--- a/packages/happy-app/sources/utils/sessionStatusBar.test.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.test.ts
@@ -27,11 +27,14 @@ describe('session status bar helpers', () => {
         // Explicit API-reported window always wins.
         expect(resolveContextMaxValue(500000, 'claude-opus-4-8[1m]')).toBe(500000);
         expect(resolveContextMaxValue(210000, 'claude-opus-4-8')).toBe(210000);
-        // No API window: size from the selected model. A [1m] model must NOT
+        // No API window: size from the selected model. A 1M model must NOT
         // clamp to the 190K default (regression #910 via SessionStatusBar).
         expect(resolveContextMaxValue(undefined, 'claude-opus-4-8[1m]')).toBe(1_000_000);
         expect(resolveContextMaxValue(0, 'claude-opus-4-8[1m]')).toBe(1_000_000);
-        expect(resolveContextMaxValue(null, 'claude-opus-4-8')).toBe(SESSION_STATUS_CONTEXT_MAX);
+        // Opus 4.8 always runs the 1M window on the Anthropic API, even without
+        // the [1m] suffix — the gauge must not clamp it to 190K.
+        expect(resolveContextMaxValue(null, 'claude-opus-4-8')).toBe(1_000_000);
+        // Unknown model + no API window stays conservative at the 190K default.
         expect(resolveContextMaxValue(undefined, undefined)).toBe(SESSION_STATUS_CONTEXT_MAX);
     });
 

--- a/packages/happy-app/sources/utils/sessionStatusBar.test.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.test.ts
@@ -3,7 +3,9 @@ import {
     clampContextSize,
     getContextUsageLevel,
     getContextUsagePercentage,
+    resolveContextMaxValue,
     resolveStatusBarGitBranch,
+    SESSION_STATUS_CONTEXT_MAX,
 } from './sessionStatusBar';
 
 describe('session status bar helpers', () => {
@@ -19,6 +21,18 @@ describe('session status bar helpers', () => {
         expect(getContextUsageLevel(89, 100)).toBe('normal');
         expect(getContextUsageLevel(90, 100)).toBe('warning');
         expect(getContextUsageLevel(95, 100)).toBe('critical');
+    });
+
+    it('sizes the context window from the API value, then the model key', () => {
+        // Explicit API-reported window always wins.
+        expect(resolveContextMaxValue(500000, 'claude-opus-4-8[1m]')).toBe(500000);
+        expect(resolveContextMaxValue(210000, 'claude-opus-4-8')).toBe(210000);
+        // No API window: size from the selected model. A [1m] model must NOT
+        // clamp to the 190K default (regression #910 via SessionStatusBar).
+        expect(resolveContextMaxValue(undefined, 'claude-opus-4-8[1m]')).toBe(1_000_000);
+        expect(resolveContextMaxValue(0, 'claude-opus-4-8[1m]')).toBe(1_000_000);
+        expect(resolveContextMaxValue(null, 'claude-opus-4-8')).toBe(SESSION_STATUS_CONTEXT_MAX);
+        expect(resolveContextMaxValue(undefined, undefined)).toBe(SESSION_STATUS_CONTEXT_MAX);
     });
 
     it('falls back to metadata git branch when git status has no branch', () => {

--- a/packages/happy-app/sources/utils/sessionStatusBar.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.ts
@@ -1,3 +1,5 @@
+import { maxContextSizeForModel } from './contextWindow';
+
 export const SESSION_STATUS_CONTEXT_MAX = 190000;
 
 export type ContextUsageLevel = 'normal' | 'warning' | 'critical';
@@ -40,4 +42,19 @@ export function getContextUsageLevel(value: number | null | undefined, maxValue 
         return 'warning';
     }
     return 'normal';
+}
+
+// Size the context window for the usage circle. Prefer the API-reported window,
+// but when it's absent (the API echoes only the base model id, so 1M-token
+// models don't report their real window) fall back to the selected model key.
+// SessionStatusBar previously hardcoded the 190K default here, which reclamped
+// [1m] models to ~100% used on a fresh session (regression of #910).
+export function resolveContextMaxValue(
+    contextWindow: number | null | undefined,
+    modelKey?: string | null,
+): number {
+    if (typeof contextWindow === 'number' && Number.isFinite(contextWindow) && contextWindow > 0) {
+        return Math.trunc(contextWindow);
+    }
+    return maxContextSizeForModel(modelKey ?? undefined);
 }


### PR DESCRIPTION
## Problem

The context-usage gauge sizes its denominator (the total window) from the selected model key, because the Agent SDK never reports the real context window — the `usage` block carries token counts only, not a window size (see `reducer.ts`). Two gaps made the gauge wrong for current models:

1. **1M models pinned to "0% left".** `maxContextSizeForModel` only returned the 1M window when the model key carried a literal `[1m]` suffix, so every other key fell to the 190K default. Fable 5 exposes no `[1m]` variant (1M is its only window), and the bare `opus`/`sonnet` aliases plus Opus 4.8/4.7 and Sonnet 5 always run the 1M window on the Anthropic API — all of them clamped to 190K, so any session past ~190K tokens showed **"0% left"** in red on a model with plenty of headroom (the #910 failure, still live for these keys).

2. **Sonnet 5 looked missing from the picker.** The bare `sonnet` key resolves to Claude Code's latest Sonnet alias (now Sonnet 5), but the picker still displayed the stale "sonnet 4.6" label — the same way bare `opus` is labelled "opus 4.8" for the latest Opus.

## Changes

- **Size the window from the model key** when the API omits it (original commit).
- **Recognise all always-1M models**, not just `[1m]`: the fable/mythos family, `opus-4-8`, `opus-4-7`, `sonnet-5`, and the bare `opus`/`sonnet` aliases. Older opt-in versions (`opus-4-6`, `sonnet-4-6`), Haiku, and unknown/`default` keys stay conservative at 190K, so a gateway-capped session is never over-reported (over-reporting the window is the more dangerous direction — it hides real usage).
- **Relabel the `sonnet` picker entry** to "sonnet 5" (key unchanged, so the resolved model is unchanged).

## Why 1M is safe here

Per Claude Code's model-config, Fable 5, Sonnet 5, Opus 4.8 and Opus 4.7 always run the 1M window on the Anthropic API — no `[1m]` opt-in required — and Happy's default Claude path runs directly against the user's own Anthropic auth (no gateway injected). The `[1m]` suffix remains meaningful only for older versions and custom `ANTHROPIC_BASE_URL`/gateway deployments, which keep the 190K default.

## Tests

- `contextWindow.test.ts`: fable/mythos, bare `opus`/`sonnet`, always-1M (`opus-4-8`/`opus-4-7`/`sonnet-5`), opt-in-only (`opus-4-6`/`sonnet-4-6` → 190K), Haiku/`default`/unknown → 190K.
- `sessionStatusBar.test.ts`: bare `claude-opus-4-8` now sizes to 1M.
- `modelModeOptions.test.ts`: locks the `sonnet` label to "sonnet 5".
- `pnpm typecheck` clean; 22 unit tests + 59 reducer tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
