### PR TITLE
fix(cli): keep ACP queue open after user abort

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.test.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.test.ts
@@ -35,8 +35,11 @@ const mocks = vi.hoisted(() => {
     startSessionMessages: [] as any[],
     startSessionCalls: 0,
     cancelCalls: [] as string[],
+    cancelStatusDetail: undefined as string | undefined,
     disposeCalls: 0,
     constructorArgs: null as any,
+    holdPromptsOpen: false,
+    heldPromptResolvers: [] as Array<() => void>,
   };
 
   return {
@@ -144,6 +147,12 @@ vi.mock('./AcpBackend', () => ({
 
     async sendPrompt(sessionId: string, prompt: string) {
       mocks.backendState.prompts.push({ sessionId, prompt });
+      if (mocks.backendState.holdPromptsOpen) {
+        await new Promise<void>((resolve) => {
+          mocks.backendState.heldPromptResolvers.push(resolve);
+        });
+        return;
+      }
       for (const listener of mocks.backendState.listeners) {
         listener({ type: 'status', status: 'running' });
         listener({ type: 'model-output', textDelta: 'hello' });
@@ -171,7 +180,7 @@ vi.mock('./AcpBackend', () => ({
     async cancel(sessionId: string) {
       mocks.backendState.cancelCalls.push(sessionId);
       for (const listener of mocks.backendState.listeners) {
-        listener({ type: 'status', status: 'stopped' });
+        listener({ type: 'status', status: 'stopped', detail: mocks.backendState.cancelStatusDetail });
       }
     }
 
@@ -203,8 +212,11 @@ describe('runAcp', () => {
     mocks.backendState.startSessionMessages = [];
     mocks.backendState.startSessionCalls = 0;
     mocks.backendState.cancelCalls = [];
+    mocks.backendState.cancelStatusDetail = undefined;
     mocks.backendState.disposeCalls = 0;
     mocks.backendState.constructorArgs = null;
+    mocks.backendState.holdPromptsOpen = false;
+    mocks.backendState.heldPromptResolvers = [];
 
     mocks.mockApiCreate.mockResolvedValue({
       getOrCreateMachine: mocks.mockGetOrCreateMachine,
@@ -285,6 +297,69 @@ describe('runAcp', () => {
     await abortHandler!({});
     await vi.waitFor(() => {
       expect(mocks.backendState.cancelCalls).toEqual(['acp-session-1']);
+    });
+
+    await mocks.getKillHandler()!();
+    await runPromise;
+  });
+
+  it('keeps the ACP message queue usable after OpenCode reports user cancellation', async () => {
+    mocks.backendState.holdPromptsOpen = true;
+    mocks.backendState.cancelStatusDetail = 'Cancelled by user';
+
+    const runPromise = runAcp({
+      credentials: { token: 'token', encryption: { type: 'legacy', secret: new Uint8Array(32) } },
+      agentName: 'opencode',
+      command: 'opencode',
+      args: ['acp'],
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.getUserMessageHandler()).toBeTypeOf('function');
+    });
+
+    mocks.getUserMessageHandler()!({
+      role: 'user',
+      content: { type: 'text', text: 'Long running prompt' },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.backendState.prompts).toEqual([
+        { sessionId: 'acp-session-1', prompt: 'Long running prompt' },
+      ]);
+    });
+
+    const abortHandler = mocks.sessionHandlers.get('abort');
+    expect(abortHandler).toBeTypeOf('function');
+    await abortHandler!({});
+
+    await vi.waitFor(() => {
+      expect(mocks.backendState.cancelCalls).toEqual(['acp-session-1']);
+    });
+
+    mocks.backendState.holdPromptsOpen = false;
+    for (const resolve of mocks.backendState.heldPromptResolvers) {
+      resolve();
+    }
+
+    await vi.waitFor(() => {
+      const turnEndStatuses = mocks.mockSession.sendSessionProtocolMessage.mock.calls
+        .map(([envelope]) => envelope.ev)
+        .filter((event) => event.t === 'turn-end')
+        .map((event) => event.status);
+      expect(turnEndStatuses).toContain('cancelled');
+    });
+
+    mocks.getUserMessageHandler()!({
+      role: 'user',
+      content: { type: 'text', text: 'Second prompt after abort' },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.backendState.prompts).toEqual([
+        { sessionId: 'acp-session-1', prompt: 'Long running prompt' },
+        { sessionId: 'acp-session-1', prompt: 'Second prompt after abort' },
+      ]);
     });
 
     await mocks.getKillHandler()!();

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -42,6 +42,15 @@ const ACP_LOG_COLORS = {
   tool: '\u001b[38;5;208m',
 } as const;
 
+const USER_CANCELLED_TURN_DETAIL = 'Cancelled by user';
+
+class AcpTurnCancelledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AcpTurnCancelledError';
+  }
+}
+
 type AcpLogKind = keyof typeof ACP_LOG_COLORS;
 type AcpFormattedLog = {
   kind: AcpLogKind;
@@ -552,6 +561,7 @@ export async function runAcp(opts: {
   let shouldExit = false;
   let abortController = new AbortController();
   let pendingTurn: PendingTurn | null = null;
+  let userCancellationPending = false;
 
   const clearPendingTurn = (error?: Error) => {
     if (!pendingTurn) {
@@ -583,6 +593,15 @@ export async function runAcp(opts: {
     shouldExit = true;
     messageQueue.close();
     clearPendingTurn(new Error(reason));
+  };
+
+  const cancelPendingTurnFromBackendStatus = (status: 'stopped', detail?: string) => {
+    const reason = detail
+      ? `${opts.agentName} backend ${status}: ${detail}`
+      : `${opts.agentName} backend ${status}`;
+    logger.debug(`[${opts.agentName}] ${reason}; keeping ACP runner active after user cancellation`);
+    userCancellationPending = false;
+    clearPendingTurn(new AcpTurnCancelledError(reason));
   };
 
   const sendEnvelopes = (envelopes: SessionEnvelope[]) => {
@@ -813,10 +832,18 @@ export async function runAcp(opts: {
         session.keepAlive(thinking, 'remote');
       }
       if (msg.status === 'idle') {
+        userCancellationPending = false;
         clearPendingTurn();
       }
-      if (msg.status === 'error' || msg.status === 'stopped') {
+      if (msg.status === 'error') {
         stopRunnerFromBackendStatus(msg.status, msg.detail);
+      }
+      if (msg.status === 'stopped') {
+        if (userCancellationPending && !shouldExit && msg.detail === USER_CANCELLED_TURN_DETAIL) {
+          cancelPendingTurnFromBackendStatus(msg.status, msg.detail);
+        } else {
+          stopRunnerFromBackendStatus(msg.status, msg.detail);
+        }
       }
     }
 
@@ -858,12 +885,14 @@ export async function runAcp(opts: {
 
   async function handleAbort() {
     try {
+      userCancellationPending = !!pendingTurn && !!acpSessionId;
       if (acpSessionId) {
         await backend.cancel(acpSessionId);
       }
       permissionHandler.reset();
       abortController.abort();
     } catch (error) {
+      userCancellationPending = false;
       logger.debug(`[${opts.agentName}] Abort failed:`, error);
     } finally {
       abortController = new AbortController();
@@ -913,6 +942,10 @@ export async function runAcp(opts: {
       logAcp('incoming', `Incoming prompt: ${formatUnknownForConsole(batch.message, ACP_EVENT_PREVIEW_CHARS)}`);
       sendEnvelopes(sessionManager.startTurn());
       const turnEnded = waitForTurnEnd();
+      let turnEndError: unknown;
+      const guardedTurnEnded = turnEnded.catch((error: unknown) => {
+        turnEndError = error;
+      });
       try {
         if (typeof batch.mode.permissionMode === 'string' && batch.mode.permissionMode.length > 0) {
           await switchPermissionModeIfRequested(batch.mode.permissionMode);
@@ -921,15 +954,23 @@ export async function runAcp(opts: {
           await switchModelIfRequested(batch.mode.model);
         }
         await backend.sendPrompt(acpSessionId, batch.message);
-        await turnEnded;
+        await guardedTurnEnded;
+        if (turnEndError) {
+          throw turnEndError;
+        }
         sendEnvelopes(sessionManager.endTurn('completed'));
         session.sendSessionEvent({ type: 'ready' });
         if (verbose) {
           logAcp('muted', `Outgoing prompt completion from ${opts.agentName}`);
         }
       } catch (error) {
-        sendEnvelopes(sessionManager.endTurn('failed'));
+        const turnWasCancelled = error instanceof AcpTurnCancelledError;
+        sendEnvelopes(sessionManager.endTurn(turnWasCancelled ? 'cancelled' : 'failed'));
         session.sendSessionEvent({ type: 'ready' });
+        if (turnWasCancelled) {
+          logAcp('muted', `Prompt cancelled from ${opts.agentName}: ${error.message}`);
+          continue;
+        }
         logAcp('error', `Prompt error from ${opts.agentName}: ${error instanceof Error ? error.message : String(error)}`);
         clearPendingTurn(error instanceof Error ? error : new Error(String(error)));
         throw error;


### PR DESCRIPTION
## Summary

OpenCode reports an ACP abort as a `stopped` backend status with `Cancelled by user` detail. The runner previously treated all stopped statuses as fatal, which ended the runner after a user abort and left the ACP message queue unable to process the next prompt.

This change distinguishes user-initiated cancellation from backend failure. While an abort is pending, the matching OpenCode cancellation status now ends the active turn as `cancelled`, clears the pending turn, sends the ready event, and keeps the runner available for later prompts. Other stopped or error statuses still stop the runner.

## Changes

- Track when a user abort is waiting for backend cancellation.
- Convert the matching OpenCode cancellation status into a turn-cancelled path instead of a runner-fatal error.
- Preserve fatal handling for backend errors and non-user-cancellation stopped statuses.
- Add regression coverage for aborting a held ACP prompt and then successfully sending a second prompt on the same session.

## Validation

Not run. The implementation branch includes targeted regression coverage in `packages/happy-cli/src/agent/acp/runAcp.test.ts`.
