### PR TITLE
fix(app): make markdown copy screen selectable

### DIFF
--- a/packages/happy-app/sources/app/(app)/text-selection.tsx
+++ b/packages/happy-app/sources/app/(app)/text-selection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, ScrollView, TextInput, Pressable } from 'react-native';
+import { View, Text, ScrollView, Pressable } from 'react-native';
 import { useRouter, useLocalSearchParams, useNavigation } from 'expo-router';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -95,17 +95,12 @@ export default function TextSelectionScreen() {
                     { paddingBottom: insets.bottom + 16 }
                 ]}
             >
-                <TextInput
-                    style={[styles.textInput, { 
-                        color: theme.colors.text,
-                        backgroundColor: 'transparent'
-                    }]}
-                    value={fullText}
-                    multiline={true}
-                    editable={false}
-                    selectTextOnFocus={false}
-                    scrollEnabled={false}
-                />
+                <Text
+                    selectable={true}
+                    style={[styles.sourceText, { color: theme.colors.text }]}
+                >
+                    {fullText}
+                </Text>
             </ScrollView>
         </View>
     );
@@ -129,17 +124,12 @@ const styles = StyleSheet.create((theme) => ({
     scrollContent: {
         flexGrow: 1,
     },
-    textInput: {
+    sourceText: {
         ...Typography.mono(),
         fontSize: 14,
         lineHeight: 20,
         color: theme.colors.text,
         minHeight: 200,
-        textAlignVertical: 'top',
-        backgroundColor: 'transparent',
-        borderWidth: 0,
-        paddingHorizontal: 0,
-        paddingVertical: 0,
     },
     copyButton: {
         padding: 8,


### PR DESCRIPTION
## Summary

Fixes the mobile markdown-copy fallback so users can select and copy an arbitrary range from Claude output after opening the text-selection screen.

`markdownCopyV2` already routes long-pressed markdown messages to `/text-selection` with the full raw response. That screen rendered the response in a read-only `TextInput`; on native platforms, a disabled text input is an unreliable selection surface and can leave the OS copy action copying something other than the intended selected range. This swaps it for selectable `Text`, preserving the header copy-all button and the existing message/code-block copy paths.

Related context: [#1386](https://github.com/slopus/happy/issues/1386), [#841](https://github.com/slopus/happy/issues/841), and the stale/unrelated-diff PR [#1449](https://github.com/slopus/happy/pull/1449).

## Validation

- `git diff --check`

Could not run `pnpm --filter happy-app typecheck` or Vitest because package manager bootstrapping was unavailable in this environment.

Visual/device proof is not included because this bug depends on native OS text-selection handles and the copy toolbar in an Expo app; the web renderer is documented in [#841](https://github.com/slopus/happy/issues/841) as already selectable.
