### PR TITLE
fix(app): honor always-show context toggle without usage

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -24,9 +24,9 @@ import { GitStatusBadge, useHasMeaningfulGitStatus } from './GitStatusBadge';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useSetting } from '@/sync/storage';
 import { hackMode, hackModes } from '@/sync/modeHacks';
-import { Theme } from '@/theme';
 import { t } from '@/text';
 import { Metadata } from '@/sync/storageTypes';
+import { resolveAgentInputContextWarning } from '@/utils/agentInputContextWarning';
 
 interface AgentInputProps {
     // `initialValue` seeds the uncontrolled textarea once; keystrokes never
@@ -98,8 +98,6 @@ interface AgentInputProps {
     onRemoveImage?: (id: string) => void;
     onAddImages?: (images: AttachmentPreview[]) => void;
 }
-
-const MAX_CONTEXT_SIZE = 190000;
 
 const stylesheet = StyleSheet.create((theme, runtime) => ({
     container: {
@@ -310,22 +308,6 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         color: theme.colors.button.primary.tint,
     },
 }));
-
-const getContextWarning = (contextSize: number, alwaysShow: boolean = false, theme: Theme, contextWindow: number = MAX_CONTEXT_SIZE) => {
-    const maxContextSize = Number.isFinite(contextWindow) && contextWindow > 0 ? contextWindow : MAX_CONTEXT_SIZE;
-    const percentageUsed = (contextSize / maxContextSize) * 100;
-    const percentageRemaining = Math.max(0, Math.min(100, 100 - percentageUsed));
-
-    if (percentageRemaining <= 5) {
-        return { text: t('agentInput.context.remaining', { percent: Math.round(percentageRemaining) }), color: theme.colors.warningCritical };
-    } else if (percentageRemaining <= 10) {
-        return { text: t('agentInput.context.remaining', { percent: Math.round(percentageRemaining) }), color: theme.colors.warning };
-    } else if (alwaysShow) {
-        // Show context remaining in neutral color when not near limit
-        return { text: t('agentInput.context.remaining', { percent: Math.round(percentageRemaining) }), color: theme.colors.warning };
-    }
-    return null; // No display needed
-};
 
 // Stable sub-trees extracted from AgentInput so they don't reconcile when
 // the input's keystroke-derived state (hasText / inputState) flips. Their
@@ -609,9 +591,11 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     }, [isSandboxEnabled]);
 
     // Calculate context warning
-    const contextWarning = props.usageData?.contextSize
-        ? getContextWarning(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme, props.usageData.contextWindow)
-        : null;
+    const contextWarning = resolveAgentInputContextWarning(
+        props.usageData,
+        props.alwaysShowContextSize ?? false,
+        theme,
+    );
 
     const agentInputEnterToSend = useSetting('agentInputEnterToSend');
 

--- a/packages/happy-app/sources/utils/agentInputContextWarning.test.ts
+++ b/packages/happy-app/sources/utils/agentInputContextWarning.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveAgentInputContextWarning } from './agentInputContextWarning';
+
+vi.mock('@/text', () => ({
+    t: (_key: string, params: { percent: number }) => `${params.percent}% remaining`,
+}));
+
+const theme = {
+    colors: {
+        warning: '#warning',
+        warningCritical: '#critical',
+    },
+};
+
+describe('agent input context warning', () => {
+    it('shows remaining context when alwaysShow is enabled before usage arrives', () => {
+        expect(resolveAgentInputContextWarning(undefined, true, theme)).toEqual({
+            text: '100% remaining',
+            color: '#warning',
+        });
+    });
+
+    it('shows remaining context when alwaysShow is enabled and usage is zero', () => {
+        expect(resolveAgentInputContextWarning({
+            contextSize: 0,
+            contextWindow: 190000,
+        }, true, theme)).toEqual({
+            text: '100% remaining',
+            color: '#warning',
+        });
+    });
+
+    it('still hides healthy context usage when alwaysShow is disabled', () => {
+        expect(resolveAgentInputContextWarning({
+            contextSize: 1000,
+            contextWindow: 190000,
+        }, false, theme)).toBeNull();
+    });
+
+    it('shows critical context usage regardless of alwaysShow', () => {
+        expect(resolveAgentInputContextWarning({
+            contextSize: 181000,
+            contextWindow: 190000,
+        }, false, theme)).toEqual({
+            text: '5% remaining',
+            color: '#critical',
+        });
+    });
+});

--- a/packages/happy-app/sources/utils/agentInputContextWarning.ts
+++ b/packages/happy-app/sources/utils/agentInputContextWarning.ts
@@ -1,0 +1,50 @@
+import { t } from '@/text';
+
+export const AGENT_INPUT_CONTEXT_MAX = 190000;
+
+type ContextWarningTheme = {
+    colors: {
+        warning: string;
+        warningCritical: string;
+    };
+};
+
+export type AgentInputUsageData = {
+    contextSize: number;
+    contextWindow?: number;
+};
+
+export type AgentInputContextWarning = {
+    text: string;
+    color: string;
+};
+
+export function getContextWarning(
+    contextSize: number,
+    alwaysShow: boolean = false,
+    theme: ContextWarningTheme,
+    contextWindow: number = AGENT_INPUT_CONTEXT_MAX,
+): AgentInputContextWarning | null {
+    const maxContextSize = Number.isFinite(contextWindow) && contextWindow > 0 ? contextWindow : AGENT_INPUT_CONTEXT_MAX;
+    const percentageUsed = (contextSize / maxContextSize) * 100;
+    const percentageRemaining = Math.max(0, Math.min(100, 100 - percentageUsed));
+
+    if (percentageRemaining <= 5) {
+        return { text: t('agentInput.context.remaining', { percent: Math.round(percentageRemaining) }), color: theme.colors.warningCritical };
+    } else if (percentageRemaining <= 10) {
+        return { text: t('agentInput.context.remaining', { percent: Math.round(percentageRemaining) }), color: theme.colors.warning };
+    } else if (alwaysShow) {
+        return { text: t('agentInput.context.remaining', { percent: Math.round(percentageRemaining) }), color: theme.colors.warning };
+    }
+    return null;
+}
+
+export function resolveAgentInputContextWarning(
+    usageData: AgentInputUsageData | undefined,
+    alwaysShow: boolean,
+    theme: ContextWarningTheme,
+): AgentInputContextWarning | null {
+    return alwaysShow || usageData?.contextSize
+        ? getContextWarning(usageData?.contextSize ?? 0, alwaysShow, theme, usageData?.contextWindow)
+        : null;
+}


### PR DESCRIPTION
## Summary

The app already receives the `alwaysShowContextSize` setting in `SessionView` and current `main` includes the usage relay from agent messages. The remaining bug is in `AgentInput`: the call site only asked for a context warning when `usageData.contextSize` was truthy, so the helper's `alwaysShow` behavior was bypassed whenever usage was missing or reset to zero.

This extracts the context-warning decision into a small pure helper and changes the gate to render whenever `alwaysShowContextSize` is enabled, treating missing usage as `0` so the composer shows `100% remaining` until real usage arrives. Threshold warnings still render independent of the toggle.

Closes https://github.com/slopus/happy/issues/1274.

## Validation

- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter happy-app exec vitest run sources/utils/agentInputContextWarning.test.ts`
- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter @slopus/happy-wire build`
- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter happy-app typecheck`
