### PR TITLE
fix(cli): default permission mode to 'default' instead of 'yolo'

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -57,7 +57,7 @@ export interface StartOptions {
     jsRuntime?: JsRuntime
 }
 
-const DEFAULT_CLAUDE_PERMISSION_MODE: PermissionMode = 'yolo';
+const DEFAULT_CLAUDE_PERMISSION_MODE: PermissionMode = 'default';
 const DEFAULT_CLAUDE_MODEL = 'opus';
 const DEFAULT_CLAUDE_EFFORT: 'low' | 'medium' | 'high' | 'xhigh' | 'max' = 'medium';
 type ClaudeGoalCommand = NonNullable<ReturnType<typeof parseClaudeGoalActionParams>>;


### PR DESCRIPTION
Fixes #1514.

**Summary:** one-line change flipping the CLI's fallback permission mode from `'yolo'` to `'default'`, so a bare `happy` run (no `--permission-mode` / `--yolo`) no longer spawns Claude Code with `--dangerously-skip-permissions`. Users never opted into bypassing permission prompts; explicit opt-in paths are untouched.

## Before / after (real run, happy 1.1.10, daemon spawn metadata)

Stock install, bare daemon-spawned session:

```
  "startedBy": "daemon",
  "flavor": "claude",
  "sandbox": null,
  "dangerouslySkipPermissions": true
```

Same flow with only this constant changed to `'default'` (hand-patched dist on 1.1.10 — same edit as this PR):

```
  "startedBy": "daemon",
  "flavor": "claude",
  "sandbox": null,
  "dangerouslySkipPermissions": false
```

Claude Code then prompts for permissions as usual; `happy --yolo` still produces `true`.

## Back-compat

- `happy --yolo` and `--permission-mode yolo` behave exactly as before (explicit opt-in, see `resolveInitialClaudePermissionMode`).
- Once #1500 lands, `HAPPY_CLAUDE_PERMISSION_MODE=yolo` restores the old default machine-wide — #1500 makes the default configurable; this PR only makes the fallback safe.
- No test changes needed: `permissionMode.test.ts` / `permissionHandler.test.ts` exercise the mapping functions, not this constant.
