### PR TITLE
chore(app): remove gemini from the new-session agent picker

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -74,7 +74,6 @@ const ALL_AGENTS: { key: AgentKey; label: string }[] = [
     { key: 'claude', label: 'claude code' },
     { key: 'codex', label: 'codex' },
     { key: 'openclaw', label: 'openclaw' },
-    { key: 'gemini', label: 'gemini (deprecated)' },
     { key: 'agy', label: 'agy' },
 ];
 


### PR DESCRIPTION
## What

Removes the `gemini (deprecated)` entry from the new-session agent picker. One-line change.

## Why

The gemini backend was deprecated in #1430 in favor of `happy agy`. This is step 1 of the staged removal proposed in #1540: stop steering new sessions to a deprecated backend, without breaking anyone who still uses it.

## What still works

- `happy gemini` from the terminal (with the existing deprecation warning)
- Rendering of existing gemini sessions (flavor handling in `AgentInput`, `ToolView`, session info etc. is untouched)
- A persisted new-session draft with `agentType: 'gemini'` is rewritten to the first available agent by the existing corrective effect in `new/index.tsx` (gemini no longer appears in `availableAgents`), so the spawn path never sees `'gemini'`

## Known inconsistency (intentional)

`settings/agents.tsx` still shows a Gemini defaults section (it iterates `agentKeys`, which drives the stored-defaults schema), and the dev-only session-composer still lists gemini. Both are deliberately left for stage 2/3 of #1540 to keep back-compat with stored defaults.

## Testing

- `tsc --noEmit` in `packages/happy-app`: clean
- `vitest`: 706/706 passing
- Built the app with Metro (`expo start --web`, full non-lazy bundle) and verified the served bundle contains claude/codex/openclaw/agy picker labels and zero occurrences of `gemini (deprecated)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)