### PR TITLE
feat(app): add Opus 4.8 (1M context) to Claude model picker

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -56,10 +56,16 @@ describe('modelModeOptions', () => {
         expect(models.map((model) => model.key)).toEqual([
             'default',
             'opus',
+            'opus[1m]',
             'fable',
             'sonnet',
             'haiku',
         ]);
+        expect(models.find((model) => model.key === 'opus[1m]')).toEqual({
+            key: 'opus[1m]',
+            name: 'opus 4.8 (1m)',
+            description: '1M-token context window',
+        });
         expect(models.find((model) => model.key === 'fable')).toEqual({
             key: 'fable',
             name: 'fable 5',

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -78,6 +78,7 @@ export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
+        { key: 'opus[1m]', name: 'opus 4.8 (1m)', description: '1M-token context window' },
         { key: 'fable', name: 'fable 5', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },
         { key: 'haiku', name: 'haiku 4.5', description: null },


### PR DESCRIPTION
## What

Adds an **Opus 4.8 (1M context)** option to the Claude model picker (`getClaudeModelModes`), with key `opus[1m]`.

## Why

Remote sessions launched from the app can currently only pick plain `opus`, which the daemon passes as `claude --model opus` → resolves to the standard **200k** `claude-opus-4-8`. Because an explicit `--model` flag overrides the user's `settings.json` default, a user who has set `"model": "opus[1m]"` locally still gets **200k** in every remote session, with no way to opt into the 1M window from the app.

## How

The `modelMode` key is passed verbatim to `claude --model` (`packages/happy-cli/src/daemon/run.ts:50-51`), and the bundled Claude Code SDK binary already accepts the `opus[1m]` model id (verified: `--model 'opus[1m]'` → init model `claude-opus-4-8[1m]`; plain `opus` → `claude-opus-4-8`). So exposing the key in the picker is the entire change — no CLI/daemon change required.

Verified locally that `--model 'opus[1m]'` yields a 1M-context session and that plain `opus`/`sonnet`/`haiku` are unaffected.

## Changes
- `getClaudeModelModes()`: add `{ key: 'opus[1m]', name: 'opus 4.8 (1m)', description: '1M-token context window' }` after `opus`.
- Updated `modelModeOptions.test.ts` to assert the new entry. Default model key stays `opus` (unchanged).

## Notes
- No default behavior change — `default`/`opus` keys and `getDefaultModelKey('claude') === 'opus'` are untouched. The 1M variant is strictly additive/opt-in.
- 1M-context pricing only applies once a session exceeds 200k tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
