### PR TITLE
fix(cli): classify SDK error result vs real crash in remote launch catch

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.test.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { classifyLaunchError, ERR_RESULT_PREFIX } from './claudeRemoteLauncher';
+
+// ---------------------------------------------------------------------------
+// Unit tests for classifyLaunchError (pure function, no mocks needed)
+// ---------------------------------------------------------------------------
+// The function classifies the value caught in claudeRemoteLauncher's inner
+// try/catch and returns the message string to be sent to the app via
+// sendSessionEvent.  Because it is a pure function the entire test suite runs
+// without mocking any module.
+// ---------------------------------------------------------------------------
+
+describe('classifyLaunchError', () => {
+    // -----------------------------------------------------------------------
+    // T1 — SDK error result (Error with prefix) → strip prefix, return real text
+    // -----------------------------------------------------------------------
+    it('T1: SDK error result with prefix → returns SDK error text (no prefix)', () => {
+        const sdkText = "You've hit your limit. Try again at 10:00";
+        const e = new Error(ERR_RESULT_PREFIX + sdkText);
+
+        const result = classifyLaunchError(e);
+
+        expect(result).toBe(sdkText);
+        expect(result).not.toContain(ERR_RESULT_PREFIX);
+        expect(result).not.toBe('Process exited unexpectedly');
+    });
+
+    // -----------------------------------------------------------------------
+    // T2 — True crash: Error without prefix → crash message
+    // -----------------------------------------------------------------------
+    it('T2: Error without prefix → "Process exited unexpectedly"', () => {
+        const e = new Error('boom');
+        expect(classifyLaunchError(e)).toBe('Process exited unexpectedly');
+    });
+
+    // -----------------------------------------------------------------------
+    // T3 — Non-Error throw: raw string → safe fallback crash message
+    // -----------------------------------------------------------------------
+    it('T3: thrown string → "Process exited unexpectedly" (safe fallback)', () => {
+        expect(classifyLaunchError('raw string error')).toBe('Process exited unexpectedly');
+    });
+
+    // -----------------------------------------------------------------------
+    // T4 — Non-Error throw: undefined → safe fallback
+    // -----------------------------------------------------------------------
+    it('T4: thrown undefined → "Process exited unexpectedly"', () => {
+        expect(classifyLaunchError(undefined)).toBe('Process exited unexpectedly');
+    });
+
+    // -----------------------------------------------------------------------
+    // T5 — Non-Error throw: object → safe fallback
+    // -----------------------------------------------------------------------
+    it('T5: thrown plain object → "Process exited unexpectedly"', () => {
+        expect(classifyLaunchError({ code: 42 })).toBe('Process exited unexpectedly');
+    });
+
+    // -----------------------------------------------------------------------
+    // T6 — Prefix contract pin (SDK upgrade regression probe)
+    // If the SDK changes its internal error prefix this test turns CI red,
+    // giving immediate warning before silent misclassification happens.
+    // -----------------------------------------------------------------------
+    it('T6: ERR_RESULT_PREFIX is exactly the expected literal (SDK contract pin)', () => {
+        expect(ERR_RESULT_PREFIX).toBe('Claude Code returned an error result: ');
+    });
+
+    // -----------------------------------------------------------------------
+    // T7 — Slice boundary: prefix present but no text after it → empty string
+    // -----------------------------------------------------------------------
+    it('T7: Error message is exactly the prefix → returns empty string (not crash message)', () => {
+        const e = new Error(ERR_RESULT_PREFIX);
+        const result = classifyLaunchError(e);
+        expect(result).toBe('');
+    });
+
+    // -----------------------------------------------------------------------
+    // T8 — Empty message (empty string) → crash message (no prefix match)
+    // -----------------------------------------------------------------------
+    it('T8: Error with empty message → "Process exited unexpectedly"', () => {
+        const e = new Error('');
+        expect(classifyLaunchError(e)).toBe('Process exited unexpectedly');
+    });
+
+    // -----------------------------------------------------------------------
+    // T9 — SDK error result with tool failure text variant
+    // -----------------------------------------------------------------------
+    it('T9: SDK tool-failure error result → returns joined errors text', () => {
+        const sdkText = 'tool failed: permission denied; tool failed: file not found';
+        const e = new Error(ERR_RESULT_PREFIX + sdkText);
+
+        const result = classifyLaunchError(e);
+
+        expect(result).toBe(sdkText);
+        expect(result).not.toContain(ERR_RESULT_PREFIX);
+    });
+
+    // -----------------------------------------------------------------------
+    // T10 — null throw → safe fallback
+    // -----------------------------------------------------------------------
+    it('T10: thrown null → "Process exited unexpectedly"', () => {
+        expect(classifyLaunchError(null)).toBe('Process exited unexpectedly');
+    });
+});

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -18,6 +18,35 @@ import { getAskUserQuestionToolCallIds } from "./utils/questionNotification";
 import { cleanupStdinAfterInk } from "@/utils/terminalStdinCleanup";
 import type { MessageParam, ContentBlockParam } from '@anthropic-ai/sdk/resources';
 
