### PR TITLE
fix(cli): graceful daemon stop always exits 1 — shutdown chain can never beat the 1s force-exit fuse

### DIFF
--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -81,20 +81,36 @@ export async function startDaemon(): Promise<void> {
   //
   // In case the setup malfunctions - our signal handlers will not properly
   // shut down. We will force exit the process with code 1.
+  // Force-exit fuse: armed when shutdown is requested, cancelled by
+  // cleanupAndShutdown once the graceful chain completes. Without the
+  // cancellation the fuse always wins on macOS: the graceful chain contains
+  // a 100ms metadata flush plus stopCaffeinate's SIGTERM grace sleep, so it
+  // can never finish within 1s and every `happy daemon stop` used to exit 1.
+  let shutdownFuseTimer: ReturnType<typeof setTimeout> | null = null;
+
   let requestShutdown: (source: 'happy-app' | 'happy-cli' | 'os-signal' | 'exception', errorMessage?: string) => void;
   let resolvesWhenShutdownRequested = new Promise<({ source: 'happy-app' | 'happy-cli' | 'os-signal' | 'exception', errorMessage?: string })>((resolve) => {
     requestShutdown = (source, errorMessage) => {
+      // A second signal (e.g. SIGTERM while the SIGINT shutdown is already
+      // running) must not arm a second fuse: resolve() is idempotent but
+      // setTimeout is not, and a fresh timer would race the clearTimeout
+      // in cleanupAndShutdown.
+      if (shutdownFuseTimer !== null) {
+        logger.debug(`[DAEMON RUN] Duplicate shutdown request ignored (source: ${source})`);
+        return;
+      }
+
       logger.debug(`[DAEMON RUN] Requesting shutdown (source: ${source}, errorMessage: ${errorMessage})`);
 
-      // Fallback - in case startup malfunctions - we will force exit the process with code 1
-      setTimeout(async () => {
-        logger.debug('[DAEMON RUN] Startup malfunctioned, forcing exit with code 1');
+      // Fallback - if the graceful shutdown chain stalls, force exit with code 1
+      shutdownFuseTimer = setTimeout(async () => {
+        logger.debug('[DAEMON RUN] Graceful shutdown did not complete in time, forcing exit with code 1');
 
         // Give time for logs to be flushed
         await new Promise(resolve => setTimeout(resolve, 100))
 
         process.exit(1);
-      }, 1_000);
+      }, 5_000);
 
       // Start graceful shutdown
       resolve({ source, errorMessage });
@@ -1000,6 +1016,12 @@ export async function startDaemon(): Promise<void> {
       await cleanupDaemonState();
       await stopCaffeinate();
       await releaseDaemonLock(daemonLockHandle);
+
+      // Graceful chain completed - disarm the force-exit fuse so we exit 0
+      if (shutdownFuseTimer !== null) {
+        clearTimeout(shutdownFuseTimer);
+        shutdownFuseTimer = null;
+      }
 
       logger.debug('[DAEMON RUN] Cleanup completed, exiting process');
       process.exit(0);

--- a/packages/happy-cli/src/utils/caffeinate.ts
+++ b/packages/happy-cli/src/utils/caffeinate.ts
@@ -83,9 +83,12 @@ export async function stopCaffeinate(): Promise<void> {
         
         try {
             caffeinateProcess.kill('SIGTERM')
-            
-            // Give it a moment to terminate gracefully
-            await new Promise(resolve => setTimeout(resolve, 1000))
+
+            // Give it a moment to terminate gracefully. caffeinate exits
+            // within milliseconds of SIGTERM in practice; 200ms is ample
+            // grace before the SIGKILL fallback and keeps the daemon's
+            // shutdown chain well under its force-exit fuse budget.
+            await new Promise(resolve => setTimeout(resolve, 200))
 
             if (caffeinateProcess && !caffeinateProcess.killed) {
                 logger.debug('[caffeinate] Force killing caffeinate process')


### PR DESCRIPTION
## The bug

`requestShutdown` in `daemon/run.ts` arms a 1s force-`exit(1)` fuse that is never cancelled. But on macOS the graceful cleanup chain **cannot** finish within 1s, deterministically:

- `cleanupAndShutdown` starts with an explicit 100ms sleep (metadata flush), then
- `stopCaffeinate()` sleeps a full 1000ms as SIGTERM grace before resolving.

100ms + 1000ms ≥ 1.1s > 1s, so the fuse always wins. Every graceful `happy daemon stop` on macOS:

1. exits with code **1** instead of 0,
2. logs the misleading `[DAEMON RUN] Startup malfunctioned, forcing exit with code 1` (nothing malfunctioned — this is a normal stop), and
3. has the tail of the cleanup chain cut off mid-flight — the caffeinate SIGKILL fallback and `releaseDaemonLock` never run, which can leave a stale daemon lock behind.

## Why it matters beyond the wrong exit code

`run.ts` carries a TODO about migrating the daemon to native service management (launchd/systemd). We run this daemon under launchd with `KeepAlive: {SuccessfulExit: false}` in our fork, and there this bug escalates from "wrong exit code" to "**`happy daemon stop` doesn't work**": launchd sees exit 1 and resurrects the daemon within seconds. The fix below is what we verified on a real supervised macOS host (stop now exits 0, launchd does not respawn).

## The fix

- **caffeinate SIGTERM grace: 1000ms → 200ms.** `caffeinate` exits within milliseconds of SIGTERM in practice; the long grace bought nothing and was the main reason the chain could not finish in time.
- **Fuse budget: 1s → 5s**, so a slow-but-progressing chain is not misread as a stall. The fuse still force-exits 1 on a genuine hang.
- **The fuse timer is captured and cleared** once the graceful chain completes.
- **Duplicate shutdown requests** (e.g. SIGTERM arriving while the SIGINT shutdown is already running) no longer arm a second fuse timer — `resolve()` is idempotent, `setTimeout` is not.

No behavior change for a genuinely stalled shutdown: the fuse still fires and exits 1.

## Verification

- `pnpm typecheck` clean on this branch.
- Equivalent change verified in our fork on a real macOS host under launchd supervision: `happy daemon stop` exits 0, no respawn, stable across the ThrottleInterval window; unit suite (856 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)