### PR TITLE
Fall back to first message for session titles

### DIFF
--- a/packages/happy-app/sources/utils/sessionUtils.test.ts
+++ b/packages/happy-app/sources/utils/sessionUtils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', () => ({
+    Platform: { OS: 'web' },
+}));
+
+vi.mock('@/text', () => ({
+    t: (key: string) => key === 'session.newChat' ? 'New chat' : key,
+}));
+
+import { getSessionName } from './sessionUtils';
+import type { Session } from '@/sync/storageTypes';
+
+function sessionWithMetadata(metadata: Session['metadata']): Session {
+    return {
+        id: 'session-1',
+        seq: 0,
+        metadata,
+        metadataVersion: 0,
+        agentState: null,
+        agentStateVersion: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        activeAt: Date.now(),
+        presence: 0,
+        active: false,
+        thinking: false,
+        thinkingAt: 0,
+    };
+}
+
+describe('getSessionName', () => {
+    it('uses the first-message fallback name when no explicit summary exists', () => {
+        expect(getSessionName(sessionWithMetadata({
+            path: '/tmp/project',
+            host: 'localhost',
+            name: 'Inspect authentication callback',
+        }))).toBe('Inspect authentication callback');
+    });
+
+    it('prefers an explicit summary over the first-message fallback name', () => {
+        expect(getSessionName(sessionWithMetadata({
+            path: '/tmp/project',
+            host: 'localhost',
+            name: 'Inspect authentication callback',
+            summary: {
+                text: 'Fix auth callback',
+                updatedAt: 123,
+            },
+        }))).toBe('Fix auth callback');
+    });
+});

--- a/packages/happy-app/sources/utils/sessionUtils.ts
+++ b/packages/happy-app/sources/utils/sessionUtils.ts
@@ -74,12 +74,16 @@ export function useSessionStatus(session: Session): SessionStatus {
 }
 
 /**
- * Extracts a display name from a session's metadata path.
- * Returns the last segment of the path, or 'unknown' if no path is available.
+ * Returns the best available display title for a session.
  */
 export function getSessionName(session: Session): string {
-    if (session.metadata?.summary) {
-        return session.metadata.summary.text;
+    const summary = session.metadata?.summary?.text.trim();
+    if (summary) {
+        return summary;
+    }
+    const name = session.metadata?.name?.trim();
+    if (name) {
+        return name;
     }
     return t('session.newChat');
 }

--- a/packages/happy-cli/src/api/apiSession.test.ts
+++ b/packages/happy-cli/src/api/apiSession.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiSessionClient } from './apiSession';
+import { ApiSessionClient, deriveFallbackSessionTitle } from './apiSession';
 import { decodeBase64, decrypt, decryptBlob, encodeBase64, encrypt } from './encryption';
-import type { Update } from './types';
+import type { Metadata, Update } from './types';
 import { logger } from '@/ui/logger';
