### PR TITLE
fix(app): use router.push when navigating to a forked session

### DIFF
--- a/packages/happy-app/sources/components/DuplicateSheet.tsx
+++ b/packages/happy-app/sources/components/DuplicateSheet.tsx
@@ -152,7 +152,10 @@ export const DuplicateSheet = React.memo(function DuplicateSheet(props: Duplicat
 
         if (result.type === 'success') {
             onClose?.();
-            router.replace(`/session/${result.sessionId}`);
+            // Use push (not replace) so the source screen stays on the back
+            // stack — replace leaves an empty stack, so on Android hardware-back
+            // exits the app instead of returning to where the fork started.
+            router.push(`/session/${encodeURIComponent(result.sessionId)}`);
             return;
         }
 


### PR DESCRIPTION
Forking a session via the Duplicate (fork-with-truncation) sheet navigated to the newly created session with `router.replace`, which drops the current screen from the navigation back stack. On Android, pressing the hardware back button on the new session screen then had nothing to return to, so the app closed instead of returning to where the fork started. This changes that one navigation call to `router.push` (with `encodeURIComponent`, matching the normal session-open path in `useNavigateToSession` and the plain "Fork" action in `useSessionQuickActions`), so the source screen stays on the stack and hardware back behaves as expected.

The two other fork/open paths (`useNavigateToSession` → `router.push`, and the non-truncating Fork action) were already correct; only `DuplicateSheet` used `replace`, so this brings it in line with them.

Note: this is Android hardware-back navigation behavior, which the web test harness can't exercise. Verified by root-cause (push vs replace back-stack semantics) and `pnpm typecheck` (rc=0) on the identical diff.