### PR TITLE
fix(cli): restore codex safe-yolo approval prompts

### DIFF
--- a/packages/happy-cli/src/codex/__tests__/executionPolicy.test.ts
+++ b/packages/happy-cli/src/codex/__tests__/executionPolicy.test.ts
@@ -29,11 +29,11 @@ describe('resolveCodexExecutionPolicy', () => {
         });
     });
 
-    it('maps safe-yolo mode to never + workspace-write without managed sandbox', () => {
+    it('maps safe-yolo mode to on-failure + workspace-write without managed sandbox', () => {
         const policy = resolveCodexExecutionPolicy('safe-yolo', false);
 
         expect(policy).toEqual({
-            approvalPolicy: 'never',
+            approvalPolicy: 'on-failure',
             sandbox: 'workspace-write',
         });
     });
@@ -59,10 +59,6 @@ describe('resolveCodexExecutionPolicy', () => {
     it('auto-approves bridge prompts for no-prompt modes without managed sandbox', () => {
         expect(shouldAutoApproveCodexApproval('default', false)).toBe(false);
         expect(shouldAutoApproveCodexApproval('read-only', false)).toBe(false);
-        // safe-yolo must keep prompting: its turns run with approvalPolicy
-        // 'never' inside the workspace sandbox, so any approval codex still
-        // surfaces is a sandbox escalation — the one thing safe-yolo
-        // promises to ask the user about.
         expect(shouldAutoApproveCodexApproval('safe-yolo', false)).toBe(false);
         expect(shouldAutoApproveCodexApproval('yolo', false)).toBe(true);
         expect(shouldAutoApproveCodexApproval('bypassPermissions', false)).toBe(true);

--- a/packages/happy-cli/src/codex/executionPolicy.ts
+++ b/packages/happy-cli/src/codex/executionPolicy.ts
@@ -17,7 +17,7 @@ export function resolveCodexExecutionPolicy(
             // Codex native modes
             case 'default': return 'untrusted';                    // Ask for non-trusted commands
             case 'read-only': return 'never';                      // Never ask, read-only enforced by sandbox
-            case 'safe-yolo': return 'never';                      // Workspace sandbox enforces safety; do not prompt
+            case 'safe-yolo': return 'on-failure';                 // Workspace sandbox first, ask before unsandboxed retry
             case 'yolo': return 'never';                           // Full YOLO: never interrupt for approvals
             // Defensive fallback for Claude-specific modes (backward compatibility)
             case 'bypassPermissions': return 'never';              // Full access: map to yolo behavior
@@ -54,8 +54,7 @@ export function shouldAutoApproveCodexApproval(
     }
 
     // safe-yolo is deliberately absent: its turns run with approvalPolicy
-    // 'never' inside the workspace sandbox, so any approval codex still
-    // surfaces (a sandbox-escalation retry or an MCP elicitation) is exactly
-    // what safe-yolo promises to ask the user about.
+    // 'on-failure' inside the workspace sandbox, so sandbox-escalation retries
+    // still ask the user.
     return permissionMode === 'yolo' || permissionMode === 'bypassPermissions';
 }


### PR DESCRIPTION
## Summary

- Restore Codex `safe-yolo` to `approvalPolicy: 'on-failure'` while keeping its `workspace-write` sandbox.
- Preserve `yolo` and `bypassPermissions` as no-prompt modes with `approvalPolicy: 'never'` and `danger-full-access` sandboxing.
- Update the existing Codex execution-policy regression test to lock the expected mapping.

Fixes #1330.

## Validation

- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter happy run typecheck`
- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter happy exec vitest run --project unit src/codex/__tests__/executionPolicy.test.ts`
