### PR TITLE
fix(app): reflect spawn-time model/permission/effort pick in session config

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -1493,6 +1493,20 @@ function NewSessionScreen() {
                     // later settings/default change must not silently rewrite
                     // an existing session's permission, model, or effort.
                     if (!spawnRigCreation) {
+                        // The just-spawned session may not be in local storage the
+                        // instant refreshSessions() resolves (server read-after-write
+                        // + broadcast timing). sessionSetAgentModes would then silently
+                        // no-op (updateSessionAgentModes returns early when the session
+                        // is missing), permanently dropping the picked model/permission/
+                        // effort so the in-session config falls back to the agent
+                        // default (e.g. shows 'opus' for a session spawned as 'fable').
+                        // Wait (bounded) for the session to land, then write the picks.
+                        let spawned = storage.getState().sessions[result.sessionId];
+                        for (let i = 0; i < 10 && !spawned; i++) {
+                            await new Promise(resolve => setTimeout(resolve, 150));
+                            await sync.refreshSessions();
+                            spawned = storage.getState().sessions[result.sessionId];
+                        }
                         sessionSetAgentModes(result.sessionId, {
                             permissionMode: permissionKey,
                             modelMode: currentModelKey,


### PR DESCRIPTION
When a new session is spawned with a non-default model (e.g. picking a model other than the agent default on the New Session screen), the per-session agent-mode override written right after `refreshSessions()` in `handleSend` can be silently dropped: if the freshly-spawned session has not yet landed in local storage at that instant, `updateSessionAgentModes()` returns early (`if (!session) return`) and the parallel metadata push throws into a swallowed `.catch`. For a Claude session the `modelMode` mirror is the only carrier of the pick (`currentModelCode` is written only on the ACP path), so the in-session model config then falls back to the agent default — e.g. a session actually running `fable` shows `opus` in its config until the user manually re-picks in the session. The neighboring `update-session` handler already guards this "session not ready yet" window (#1251), but the new-session override write did not.

Fix: bounded-wait for the spawned session to appear in local storage (reusing the public `refreshSessions()`) before writing the picks. This applies to all three overrides — permission / model / effort — which shared the same silent-drop.

## Proof

Verified locally end-to-end via a standalone `happy-server` (PGlite) + Expo web with a paired `happy-cli` daemon, driven headlessly with Playwright: spawn a new session picking the `fable` model, then open the in-session model config — it correctly shows **fable 5** selected (before the fix it fell back to the default). Screenshot in the follow-up comment.
