### PR TITLE
Fix ghost transcript watcher recovery

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -477,7 +477,10 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             // the chat on reconnect. The scanner's real job is forwarding
             // *future* JSONL writes from a parallel `claude --resume`
             // terminal, which the file watcher will pick up.
-            remoteScanner.onNewSession(sessionId, { treatExistingAsProcessed: true });
+            remoteScanner.onNewSession(sessionId, {
+                treatExistingAsProcessed: true,
+                transcriptPath: typeof data.transcript_path === 'string' ? data.transcript_path : undefined,
+            });
 
             // Update session ID in the Session instance
             if (currentSession) {

--- a/packages/happy-cli/src/claude/utils/sessionScanner.test.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.test.ts
@@ -14,6 +14,38 @@ describe('sessionScanner', () => {
   let collectedMessages: RawJSONLines[]
   let collectedTranscriptEvents: ClaudeGoalStatusTranscriptEvent[]
   let scanner: Awaited<ReturnType<typeof createSessionScanner>> | null = null
+
+  const createScanner = async () => {
+    scanner = await createSessionScanner({
+      sessionId: null,
+      workingDirectory: testDir,
+      onMessage: (msg) => collectedMessages.push(msg),
+      onTranscriptEvent: (event) => collectedTranscriptEvents.push(event),
+      missingFileTimeoutMs: 120,
+      watcherInitialRetryDelayMs: 20,
+      watcherMaxRetryDelayMs: 20,
+    })
+    return scanner
+  }
+
+  const writeUserTranscript = async (sessionId: string, content: string = `message from ${sessionId}`) => {
+    const sessionFile = join(projectDir, `${sessionId}.jsonl`)
+    await writeFile(sessionFile, JSON.stringify({
+      type: 'user',
+      uuid: `${sessionId}:user`,
+      parentUuid: null,
+      sessionId,
+      message: {
+        role: 'user',
+        content,
+      },
+    }) + '\n')
+    return sessionFile
+  }
+
+  const waitForWatcherGiveUp = async () => {
+    await new Promise((r) => setTimeout(r, 350))
+  }
   
   beforeEach(async () => {
     testDir = join(tmpdir(), `scanner-test-${Date.now()}`)
@@ -324,19 +356,13 @@ describe('sessionScanner', () => {
     // (e.g. a remote launch) but its .jsonl is never written. The scanner
     // must give up on it instead of spinning forever, and must still process
     // a real session that arrives afterwards.
-    scanner = await createSessionScanner({
-      sessionId: null,
-      workingDirectory: testDir,
-      onMessage: (msg) => collectedMessages.push(msg),
-      missingFileTimeoutMs: 100,
-    })
+    scanner = await createScanner()
 
     // Phantom: announced but no file on disk, ever.
     const phantomId = 'fd4aa0c2-000a-4cd3-a066-80c6d87c3456'
     scanner.onNewSession(phantomId)
 
-    // Long enough for the first ~1s backoff + give-up to fire.
-    await new Promise((r) => setTimeout(r, 2500))
+    await waitForWatcherGiveUp()
 
     expect(collectedMessages).toHaveLength(0)
 
@@ -352,5 +378,69 @@ describe('sessionScanner', () => {
 
     expect(collectedMessages).toHaveLength(1)
     expect(collectedMessages[0].type).toBe('user')
+  })
+
+  it('recovers a phantom session to the hook transcript path when Claude reports a different file', async () => {
+    scanner = await createScanner()
+
+    const ghostId = 'fd4aa0c2-000a-4cd3-a066-80c6d87c3456'
+    const realId = '25ef1f81-a227-4ffe-a2e8-495b772f6ca3'
+    const realFile = await writeUserTranscript(realId, 'real hook transcript')
+
+    scanner.onNewSession(ghostId, { transcriptPath: realFile })
+    await waitForWatcherGiveUp()
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(collectedMessages).toHaveLength(1)
+    expect(collectedMessages[0]).toMatchObject({
+      type: 'user',
+      sessionId: realId,
+    })
+  })
+
+  it('does not infer recovery from a single new transcript without a hook path', async () => {
+    await writeUserTranscript('93a9705e-bc6a-406d-8dce-8acc014dedbd', 'existing session before scanner start')
+    scanner = await createScanner()
+
+    const ghostId = 'fd4aa0c2-000a-4cd3-a066-80c6d87c3456'
+    scanner.onNewSession(ghostId)
+
+    const realId = '25ef1f81-a227-4ffe-a2e8-495b772f6ca3'
+    await writeUserTranscript(realId, 'only new transcript')
+
+    await waitForWatcherGiveUp()
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(collectedMessages).toHaveLength(0)
+  })
+
+  it('does not recover a phantom session when multiple new transcript candidates exist', async () => {
+    scanner = await createScanner()
+
+    const ghostId = 'fd4aa0c2-000a-4cd3-a066-80c6d87c3456'
+    scanner.onNewSession(ghostId)
+
+    await writeUserTranscript('25ef1f81-a227-4ffe-a2e8-495b772f6ca3', 'first concurrent transcript')
+    await writeUserTranscript('789e105f-ae33-486d-9271-0696266f072d', 'second concurrent transcript')
+
+    await waitForWatcherGiveUp()
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(collectedMessages).toHaveLength(0)
+  })
+
+  it('stops phantom recovery and retries after cleanup', async () => {
+    scanner = await createScanner()
+
+    const ghostId = 'fd4aa0c2-000a-4cd3-a066-80c6d87c3456'
+    scanner.onNewSession(ghostId)
+    await scanner.cleanup()
+    scanner = null
+
+    await writeUserTranscript('25ef1f81-a227-4ffe-a2e8-495b772f6ca3', 'written after cleanup')
+    await waitForWatcherGiveUp()
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(collectedMessages).toHaveLength(0)
   })
 })

--- a/packages/happy-cli/src/claude/utils/sessionScanner.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.ts
@@ -1,8 +1,8 @@
 import { InvalidateSync } from "@/utils/sync";
 import { RawJSONLines, RawJSONLinesSchema } from "../types";
 import { parseClaudeGoalStatusTranscriptEvent, type ClaudeGoalStatusTranscriptEvent } from "../claudeGoalStatus";
-import { join } from "node:path";
-import { readFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { access, readdir, readFile, stat } from "node:fs/promises";
 import { logger } from "@/ui/logger";
 import { startFileWatcher } from "@/modules/watcher/startFileWatcher";
 import { getProjectPath } from "./path";
@@ -18,11 +18,27 @@ const INTERNAL_CLAUDE_EVENT_TYPES = new Set([
     'queue-operation',
 ]);
 
+const CLAUDE_SESSION_FILE_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i;
+
 export type ScannerTranscriptEvent = ClaudeGoalStatusTranscriptEvent;
+export type TranscriptRecoveryResult =
+    | { type: 'recovered'; sessionId: string; reason: 'hook-transcript-path' }
+    | { type: 'none' }
+    | { type: 'ambiguous'; candidates: string[] };
 
 type SessionLogEntry =
     | { kind: 'message'; key: string; message: RawJSONLines }
     | { kind: 'transcript-event'; key: string; event: ScannerTranscriptEvent };
+
+type WatcherInfo = {
+    stop: () => void;
+    baselineSessionIds: Set<string>;
+};
+
+type NewSessionOptions = {
+    treatExistingAsProcessed?: boolean;
+    transcriptPath?: string;
+};
 
 export async function createSessionScanner(opts: {
     sessionId: string | null,
@@ -35,6 +51,12 @@ export async function createSessionScanner(opts: {
      * (60s). Exposed mainly so tests can exercise the drop path quickly.
      */
     missingFileTimeoutMs?: number
+    /**
+     * Passed through to startFileWatcher. Tests lower this so phantom
+     * transcript recovery and give-up behavior can run quickly.
+     */
+    watcherInitialRetryDelayMs?: number
+    watcherMaxRetryDelayMs?: number
 }) {
 
     // Resolve project directory
@@ -44,14 +66,18 @@ export async function createSessionScanner(opts: {
     let finishedSessions = new Set<string>();
     let pendingSessions = new Set<string>();
     let currentSessionId: string | null = null;
-    let watchers = new Map<string, (() => void)>();
+    let watchers = new Map<string, WatcherInfo>();
     let processedEntryKeys = new Set<string>();
+    let explicitTranscriptPaths = new Map<string, string>();
+    let scannerStopped = false;
     // Sessions whose transcript file never appeared. Their watcher gave up,
     // so we must stop re-reading them and never re-create a watcher for them
     // — otherwise a phantom session id (e.g. a remote launch whose .jsonl is
     // never written) keeps itself alive forever via the watchers map below
     // and spins the CPU / floods the log (the "dead Happy instance" bug).
     let deadSessions = new Set<string>();
+
+    const initialKnownSessionIds = await listValidSessionIds(projectDir);
 
     // Mark existing entries as processed and start watching the initial session
     if (opts.sessionId) {
@@ -68,6 +94,9 @@ export async function createSessionScanner(opts: {
 
     // Main sync function
     const sync = new InvalidateSync(async () => {
+        if (scannerStopped) {
+            return;
+        }
 
         // Collect session ids - include ALL sessions that have watchers
         // This ensures we continue processing sessions that Claude Code may still write to
@@ -126,25 +155,21 @@ export async function createSessionScanner(opts: {
         for (let p of sessions) {
             if (!watchers.has(p) && !deadSessions.has(p)) {
                 logger.debug(`[SESSION_SCANNER] Starting watcher for session: ${p}`);
-                watchers.set(p, startFileWatcher(
-                    join(projectDir, `${p}.jsonl`),
-                    () => { sync.invalidate(); },
-                    {
-                        missingFileTimeoutMs: opts.missingFileTimeoutMs,
-                        onGaveUp: () => {
-                            // The transcript for this session never appeared.
-                            // Tear the watcher down and blacklist the session
-                            // so the collection loop above stops resurrecting
-                            // it. Without this the phantom session would keep
-                            // itself in `watchers` forever.
-                            logger.debug(`[SESSION_SCANNER] Session ${p} transcript never appeared — dropping it`);
-                            watchers.get(p)?.();
-                            watchers.delete(p);
-                            deadSessions.add(p);
-                            pendingSessions.delete(p);
+                watchers.set(p, {
+                    baselineSessionIds: new Set(initialKnownSessionIds),
+                    stop: startFileWatcher(
+                        join(projectDir, `${p}.jsonl`),
+                        () => { sync.invalidate(); },
+                        {
+                            missingFileTimeoutMs: opts.missingFileTimeoutMs,
+                            initialRetryDelayMs: opts.watcherInitialRetryDelayMs,
+                            maxRetryDelayMs: opts.watcherMaxRetryDelayMs,
+                            onGaveUp: () => {
+                                void handleMissingSession(p);
+                            },
                         },
-                    },
-                ));
+                    ),
+                });
             }
         }
     });
@@ -154,20 +179,26 @@ export async function createSessionScanner(opts: {
     const intervalId = setInterval(() => { sync.invalidate(); }, 3000);
 
     // Public interface
-    return {
+    const scannerApi = {
         cleanup: async () => {
+            scannerStopped = true;
             clearInterval(intervalId);
             for (let w of watchers.values()) {
-                w();
+                w.stop();
             }
             watchers.clear();
-            await sync.invalidateAndAwait();
             sync.stop();
         },
-        onNewSession: async (sessionId: string, options?: { treatExistingAsProcessed?: boolean }) => {
+        onNewSession: async (sessionId: string, options?: NewSessionOptions) => {
             if (currentSessionId === sessionId) {
                 logger.debug(`[SESSION_SCANNER] New session: ${sessionId} is the same as the current session, skipping`);
+                if (options?.transcriptPath) {
+                    explicitTranscriptPaths.set(sessionId, options.transcriptPath);
+                }
                 return;
+            }
+            if (options?.transcriptPath) {
+                explicitTranscriptPaths.set(sessionId, options.transcriptPath);
             }
             // The caller explicitly re-announces this session, so give a
             // previously-dropped id another chance (its file may exist now).
@@ -203,6 +234,49 @@ export async function createSessionScanner(opts: {
             currentSessionId = sessionId;
             sync.invalidate();
         },
+    };
+
+    return scannerApi;
+
+    async function handleMissingSession(sessionId: string) {
+        if (scannerStopped) {
+            return;
+        }
+
+        const recovery = await recoverMissingSession({
+            missingSessionId: sessionId,
+            projectDir,
+            baselineSessionIds: watchers.get(sessionId)?.baselineSessionIds ?? new Set(initialKnownSessionIds),
+            explicitTranscriptPath: explicitTranscriptPaths.get(sessionId),
+        });
+        if (scannerStopped) {
+            return;
+        }
+        if (recovery.type === 'recovered') {
+            logger.debug(`[SESSION_SCANNER] Recovered missing session ${sessionId} as ${recovery.sessionId} via ${recovery.reason}`);
+            dropSession(sessionId);
+            void scannerApi.onNewSession(recovery.sessionId, { treatExistingAsProcessed: false });
+            return;
+        }
+
+        if (recovery.type === 'ambiguous') {
+            logger.debug(`[SESSION_SCANNER] Session ${sessionId} transcript never appeared; not recovering because candidates are ambiguous: ${recovery.candidates.join(', ')}`);
+        } else {
+            logger.debug(`[SESSION_SCANNER] Session ${sessionId} transcript never appeared — dropping it`);
+        }
+        dropSession(sessionId);
+    }
+
+    function dropSession(sessionId: string) {
+        const watcher = watchers.get(sessionId);
+        watcher?.stop();
+        watchers.delete(sessionId);
+        deadSessions.add(sessionId);
+        pendingSessions.delete(sessionId);
+        explicitTranscriptPaths.delete(sessionId);
+        if (currentSessionId === sessionId) {
+            currentSessionId = null;
+        }
     }
 }
 
@@ -287,4 +361,78 @@ async function readSessionEntries(projectDir: string, sessionId: string): Promis
         }
     }
     return entries;
+}
+
+export async function recoverMissingSession(opts: {
+    missingSessionId: string;
+    projectDir: string;
+    baselineSessionIds: Set<string>;
+    explicitTranscriptPath?: string;
+}): Promise<TranscriptRecoveryResult> {
+    const explicitSessionId = await resolveExplicitTranscriptSession(opts.projectDir, opts.explicitTranscriptPath);
+    if (explicitSessionId && explicitSessionId !== opts.missingSessionId) {
+        return { type: 'recovered', sessionId: explicitSessionId, reason: 'hook-transcript-path' };
+    }
+
+    const currentSessionIds = await listValidSessionIds(opts.projectDir);
+    const candidates = [...currentSessionIds]
+        .filter((sessionId) => sessionId !== opts.missingSessionId)
+        .filter((sessionId) => !opts.baselineSessionIds.has(sessionId))
+        .sort();
+
+    if (candidates.length === 0) {
+        return { type: 'none' };
+    }
+    return { type: 'ambiguous', candidates };
+}
+
+async function resolveExplicitTranscriptSession(projectDir: string, transcriptPath: string | undefined): Promise<string | null> {
+    if (!transcriptPath) {
+        return null;
+    }
+    if (resolve(dirname(transcriptPath)) !== resolve(projectDir)) {
+        logger.debug(`[SESSION_SCANNER] Ignoring transcript_path outside project dir: ${transcriptPath}`);
+        return null;
+    }
+    const filename = basename(transcriptPath);
+    if (!CLAUDE_SESSION_FILE_RE.test(filename)) {
+        logger.debug(`[SESSION_SCANNER] Ignoring non-session transcript_path: ${transcriptPath}`);
+        return null;
+    }
+
+    const sessionId = filename.slice(0, -'.jsonl'.length);
+    try {
+        await access(transcriptPath);
+    } catch {
+        return null;
+    }
+    const entries = await readSessionEntries(projectDir, sessionId);
+    return entries.length > 0 ? sessionId : null;
+}
+
+async function listValidSessionIds(projectDir: string): Promise<Set<string>> {
+    let files: string[];
+    try {
+        files = await readdir(projectDir);
+    } catch {
+        return new Set();
+    }
+
+    const sessionIds = await Promise.all(files
+        .filter((file) => CLAUDE_SESSION_FILE_RE.test(file))
+        .map(async (file) => {
+            const sessionId = file.slice(0, -'.jsonl'.length);
+            try {
+                const fileStat = await stat(join(projectDir, file));
+                if (!fileStat.isFile()) {
+                    return null;
+                }
+                const entries = await readSessionEntries(projectDir, sessionId);
+                return entries.length > 0 ? sessionId : null;
+            } catch {
+                return null;
+            }
+        }));
+
+    return new Set(sessionIds.filter((sessionId): sessionId is string => sessionId !== null));
 }

--- a/packages/happy-cli/src/modules/watcher/startFileWatcher.ts
+++ b/packages/happy-cli/src/modules/watcher/startFileWatcher.ts
@@ -16,6 +16,16 @@ export interface FileWatcherOptions {
      * so a session id that never produces a file cannot wedge the process.
      */
     missingFileTimeoutMs?: number;
+    /**
+     * Initial retry delay after watch setup fails. Defaults to 1s; tests can
+     * lower it so bounded-missing behavior stays deterministic without waiting
+     * for wall-clock seconds.
+     */
+    initialRetryDelayMs?: number;
+    /**
+     * Maximum retry delay after repeated watch setup failures. Defaults to 15s.
+     */
+    maxRetryDelayMs?: number;
 }
 
 /**
@@ -43,6 +53,8 @@ export function startFileWatcher(
 ) {
     const abortController = new AbortController();
     const missingFileTimeoutMs = options.missingFileTimeoutMs ?? 60_000;
+    const initialRetryDelayMs = options.initialRetryDelayMs ?? 1_000;
+    const maxRetryDelayMs = options.maxRetryDelayMs ?? 15_000;
 
     // Timeout/abort-aware wait so a long backoff does not delay cleanup.
     const wait = (ms: number) => new Promise<void>((resolve) => {
@@ -106,7 +118,7 @@ export function startFileWatcher(
                 }
 
                 failureCount++;
-                const backoffMs = Math.min(1000 * 2 ** Math.min(failureCount - 1, 4), 15_000);
+                const backoffMs = Math.min(initialRetryDelayMs * 2 ** Math.min(failureCount - 1, 4), maxRetryDelayMs);
                 logger.debug(`[FILE_WATCHER] Watch error: ${e.message}, retrying in ${backoffMs}ms`);
                 await wait(backoffMs);
             }


### PR DESCRIPTION
## Motivation

A ghost Claude transcript id can leave Happy watching a `.jsonl` path that never exists. The bounded watcher on main prevents the original infinite retry loop, but it only drops the ghost id and cannot recover when Claude has explicitly reported the real transcript file. Blindly choosing the newest transcript is unsafe when multiple Happy or Claude sessions share the same project directory.

## Changes

- Pass Claude's SessionStart `transcript_path` from the hook handler into the remote transcript scanner.
- Teach the scanner to recover a missing watched session only when that explicit transcript path points to a valid UUID `.jsonl` inside the same Claude project directory.
- Treat any filesystem-only candidates as ambiguous and drop the ghost watcher after bounded retries instead of attaching to another concurrent session's file.
- Make watcher retry delays configurable for deterministic regression tests, while preserving the production defaults.
- Stop late watcher recovery after scanner cleanup so a disposed scanner cannot recreate watchers or forward transcript entries.

## Validation

- `vitest run --project unit src/claude/utils/sessionScanner.test.ts src/modules/watcher/startFileWatcher.test.ts --maxWorkers=1 --minWorkers=1`
- `pnpm --filter @slopus/happy-wire run build`
- `pnpm --filter happy run typecheck`
