### PR TITLE
fix(cli): pass through update subcommand to claude directly

### DIFF
--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -608,6 +608,18 @@ ${chalk.bold('To clean up runaway processes:')} Use ${chalk.cyan('happy doctor c
 `)
     }
     return;
+  } else if (subcommand === 'update') {
+    // Pass through to claude update directly without session wrapper/hooks
+    // The session launcher appends --settings which claude update doesn't accept
+    try {
+      execFileSync(claudeCliPath, args, { stdio: 'inherit', windowsHide: true })
+    } catch (error) {
+      if (error && typeof error === 'object' && 'status' in error) {
+        process.exit((error as { status: number }).status || 1)
+      }
+      process.exit(1)
+    }
+    return;
   } else {
 
     // If the first argument is claude, remove it


### PR DESCRIPTION
## Summary

- `happy update` fails with `error: unknown option '--settings'` because `update` is not a recognized subcommand — it falls through to the main session launcher which appends `--settings <hook-settings-path>` before spawning claude
- Add `update` as a passthrough subcommand that delegates directly to the claude binary without session wrapper/hooks

Fixes #1529

## Test plan

- [ ] Run `happy update` — should pass through to `claude update` without error
- [ ] Run `happy update --help` — should show claude update help
- [ ] Verify existing `happy` (no subcommand) still works as before

> [!Note]
> Responses generated with Claude

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)