### PR TITLE
fix(cli): forward Codex passthrough args

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Step 3: Start using `happy` instead of `claude` or `codex`
 happy claude
 # or
 happy codex
+
+# Forward Codex-only CLI flags after --
+happy codex -- --dangerously-bypass-approvals-and-sandbox
 ```
 
 ## How does it work?

--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -41,6 +41,14 @@ happy acp opencode
 happy acp -- custom-agent --flag
 ```
 
+Codex-only CLI flags can be forwarded after `--`:
+
+```bash
+happy codex -- --dangerously-bypass-approvals-and-sandbox
+```
+
+Arguments after `--` are passed to the Codex CLI before Happy starts Codex's app-server. They apply only to `happy codex`; other agents keep their existing argument handling.
+
 ## Daemon
 
 The daemon is a background service that stays running on your machine. It lets you spawn and manage coding sessions remotely — from your phone or the web app — without needing an open terminal.

--- a/packages/happy-cli/src/codex/cliArgs.test.ts
+++ b/packages/happy-cli/src/codex/cliArgs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractCodexResumeFlag } from './cliArgs';
+import { extractCodexPassthroughArgs, extractCodexResumeFlag } from './cliArgs';
 
 describe('extractCodexResumeFlag', () => {
     it('returns null and preserves args when resume flag is absent', () => {
@@ -28,5 +28,41 @@ describe('extractCodexResumeFlag', () => {
         expect(() => extractCodexResumeFlag(['--resume'])).toThrow(
             'Codex resume requires a thread ID: happy codex --resume <thread-id>',
         );
+    });
+});
+
+describe('extractCodexPassthroughArgs', () => {
+    it('preserves all args as Happy args when delimiter is absent', () => {
+        const parsed = extractCodexPassthroughArgs(['--resume', 'thread-123', '--model', 'gpt-5.5']);
+
+        expect(parsed).toEqual({
+            happyArgs: ['--resume', 'thread-123', '--model', 'gpt-5.5'],
+            codexArgs: [],
+        });
+    });
+
+    it('splits Codex args after the first delimiter', () => {
+        const parsed = extractCodexPassthroughArgs([
+            '--started-by',
+            'terminal',
+            '--',
+            '--dangerously-bypass-approvals-and-sandbox',
+            '--config',
+            'model="gpt-5.5"',
+        ]);
+
+        expect(parsed).toEqual({
+            happyArgs: ['--started-by', 'terminal'],
+            codexArgs: ['--dangerously-bypass-approvals-and-sandbox', '--config', 'model="gpt-5.5"'],
+        });
+    });
+
+    it('keeps later delimiters in the Codex args', () => {
+        const parsed = extractCodexPassthroughArgs(['--', '--config', 'foo=bar', '--', 'value']);
+
+        expect(parsed).toEqual({
+            happyArgs: [],
+            codexArgs: ['--config', 'foo=bar', '--', 'value'],
+        });
     });
 });

--- a/packages/happy-cli/src/codex/cliArgs.ts
+++ b/packages/happy-cli/src/codex/cliArgs.ts
@@ -42,3 +42,18 @@ export function extractCodexResumeFlag(args: string[]): { resumeThreadId: string
         args: remainingArgs,
     };
 }
+
+export function extractCodexPassthroughArgs(args: string[]): { happyArgs: string[]; codexArgs: string[] } {
+    const delimiterIndex = args.indexOf('--');
+    if (delimiterIndex === -1) {
+        return {
+            happyArgs: args,
+            codexArgs: [],
+        };
+    }
+
+    return {
+        happyArgs: args.slice(0, delimiterIndex),
+        codexArgs: args.slice(delimiterIndex + 1),
+    };
+}

--- a/packages/happy-cli/src/codex/codexAppServerClient.test.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.test.ts
@@ -162,6 +162,60 @@ describe('CodexAppServerClient sandbox integration', () => {
         await client.disconnect();
     });
 
+    it('forwards Codex CLI args before the app-server subcommand', async () => {
+        const { CodexAppServerClient } = await import('./codexAppServerClient');
+        const client = new CodexAppServerClient(undefined, [
+            '--dangerously-bypass-approvals-and-sandbox',
+            '--config',
+            'model="gpt-5.5"',
+        ]);
+
+        await client.connect();
+
+        expect(mockWrapForMcpTransport).not.toHaveBeenCalled();
+        expect(mockSpawn).toHaveBeenCalledWith(
+            'codex',
+            [
+                '--dangerously-bypass-approvals-and-sandbox',
+                '--config',
+                'model="gpt-5.5"',
+                'app-server',
+                '--listen',
+                'stdio://',
+            ],
+            expect.objectContaining({
+                env: expect.objectContaining({
+                    RUST_LOG: expect.stringContaining('codex_core::rollout::list=off'),
+                }),
+            }),
+        );
+
+        await client.disconnect();
+    });
+
+    it('passes forwarded Codex CLI args into the sandbox wrapper', async () => {
+        const { CodexAppServerClient } = await import('./codexAppServerClient');
+        const client = new CodexAppServerClient(sandboxConfig, [
+            '--dangerously-bypass-approvals-and-sandbox',
+        ]);
+
+        await client.connect();
+
+        expect(mockWrapForMcpTransport).toHaveBeenCalledWith('codex', [
+            '--dangerously-bypass-approvals-and-sandbox',
+            'app-server',
+            '--listen',
+            'stdio://',
+        ]);
+        expect(mockSpawn).toHaveBeenCalledWith(
+            'sh',
+            ['-c', 'wrapped codex app-server'],
+            expect.anything(),
+        );
+
+        await client.disconnect();
+    });
+
     it('falls back to non-sandbox transport when sandbox initialization fails', async () => {
         mockInitializeSandbox.mockRejectedValue(new Error('sandbox init failed'));
         const { CodexAppServerClient } = await import('./codexAppServerClient');

--- a/packages/happy-cli/src/codex/codexAppServerClient.ts
+++ b/packages/happy-cli/src/codex/codexAppServerClient.ts
@@ -218,6 +218,7 @@ export class CodexAppServerClient {
     private processEpoch = 0;
     private connected = false;
     private sandboxConfig?: SandboxConfig;
+    private codexCliArgs: string[];
     private sandboxCleanup: (() => Promise<void>) | null = null;
     public sandboxEnabled = false;
 
@@ -257,8 +258,9 @@ export class CodexAppServerClient {
     private eventHandler: ((msg: EventMsg) => void) | null = null;
     private approvalHandler: ApprovalHandler | null = null;
 
-    constructor(sandboxConfig?: SandboxConfig) {
+    constructor(sandboxConfig?: SandboxConfig, codexCliArgs: string[] = []) {
         this.sandboxConfig = sandboxConfig;
+        this.codexCliArgs = [...codexCliArgs];
     }
 
     get threadId(): string | null {
@@ -606,13 +608,13 @@ export class CodexAppServerClient {
         }
 
         let command = 'codex';
-        let args = ['app-server', '--listen', 'stdio://'];
+        let args = [...this.codexCliArgs, 'app-server', '--listen', 'stdio://'];
         this.sandboxEnabled = false;
 
         if (this.sandboxConfig?.enabled && process.platform !== 'win32') {
             try {
                 this.sandboxCleanup = await initializeSandbox(this.sandboxConfig, process.cwd());
-                const wrapped = await wrapForMcpTransport('codex', ['app-server', '--listen', 'stdio://']);
+                const wrapped = await wrapForMcpTransport('codex', args);
                 command = wrapped.command;
                 args = wrapped.args;
                 this.sandboxEnabled = true;

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -95,6 +95,7 @@ export async function runCodex(opts: {
     permissionMode?: PermissionMode;
     model?: string;
     effort?: ReasoningEffort;
+    codexCliArgs?: string[];
 }): Promise<void> {
     // Early check: ensure Codex CLI is installed before proceeding
     try {
@@ -592,7 +593,7 @@ export async function runCodex(opts: {
     // Start Context 
     //
 
-    client = new CodexAppServerClient(sandboxConfig);
+    client = new CodexAppServerClient(sandboxConfig, opts.codexCliArgs);
 
     permissionHandler = new CodexPermissionHandler(session);
     // Drop any permission requests left in agent state from a previous CLI

--- a/packages/happy-cli/src/commands/codexCommand.test.ts
+++ b/packages/happy-cli/src/commands/codexCommand.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   mockAuthAndSetupMachineIfNeeded: vi.fn(),
   mockRunCodex: vi.fn(),
   mockExtractCodexResumeFlag: vi.fn(),
+  mockExtractCodexPassthroughArgs: vi.fn(),
   mockExtractNoSandboxFlag: vi.fn(),
   mockEnsureDaemonRunning: vi.fn(),
 }))
@@ -18,6 +19,7 @@ vi.mock('@/codex/runCodex', () => ({
 
 vi.mock('@/codex/cliArgs', () => ({
   extractCodexResumeFlag: mocks.mockExtractCodexResumeFlag,
+  extractCodexPassthroughArgs: mocks.mockExtractCodexPassthroughArgs,
 }))
 
 vi.mock('@/utils/sandboxFlags', () => ({
@@ -40,6 +42,10 @@ describe('handleCodexCommand', () => {
       noSandbox: false,
       args,
     }))
+    mocks.mockExtractCodexPassthroughArgs.mockImplementation((args: string[]) => ({
+      happyArgs: args,
+      codexArgs: [],
+    }))
     mocks.mockExtractCodexResumeFlag.mockImplementation((args: string[]) => ({
       resumeThreadId: null,
       args,
@@ -60,6 +66,7 @@ describe('handleCodexCommand', () => {
       permissionMode: undefined,
       model: undefined,
       effort: undefined,
+      codexCliArgs: [],
     })
     expect(
       mocks.mockEnsureDaemonRunning.mock.invocationCallOrder[0],
@@ -86,6 +93,35 @@ describe('handleCodexCommand', () => {
       permissionMode: undefined,
       model: undefined,
       effort: undefined,
+      codexCliArgs: [],
+    })
+  })
+
+  it('passes only delimiter-separated args through to the Codex CLI', async () => {
+    mocks.mockExtractCodexPassthroughArgs.mockReturnValue({
+      happyArgs: ['--started-by', 'terminal'],
+      codexArgs: ['--dangerously-bypass-approvals-and-sandbox', '--config', 'model="gpt-5.5"'],
+    })
+
+    await handleCodexCommand([
+      '--started-by',
+      'terminal',
+      '--',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--config',
+      'model="gpt-5.5"',
+    ])
+
+    expect(mocks.mockExtractNoSandboxFlag).toHaveBeenCalledWith(['--started-by', 'terminal'])
+    expect(mocks.mockRunCodex).toHaveBeenCalledWith({
+      credentials: { token: 'token' },
+      startedBy: 'terminal',
+      noSandbox: false,
+      resumeThreadId: undefined,
+      permissionMode: undefined,
+      model: undefined,
+      effort: undefined,
+      codexCliArgs: ['--dangerously-bypass-approvals-and-sandbox', '--config', 'model="gpt-5.5"'],
     })
   })
 
@@ -100,6 +136,7 @@ describe('handleCodexCommand', () => {
       permissionMode: 'yolo',
       model: undefined,
       effort: undefined,
+      codexCliArgs: [],
     })
   })
 
@@ -114,6 +151,7 @@ describe('handleCodexCommand', () => {
       permissionMode: 'yolo',
       model: undefined,
       effort: undefined,
+      codexCliArgs: [],
     })
   })
 
@@ -128,6 +166,7 @@ describe('handleCodexCommand', () => {
       permissionMode: undefined,
       model: 'gpt-5.4',
       effort: 'xhigh',
+      codexCliArgs: [],
     })
   })
 })

--- a/packages/happy-cli/src/commands/codexCommand.ts
+++ b/packages/happy-cli/src/commands/codexCommand.ts
@@ -1,6 +1,6 @@
 import { authAndSetupMachineIfNeeded } from '@/ui/auth'
 import { runCodex } from '@/codex/runCodex'
-import { extractCodexResumeFlag } from '@/codex/cliArgs'
+import { extractCodexPassthroughArgs, extractCodexResumeFlag } from '@/codex/cliArgs'
 import { extractNoSandboxFlag } from '@/utils/sandboxFlags'
 import { ensureDaemonRunning } from '@/daemon/ensureDaemonRunning'
 import type { PermissionMode } from '@/api/types'
@@ -11,7 +11,8 @@ export async function handleCodexCommand(args: string[]): Promise<void> {
   let permissionMode: PermissionMode | undefined = undefined
   let model: string | undefined = undefined
   let effort: ReasoningEffort | undefined = undefined
-  const sandboxArgs = extractNoSandboxFlag(args)
+  const passthroughArgs = extractCodexPassthroughArgs(args)
+  const sandboxArgs = extractNoSandboxFlag(passthroughArgs.happyArgs)
   const codexArgs = extractCodexResumeFlag(sandboxArgs.args)
 
   for (let i = 0; i < codexArgs.args.length; i++) {
@@ -39,5 +40,6 @@ export async function handleCodexCommand(args: string[]): Promise<void> {
     permissionMode,
     model,
     effort,
+    codexCliArgs: passthroughArgs.codexArgs,
   })
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/slopus/happy/issues/1246 by adding Codex-only `--` pass-through support for users who need to forward Codex CLI flags such as `--dangerously-bypass-approvals-and-sandbox`.

## Changes

- Split `happy codex` arguments at the first `--`, keeping Happy-owned flags before the delimiter and forwarding only the trailing args to Codex.
- Pass forwarded args into the `codex app-server --listen stdio://` launch before the `app-server` subcommand, matching Codex global option ordering.
- Preserve existing `happy codex` behavior when no delimiter is provided.
- Document the Codex pass-through syntax in the root and CLI READMEs.

## Validation

- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter @slopus/happy-wire build`
- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter happy exec vitest run src/codex/cliArgs.test.ts src/commands/codexCommand.test.ts src/codex/codexAppServerClient.test.ts`
- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter happy typecheck`
- `NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false pnpm --filter happy build`
