### PR TITLE
fix(claude): forward --permission-mode to Claude in local mode

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -12,7 +12,7 @@ import { projectPath } from "@/projectPath";
 import { systemPrompt } from "./utils/systemPrompt";
 import type { SandboxConfig } from "@/persistence";
 import { initializeSandbox, wrapCommand } from "@/sandbox/manager";
-import { mapToClaudeMode } from "./utils/permissionMode";
+import { normalizeLocalClaudePermissionArgs } from "./utils/permissionMode";
 import type { PermissionMode } from "@/api/types";
 
 /**
@@ -242,23 +242,15 @@ export async function claudeLocal(opts: {
                 args.push('--allowedTools', opts.allowedTools.join(','));
             }
 
-            // Add custom Claude arguments
-            if (opts.claudeArgs) {
-                args.push(...opts.claudeArgs)
-            }
-
-            // Forward the resolved permission mode to Claude. Local mode does not
-            // install --permission-prompt-tool (unlike daemon/remote mode, which
-            // intercepts canUseTool via the SDK), so Claude manages permissions
-            // itself and must be told the mode explicitly. Without this,
-            // `--permission-mode bypassPermissions` is silently dropped in local
-            // mode and Claude falls back to default/manual.
-            if (opts.permissionMode) {
-                const claudeMode = mapToClaudeMode(opts.permissionMode);
-                if (claudeMode !== 'default') {
-                    args.push('--permission-mode', claudeMode);
-                }
-            }
+            // Local Claude manages permissions itself. Forward the resolved mode
+            // as the single source of truth, replacing any raw permission-mode
+            // argument and avoiding a redundant flag when sandbox/bypass already
+            // enforces the policy at the process boundary.
+            args.push(...normalizeLocalClaudePermissionArgs(
+                opts.claudeArgs,
+                opts.permissionMode,
+                Boolean(opts.sandboxConfig?.enabled),
+            ));
 
             // Add hook settings for session tracking (when available)
             if (opts.hookSettingsPath) {

--- a/packages/happy-cli/src/claude/claudeLocal.ts
+++ b/packages/happy-cli/src/claude/claudeLocal.ts
@@ -12,6 +12,8 @@ import { projectPath } from "@/projectPath";
 import { systemPrompt } from "./utils/systemPrompt";
 import type { SandboxConfig } from "@/persistence";
 import { initializeSandbox, wrapCommand } from "@/sandbox/manager";
+import { mapToClaudeMode } from "./utils/permissionMode";
+import type { PermissionMode } from "@/api/types";
 
 /**
  * Error thrown when the Claude process exits with a non-zero exit code.
@@ -47,6 +49,7 @@ export async function claudeLocal(opts: {
     /** Path to temporary settings file with SessionStart hook (optional - for session tracking) */
     hookSettingsPath?: string,
     sandboxConfig?: SandboxConfig,
