### PR TITLE
Preserve effort message metadata

### DIFF
--- a/packages/happy-cli/src/api/types.test.ts
+++ b/packages/happy-cli/src/api/types.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { UserMessageSchema } from './types';
+
+describe('UserMessageSchema', () => {
+    it('preserves message effort metadata for runtime model selection', () => {
+        const parsed = UserMessageSchema.parse({
+            role: 'user',
+            content: {
+                type: 'text',
+                text: 'use maximum effort',
+            },
+            meta: {
+                sentFrom: 'web',
+                appendSystemPrompt: 'focus on correctness',
+                effort: 'max',
+            },
+        });
+
+        expect(parsed.meta).toMatchObject({
+            sentFrom: 'web',
+            appendSystemPrompt: 'focus on correctness',
+            effort: 'max',
+        });
+    });
+
+    it('preserves null effort metadata so callers can reset the override', () => {
+        const parsed = UserMessageSchema.parse({
+            role: 'user',
+            content: {
+                type: 'text',
+                text: 'reset effort',
+            },
+            meta: {
+                effort: null,
+            },
+        });
+
+        expect(parsed.meta?.effort).toBeNull();
+    });
+});

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -194,7 +194,8 @@ export const MessageMetaSchema = z.object({
   customSystemPrompt: z.string().nullable().optional(), // Custom system prompt for this message (null = reset)
   appendSystemPrompt: z.string().nullable().optional(), // Append to system prompt for this message (null = reset)
   allowedTools: z.array(z.string()).nullable().optional(), // Allowed tools for this message (null = reset)
-  disallowedTools: z.array(z.string()).nullable().optional() // Disallowed tools for this message (null = reset)
+  disallowedTools: z.array(z.string()).nullable().optional(), // Disallowed tools for this message (null = reset)
+  effort: z.string().nullable().optional() // Reasoning effort for this message (null = reset)
 })
 
 export type MessageMeta = z.infer<typeof MessageMetaSchema>

--- a/packages/happy-wire/src/messageMeta.ts
+++ b/packages/happy-wire/src/messageMeta.ts
@@ -9,6 +9,7 @@ export const MessageMetaSchema = z.object({
   appendSystemPrompt: z.string().nullable().optional(),
   allowedTools: z.array(z.string()).nullable().optional(),
   disallowedTools: z.array(z.string()).nullable().optional(),
+  effort: z.string().nullable().optional(),
   displayText: z.string().optional(),
 });
 export type MessageMeta = z.infer<typeof MessageMetaSchema>;

--- a/packages/happy-wire/src/messages.test.ts
+++ b/packages/happy-wire/src/messages.test.ts
@@ -130,10 +130,12 @@ describe('shared wire message schemas', () => {
       },
       meta: {
         sentFrom: 'mobile',
+        effort: 'max',
       },
     });
 
     expect(parsed.success).toBe(true);
+    expect(parsed.data?.meta?.effort).toBe('max');
   });
 
   it('parses legacy decrypted agent message payload', () => {
@@ -189,10 +191,12 @@ describe('shared wire message schemas', () => {
       },
       meta: {
         sentFrom: 'cli',
+        effort: null,
       },
     });
 
     expect(parsed.success).toBe(true);
+    expect(parsed.data?.meta?.effort).toBeNull();
   });
 
   it('parses top-level message discriminated union for legacy and modern roles', () => {


### PR DESCRIPTION
## Summary

Issue #1375 reports that effort selections sent from the app are dropped before `runClaude.ts` can apply them because the CLI API `MessageMetaSchema` does not include `effort`. Zod strips unknown metadata keys during parsing, so `message.meta?.hasOwnProperty('effort')` never sees the override.

This change adds nullable optional `effort` metadata to the CLI parser and keeps the shared `@slopus/happy-wire` message metadata schema aligned so shared wire parsing preserves the same field. Invalid effort strings continue to be validated and ignored by the existing Claude/Codex runtime logic; the schema only preserves the field long enough for that logic to run.

## Validation

- `pnpm --filter happy exec vitest run --project unit src/api/types.test.ts`
- `pnpm --filter @slopus/happy-wire exec vitest run src/messages.test.ts`
- `pnpm --filter happy run typecheck`
- `pnpm --filter @slopus/happy-wire run typecheck`
- `pnpm --filter @slopus/happy-wire test`
- `pnpm --filter happy test`