+
+const LONG_FIRST_USER_MESSAGE = 'Please inspect the account authentication callback regression and identify the smallest safe fix for mobile users.';
+const TRUNCATED_LONG_FIRST_USER_MESSAGE = 'Please inspect the account authentication callback regression and identify th...';
 
 const {
     mockIo,
@@ -82,17 +85,19 @@ type SocketHandler = (...args: any[]) => void;
 type SocketHandlers = Record<string, SocketHandler[]>;
 
 function makeSession() {
+    const metadata: Metadata = {
+        path: '/tmp',
+        host: 'localhost',
+        homeDir: '/home/user',
+        happyHomeDir: '/home/user/.happy',
+        happyLibDir: '/home/user/.happy/lib',
+        happyToolsDir: '/home/user/.happy/tools'
+    };
+
     return {
         id: 'test-session-id',
         seq: 0,
-        metadata: {
-            path: '/tmp',
-            host: 'localhost',
-            homeDir: '/home/user',
-            happyHomeDir: '/home/user/.happy',
-            happyLibDir: '/home/user/.happy/lib',
-            happyToolsDir: '/home/user/.happy/tools'
-        },
+        metadata,
         metadataVersion: 0,
         agentState: null,
         agentStateVersion: 0,
@@ -126,6 +131,14 @@ function createNewMessageUpdate(seq: number, encryptedContent: string): Update {
             }
         }
     };
+}
+
+function mockSuccessfulMetadataUpdate(socket: { emitWithAck: ReturnType<typeof vi.fn> }) {
+    socket.emitWithAck.mockImplementation(async (_event: string, payload: { metadata: string }) => ({
+        result: 'success',
+        version: 1,
+        metadata: payload.metadata
+    }));
 }
 
 async function waitForCheck(check: () => void, timeoutMs = 2000) {
@@ -1039,6 +1052,7 @@ describe('ApiSessionClient v3 messages API migration', () => {
         const client = new ApiSessionClient('fake-token', session);
         const onUserMessage = vi.fn();
         client.onUserMessage(onUserMessage);
+        mockSuccessfulMetadataUpdate(mockSocket);
         mockAxiosGet.mockResolvedValueOnce({
             data: {
                 messages: [],
@@ -1048,7 +1062,7 @@ describe('ApiSessionClient v3 messages API migration', () => {
 
         const firstMessage = {
             role: 'user',
-            content: { type: 'text', text: 'first' }
+            content: { type: 'text', text: LONG_FIRST_USER_MESSAGE }
         };
 
         try {
@@ -1058,6 +1072,46 @@ describe('ApiSessionClient v3 messages API migration', () => {
             expect(onUserMessage).toHaveBeenCalledWith(firstMessage);
             expect((client as any).lastSeq).toBe(1);
             expect(mockAxiosGet).not.toHaveBeenCalled();
+            await waitForCheck(() => {
+                expect(mockSocket.emitWithAck).toHaveBeenCalledTimes(1);
+            });
+
+            const metadataPayload = mockSocket.emitWithAck.mock.calls[0][1].metadata;
+            const metadata = decrypt(
+                session.encryptionKey,
+                session.encryptionVariant,
+                decodeBase64(metadataPayload)
+            );
+            expect(metadata).toMatchObject({
+                name: TRUNCATED_LONG_FIRST_USER_MESSAGE
+            });
+        } finally {
+            await client.close();
+        }
+    });
+
+    it('does not attempt to replace an existing explicit summary or metadata name with the first user message', async () => {
+        session.metadata.name = 'Existing fallback';
+        session.metadata.summary = {
+            text: 'Explicit session title',
+            updatedAt: 123,
+        };
+        const client = new ApiSessionClient('fake-token', session);
+        const onUserMessage = vi.fn();
+        client.onUserMessage(onUserMessage);
+        mockSuccessfulMetadataUpdate(mockSocket);
+
+        const userMessage = {
+            role: 'user',
+            content: { type: 'text', text: 'New request that should not rename the session' }
+        };
+
+        try {
+            emitSocketEvent('update', createNewMessageUpdate(1, encryptContent(session, userMessage)));
+
+            expect(onUserMessage).toHaveBeenCalledWith(userMessage);
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            expect(mockSocket.emitWithAck).not.toHaveBeenCalled();
         } finally {
             await client.close();
         }
@@ -1181,5 +1235,16 @@ describe('ApiSessionClient v3 messages API migration', () => {
         expect(mockSocket.close).toHaveBeenCalledTimes(1);
         expect(mockAxiosGet).not.toHaveBeenCalled();
         expect(mockAxiosPost).not.toHaveBeenCalled();
+    });
+});
+
+describe('deriveFallbackSessionTitle', () => {
+    it('normalizes whitespace and truncates long first messages', () => {
+        expect(deriveFallbackSessionTitle(`  ${LONG_FIRST_USER_MESSAGE}\n\nThanks!  `))
+            .toBe(TRUNCATED_LONG_FIRST_USER_MESSAGE);
+    });
+
+    it('returns null for blank messages', () => {
+        expect(deriveFallbackSessionTitle(' \n\t ')).toBeNull();
     });
 });

--- a/packages/happy-cli/src/api/apiSession.ts
+++ b/packages/happy-cli/src/api/apiSession.ts
@@ -80,6 +80,8 @@ type AttachmentUploadResult = {
     formFields?: Record<string, string>;
 };
 
+const FALLBACK_SESSION_TITLE_MAX_CHARS = 80;
+
 export type LocalImageAttachment = {
     data: Uint8Array;
     mimeType: string;
@@ -88,6 +90,17 @@ export type LocalImageAttachment = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
+}
+
+export function deriveFallbackSessionTitle(message: string): string | null {
+    const title = message.replace(/\s+/g, ' ').trim();
+    if (title.length === 0) {
+        return null;
+    }
+    if (title.length <= FALLBACK_SESSION_TITLE_MAX_CHARS) {
+        return title;
+    }
+    return `${title.slice(0, FALLBACK_SESSION_TITLE_MAX_CHARS - 3).trimEnd()}...`;
 }
 
 function extensionForImageMime(mimeType: string): string {
@@ -551,6 +564,18 @@ export class ApiSessionClient extends EventEmitter {
     private routeIncomingMessage(message: unknown) {
         const userResult = UserMessageSchema.safeParse(message);
         if (userResult.success) {
+            const title = deriveFallbackSessionTitle(userResult.data.content.text);
+            if (title && !this.metadata?.name?.trim() && !this.metadata?.summary?.text.trim()) {
+                this.updateMetadata((metadata) => {
+                    if (metadata.name?.trim() || metadata.summary?.text.trim()) {
+                        return metadata;
+                    }
+                    return {
+                        ...metadata,
+                        name: title,
+                    };
+                });
+            }
             if (this.pendingMessageCallback) {
                 this.pendingMessageCallback(userResult.data);
             } else {


### PR DESCRIPTION
## Summary

Remote sessions can stay titled "New chat" when the model never calls the Happy `change_title` MCP tool. This adds a deterministic fallback so the first user message seeds a provisional session title, while later explicit title updates still take precedence.

## Changes

- Derive a normalized, truncated fallback title from the first incoming user text message when the session has no existing title metadata.
- Teach session display helpers to use explicit summary/title metadata first, then the provisional metadata name, then the localized "New chat" fallback.
- Add regression coverage for fallback title derivation, preserving existing explicit titles, and display precedence.

Closes https://github.com/slopus/happy/issues/1365.

## Validation

- `pnpm --filter happy exec vitest run --project unit src/api/apiSession.test.ts`
- `pnpm --filter happy-app exec vitest run sources/utils/sessionUtils.test.ts`
- `pnpm --filter happy typecheck`
- `pnpm --filter happy-app typecheck`