+    permissionMode?: PermissionMode,
 }) {
 
     // Ensure project directory exists
@@ -242,6 +245,19 @@ export async function claudeLocal(opts: {
             // Add custom Claude arguments
             if (opts.claudeArgs) {
                 args.push(...opts.claudeArgs)
+            }
+
+            // Forward the resolved permission mode to Claude. Local mode does not
+            // install --permission-prompt-tool (unlike daemon/remote mode, which
+            // intercepts canUseTool via the SDK), so Claude manages permissions
+            // itself and must be told the mode explicitly. Without this,
+            // `--permission-mode bypassPermissions` is silently dropped in local
+            // mode and Claude falls back to default/manual.
+            if (opts.permissionMode) {
+                const claudeMode = mapToClaudeMode(opts.permissionMode);
+                if (claudeMode !== 'default') {
+                    args.push('--permission-mode', claudeMode);
+                }
             }
 
             // Add hook settings for session tracking (when available)

--- a/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
@@ -103,6 +103,7 @@ describe('claudeLocalLauncher', () => {
             allowedTools: [],
             hookSettingsPath: '/tmp/hook-settings.json',
             sandboxConfig: undefined,
+            permissionMode: 'plan',
         };
 
         const launcher = claudeLocalLauncher(session as any);
@@ -111,6 +112,9 @@ describe('claudeLocalLauncher', () => {
             expect(observed.localAbortSignal).toBeDefined();
             expect(observed.queueHandler).toBeDefined();
         });
+        expect(mockClaudeLocal).toHaveBeenCalledWith(expect.objectContaining({
+            permissionMode: 'plan',
+        }));
 
         queuedMessages = 1;
         const handler = observed.queueHandler;
@@ -205,5 +209,55 @@ describe('claudeLocalLauncher', () => {
 
         localRun.resolve();
         await launcher;
+    });
+
+    it('reports the underlying error when a launch throws, instead of a bare notice', async () => {
+        // The SDK surfaces an unresolvable native binary as a plain Error; the
+        // launcher used to drop it and report only "Process exited unexpectedly".
+        const sdkFailure = new Error(
+            'Native CLI binary for darwin-arm64 not found. Reinstall @anthropic-ai/claude-agent-sdk without --omit=optional, or set options.pathToClaudeCodeExecutable.'
+        );
+        mockClaudeLocal
+            .mockRejectedValueOnce(sdkFailure)
+            .mockResolvedValueOnce(undefined);
+
+        const session = {
+            sessionId: 'claude-session-3',
+            path: '/tmp/project',
+            client: {
+                sendClaudeSessionMessage: vi.fn(),
+                sendClaudeSessionMessageFromLocalTranscript: vi.fn(async () => {}),
+                closeClaudeSessionTurn: vi.fn(),
+                sendSessionEvent: vi.fn(),
+                rpcHandlerManager: {
+                    registerHandler: vi.fn(),
+                },
+            },
+            queue: {
+                reset: vi.fn(),
+                setOnMessage: vi.fn(),
+                size: vi.fn(() => 0),
+            },
+            addSessionFoundCallback: vi.fn(),
+            removeSessionFoundCallback: vi.fn(),
+            onAbort: vi.fn(),
+            onSessionFound: vi.fn(),
+            onThinkingChange: vi.fn(),
+            consumeOneTimeFlags: vi.fn(),
+            claudeEnvVars: undefined,
+            claudeArgs: undefined,
+            mcpServers: {},
+            allowedTools: [],
+            hookSettingsPath: '/tmp/hook-settings.json',
+            sandboxConfig: undefined,
+        };
+
+        // The failed launch retries, so the second attempt settles the launcher.
+        await expect(claudeLocalLauncher(session as any)).resolves.toEqual({ type: 'exit', code: 0 });
+
+        expect(session.client.sendSessionEvent).toHaveBeenCalledWith({
+            type: 'message',
+            message: `Process exited unexpectedly: ${sdkFailure.message}`,
+        });
     });
 });

--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -121,6 +121,7 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
                     allowedTools: session.allowedTools,
                     hookSettingsPath: session.hookSettingsPath,
                     sandboxConfig: session.sandboxConfig,
+                    permissionMode: session.permissionMode,
                 });
 
                 // Consume one-time Claude flags after spawn

