### PR TITLE
fix(cli): treat EADDRNOTAVAIL/EAI_AGAIN/EPIPE as transient network errors

### DIFF
--- a/packages/happy-cli/src/utils/serverConnectionErrors.test.ts
+++ b/packages/happy-cli/src/utils/serverConnectionErrors.test.ts
@@ -577,13 +577,16 @@ describe('isNetworkError', () => {
         expect(isNetworkError('')).toBe(false);
     });
 
-    it('should have exactly 6 network error codes', () => {
-        expect(NETWORK_ERROR_CODES).toHaveLength(6);
+    it('should have exactly 9 network error codes', () => {
+        expect(NETWORK_ERROR_CODES).toHaveLength(9);
         expect(NETWORK_ERROR_CODES).toContain('ECONNREFUSED');
         expect(NETWORK_ERROR_CODES).toContain('ENOTFOUND');
         expect(NETWORK_ERROR_CODES).toContain('ETIMEDOUT');
         expect(NETWORK_ERROR_CODES).toContain('ECONNRESET');
         expect(NETWORK_ERROR_CODES).toContain('EHOSTUNREACH');
         expect(NETWORK_ERROR_CODES).toContain('ENETUNREACH');
+        expect(NETWORK_ERROR_CODES).toContain('EADDRNOTAVAIL');
+        expect(NETWORK_ERROR_CODES).toContain('EAI_AGAIN');
+        expect(NETWORK_ERROR_CODES).toContain('EPIPE');
     });
 });

--- a/packages/happy-cli/src/utils/serverConnectionErrors.ts
+++ b/packages/happy-cli/src/utils/serverConnectionErrors.ts
@@ -247,7 +247,12 @@ export function startOfflineReconnection<TSession>(
 /** All network error codes that trigger offline mode */
 export const NETWORK_ERROR_CODES = [
     'ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT',
-    'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH'
+    'ECONNRESET', 'EHOSTUNREACH', 'ENETUNREACH',
+    // Transient egress / DNS / mid-request codes seen during daemon startup on
+    // laptops (VPN toggles, sleep/wake, network switches). Treating these as
+    // "server unreachable" lets the daemon degrade to offline mode and
+    // auto-reconnect instead of crashing on a momentary blip.
+    'EADDRNOTAVAIL', 'EAI_AGAIN', 'EPIPE'
 ] as const;
 
 /** Check if error code indicates server unreachable */
@@ -264,6 +269,9 @@ export const ERROR_DESCRIPTIONS: Record<string, string> = {
     ECONNRESET: 'connection reset by server',
     EHOSTUNREACH: 'server host unreachable',
     ENETUNREACH: 'network unreachable',
+    EADDRNOTAVAIL: 'local egress address temporarily unavailable',
+    EAI_AGAIN: 'DNS lookup temporarily failed',
+    EPIPE: 'connection closed by server mid-request',
     // HTTP errors
     '401': 'authentication failed - run `happy auth`',
     '403': 'access forbidden',


### PR DESCRIPTION
## Problem

When the `happy daemon` starts up and the machine's network is momentarily unavailable — a VPN toggle, sleep/wake, or a Wi-Fi/Ethernet switch — startup can throw one of three transient error codes that are **not** in `NETWORK_ERROR_CODES`:

- `EADDRNOTAVAIL` — local egress socket temporarily unavailable
- `EAI_AGAIN` — transient DNS resolution failure
- `EPIPE` — connection closed by the server mid-request

`getOrCreateMachine` already degrades gracefully to an offline minimal-machine for whitelisted network errors, but because these three codes are missing, the error falls through to the top-level `catch` in `startDaemon` and kills the daemon with `process.exit(1)`. The machine then shows offline until the user manually restarts the daemon. On a laptop with an unstable link this can happen repeatedly.

## Fix

Add the three codes to `NETWORK_ERROR_CODES` (plus matching `ERROR_DESCRIPTIONS` entries). They now route through the existing offline-degrade + auto-reconnect path instead of crashing. This is a data-only change — no new control flow.

## Testing

- Updated the whitelist-length test (6 → 9) and added `toContain` assertions for the three codes.
- `serverConnectionErrors.test.ts` passes (this change has shipped in our fork since our internal release, 39/39 green).

## Repro

Start the daemon while the egress interface is briefly down (e.g. disconnect Wi-Fi for ~1s during `happy daemon` startup, or point the server host at a temporarily unroutable address). Before: daemon exits 1, machine offline. After: daemon stays up in offline mode and reconnects when the network returns.