### PR TITLE
test(cli): cover remote Claude system prompt composition

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocal.test.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.test.ts
@@ -157,6 +157,25 @@ describe('claudeLocal --continue handling', () => {
         expect(spawnArgs).not.toContain('--resume');
     });
 
+    it('should inject Happy base system prompt once in local mode', async () => {
+        await claudeLocal({
+            abort: new AbortController().signal,
+            sessionId: null,
+            path: '/tmp',
+            onSessionFound,
+            claudeArgs: [],
+            hookSettingsPath: '/tmp/happy-test-settings.json'
+        });
+
+        const spawnArgs = mockSpawn.mock.calls[0][1];
+        const appendPromptIndexes = spawnArgs
+            .map((arg: string, index: number) => arg === '--append-system-prompt' ? index : -1)
+            .filter((index: number) => index >= 0);
+
+        expect(appendPromptIndexes).toHaveLength(1);
+        expect(spawnArgs[appendPromptIndexes[0] + 1]).toBe('test-system-prompt');
+    });
+
     it('should handle --resume with specific session ID without conflict', async () => {
         mockClaudeFindLastSession.mockReturnValue(null);
 

--- a/packages/happy-cli/src/claude/claudeRemote.test.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.test.ts
@@ -8,13 +8,96 @@ vi.mock('@/claude/sdk', () => ({
     AbortError: class AbortError extends Error {},
 }));
 
+vi.mock('./utils/systemPrompt', () => ({
+    systemPrompt: 'happy-base-system-prompt',
+}));
+
 const mode: EnhancedMode = {
     permissionMode: 'default',
 };
 
+const asyncResult = () => ({
+    setPermissionMode: vi.fn(),
+    async *[Symbol.asyncIterator]() {
+        yield {
+            type: 'result',
+            subtype: 'success',
+        };
+    },
+}) as any;
+
 describe('claudeRemote', () => {
     beforeEach(() => {
         vi.mocked(query).mockReset();
+    });
+
+    it('combines message append prompt with Happy base prompt for remote SDK sessions', async () => {
+        vi.mocked(query).mockReturnValue(asyncResult());
+        let messageCount = 0;
+
+        await claudeRemote({
+            sessionId: null,
+            path: process.cwd(),
+            allowedTools: [],
+            hookSettingsPath: '/tmp/happy-test-settings.json',
+            nextMessage: async () => {
+                messageCount += 1;
+                return messageCount === 1
+                    ? {
+                        message: 'hello',
+                        mode: {
+                            ...mode,
+                            appendSystemPrompt: '# Options\n\nPick one.',
+                        },
+                    }
+                    : null;
+            },
+            onReady: vi.fn(),
+            canCallTool: async () => ({ behavior: 'allow' }) as any,
+            isAborted: () => false,
+            onSessionFound: vi.fn(),
+            onThinkingChange: vi.fn(),
+            onMessage: vi.fn(),
+        });
+
+        expect(query).toHaveBeenCalledWith(expect.objectContaining({
+            options: expect.objectContaining({
+                appendSystemPrompt: '# Options\n\nPick one.\n\nhappy-base-system-prompt',
+            }),
+        }));
+    });
+
+    it('uses Happy base prompt for remote SDK sessions without a message append prompt', async () => {
+        vi.mocked(query).mockReturnValue(asyncResult());
+        let messageCount = 0;
+
+        await claudeRemote({
+            sessionId: null,
+            path: process.cwd(),
+            allowedTools: [],
+            hookSettingsPath: '/tmp/happy-test-settings.json',
+            nextMessage: async () => {
+                messageCount += 1;
+                return messageCount === 1
+                    ? {
+                        message: 'hello',
+                        mode,
+                    }
+                    : null;
+            },
+            onReady: vi.fn(),
+            canCallTool: async () => ({ behavior: 'allow' }) as any,
+            isAborted: () => false,
+            onSessionFound: vi.fn(),
+            onThinkingChange: vi.fn(),
+            onMessage: vi.fn(),
+        });
+
+        expect(query).toHaveBeenCalledWith(expect.objectContaining({
+            options: expect.objectContaining({
+                appendSystemPrompt: 'happy-base-system-prompt',
+            }),
+        }));
     });
 
     it('marks /clear as a completed reset turn', async () => {
@@ -51,6 +134,7 @@ describe('claudeRemote', () => {
         expect(onCompletionEvent).toHaveBeenCalledWith('Context was reset');
         expect(onSessionReset).toHaveBeenCalledOnce();
         expect(onReady).toHaveBeenCalledOnce();
+        expect(query).not.toHaveBeenCalled();
         expect(callbackOrder).toEqual(['event:Context was reset', 'reset', 'ready']);
     });
 
@@ -86,7 +170,10 @@ describe('claudeRemote', () => {
                 return messageCount === 1
                     ? {
                         message: '/compact',
-                        mode,
+                        mode: {
+                            ...mode,
+                            appendSystemPrompt: '# Options\n\nCompact choices.',
+                        },
                     }
                     : null;
             },
@@ -103,6 +190,11 @@ describe('claudeRemote', () => {
         expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({
             type: 'assistant',
             isCompactSummary: true,
+        }));
+        expect(query).toHaveBeenCalledWith(expect.objectContaining({
+            options: expect.objectContaining({
+                appendSystemPrompt: '# Options\n\nCompact choices.\n\nhappy-base-system-prompt',
+            }),
         }));
     });
 });


### PR DESCRIPTION
## Summary

Current `main` already composes remote Claude SDK `appendSystemPrompt` values with Happy's base system prompt in `claudeRemote.ts`, so this PR does not reapply the source patch for issue #1398. Instead, it adds focused regression coverage to prevent daemon/phone-spawned remote sessions from regressing back to the smaller per-message options-only prompt.

## What changed

- Adds remote Claude tests that assert SDK launches receive:
  - the message-provided append prompt followed by Happy's base system prompt
  - Happy's base system prompt when no per-message append prompt exists
  - the same composed prompt for `/compact` turns
- Extends the `/clear` test to assert it resets without launching the SDK, preserving existing clear behavior.
- Adds a local Claude spawn test proving local mode injects Happy's base `--append-system-prompt` exactly once, guarding against duplicate injection in local sessions.

## Validation

- `pnpm --filter happy exec vitest run src/claude/claudeRemote.test.ts src/claude/claudeLocal.test.ts --project unit`
- `pnpm --filter happy typecheck`
- `pnpm --filter happy test`