+/**
+ * Error message prefix emitted by the Claude Code SDK when the run completes
+ * with is_error=true (e.g. rate-limit hits, tool failures, API errors).
+ * Defined here as a local constant because the SDK does not export it as a
+ * named symbol.  The single-test T6 in claudeRemoteLauncher.test.ts pins this
+ * value, so a SDK upgrade that changes the prefix will turn CI red immediately.
+ */
+export const ERR_RESULT_PREFIX = 'Claude Code returned an error result: ';
+
+/**
+ * Classify an error caught in the claudeRemoteLauncher inner try/catch and
+ * return the string that should be sent to the app via sendSessionEvent.
+ *
+ * Rules:
+ * - e instanceof Error && e.message.startsWith(ERR_RESULT_PREFIX)
+ *   → SDK returned an is_error=true result (rate-limit / tool error / API error)
+ *   → return the SDK error text with the prefix stripped (user sees real reason)
+ * - anything else (real crash / non-Error throw / throw string / undefined)
+ *   → return 'Process exited unexpectedly' (safe default, unchanged behaviour)
+ *
+ * This is a pure function with no side-effects and no throws.
+ */
+export function classifyLaunchError(e: unknown): string {
+    if (e instanceof Error && e.message.startsWith(ERR_RESULT_PREFIX)) {
+        return e.message.slice(ERR_RESULT_PREFIX.length);
+    }
+    return 'Process exited unexpectedly';
+}
+
 interface PermissionsField {
     date: number;
     result: 'approved' | 'denied';
@@ -445,7 +474,7 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                 logger.debug('[remote]: launch error', e);
                 if (!exitReason) {
                     session.client.closeClaudeSessionTurn('failed');
-                    session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
+                    session.client.sendSessionEvent({ type: 'message', message: classifyLaunchError(e) });
                     continue;
                 }
             } finally {


### PR DESCRIPTION
## Problem

The remote launch inner `try/catch` in `claudeRemoteLauncher.ts` reports **every** launch error as the misleading message **"Process exited unexpectedly"**:

```ts
} catch (e) {
    logger.debug('[remote]: launch error', e);
    if (!exitReason) {
        session.client.closeClaudeSessionTurn('failed');
        session.client.sendSessionEvent({ type: 'message', message: 'Process exited unexpectedly' });
        continue;
    }
}
```

But this catch also fires for **SDK `is_error=true` results** (rate-limit hits, tool failures, API errors), which the SDK surfaces as an `Error` whose message is prefixed with `Claude Code returned an error result: `. Those are not process crashes.

### Reproduction

Switching models in the app triggers a remote-loop **query restart** (the SDK `query()` is torn down and re-launched with the new model). If the **first query after the restart hits a rate limit**, the SDK returns an `is_error` result → the catch above renders it to the app as **"Process exited unexpectedly"**, even though nothing crashed and the session self-heals on the next launch (resume). The user is told the process died when they actually just hit their usage limit.

## Fix

Introduce a small pure function `classifyLaunchError(e)`:

- `e instanceof Error && e.message.startsWith(ERR_RESULT_PREFIX)` → strip the prefix and pass through the **real SDK error text** (user sees the actual reason, e.g. the rate-limit message).
- anything else (real crash / non-`Error` throw / thrown string / `undefined` / `null`) → keep the existing **"Process exited unexpectedly"** fallback (behaviour unchanged).

The misclassification direction is safe: only errors carrying the SDK's explicit error-result prefix are reclassified; genuine crashes still get the crash message.

## ⚠️ Fragility note (worth a maintainer's eye)

`ERR_RESULT_PREFIX` (`'Claude Code returned an error result: '`) is the SDK's **internal** error-result prefix string — it is **not exported as a named symbol**, so this fix depends on matching that literal. Test **T6** pins the literal so that an SDK upgrade which changes the prefix turns CI red immediately, before silent misclassification can regress.

A cleaner long-term fix would be for the SDK to expose **structured** classification (e.g. `is_error` / `subtype`) on the thrown error so consumers don't have to string-match. Flagging in case that's preferable upstream.

## Changes

- `claudeRemoteLauncher.ts`: add `ERR_RESULT_PREFIX` constant + `classifyLaunchError()` pure function; the catch now sends `classifyLaunchError(e)` instead of the hardcoded string. Timing / self-heal / `continue` flow untouched.
- `claudeRemoteLauncher.test.ts`: 10 colocated unit tests, no mocks (pure function) — SDK error result pass-through, crash fallbacks for every non-matching throw shape, prefix-contract pin (T6), and slice boundary cases.

`pnpm typecheck` clean; the 10 unit tests pass.