--- a/packages/happy-cli/src/claude/loop.ts
+++ b/packages/happy-cli/src/claude/loop.ts
@@ -65,6 +65,7 @@ export async function loop(opts: LoopOptions): Promise<number> {
         messageQueue: opts.messageQueue,
         allowedTools: opts.allowedTools,
         sandboxConfig: opts.sandboxConfig,
+        permissionMode: opts.permissionMode,
         onModeChange: opts.onModeChange,
         onAbort: opts.onAbort,
         hookSettingsPath: opts.hookSettingsPath,

--- a/packages/happy-cli/src/claude/session.ts
+++ b/packages/happy-cli/src/claude/session.ts
@@ -4,6 +4,7 @@ import { EnhancedMode } from "./loop";
 import { logger } from "@/ui/logger";
 import type { JsRuntime } from "./runClaude";
 import type { SandboxConfig } from "@/persistence";
+import type { PermissionMode } from "@/api/types";
 
 export class Session {
     readonly path: string;
@@ -16,6 +17,8 @@ export class Session {
     readonly mcpServers: Record<string, any>;
     readonly allowedTools?: string[];
     readonly sandboxConfig?: SandboxConfig;
+    /** Resolved permission mode forwarded to Claude in local mode (see claudeLocal) */
+    readonly permissionMode?: PermissionMode;
     readonly _onModeChange: (mode: 'local' | 'remote') => void;
     readonly _onAbort?: () => void;
     /** Path to temporary settings file with SessionStart hook (required for session tracking) */
@@ -47,6 +50,7 @@ export class Session {
         onAbort?: () => void,
         allowedTools?: string[],
         sandboxConfig?: SandboxConfig,
+        permissionMode?: PermissionMode,
         /** Path to temporary settings file with SessionStart hook (required for session tracking) */
         hookSettingsPath: string,
         /** JavaScript runtime to use for spawning Claude Code (default: 'node') */
@@ -63,6 +67,7 @@ export class Session {
         this.mcpServers = opts.mcpServers;
         this.allowedTools = opts.allowedTools;
         this.sandboxConfig = opts.sandboxConfig;
+        this.permissionMode = opts.permissionMode;
         this._onModeChange = opts.onModeChange;
         this._onAbort = opts.onAbort;
         this.hookSettingsPath = opts.hookSettingsPath;

--- a/packages/happy-cli/src/claude/utils/permissionMode.test.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applySandboxPermissionPolicy, extractPermissionModeFromClaudeArgs, mapToClaudeMode, resolveInitialClaudePermissionMode, resolveRemoteClaudePermissionMode } from './permissionMode';
+import { applySandboxPermissionPolicy, extractPermissionModeFromClaudeArgs, mapToClaudeMode, normalizeLocalClaudePermissionArgs, resolveInitialClaudePermissionMode, resolveRemoteClaudePermissionMode } from './permissionMode';
 import type { PermissionMode } from '@/api/types';
 
 describe('mapToClaudeMode', () => {
@@ -63,6 +63,48 @@ describe('extractPermissionModeFromClaudeArgs', () => {
 
     it('returns undefined for invalid mode', () => {
         expect(extractPermissionModeFromClaudeArgs(['--permission-mode', 'invalid'])).toBeUndefined();
+    });
+});
+
+describe('normalizeLocalClaudePermissionArgs', () => {
+    it('forwards a resolved Claude mode', () => {
+        expect(normalizeLocalClaudePermissionArgs(['--verbose'], 'plan', false)).toEqual([
+            '--verbose',
+            '--permission-mode',
+            'plan',
+        ]);
+    });
+
+    it('maps yolo and replaces both raw permission-mode forms', () => {
+        expect(normalizeLocalClaudePermissionArgs([
+            '--permission-mode',
+            'plan',
+            '--permission-mode=acceptEdits',
+            '--verbose',
+        ], 'yolo', false)).toEqual([
+            '--verbose',
+            '--permission-mode',
+            'bypassPermissions',
+        ]);
+    });
+
+    it('does not add a flag for modes that map to default', () => {
+        expect(normalizeLocalClaudePermissionArgs(['--verbose'], 'safe-yolo', false)).toEqual(['--verbose']);
+    });
+
+    it('does not duplicate an existing dangerous bypass flag', () => {
+        expect(normalizeLocalClaudePermissionArgs([
+            '--dangerously-skip-permissions',
+            '--permission-mode',
+            'plan',
+        ], 'bypassPermissions', false)).toEqual(['--dangerously-skip-permissions']);
+    });
+
+    it('leaves permission enforcement to the sandbox boundary', () => {
+        expect(normalizeLocalClaudePermissionArgs([
+            '--permission-mode=plan',
+            '--verbose',
+        ], 'bypassPermissions', true)).toEqual(['--verbose']);
     });
 });
 

--- a/packages/happy-cli/src/claude/utils/permissionMode.ts
+++ b/packages/happy-cli/src/claude/utils/permissionMode.ts
@@ -25,6 +25,49 @@ export function mapToClaudeMode(mode: PermissionMode): ClaudeSdkPermissionMode {
     return codexToClaudeMap[mode] ?? (mode as ClaudeSdkPermissionMode);
 }
 
+/**
+ * Build the user-supplied Claude arguments for local mode with one canonical
+ * permission policy. The resolved mode is the source of truth, so raw
+ * --permission-mode flags must not be forwarded alongside it.
+ *
+ * Sandbox mode and --dangerously-skip-permissions already enforce bypass at
+ * the process boundary; adding --permission-mode as well would be redundant.
+ */
+export function normalizeLocalClaudePermissionArgs(
+    claudeArgs: string[] | undefined,
+    permissionMode: PermissionMode | undefined,
+    sandboxEnabled: boolean,
+): string[] {
+    const normalized: string[] = [];
+
+    for (let i = 0; i < (claudeArgs?.length ?? 0); i++) {
+        const arg = claudeArgs![i];
+        if (arg === '--permission-mode') {
+            i += 1;
+            continue;
+        }
+        if (arg.startsWith('--permission-mode=')) {
+            continue;
+        }
+        normalized.push(arg);
+    }
+
+    if (
+        sandboxEnabled ||
+        normalized.includes('--dangerously-skip-permissions') ||
+        !permissionMode
+    ) {
+        return normalized;
+    }
+
+    const claudeMode = mapToClaudeMode(permissionMode);
+    if (claudeMode !== 'default') {
+        normalized.push('--permission-mode', claudeMode);
+    }
+
+    return normalized;
+}
+
 const VALID_PERMISSION_MODES: readonly PermissionMode[] = [
     'default',
     'acceptEdits',


### PR DESCRIPTION
## Problem

`happy --permission-mode bypassPermissions` is silently dropped in **local mode**: Claude falls back to `default`/`manual` and the status bar shows `⏸ manual mode on` instead of bypass.

## Root cause

`--permission-mode` is parsed into `options.permissionMode` at the CLI layer and resolved into `initialPermissionMode` in `runClaude`, which passes it to `loop()`. But `loop()` never forwards it to the local launcher:

- `loop.ts` creates `Session` without `permissionMode`
- `claudeLocalLauncher(session)` only receives `session`
- `claudeLocal()` builds args from `opts.claudeArgs` only

So the resolved mode is discarded. Only daemon/remote mode forwards it (`appendDaemonSpawnModeArgs`).

This matters because **local mode does not install `--permission-prompt-tool`** — unlike remote mode, which intercepts `canUseTool` via the SDK. In local mode Claude manages permissions itself, so it must be told the mode explicitly. The flag being parsed-but-not-forwarded leaves happy and Claude in inconsistent states: happy thinks it's in bypass, Claude runs in default.

`--yolo` / `--dangerously-skip-permissions` already works because they stay in `claudeArgs` and pass through. `--permission-mode` is the one silently swallowed.

## Fix

Forward the resolved `permissionMode` through `loop → Session → claudeLocalLauncher → claudeLocal`, and push `--permission-mode <mode>` to the Claude args (mapped via `mapToClaudeMode` so `yolo` → `bypassPermissions`, and skipped for `default`).

- `session.ts`: add `permissionMode` field
- `loop.ts`: pass `opts.permissionMode` to `Session`
- `claudeLocalLauncher.ts`: pass `session.permissionMode` to `claudeLocal`
- `claudeLocal.ts`: accept `permissionMode`, push `--permission-mode` to args

## Behavior

| Command (local mode) | Before | After |
|---|---|---|
| `--permission-mode bypassPermissions` | manual (dropped) | bypass |
| `--permission-mode plan` | default (dropped) | plan |
| `--yolo` | bypass (already worked) | bypass (unchanged) |
| daemon/remote | already forwarded | unchanged |
