### PR TITLE
test(cli): cover daemon permission mode inheritance

### DIFF
--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -28,31 +28,11 @@ import { detectCLIAvailability } from '@/utils/detectCLI';
 import { buildResumeLaunch } from '@/resume/handleResumeCommand';
 import { detectResumeSupport } from '@/resume/localHappyAgentAuth';
 import { encodeBase64, decodeBase64, decrypt } from '@/api/encryption';
+import { appendDaemonSpawnModeArgs } from './spawnModeArgs';
 
 /** Shell-escape a string for safe interpolation into tmux commands. */
 function shellescape(s: string): string {
     return "'" + s.replace(/'/g, "'\\''") + "'";
-}
-
-function appendDaemonSpawnModeArgs(args: string[], options: SpawnSessionOptions, agent: string): void {
-  if (agent !== 'claude' && agent !== 'codex') {
-    return;
-  }
-  // For claude, 'default' is the app's ambient "no override" value — forwarding
-  // it would pin the session to prompting mode and lose the CLI's own default
-  // (e.g. a --yolo setup where sessions must bypass permissions). For codex,
-  // 'default' IS a concrete ask-first mode (untrusted + workspace-write)
-  // distinct from the codex launch default ('yolo'), so it must be forwarded
-  // or the user's explicit ask-first pick silently yields a yolo session.
-  if (options.permissionMode && (agent === 'codex' || options.permissionMode !== 'default')) {
-    args.push('--permission-mode', options.permissionMode);
-  }
-  if (options.modelMode && options.modelMode !== 'default') {
-    args.push('--model', options.modelMode);
-  }
-  if (options.effortLevel) {
-    args.push('--effort', options.effortLevel);
-  }
 }
 
 // Prepare initial metadata

--- a/packages/happy-cli/src/daemon/spawnModeArgs.test.ts
+++ b/packages/happy-cli/src/daemon/spawnModeArgs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendDaemonSpawnModeArgs } from './spawnModeArgs';
+
+describe('appendDaemonSpawnModeArgs', () => {
+  it('forwards bypassPermissions for Claude daemon-started sessions', () => {
+    const args = ['claude', '--happy-starting-mode', 'remote'];
+
+    appendDaemonSpawnModeArgs(args, { directory: '.', permissionMode: 'bypassPermissions' }, 'claude');
+
+    expect(args).toEqual([
+      'claude',
+      '--happy-starting-mode',
+      'remote',
+      '--permission-mode',
+      'bypassPermissions',
+    ]);
+  });
+
+  it('forwards plan for Claude daemon-started sessions', () => {
+    const args = ['claude', '--happy-starting-mode', 'remote'];
+
+    appendDaemonSpawnModeArgs(args, { directory: '.', permissionMode: 'plan' }, 'claude');
+
+    expect(args).toEqual([
+      'claude',
+      '--happy-starting-mode',
+      'remote',
+      '--permission-mode',
+      'plan',
+    ]);
+  });
+
+  it('does not forward ambient Claude default so the CLI launch default is inherited', () => {
+    const args = ['claude', '--happy-starting-mode', 'remote'];
+
+    appendDaemonSpawnModeArgs(args, { directory: '.', permissionMode: 'default' }, 'claude');
+
+    expect(args).toEqual(['claude', '--happy-starting-mode', 'remote']);
+  });
+
+  it('forwards explicit Codex default because it is ask-first, not ambient', () => {
+    const args = ['codex', '--happy-starting-mode', 'remote'];
+
+    appendDaemonSpawnModeArgs(args, { directory: '.', permissionMode: 'default' }, 'codex');
+
+    expect(args).toEqual([
+      'codex',
+      '--happy-starting-mode',
+      'remote',
+      '--permission-mode',
+      'default',
+    ]);
+  });
+
+  it('forwards model and effort overrides without forwarding ambient default model', () => {
+    const args = ['claude'];
+
+    appendDaemonSpawnModeArgs(args, {
+      directory: '.',
+      permissionMode: 'bypassPermissions',
+      modelMode: 'default',
+      effortLevel: 'high',
+    }, 'claude');
+
+    expect(args).toEqual(['claude', '--permission-mode', 'bypassPermissions', '--effort', 'high']);
+  });
+});

--- a/packages/happy-cli/src/daemon/spawnModeArgs.ts
+++ b/packages/happy-cli/src/daemon/spawnModeArgs.ts
@@ -1,0 +1,21 @@
+import type { SpawnSessionOptions } from '@/modules/common/registerCommonHandlers';
+
+export function appendDaemonSpawnModeArgs(args: string[], options: SpawnSessionOptions, agent: string): void {
+  if (agent !== 'claude' && agent !== 'codex') {
+    return;
+  }
+  // For Claude, 'default' is the app's ambient "no override" value. Forwarding
+  // it would pin daemon-started sessions to prompting mode and lose the CLI
+  // default (for example a yolo setup where sessions must bypass permissions).
+  // For Codex, 'default' is a concrete ask-first mode distinct from Codex's
+  // launch default ('yolo'), so explicit app picks must be forwarded.
+  if (options.permissionMode && (agent === 'codex' || options.permissionMode !== 'default')) {
+    args.push('--permission-mode', options.permissionMode);
+  }
+  if (options.modelMode && options.modelMode !== 'default') {
+    args.push('--model', options.modelMode);
+  }
+  if (options.effortLevel) {
+    args.push('--effort', options.effortLevel);
+  }
+}


### PR DESCRIPTION
## Summary

- Extract daemon session spawn mode argument construction into a focused helper.
- Add regression coverage for daemon-started permission mode inheritance so Claude `bypassPermissions` and `plan` are forwarded, ambient Claude `default` inherits the CLI launch mode, and explicit Codex `default` remains ask-first.

## Context

This covers the permission-mode inheritance edge from issue https://github.com/slopus/happy/issues/1489 without changing the current product defaults. Current `main` already has the canonical behavior in source; this PR locks it down at the daemon/app session boundary.

## Validation

- `pnpm --filter happy test -- --project unit src/daemon/spawnModeArgs.test.ts src/claude/utils/permissionMode.test.ts`
- `pnpm --filter happy run typecheck`
