### PR TITLE
Fix browser and Tauri zoom defaults

### DIFF
--- a/packages/happy-app/sources/hooks/useTauriZoom.test.ts
+++ b/packages/happy-app/sources/hooks/useTauriZoom.test.ts
@@ -4,11 +4,38 @@ vi.mock('react-native', () => ({
     Platform: { OS: 'web' },
 }));
 
-import { BROWSER_APP_ZOOM, getBrowserAppZoomValue } from './useTauriZoom';
+import { applyBrowserZoom, DEFAULT_APP_ZOOM } from './useTauriZoom';
 
 describe('useTauriZoom browser defaults', () => {
-    it('keeps browser web zoom fixed at 1x', () => {
-        expect(BROWSER_APP_ZOOM).toBe(1);
-        expect(getBrowserAppZoomValue()).toBe('1');
+    it('keeps browser CSS zoom fixed at 1x while desktop uses the Tauri default', () => {
+        const properties = new Map<string, string>();
+        const classes = new Set<string>();
+        const root = {
+            style: {
+                getPropertyValue: (key: string) => properties.get(key) ?? '',
+                removeProperty: (key: string) => {
+                    properties.delete(key);
+                    return '';
+                },
+                setProperty: (key: string, value: string) => properties.set(key, value),
+            },
+            classList: {
+                add: (className: string) => classes.add(className),
+                contains: (className: string) => classes.has(className),
+                remove: (className: string) => classes.delete(className),
+            },
+        } as unknown as Pick<HTMLElement, 'style' | 'classList'>;
+
+        expect(DEFAULT_APP_ZOOM).toBe(0.75);
+
+        const cleanup = applyBrowserZoom(root);
+
+        expect(root.style.getPropertyValue('--happy-app-zoom')).toBe('1');
+        expect(root.classList.contains('happy-app-zoomed')).toBe(true);
+
+        cleanup();
+
+        expect(root.style.getPropertyValue('--happy-app-zoom')).toBe('');
+        expect(root.classList.contains('happy-app-zoomed')).toBe(false);
     });
 });

--- a/packages/happy-app/sources/hooks/useTauriZoom.ts
+++ b/packages/happy-app/sources/hooks/useTauriZoom.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Platform } from 'react-native';
 import { isTauri } from '@/utils/isTauri';
 
-export const DEFAULT_APP_ZOOM = 1.0;
+export const DEFAULT_APP_ZOOM = 0.75;
 export const BROWSER_APP_ZOOM = 1.0;
 
 const MIN_APP_ZOOM = 0.5;
@@ -13,6 +13,15 @@ const clampZoom = (zoom: number) => Math.max(MIN_APP_ZOOM, Math.min(MAX_APP_ZOOM
 
 export function getBrowserAppZoomValue(): string {
     return String(BROWSER_APP_ZOOM);
+}
+
+export function applyBrowserZoom(root: Pick<HTMLElement, 'style' | 'classList'>): () => void {
+    root.style.setProperty('--happy-app-zoom', getBrowserAppZoomValue());
+    root.classList.add(WEB_ZOOM_CLASS);
+    return () => {
+        root.classList.remove(WEB_ZOOM_CLASS);
+        root.style.removeProperty('--happy-app-zoom');
+    };
 }
 
 // Cmd/Ctrl+=, Cmd/Ctrl+-, Cmd/Ctrl+0 zoom shortcuts for the Tauri desktop app.
@@ -27,12 +36,7 @@ export function useTauriZoom() {
         const root = document.documentElement;
 
         if (!inTauri) {
-            root.style.setProperty('--happy-app-zoom', getBrowserAppZoomValue());
-            root.classList.add(WEB_ZOOM_CLASS);
-            return () => {
-                root.classList.remove(WEB_ZOOM_CLASS);
-                root.style.removeProperty('--happy-app-zoom');
-            };
+            return applyBrowserZoom(root);
         }
 
         root.classList.remove(WEB_ZOOM_CLASS);


### PR DESCRIPTION
## Summary

Fixes https://github.com/slopus/happy/issues/1309 by keeping browser CSS zoom independent from the Tauri desktop default.

The previous fix on `main` pinned browser zoom at 1x by changing the shared `DEFAULT_APP_ZOOM` to `1.0`, but that also removed the desktop default zoom tuning introduced for Tauri. This change restores `DEFAULT_APP_ZOOM` to `0.75` for the Tauri path and keeps the non-Tauri browser branch using the separate browser zoom value of `1.0`.

## Changes

- Restore the Tauri desktop default zoom to `0.75`.
- Extract the browser CSS zoom application into `applyBrowserZoom`, which always writes `--happy-app-zoom: 1` and cleans up the zoom class/style on unmount.
- Strengthen the regression test so browser zoom remains 1x while the desktop default remains 0.75.

## Validation

- `pnpm --filter happy-app exec vitest run sources/hooks/useTauriZoom.test.ts`
- `pnpm --filter happy-app typecheck`
