### PR TITLE
feat(cli,app): surface Claude plan rate limits in the session status bar

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -834,6 +834,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                 onEffortLevelChange={isRigReasoningSelectionEnabled(session.metadata) ? updateEffortLevel : undefined}
                 contextSize={usageData?.contextSize}
                 contextWindow={usageData?.contextWindow}
+                usageLimits={session.metadata?.usageLimits}
             />
         </CenteredInputWidth>
     ) : null;

--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -834,7 +834,7 @@ function SessionViewLoaded({ sessionId, session }: { sessionId: string, session:
                 onEffortLevelChange={isRigReasoningSelectionEnabled(session.metadata) ? updateEffortLevel : undefined}
                 contextSize={usageData?.contextSize}
                 contextWindow={usageData?.contextWindow}
-                usageLimits={session.metadata?.usageLimits}
+                usageLimits={session.agentState?.usageLimits}
             />
         </CenteredInputWidth>
     ) : null;

--- a/packages/happy-app/sources/app/(app)/settings/appearance.tsx
+++ b/packages/happy-app/sources/app/(app)/settings/appearance.tsx
@@ -205,6 +205,7 @@ export default function AppearanceSettingsScreen() {
     const [showFlavorIcons, setShowFlavorIcons] = useSettingMutable('showFlavorIcons');
     const [userMessageBubbleColor, setUserMessageBubbleColor] = useSettingMutable('userMessageBubbleColor');
     const [sessionStatusBarDisplay, setSessionStatusBarDisplay] = useSettingMutable('sessionStatusBarDisplay');
+    const [usageLimitShowRemaining, setUsageLimitShowRemaining] = useSettingMutable('usageLimitShowRemaining');
     const [themePreference, setThemePreference] = useLocalSettingMutable('themePreference');
     const [preferredLanguage] = useSettingMutable('preferredLanguage');
     const [statusPlacementDropdownOpen, setStatusPlacementDropdownOpen] = React.useState(false);
@@ -311,6 +312,17 @@ export default function AppearanceSettingsScreen() {
                         ))}
                     </View>
                 )}
+                <Item
+                    title={t('settingsAppearance.usageLimitShowRemaining')}
+                    subtitle={t('settingsAppearance.usageLimitShowRemainingDescription')}
+                    icon={<Ionicons name="speedometer-outline" size={29} color={theme.colors.status.connecting} />}
+                    rightElement={
+                        <Switch
+                            value={usageLimitShowRemaining}
+                            onValueChange={setUsageLimitShowRemaining}
+                        />
+                    }
+                />
                 <Item
                     title={t('settingsAppearance.userMessageBubbleColor')}
                     subtitle={t('settingsAppearance.userMessageBubbleColorDescription')}

--- a/packages/happy-app/sources/components/SessionStatusBar.tsx
+++ b/packages/happy-app/sources/components/SessionStatusBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Platform, Pressable, ScrollView, Text, View } from 'react-native';
+import { Platform, Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import Svg, { Circle } from 'react-native-svg';
@@ -8,9 +8,14 @@ import { t } from '@/text';
 import type { EffortLevel, ModelMode, ModeOption } from './modelModeOptions';
 import {
     clampContextSize,
+    formatUsageLimitAge,
     getContextUsageLevel,
     getContextUsagePercentage,
+    getUsageLimitChips,
+    getUsageLimitRows,
     SESSION_STATUS_CONTEXT_MAX,
+    type UsageLimitsLike,
+    type UsageLimitStatus,
 } from '@/utils/sessionStatusBar';
 
 type StatusIconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -27,9 +32,15 @@ type SessionStatusBarProps = {
     onEffortLevelChange?: (level: EffortLevel) => void;
     contextSize: number | null | undefined;
     contextWindow?: number | null | undefined;
+    usageLimits?: UsageLimitsLike;
 };
 
-type OpenMenu = 'model' | 'effort' | null;
+type OpenMenu = 'model' | 'effort' | 'limits' | null;
+
+// Below this window width the two limit chips collapse into one (the window
+// closest to its limit). Width-based rather than device-based: a narrow
+// desktop window needs the collapse just as much as a phone does.
+const LIMIT_CHIP_COLLAPSE_WIDTH = 480;
 
 export function SessionStatusBar(props: SessionStatusBarProps) {
     const styles = stylesheet;
@@ -50,6 +61,13 @@ export function SessionStatusBar(props: SessionStatusBarProps) {
         : contextLevel === 'warning'
             ? theme.colors.warning
             : theme.colors.status.connecting;
+    const { width: windowWidth } = useWindowDimensions();
+    const limitChips = getUsageLimitChips(props.usageLimits, windowWidth < LIMIT_CHIP_COLLAPSE_WIDTH);
+    const limitStatusColor = (status: UsageLimitStatus): string | undefined => {
+        if (status === 'rejected') return theme.colors.warningCritical;
+        if (status === 'allowed_warning') return theme.colors.warning;
+        return undefined;
+    };
 
     return (
         <View style={styles.wrapper}>
@@ -75,6 +93,9 @@ export function SessionStatusBar(props: SessionStatusBarProps) {
                     }}
                 />
             ) : null}
+            {openMenu === 'limits' ? (
+                <UsageLimitMenu usageLimits={props.usageLimits} statusColor={limitStatusColor} />
+            ) : null}
             <View style={styles.container}>
                 <View style={styles.leftCluster}>
                     {props.gitBranch ? (
@@ -98,6 +119,16 @@ export function SessionStatusBar(props: SessionStatusBarProps) {
                             onPress={canSelectEffort ? () => setOpenMenu((current) => current === 'effort' ? null : 'effort') : undefined}
                         />
                     ) : null}
+                    {limitChips.map((chip) => (
+                        <StatusChip
+                            key={chip.id}
+                            icon="speedometer-outline"
+                            text={`${chip.shortLabel} ${chip.utilization}%`}
+                            tint={limitStatusColor(chip.status)}
+                            active={openMenu === 'limits'}
+                            onPress={() => setOpenMenu((current) => current === 'limits' ? null : 'limits')}
+                        />
+                    ))}
                     <ContextUsageCircle
                         value={contextValue}
                         maxValue={contextMaxValue}
@@ -166,6 +197,62 @@ function StatusOptionMenu<TOption extends ModeOption>(props: {
     );
 }
 
+function formatResetTime(ms: number): string {
+    const d = new Date(ms);
+    if (ms - Date.now() < 22 * 3600_000) {
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function UsageLimitMenu(props: {
+    usageLimits: UsageLimitsLike;
+    statusColor: (status: UsageLimitStatus) => string | undefined;
+}) {
+    const styles = stylesheet;
+    const { theme } = useUnistyles();
+    const rows = getUsageLimitRows(props.usageLimits);
+    const knownLabels: Record<string, string> = {
+        five_hour: t('components.sessionStatusBar.limitFiveHour'),
+        seven_day: t('components.sessionStatusBar.limitSevenDay'),
+    };
+
+    return (
+        <View style={styles.menu}>
+            <View style={styles.limitMenuContent}>
+                {rows.map((row) => (
+                    <View key={row.id} style={styles.limitRow}>
+                        <View
+                            style={[
+                                styles.limitDot,
+                                { backgroundColor: props.statusColor(row.status) ?? theme.colors.status.connecting },
+                            ]}
+                        />
+                        <Text style={styles.limitRowLabel} numberOfLines={1}>
+                            {knownLabels[row.id] ?? row.label}
+                        </Text>
+                        <Text style={styles.limitRowValue}>
+                            {row.utilization !== null ? `${row.utilization}%` : '—'}
+                        </Text>
+                        {row.resetsAt !== null ? (
+                            <Text style={styles.limitRowReset} numberOfLines={1}>
+                                {t('components.sessionStatusBar.limitResets', { time: formatResetTime(row.resetsAt) })}
+                            </Text>
+                        ) : null}
+                    </View>
+                ))}
+                {props.usageLimits ? (
+                    <Text style={styles.limitFooter}>
+                        {t('components.sessionStatusBar.limitAsOf', {
+                            age: formatUsageLimitAge(props.usageLimits.capturedAt, Date.now()),
+                        })}
+                    </Text>
+                ) : null}
+            </View>
+        </View>
+    );
+}
+
 function ContextUsageCircle(props: {
     value: number;
     maxValue: number;
@@ -222,15 +309,17 @@ function StatusChip(props: {
     onPress?: () => void;
     active?: boolean;
     wide?: boolean;
+    /** Overrides the idle color, e.g. warning tint on limit chips. */
+    tint?: string;
 }) {
     const styles = stylesheet;
     const { theme } = useUnistyles();
-    const tint = props.active ? theme.colors.radio.active : theme.colors.textSecondary;
+    const tint = props.active ? theme.colors.radio.active : (props.tint ?? theme.colors.textSecondary);
     const content = (
         <>
             <Ionicons name={props.icon} size={13} color={tint} />
             <Text
-                style={[styles.chipText, props.wide && styles.chipTextWide, props.active && { color: tint }]}
+                style={[styles.chipText, props.wide && styles.chipTextWide, (props.active || props.tint) && { color: tint }]}
                 numberOfLines={1}
                 ellipsizeMode="middle"
             >
@@ -285,7 +374,10 @@ const stylesheet = StyleSheet.create((theme) => ({
         justifyContent: 'flex-start',
     },
     rightCluster: {
-        flexShrink: 0,
+        // Shrinkable so added chips compress (ellipsize) instead of pushing
+        // the row off-screen — the container row is flexWrap:'nowrap'.
+        flexShrink: 1,
+        minWidth: 0,
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'flex-end',
@@ -394,5 +486,45 @@ const stylesheet = StyleSheet.create((theme) => ({
         color: theme.colors.textSecondary,
         fontSize: 11,
         lineHeight: 14,
+    },
+    limitMenuContent: {
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+        gap: 6,
+    },
+    limitRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+        minHeight: 22,
+    },
+    limitDot: {
+        width: 8,
+        height: 8,
+        borderRadius: 4,
+        flexShrink: 0,
+    },
+    limitRowLabel: {
+        color: theme.colors.text,
+        fontSize: 13,
+        fontWeight: '500',
+        flexShrink: 1,
+        minWidth: 0,
+    },
+    limitRowValue: {
+        color: theme.colors.text,
+        fontSize: 13,
+        fontVariant: ['tabular-nums'],
+        marginLeft: 'auto',
+    },
+    limitRowReset: {
+        color: theme.colors.textSecondary,
+        fontSize: 11,
+        flexShrink: 0,
+    },
+    limitFooter: {
+        marginTop: 2,
+        color: theme.colors.textSecondary,
+        fontSize: 11,
     },
 }));

--- a/packages/happy-app/sources/components/SessionStatusBar.tsx
+++ b/packages/happy-app/sources/components/SessionStatusBar.tsx
@@ -12,11 +12,13 @@ import {
     getContextUsageLevel,
     getContextUsagePercentage,
     getUsageLimitChips,
+    getUsageLimitDisplayPercentage,
     getUsageLimitRows,
     SESSION_STATUS_CONTEXT_MAX,
     type UsageLimitsLike,
     type UsageLimitStatus,
 } from '@/utils/sessionStatusBar';
+import { useSetting } from '@/sync/storage';
 
 type StatusIconName = React.ComponentProps<typeof Ionicons>['name'];
 
@@ -62,6 +64,7 @@ export function SessionStatusBar(props: SessionStatusBarProps) {
             ? theme.colors.warning
             : theme.colors.status.connecting;
     const { width: windowWidth } = useWindowDimensions();
+    const showRemaining = useSetting('usageLimitShowRemaining');
     const limitChips = getUsageLimitChips(props.usageLimits, windowWidth < LIMIT_CHIP_COLLAPSE_WIDTH);
     const limitStatusColor = (status: UsageLimitStatus): string | undefined => {
         if (status === 'rejected') return theme.colors.warningCritical;
@@ -94,7 +97,7 @@ export function SessionStatusBar(props: SessionStatusBarProps) {
                 />
             ) : null}
             {openMenu === 'limits' ? (
-                <UsageLimitMenu usageLimits={props.usageLimits} statusColor={limitStatusColor} />
+                <UsageLimitMenu usageLimits={props.usageLimits} statusColor={limitStatusColor} showRemaining={showRemaining} />
             ) : null}
             <View style={styles.container}>
                 <View style={styles.leftCluster}>
@@ -123,7 +126,7 @@ export function SessionStatusBar(props: SessionStatusBarProps) {
                         <StatusChip
                             key={chip.id}
                             icon="speedometer-outline"
-                            text={`${chip.shortLabel} ${chip.utilization}%`}
+                            text={`${chip.shortLabel} ${getUsageLimitDisplayPercentage(chip.utilization, showRemaining)}%`}
                             tint={limitStatusColor(chip.status)}
                             active={openMenu === 'limits'}
                             onPress={() => setOpenMenu((current) => current === 'limits' ? null : 'limits')}
@@ -208,6 +211,7 @@ function formatResetTime(ms: number): string {
 function UsageLimitMenu(props: {
     usageLimits: UsageLimitsLike;
     statusColor: (status: UsageLimitStatus) => string | undefined;
+    showRemaining: boolean;
 }) {
     const styles = stylesheet;
     const { theme } = useUnistyles();
@@ -232,7 +236,15 @@ function UsageLimitMenu(props: {
                             {knownLabels[row.id] ?? row.label}
                         </Text>
                         <Text style={styles.limitRowValue}>
-                            {row.utilization !== null ? `${row.utilization}%` : '—'}
+                            {row.utilization === null
+                                ? '—'
+                                : props.showRemaining
+                                    // The bare chip percentage is ambiguous once it can mean
+                                    // either direction, so the popover spells this one out.
+                                    ? t('components.sessionStatusBar.limitRemaining', {
+                                        percent: getUsageLimitDisplayPercentage(row.utilization, true),
+                                    })
+                                    : `${row.utilization}%`}
                         </Text>
                         {row.resetsAt !== null ? (
                             <Text style={styles.limitRowReset} numberOfLines={1}>

--- a/packages/happy-app/sources/sync/settings.spec.ts
+++ b/packages/happy-app/sources/sync/settings.spec.ts
@@ -190,6 +190,7 @@ describe('settings', () => {
                 showFlavorIcons: false,
                 userMessageBubbleColor: 'gray',
                 sessionStatusBarDisplay: 'hidden',
+                usageLimitShowRemaining: false,
                 hideInactiveSessions: false,
                 sortSessionsByActivity: false,
                 expResumeSession: false,

--- a/packages/happy-app/sources/sync/settings.ts
+++ b/packages/happy-app/sources/sync/settings.ts
@@ -34,6 +34,7 @@ export const SettingsSchema = z.object({
     showFlavorIcons: z.boolean().describe('Whether to show AI provider icons in avatars'),
     userMessageBubbleColor: z.string().describe('User message bubble color preset'),
     sessionStatusBarDisplay: z.enum(SESSION_STATUS_BAR_DISPLAY_MODES).describe('Whether/where to show the branch, model, effort, and context status bar'),
+    usageLimitShowRemaining: z.boolean().describe('Show plan rate limits as quota remaining instead of quota used'),
 
     hideInactiveSessions: z.boolean().describe('Hide inactive sessions in the main list'),
     sortSessionsByActivity: z.boolean().describe('Sort the session list by last activity instead of creation date'),
@@ -110,6 +111,7 @@ export const settingsDefaults: Settings = {
     // Hidden everywhere by default — the context usage indicator is still too
     // raw to roll out; users can opt back in from appearance settings.
     sessionStatusBarDisplay: 'hidden',
+    usageLimitShowRemaining: false,
 
     hideInactiveSessions: false,
     sortSessionsByActivity: false,

--- a/packages/happy-app/sources/sync/storageTypes.spec.ts
+++ b/packages/happy-app/sources/sync/storageTypes.spec.ts
@@ -169,4 +169,22 @@ describe('AgentGoalStatusSchema', () => {
 
         expect(state.agentGoalStatus?.status).toBe('active');
     });
+
+    it('preserves usage limits in agent state and degrades malformed snapshots', () => {
+        const state = AgentStateSchema.parse({
+            controlledByUser: true,
+            usageLimits: {
+                capturedAt: 1710000000000,
+                windows: [{ id: 'five_hour', status: 'allowed', utilization: 42, resetsAt: null }],
+            },
+        });
+        expect(state.usageLimits?.windows[0].id).toBe('five_hour');
+
+        const malformed = AgentStateSchema.parse({
+            controlledByUser: true,
+            usageLimits: { capturedAt: 'bad', windows: [] },
+        });
+        expect(malformed.controlledByUser).toBe(true);
+        expect(malformed.usageLimits).toBeUndefined();
+    });
 });

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -154,6 +154,23 @@ export const MetadataSchema = z.object({
     permissionMode: z.string().nullish(),
     modelMode: z.string().nullish(),
     effortLevel: z.string().nullish(),
+    /**
+     * Plan rate-limit windows reported by the CLI (backend-neutral shape).
+     * Parse-lenient by design: `status` stays a plain string (newer CLIs
+     * may send values this app doesn't know) and the whole field catches to
+     * undefined so a malformed value can never invalidate the entire
+     * metadata object.
+     */
+    usageLimits: z.object({
+        capturedAt: z.number(),
+        windows: z.array(z.object({
+            id: z.string(),
+            label: z.string().optional(),
+            status: z.string().optional(),
+            utilization: z.number().nullish(),
+            resetsAt: z.number().nullish(),
+        }).passthrough()),
+    }).passthrough().optional().catch(undefined),
     // Passthrough so read-modify-write metadata updates from this app never
     // drop fields written by newer CLI or app versions.
 }).passthrough();

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -154,23 +154,6 @@ export const MetadataSchema = z.object({
     permissionMode: z.string().nullish(),
     modelMode: z.string().nullish(),
     effortLevel: z.string().nullish(),
-    /**
-     * Plan rate-limit windows reported by the CLI (backend-neutral shape).
-     * Parse-lenient by design: `status` stays a plain string (newer CLIs
-     * may send values this app doesn't know) and the whole field catches to
-     * undefined so a malformed value can never invalidate the entire
-     * metadata object.
-     */
-    usageLimits: z.object({
-        capturedAt: z.number(),
-        windows: z.array(z.object({
-            id: z.string(),
-            label: z.string().optional(),
-            status: z.string().optional(),
-            utilization: z.number().nullish(),
-            resetsAt: z.number().nullish(),
-        }).passthrough()),
-    }).passthrough().optional().catch(undefined),
     // Passthrough so read-modify-write metadata updates from this app never
     // drop fields written by newer CLI or app versions.
 }).passthrough();
@@ -223,8 +206,23 @@ export const AgentGoalStatusSchema = z.discriminatedUnion('status', [
 
 export type AgentGoalStatus = z.infer<typeof AgentGoalStatusSchema>;
 
+const UsageLimitsSchema = z.object({
+    capturedAt: z.number(),
+    windows: z.array(z.object({
+        id: z.string(),
+        label: z.string().optional(),
+        // Plain string so statuses introduced by newer CLIs degrade safely.
+        status: z.string().optional(),
+        utilization: z.number().nullish(),
+        resetsAt: z.number().nullish(),
+    }).passthrough()),
+}).passthrough().optional().catch(undefined);
+
 export const AgentStateSchema = z.object({
     controlledByUser: z.boolean().nullish(),
+    // Ephemeral runtime state. A malformed snapshot must not invalidate
+    // permission requests or the rest of the agent state.
+    usageLimits: UsageLimitsSchema,
     requests: z.record(z.string(), z.object({
         tool: z.string(),
         arguments: z.any(),

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -169,6 +169,8 @@ export const en = {
             above: 'Above composer',
             below: 'Below composer',
         },
+        usageLimitShowRemaining: 'Show Quota Remaining',
+        usageLimitShowRemainingDescription: 'Count plan limits down from full instead of up from empty',
         userMessageBubbleColor: 'User Bubble Color',
         userMessageBubbleColorDescription: 'Make your messages easier to spot in long chats',
         userMessageBubbleColorOptions: {
@@ -460,6 +462,7 @@ export const en = {
             limitSevenDay: '7-day limit',
             limitResets: ({ time }: { time: string }) => `resets ${time}`,
             limitAsOf: ({ age }: { age: string }) => `as of ${age} ago`,
+            limitRemaining: ({ percent }: { percent: number }) => `${percent}% left`,
         },
     },
 

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -456,6 +456,10 @@ export const en = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Context ${used} of ${total} tokens, ${percent}%`,
+            limitFiveHour: '5-hour limit',
+            limitSevenDay: '7-day limit',
+            limitResets: ({ time }: { time: string }) => `resets ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `as of ${age} ago`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -171,6 +171,8 @@ export const ca: TranslationStructure = {
             above: 'Sobre el compositor',
             below: 'Sota el compositor',
         },
+        usageLimitShowRemaining: 'Mostra la quota restant',
+        usageLimitShowRemainingDescription: 'Els indicadors de límit compten enrere en lloc d\'endavant',
         userMessageBubbleColor: 'Color dels teus missatges',
         userMessageBubbleColorDescription: 'Fes que els teus missatges siguin més fàcils de trobar en xats llargs',
         userMessageBubbleColorOptions: {
@@ -446,6 +448,7 @@ export const ca: TranslationStructure = {
             limitSevenDay: 'Límit de 7 dies',
             limitResets: ({ time }: { time: string }) => `es restableix ${time}`,
             limitAsOf: ({ age }: { age: string }) => `fa ${age}`,
+            limitRemaining: ({ percent }: { percent: number }) => `${percent}% restant`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -442,6 +442,10 @@ export const ca: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Context ${used} de ${total} tokens, ${percent}%`,
+            limitFiveHour: 'Límit de 5 hores',
+            limitSevenDay: 'Límit de 7 dies',
+            limitResets: ({ time }: { time: string }) => `es restableix ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `fa ${age}`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -185,6 +185,8 @@ export const en: TranslationStructure = {
             above: 'Above composer',
             below: 'Below composer',
         },
+        usageLimitShowRemaining: 'Show Quota Remaining',
+        usageLimitShowRemainingDescription: 'Count plan limits down from full instead of up from empty',
         userMessageBubbleColor: 'User Bubble Color',
         userMessageBubbleColorDescription: 'Make your messages easier to spot in long chats',
         userMessageBubbleColorOptions: {
@@ -460,6 +462,7 @@ export const en: TranslationStructure = {
             limitSevenDay: '7-day limit',
             limitResets: ({ time }: { time: string }) => `resets ${time}`,
             limitAsOf: ({ age }: { age: string }) => `as of ${age} ago`,
+            limitRemaining: ({ percent }: { percent: number }) => `${percent}% left`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -456,6 +456,10 @@ export const en: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Context ${used} of ${total} tokens, ${percent}%`,
+            limitFiveHour: '5-hour limit',
+            limitSevenDay: '7-day limit',
+            limitResets: ({ time }: { time: string }) => `resets ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `as of ${age} ago`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -171,6 +171,8 @@ export const es: TranslationStructure = {
             above: 'Sobre el compositor',
             below: 'Bajo el compositor',
         },
+        usageLimitShowRemaining: 'Mostrar cuota restante',
+        usageLimitShowRemainingDescription: 'Los indicadores de límite cuentan hacia atrás en vez de hacia adelante',
         userMessageBubbleColor: 'Color de tus mensajes',
         userMessageBubbleColorDescription: 'Haz que tus mensajes sean más fáciles de encontrar en chats largos',
         userMessageBubbleColorOptions: {
@@ -446,6 +448,7 @@ export const es: TranslationStructure = {
             limitSevenDay: 'Límite de 7 días',
             limitResets: ({ time }: { time: string }) => `se restablece ${time}`,
             limitAsOf: ({ age }: { age: string }) => `hace ${age}`,
+            limitRemaining: ({ percent }: { percent: number }) => `${percent}% restante`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -442,6 +442,10 @@ export const es: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Contexto ${used} de ${total} tokens, ${percent}%`,
+            limitFiveHour: 'Límite de 5 horas',
+            limitSevenDay: 'Límite de 7 días',
+            limitResets: ({ time }: { time: string }) => `se restablece ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `hace ${age}`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -440,6 +440,10 @@ export const it: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Contesto ${used} di ${total} token, ${percent}%`,
+            limitFiveHour: 'Limite di 5 ore',
+            limitSevenDay: 'Limite di 7 giorni',
+            limitResets: ({ time }: { time: string }) => `si azzera ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `${age} fa`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -169,6 +169,8 @@ export const it: TranslationStructure = {
             above: 'Sopra il compositore',
             below: 'Sotto il compositore',
         },
+        usageLimitShowRemaining: 'Mostra la quota rimanente',
+        usageLimitShowRemainingDescription: 'Gli indicatori di limite contano alla rovescia invece che in avanti',
         userMessageBubbleColor: 'Colore dei tuoi messaggi',
         userMessageBubbleColorDescription: 'Rendi i tuoi messaggi più facili da trovare nelle chat lunghe',
         userMessageBubbleColorOptions: {
@@ -444,6 +446,7 @@ export const it: TranslationStructure = {
             limitSevenDay: 'Limite di 7 giorni',
             limitResets: ({ time }: { time: string }) => `si azzera ${time}`,
             limitAsOf: ({ age }: { age: string }) => `${age} fa`,
+            limitRemaining: ({ percent }: { percent: number }) => `${percent}% rimanente`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -443,6 +443,10 @@ export const ja: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `コンテキスト ${total}トークン中${used}、${percent}%`,
+            limitFiveHour: '5時間の上限',
+            limitSevenDay: '7日間の上限',
+            limitResets: ({ time }: { time: string }) => `${time} リセット`,
+            limitAsOf: ({ age }: { age: string }) => `${age}前のデータ`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -172,6 +172,8 @@ export const ja: TranslationStructure = {
             above: '入力欄の上',
             below: '入力欄の下',
         },
+        usageLimitShowRemaining: '残量を表示',
+        usageLimitShowRemainingDescription: '上限を使用量ではなく残量で表示します',
         userMessageBubbleColor: 'ユーザーバブルの色',
         userMessageBubbleColorDescription: '長いチャットで自分のメッセージを見つけやすくします',
         userMessageBubbleColorOptions: {
@@ -447,6 +449,7 @@ export const ja: TranslationStructure = {
             limitSevenDay: '7日間の上限',
             limitResets: ({ time }: { time: string }) => `${time} リセット`,
             limitAsOf: ({ age }: { age: string }) => `${age}前のデータ`,
+            limitRemaining: ({ percent }: { percent: number }) => `残り ${percent}%`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -188,6 +188,8 @@ export const pl: TranslationStructure = {
             above: 'Nad polem wprowadzania',
             below: 'Pod polem wprowadzania',
         },
+        usageLimitShowRemaining: 'Pokaż pozostały limit',
+        usageLimitShowRemainingDescription: 'Wskaźniki limitu odliczają w dół zamiast w górę',
         userMessageBubbleColor: 'Kolor Twoich wiadomości',
         userMessageBubbleColorDescription: 'Ułatw znajdowanie swoich wiadomości w długich czatach',
         userMessageBubbleColorOptions: {
@@ -462,6 +464,7 @@ export const pl: TranslationStructure = {
             limitSevenDay: 'Limit 7-dniowy',
             limitResets: ({ time }: { time: string }) => `reset ${time}`,
             limitAsOf: ({ age }: { age: string }) => `sprzed ${age}`,
+            limitRemaining: ({ percent }: { percent: number }) => `pozostało ${percent}%`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -458,6 +458,10 @@ export const pl: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Kontekst ${used} z ${total} tokenów, ${percent}%`,
+            limitFiveHour: 'Limit 5-godzinny',
+            limitSevenDay: 'Limit 7-dniowy',
+            limitResets: ({ time }: { time: string }) => `reset ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `sprzed ${age}`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -170,6 +170,8 @@ export const pt: TranslationStructure = {
             above: 'Acima do compositor',
             below: 'Abaixo do compositor',
         },
+        usageLimitShowRemaining: 'Mostrar cota restante',
+        usageLimitShowRemainingDescription: 'Os indicadores de limite contam para baixo em vez de para cima',
         userMessageBubbleColor: 'Cor das suas mensagens',
         userMessageBubbleColorDescription: 'Torne suas mensagens mais fáceis de encontrar em chats longos',
         userMessageBubbleColorOptions: {
@@ -445,6 +447,7 @@ export const pt: TranslationStructure = {
             limitSevenDay: 'Limite de 7 dias',
             limitResets: ({ time }: { time: string }) => `redefine ${time}`,
             limitAsOf: ({ age }: { age: string }) => `há ${age}`,
+            limitRemaining: ({ percent }: { percent: number }) => `${percent}% restante`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -441,6 +441,10 @@ export const pt: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Contexto ${used} de ${total} tokens, ${percent}%`,
+            limitFiveHour: 'Limite de 5 horas',
+            limitSevenDay: 'Limite de 7 dias',
+            limitResets: ({ time }: { time: string }) => `redefine ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `há ${age}`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -397,6 +397,10 @@ export const ru: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `Контекст ${used} из ${total} токенов, ${percent}%`,
+            limitFiveHour: 'Лимит 5 часов',
+            limitSevenDay: 'Лимит 7 дней',
+            limitResets: ({ time }: { time: string }) => `сброс ${time}`,
+            limitAsOf: ({ age }: { age: string }) => `данные ${age} назад`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -157,6 +157,8 @@ export const ru: TranslationStructure = {
             above: 'Над полем ввода',
             below: 'Под полем ввода',
         },
+        usageLimitShowRemaining: 'Показывать остаток',
+        usageLimitShowRemainingDescription: 'Индикаторы лимита отсчитывают остаток, а не использование',
         userMessageBubbleColor: 'Цвет ваших сообщений',
         userMessageBubbleColorDescription: 'Сделайте ваши сообщения заметнее в длинных чатах',
         userMessageBubbleColorOptions: {
@@ -401,6 +403,7 @@ export const ru: TranslationStructure = {
             limitSevenDay: 'Лимит 7 дней',
             limitResets: ({ time }: { time: string }) => `сброс ${time}`,
             limitAsOf: ({ age }: { age: string }) => `данные ${age} назад`,
+            limitRemaining: ({ percent }: { percent: number }) => `осталось ${percent}%`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -443,6 +443,10 @@ export const zhHans: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `上下文 ${used}/${total} 个令牌，${percent}%`,
+            limitFiveHour: '5 小时额度',
+            limitSevenDay: '7 天额度',
+            limitResets: ({ time }: { time: string }) => `${time} 重置`,
+            limitAsOf: ({ age }: { age: string }) => `数据为 ${age} 前`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -172,6 +172,8 @@ export const zhHans: TranslationStructure = {
             above: '输入框上方',
             below: '输入框下方',
         },
+        usageLimitShowRemaining: '显示剩余额度',
+        usageLimitShowRemainingDescription: '额度指示器显示剩余量，而不是已用量',
         userMessageBubbleColor: '用户气泡颜色',
         userMessageBubbleColorDescription: '让您的消息在长聊天中更容易找到',
         userMessageBubbleColorOptions: {
@@ -447,6 +449,7 @@ export const zhHans: TranslationStructure = {
             limitSevenDay: '7 天额度',
             limitResets: ({ time }: { time: string }) => `${time} 重置`,
             limitAsOf: ({ age }: { age: string }) => `数据为 ${age} 前`,
+            limitRemaining: ({ percent }: { percent: number }) => `剩余 ${percent}%`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -171,6 +171,8 @@ export const zhHant: TranslationStructure = {
             above: '輸入框上方',
             below: '輸入框下方',
         },
+        usageLimitShowRemaining: '顯示剩餘額度',
+        usageLimitShowRemainingDescription: '額度指示器顯示剩餘量，而非已用量',
         userMessageBubbleColor: '使用者氣泡顏色',
         userMessageBubbleColorDescription: '讓您的訊息在長聊天中更容易找到',
         userMessageBubbleColorOptions: {
@@ -446,6 +448,7 @@ export const zhHant: TranslationStructure = {
             limitSevenDay: '7 天額度',
             limitResets: ({ time }: { time: string }) => `${time} 重置`,
             limitAsOf: ({ age }: { age: string }) => `數據為 ${age} 前`,
+            limitRemaining: ({ percent }: { percent: number }) => `剩餘 ${percent}%`,
         },
     },
 

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -442,6 +442,10 @@ export const zhHant: TranslationStructure = {
         },
         sessionStatusBar: {
             contextUsage: ({ used, total, percent }: { used: string; total: string; percent: number }) => `上下文 ${used}/${total} 個權杖，${percent}%`,
+            limitFiveHour: '5 小時額度',
+            limitSevenDay: '7 天額度',
+            limitResets: ({ time }: { time: string }) => `${time} 重置`,
+            limitAsOf: ({ age }: { age: string }) => `數據為 ${age} 前`,
         },
     },
 

--- a/packages/happy-app/sources/utils/sessionStatusBar.test.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.test.ts
@@ -5,6 +5,7 @@ import {
     getContextUsageLevel,
     getContextUsagePercentage,
     getUsageLimitChips,
+    getUsageLimitDisplayPercentage,
     getUsageLimitRows,
     getUsageLimitStatus,
     resolveStatusBarGitBranch,
@@ -81,6 +82,15 @@ describe('usage limit helpers', () => {
         expect(getUsageLimitStatus({ id: 'x', status: 'future_status', utilization: 95 })).toBe('allowed_warning');
         expect(getUsageLimitStatus({ id: 'x', utilization: 100 })).toBe('rejected');
         expect(getUsageLimitStatus({ id: 'x' })).toBe('allowed');
+    });
+
+    it('flips utilization for the remaining view without touching status', () => {
+        expect(getUsageLimitDisplayPercentage(42, false)).toBe(42);
+        expect(getUsageLimitDisplayPercentage(42, true)).toBe(58);
+        expect(getUsageLimitDisplayPercentage(100, true)).toBe(0);
+        // The collapsed chip still picks the window closest to its limit,
+        // which is the one with the least remaining.
+        expect(getUsageLimitChips(limits, true)[0].id).toBe('seven_day');
     });
 
     it('formats snapshot age compactly', () => {

--- a/packages/happy-app/sources/utils/sessionStatusBar.test.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
     clampContextSize,
+    formatUsageLimitAge,
     getContextUsageLevel,
     getContextUsagePercentage,
+    getUsageLimitChips,
+    getUsageLimitRows,
+    getUsageLimitStatus,
     resolveStatusBarGitBranch,
 } from './sessionStatusBar';
 
@@ -27,5 +31,62 @@ describe('session status bar helpers', () => {
         expect(resolveStatusBarGitBranch('', 'fix/session')).toBe('fix/session');
         expect(resolveStatusBarGitBranch('   ', 'fix/session')).toBe('fix/session');
         expect(resolveStatusBarGitBranch(null, null)).toBe(null);
+    });
+});
+
+
+describe('usage limit helpers', () => {
+    const limits = {
+        capturedAt: 1000,
+        windows: [
+            { id: 'five_hour', status: 'allowed', utilization: 42, resetsAt: 1 },
+            { id: 'seven_day', status: 'allowed_warning', utilization: 91, resetsAt: 2 },
+            { id: 'seven_day_opus', utilization: 10, resetsAt: null },
+        ],
+    };
+
+    it('builds dual chips from the well-known windows only', () => {
+        const chips = getUsageLimitChips(limits, false);
+        expect(chips.map(c => c.id)).toEqual(['five_hour', 'seven_day']);
+        expect(chips[0].shortLabel).toBe('5h');
+        expect(chips[1].status).toBe('allowed_warning');
+    });
+
+    it('collapses to the window closest to its limit when narrow', () => {
+        const chips = getUsageLimitChips(limits, true);
+        expect(chips).toHaveLength(1);
+        expect(chips[0].id).toBe('seven_day');
+    });
+
+    it('hides chips for windows without numeric utilization and for absent data', () => {
+        expect(getUsageLimitChips({ capturedAt: 1, windows: [{ id: 'five_hour', utilization: null }] }, false)).toEqual([]);
+        expect(getUsageLimitChips(undefined, false)).toEqual([]);
+        expect(getUsageLimitChips({ capturedAt: 1, windows: 'garbage' as any }, false)).toEqual([]);
+    });
+
+    it('lists all windows in the popover rows, well-known ids first', () => {
+        const rows = getUsageLimitRows({
+            capturedAt: 1,
+            windows: [
+                { id: 'seven_day_opus', utilization: 10, resetsAt: null },
+                { id: 'five_hour', utilization: 42, resetsAt: 5 },
+            ],
+        });
+        expect(rows.map(r => r.id)).toEqual(['five_hour', 'seven_day_opus']);
+        expect(rows[1].label).toBe('seven day opus');
+    });
+
+    it('trusts known status values and falls back to utilization thresholds otherwise', () => {
+        expect(getUsageLimitStatus({ id: 'x', status: 'rejected', utilization: 10 })).toBe('rejected');
+        expect(getUsageLimitStatus({ id: 'x', status: 'future_status', utilization: 95 })).toBe('allowed_warning');
+        expect(getUsageLimitStatus({ id: 'x', utilization: 100 })).toBe('rejected');
+        expect(getUsageLimitStatus({ id: 'x' })).toBe('allowed');
+    });
+
+    it('formats snapshot age compactly', () => {
+        expect(formatUsageLimitAge(0, 30_000)).toBe('<1m');
+        expect(formatUsageLimitAge(0, 3 * 60_000)).toBe('3m');
+        expect(formatUsageLimitAge(0, 2 * 3600_000)).toBe('2h');
+        expect(formatUsageLimitAge(0, 3 * 86400_000)).toBe('3d');
     });
 });

--- a/packages/happy-app/sources/utils/sessionStatusBar.test.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.test.ts
@@ -65,6 +65,21 @@ describe('usage limit helpers', () => {
         expect(getUsageLimitChips({ capturedAt: 1, windows: 'garbage' as any }, false)).toEqual([]);
     });
 
+    it('shows a critical fallback chip for an id-less rejected event', () => {
+        expect(getUsageLimitChips({
+            capturedAt: 1,
+            windows: [
+                { id: 'future_window', status: 'allowed_warning', utilization: 95 },
+                { id: 'plan', status: 'rejected', utilization: null },
+            ],
+        }, false)).toEqual([{
+            id: 'plan',
+            shortLabel: 'Plan',
+            utilization: 100,
+            status: 'rejected',
+        }]);
+    });
+
     it('lists all windows in the popover rows, well-known ids first', () => {
         const rows = getUsageLimitRows({
             capturedAt: 1,

--- a/packages/happy-app/sources/utils/sessionStatusBar.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.ts
@@ -146,6 +146,15 @@ export function getUsageLimitRows(limits: UsageLimitsLike): UsageLimitRow[] {
     }));
 }
 
+/**
+ * `utilization` is always "percent used" — the wire format and the color
+ * thresholds both depend on that, so the remaining view is a display-time
+ * flip only.
+ */
+export function getUsageLimitDisplayPercentage(utilization: number, showRemaining: boolean): number {
+    return showRemaining ? 100 - utilization : utilization;
+}
+
 /** Compact age like "3m" / "2h" for the "as of" footer. */
 export function formatUsageLimitAge(capturedAt: number, now: number): string {
     const deltaMin = Math.max(0, Math.floor((now - capturedAt) / 60000));

--- a/packages/happy-app/sources/utils/sessionStatusBar.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.ts
@@ -42,7 +42,7 @@ export function getContextUsageLevel(value: number | null | undefined, maxValue 
     return 'normal';
 }
 
-// --- Plan rate-limit windows (metadata.usageLimits) ---
+// --- Plan rate-limit windows (agentState.usageLimits) ---
 
 export type UsageLimitWindowLike = {
     id: string;
@@ -89,9 +89,10 @@ export type UsageLimitChip = {
 };
 
 /**
- * Chips show only the well-known windows (5h/7d) with a numeric utilization;
- * everything else (opus/sonnet/overage/unknown ids) is popover-only. When
- * `collapsed` (narrow bar), only the window closest to its limit survives.
+ * Chips normally show only the well-known windows (5h/7d) with a numeric
+ * utilization. If none exist, surface one critical unknown/unbound window so
+ * a rejected or warning state can never disappear entirely. When `collapsed`
+ * (narrow bar), only the window closest to its limit survives.
  */
 export function getUsageLimitChips(limits: UsageLimitsLike, collapsed: boolean): UsageLimitChip[] {
     if (!limits || !Array.isArray(limits.windows)) {
@@ -109,6 +110,25 @@ export function getUsageLimitChips(limits: UsageLimitsLike, collapsed: boolean):
             utilization: Math.round(Math.min(100, Math.max(0, u))),
             status: getUsageLimitStatus(window),
         });
+    }
+    if (chips.length === 0) {
+        const fallbackCandidates = limits.windows
+            .map(window => ({ window, status: getUsageLimitStatus(window) }));
+        const fallback = fallbackCandidates.find(({ status }) => status === 'rejected')
+            ?? fallbackCandidates.find(({ status }) => status === 'allowed_warning');
+        if (fallback) {
+            const u = fallback.window.utilization;
+            const utilization = typeof u === 'number' && Number.isFinite(u)
+                ? Math.round(Math.min(100, Math.max(0, u)))
+                : fallback.status === 'rejected' ? 100 : 90;
+            chips.push({
+                id: fallback.window.id,
+                shortLabel: fallback.window.label?.trim()
+                    || (fallback.window.id === 'plan' ? 'Plan' : fallback.window.id.replace(/_/g, ' ')),
+                utilization,
+                status: fallback.status,
+            });
+        }
     }
     if (collapsed && chips.length > 1) {
         return [chips.reduce((a, b) => (b.utilization > a.utilization ? b : a))];

--- a/packages/happy-app/sources/utils/sessionStatusBar.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.ts
@@ -41,3 +41,117 @@ export function getContextUsageLevel(value: number | null | undefined, maxValue 
     }
     return 'normal';
 }
+
+// --- Plan rate-limit windows (metadata.usageLimits) ---
+
+export type UsageLimitWindowLike = {
+    id: string;
+    label?: string;
+    status?: string;
+    utilization?: number | null;
+    resetsAt?: number | null;
+};
+
+export type UsageLimitsLike = {
+    capturedAt: number;
+    windows: UsageLimitWindowLike[];
+} | null | undefined;
+
+export type UsageLimitStatus = 'allowed' | 'allowed_warning' | 'rejected';
+
+const CHIP_WINDOW_LABELS: Record<string, string> = {
+    five_hour: '5h',
+    seven_day: '7d',
+};
+
+/**
+ * Trust the CLI-provided status when it's a value we know; otherwise fall
+ * back to utilization thresholds so an unknown status string from a newer
+ * CLI degrades instead of breaking the color mapping.
+ */
+export function getUsageLimitStatus(window: UsageLimitWindowLike): UsageLimitStatus {
+    if (window.status === 'allowed' || window.status === 'allowed_warning' || window.status === 'rejected') {
+        return window.status;
+    }
+    const u = window.utilization;
+    if (typeof u === 'number' && Number.isFinite(u)) {
+        if (u >= 100) return 'rejected';
+        if (u >= 90) return 'allowed_warning';
+    }
+    return 'allowed';
+}
+
+export type UsageLimitChip = {
+    id: string;
+    shortLabel: string;
+    utilization: number;
+    status: UsageLimitStatus;
+};
+
+/**
+ * Chips show only the well-known windows (5h/7d) with a numeric utilization;
+ * everything else (opus/sonnet/overage/unknown ids) is popover-only. When
+ * `collapsed` (narrow bar), only the window closest to its limit survives.
+ */
+export function getUsageLimitChips(limits: UsageLimitsLike, collapsed: boolean): UsageLimitChip[] {
+    if (!limits || !Array.isArray(limits.windows)) {
+        return [];
+    }
+    const chips: UsageLimitChip[] = [];
+    for (const id of Object.keys(CHIP_WINDOW_LABELS)) {
+        const window = limits.windows.find(w => w.id === id);
+        if (!window) continue;
+        const u = window.utilization;
+        if (typeof u !== 'number' || !Number.isFinite(u)) continue;
+        chips.push({
+            id,
+            shortLabel: CHIP_WINDOW_LABELS[id],
+            utilization: Math.round(Math.min(100, Math.max(0, u))),
+            status: getUsageLimitStatus(window),
+        });
+    }
+    if (collapsed && chips.length > 1) {
+        return [chips.reduce((a, b) => (b.utilization > a.utilization ? b : a))];
+    }
+    return chips;
+}
+
+export type UsageLimitRow = {
+    id: string;
+    label: string;
+    utilization: number | null;
+    resetsAt: number | null;
+    status: UsageLimitStatus;
+};
+
+/** All windows for the detail popover, well-known ids first. */
+export function getUsageLimitRows(limits: UsageLimitsLike): UsageLimitRow[] {
+    if (!limits || !Array.isArray(limits.windows)) {
+        return [];
+    }
+    const known = Object.keys(CHIP_WINDOW_LABELS);
+    const sorted = [...limits.windows].sort((a, b) => {
+        const ai = known.indexOf(a.id);
+        const bi = known.indexOf(b.id);
+        return (ai < 0 ? known.length : ai) - (bi < 0 ? known.length : bi);
+    });
+    return sorted.map(w => ({
+        id: w.id,
+        label: w.label ?? w.id.replace(/_/g, ' '),
+        utilization: typeof w.utilization === 'number' && Number.isFinite(w.utilization)
+            ? Math.round(Math.min(100, Math.max(0, w.utilization)))
+            : null,
+        resetsAt: typeof w.resetsAt === 'number' && Number.isFinite(w.resetsAt) ? w.resetsAt : null,
+        status: getUsageLimitStatus(w),
+    }));
+}
+
+/** Compact age like "3m" / "2h" for the "as of" footer. */
+export function formatUsageLimitAge(capturedAt: number, now: number): string {
+    const deltaMin = Math.max(0, Math.floor((now - capturedAt) / 60000));
+    if (deltaMin < 1) return '<1m';
+    if (deltaMin < 60) return `${deltaMin}m`;
+    const hours = Math.round(deltaMin / 60);
+    if (hours < 48) return `${hours}h`;
+    return `${Math.round(hours / 24)}d`;
+}

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -325,12 +325,6 @@ export type Metadata = {
   /** Lineage for sessions created via the fork / duplicate flow. */
   parentSessionId?: string
   forkedFromMessageId?: string
-  /**
-   * Plan rate-limit windows reported by the agent backend, backend-neutral.
-   * Written by the CLI via updateMetadata (read-modify-write merge); apps
-   * must tolerate window ids they don't recognize.
-   */
-  usageLimits?: UsageLimits
 };
 
 export type UsageLimitWindowStatus = 'allowed' | 'allowed_warning' | 'rejected'
@@ -387,6 +381,11 @@ export type AgentGoalStatus = {
 
 export type AgentState = {
   controlledByUser?: boolean | null | undefined
+  /**
+   * Ephemeral plan rate-limit windows reported by the agent backend.
+   * Apps must tolerate window ids they don't recognize.
+   */
+  usageLimits?: UsageLimits
   requests?: {
     [id: string]: {
       tool: string,

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -325,7 +325,31 @@ export type Metadata = {
   /** Lineage for sessions created via the fork / duplicate flow. */
   parentSessionId?: string
   forkedFromMessageId?: string
+  /**
+   * Plan rate-limit windows reported by the agent backend, backend-neutral.
+   * Written by the CLI via updateMetadata (read-modify-write merge); apps
+   * must tolerate window ids they don't recognize.
+   */
+  usageLimits?: UsageLimits
 };
+
+export type UsageLimitWindowStatus = 'allowed' | 'allowed_warning' | 'rejected'
+
+export type UsageLimitWindow = {
+  /** Stable machine key, e.g. 'five_hour' / 'seven_day'. */
+  id: string,
+  label?: string,
+  status?: UsageLimitWindowStatus,
+  /** Percent of the window used, 0-100. */
+  utilization?: number | null,
+  /** Epoch milliseconds when the window resets. */
+  resetsAt?: number | null,
+}
+
+export type UsageLimits = {
+  capturedAt: number,
+  windows: UsageLimitWindow[],
+}
 
 export type AgentGoalStatus = {
   source: 'claude' | 'codex',

--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -45,7 +45,7 @@ export async function claudeRemote(opts: {
     onCompletionEvent?: (message: string) => void,
     onSessionReset?: () => void,
     onSDKMetadata?: (metadata: { tools?: string[]; slashCommands?: string[]; mcpServers?: { name: string; status: string }[]; skills?: string[] }) => void,
-    /** Per-turn plan rate-limit delta; the launcher merges it into session metadata. */
+    /** Per-turn plan rate-limit delta; the launcher merges it into agent state. */
     onUsageLimits?: (patch: UsageLimitsPatch) => void
 }) {
 
@@ -178,7 +178,7 @@ export async function claudeRemote(opts: {
     }
 
     // Plan rate-limit accumulation: events are buffered and flushed once per
-    // result (coalescing metadata writes to at most one per turn). The seed
+    // result (coalescing agent-state writes to at most one per turn). The seed
     // runs on the first result of this invocation — the Query object does not
     // exist before the first user message, so there is no session-start hook.
     const pendingUsageWindows = new Map<string, UsageLimitWindow>();

--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -12,6 +12,8 @@ import { awaitFileExist } from "@/modules/watcher/awaitFileExist";
 import { systemPrompt } from "./utils/systemPrompt";
 import { PermissionResult } from "./sdk/types";
 import type { JsRuntime } from "./runClaude";
+import { fromRateLimitEvent, windowsFromGetUsage, type UnboundRateLimit, type UsageLimitsPatch, type RateLimitEventInfo } from "./utils/usageLimits";
+import type { UsageLimitWindow } from "@/api/types";
 
 export async function claudeRemote(opts: {
 
@@ -42,7 +44,9 @@ export async function claudeRemote(opts: {
     onMessage: (message: SDKMessage) => void,
     onCompletionEvent?: (message: string) => void,
     onSessionReset?: () => void,
-    onSDKMetadata?: (metadata: { tools?: string[]; slashCommands?: string[]; mcpServers?: { name: string; status: string }[]; skills?: string[] }) => void
+    onSDKMetadata?: (metadata: { tools?: string[]; slashCommands?: string[]; mcpServers?: { name: string; status: string }[]; skills?: string[] }) => void,
+    /** Per-turn plan rate-limit delta; the launcher merges it into session metadata. */
+    onUsageLimits?: (patch: UsageLimitsPatch) => void
 }) {
 
     // Check if session is valid
@@ -173,6 +177,71 @@ export async function claudeRemote(opts: {
         });
     }
 
+    // Plan rate-limit accumulation: events are buffered and flushed once per
+    // result (coalescing metadata writes to at most one per turn). The seed
+    // runs on the first result of this invocation — the Query object does not
+    // exist before the first user message, so there is no session-start hook.
+    const pendingUsageWindows = new Map<string, UsageLimitWindow>();
+    let pendingUnbound: UnboundRateLimit | null = null;
+    let usageSeeded = false;
+    let lastUsageSignature: string | null = null;
+    let lastUsageEmittedAt = 0;
+    // Identical data still gets re-written occasionally so the snapshot's
+    // capturedAt (the app's "as of" footer) doesn't misreport freshness.
+    const USAGE_REFRESH_INTERVAL_MS = 5 * 60_000;
+    const flushUsageLimits = async () => {
+        if (!opts.onUsageLimits) return;
+        let seededThisFlush = false;
+        if (!usageSeeded) {
+            usageSeeded = true;
+            // typeof-gated: the method is experimental and absent in older SDKs.
+            const usageFn = (response as any).usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET;
+            if (typeof usageFn === 'function') {
+                try {
+                    const usage = await usageFn.call(response);
+                    if (usage?.rate_limits_available && usage.rate_limits) {
+                        for (const w of windowsFromGetUsage(usage.rate_limits)) {
+                            // Events are fresher than the seed for the same window
+                            if (!pendingUsageWindows.has(w.id)) {
+                                pendingUsageWindows.set(w.id, w);
+                            }
+                        }
+                        seededThisFlush = true;
+                    }
+                } catch (e) {
+                    logger.debug('[claudeRemote] usage seed failed (ignored)', e);
+                }
+            }
+        }
+        if (pendingUsageWindows.size === 0 && !pendingUnbound) return;
+        const patch: UsageLimitsPatch = {
+            capturedAt: Date.now(),
+            windows: [...pendingUsageWindows.values()],
+            unbound: pendingUnbound ?? undefined,
+            // A full snapshot replaces persisted windows so ones the backend
+            // stopped reporting don't linger with a stale status.
+            replace: seededThisFlush || undefined,
+        };
+        pendingUsageWindows.clear();
+        pendingUnbound = null;
+        const signature = JSON.stringify([patch.windows, patch.unbound ?? null]);
+        if (signature === lastUsageSignature && Date.now() - lastUsageEmittedAt < USAGE_REFRESH_INTERVAL_MS) return;
+        lastUsageSignature = signature;
+        lastUsageEmittedAt = Date.now();
+        opts.onUsageLimits(patch);
+    };
+    // Serialized: a second result must not interleave with a flush that is
+    // still awaiting the seed, or it would drain the buffer mid-merge and
+    // emit a second, out-of-order patch.
+    let usageFlushChain: Promise<void> = Promise.resolve();
+    const scheduleUsageFlush = () => {
+        usageFlushChain = usageFlushChain
+            .then(flushUsageLimits)
+            .catch((e) => {
+                logger.debug('[claudeRemote] usage flush failed (ignored)', e);
+            });
+    };
+
     updateThinking(true);
     try {
         logger.debug(`[claudeRemote] Starting to iterate over response`);
@@ -230,10 +299,27 @@ export async function claudeRemote(opts: {
                 }
             }
 
+            // Buffer plan rate-limit events; flushed on the next result
+            if (message.type === 'rate_limit_event') {
+                const info = (message as { rate_limit_info?: RateLimitEventInfo }).rate_limit_info;
+                if (info) {
+                    const normalized = fromRateLimitEvent(info);
+                    if (normalized.window) {
+                        pendingUsageWindows.set(normalized.window.id, normalized.window);
+                    } else if (normalized.unbound) {
+                        pendingUnbound = normalized.unbound;
+                    }
+                }
+            }
+
             // Handle result messages
             if (message.type === 'result') {
                 updateThinking(false);
                 logger.debug('[claudeRemote] Result received');
+
+                // Fire-and-forget: unavailable for API key / Bedrock / Vertex
+                // sessions and experimental besides, so failures are ignored.
+                scheduleUsageFlush();
 
                 // Send completion messages
                 if (isCompactCommand) {

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -5,6 +5,7 @@ import { RemoteModeDisplay } from "@/ui/ink/RemoteModeDisplay";
 import React from "react";
 import { claudeRemote } from "./claudeRemote";
 import { PermissionHandler } from "./utils/permissionHandler";
+import { mergeUsageLimits } from "./utils/usageLimits";
 import { Future } from "@/utils/future";
 import { SDKAssistantMessage, SDKMessage, SDKUserMessage } from "./sdk";
 import { formatClaudeMessageForInk } from "@/ui/messageFormatterInk";
@@ -398,6 +399,14 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                             slashCommands: metadata.slashCommands,
                             mcpServers: metadata.mcpServers,
                             skills: metadata.skills,
+                        }));
+                    },
+                    onUsageLimits: (patch) => {
+                        // Merging against currentMetadata re-hydrates window
+                        // state across claudeRemote re-entries (mode switches).
+                        session.client.updateMetadata((currentMetadata) => ({
+                            ...currentMetadata,
+                            usageLimits: mergeUsageLimits(currentMetadata.usageLimits, patch),
                         }));
                     },
                     onQueryReady: (q) => {

--- a/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeRemoteLauncher.ts
@@ -402,11 +402,11 @@ export async function claudeRemoteLauncher(session: Session): Promise<'switch' |
                         }));
                     },
                     onUsageLimits: (patch) => {
-                        // Merging against currentMetadata re-hydrates window
+                        // Merging against currentAgentState re-hydrates window
                         // state across claudeRemote re-entries (mode switches).
-                        session.client.updateMetadata((currentMetadata) => ({
-                            ...currentMetadata,
-                            usageLimits: mergeUsageLimits(currentMetadata.usageLimits, patch),
+                        session.client.updateAgentState((currentAgentState) => ({
+                            ...currentAgentState,
+                            usageLimits: mergeUsageLimits(currentAgentState.usageLimits, patch),
                         }));
                     },
                     onQueryReady: (q) => {

--- a/packages/happy-cli/src/claude/utils/usageLimits.test.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { fromRateLimitEvent, mergeUsageLimits, synthesizeStatus, windowsFromGetUsage } from './usageLimits';
+
+describe('windowsFromGetUsage', () => {
+    it('normalizes ISO resets_at to epoch ms and keeps 0-100 utilization as-is', () => {
+        const windows = windowsFromGetUsage({
+            five_hour: { utilization: 42, resets_at: '2026-07-17T20:00:00Z' },
+            seven_day: { utilization: 91.5, resets_at: null },
+        });
+        expect(windows).toHaveLength(2);
+        const fiveHour = windows.find(w => w.id === 'five_hour')!;
+        expect(fiveHour.utilization).toBe(42);
+        expect(fiveHour.resetsAt).toBe(Date.parse('2026-07-17T20:00:00Z'));
+        expect(fiveHour.status).toBe('allowed');
+        const sevenDay = windows.find(w => w.id === 'seven_day')!;
+        expect(sevenDay.resetsAt).toBeNull();
+        expect(sevenDay.status).toBe('allowed_warning');
+    });
+
+    it('carries unknown window ids through and skips null / non-window entries', () => {
+        const windows = windowsFromGetUsage({
+            seven_day_opus: { utilization: 10, resets_at: null },
+            seven_day_oauth_apps: null,
+            extra_usage: { spent_cents: 120 },
+        });
+        expect(windows.map(w => w.id)).toEqual(['seven_day_opus']);
+    });
+
+    it('degrades non-numeric utilization to null without a status', () => {
+        const windows = windowsFromGetUsage({ five_hour: { utilization: null, resets_at: null } });
+        expect(windows[0].utilization).toBeNull();
+        expect(windows[0].status).toBeUndefined();
+    });
+});
+
+describe('fromRateLimitEvent', () => {
+    it('converts fraction utilization and unix-seconds resetsAt', () => {
+        const { window } = fromRateLimitEvent({
+            status: 'allowed',
+            rateLimitType: 'five_hour',
+            utilization: 0.63,
+            resetsAt: 1784736000, // seconds
+        });
+        expect(window).toEqual({
+            id: 'five_hour',
+            status: 'allowed',
+            utilization: 63,
+            resetsAt: 1784736000_000,
+        });
+    });
+
+    it('passes already-ms resetsAt and percent utilization through the guards unchanged', () => {
+        const { window } = fromRateLimitEvent({
+            status: 'allowed_warning',
+            rateLimitType: 'seven_day',
+            utilization: 92,
+            resetsAt: 1784736000000,
+        });
+        expect(window!.utilization).toBe(92);
+        expect(window!.resetsAt).toBe(1784736000000);
+    });
+
+    it('returns an unbound patch when rateLimitType is absent (including rejected)', () => {
+        const { window, unbound } = fromRateLimitEvent({ status: 'rejected', utilization: 1 });
+        expect(window).toBeUndefined();
+        expect(unbound).toEqual({ status: 'rejected', utilization: 100, resetsAt: null });
+    });
+});
+
+describe('mergeUsageLimits', () => {
+    const base = {
+        capturedAt: 1000,
+        windows: [
+            { id: 'five_hour', status: 'allowed' as const, utilization: 40, resetsAt: 1 },
+            { id: 'seven_day', status: 'allowed' as const, utilization: 70, resetsAt: 2 },
+        ],
+    };
+
+    it('upserts by id and preserves untouched windows (re-hydration across re-entries)', () => {
+        const merged = mergeUsageLimits(base, {
+            capturedAt: 2000,
+            windows: [{ id: 'five_hour', status: 'allowed_warning', utilization: 93, resetsAt: 3 }],
+        });
+        expect(merged.capturedAt).toBe(2000);
+        expect(merged.windows).toHaveLength(2);
+        expect(merged.windows.find(w => w.id === 'five_hour')!.utilization).toBe(93);
+        expect(merged.windows.find(w => w.id === 'seven_day')!.utilization).toBe(70);
+    });
+
+    it('applies an unbound event to the max-utilization window', () => {
+        const merged = mergeUsageLimits(base, {
+            capturedAt: 2000,
+            windows: [],
+            unbound: { status: 'rejected', utilization: null, resetsAt: null },
+        });
+        expect(merged.windows.find(w => w.id === 'seven_day')!.status).toBe('rejected');
+        expect(merged.windows.find(w => w.id === 'seven_day')!.utilization).toBe(70);
+        expect(merged.windows.find(w => w.id === 'five_hour')!.status).toBe('allowed');
+    });
+
+    it('creates a synthetic window for an unbound event when no windows exist yet', () => {
+        const merged = mergeUsageLimits(undefined, {
+            capturedAt: 2000,
+            windows: [],
+            unbound: { status: 'rejected', utilization: 100, resetsAt: null },
+        });
+        expect(merged.windows).toEqual([{ id: 'plan', status: 'rejected', utilization: 100, resetsAt: null }]);
+    });
+
+    it('tolerates malformed current metadata (windows not an array)', () => {
+        const merged = mergeUsageLimits({ capturedAt: 1, windows: 'garbage' as any }, {
+            capturedAt: 2000,
+            windows: [{ id: 'five_hour', utilization: 10, resetsAt: null }],
+        });
+        expect(merged.windows).toHaveLength(1);
+    });
+});
+
+describe('synthesizeStatus', () => {
+    it('maps thresholds', () => {
+        expect(synthesizeStatus(89.9)).toBe('allowed');
+        expect(synthesizeStatus(90)).toBe('allowed_warning');
+        expect(synthesizeStatus(100)).toBe('rejected');
+        expect(synthesizeStatus(null)).toBeUndefined();
+    });
+});
+
+describe('mergeUsageLimits review fixes', () => {
+    it('replace:true drops windows the snapshot no longer reports', () => {
+        const merged = mergeUsageLimits(
+            {
+                capturedAt: 1,
+                windows: [
+                    { id: 'five_hour', utilization: 40, resetsAt: 1 },
+                    { id: 'plan', status: 'rejected', utilization: null, resetsAt: null },
+                ],
+            },
+            {
+                capturedAt: 2000,
+                windows: [{ id: 'five_hour', status: 'allowed', utilization: 41, resetsAt: 2 }],
+                replace: true,
+            },
+        );
+        expect(merged.windows.map(w => w.id)).toEqual(['five_hour']);
+    });
+
+    it('repeated unbound events without numeric windows upsert one plan window, not duplicates', () => {
+        const first = mergeUsageLimits(undefined, {
+            capturedAt: 1,
+            windows: [],
+            unbound: { status: 'rejected', utilization: null, resetsAt: null },
+        });
+        const second = mergeUsageLimits(first, {
+            capturedAt: 2,
+            windows: [],
+            unbound: { status: 'allowed_warning', utilization: null, resetsAt: null },
+        });
+        expect(second.windows.filter(w => w.id === 'plan')).toHaveLength(1);
+        expect(second.windows[0].status).toBe('allowed_warning');
+    });
+});

--- a/packages/happy-cli/src/claude/utils/usageLimits.test.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.test.ts
@@ -17,11 +17,13 @@ describe('windowsFromGetUsage', () => {
         expect(sevenDay.status).toBe('allowed_warning');
     });
 
-    it('carries unknown window ids through and skips null / non-window entries', () => {
+    it('carries unknown window ids through and explicitly excludes extra_usage', () => {
         const windows = windowsFromGetUsage({
             seven_day_opus: { utilization: 10, resets_at: null },
             seven_day_oauth_apps: null,
-            extra_usage: { spent_cents: 120 },
+            // The real SDK shape can include utilization, so shape detection
+            // alone is not enough to distinguish this billing entry.
+            extra_usage: { utilization: 55, resets_at: '2026-07-17T20:00:00Z' },
         });
         expect(windows.map(w => w.id)).toEqual(['seven_day_opus']);
     });
@@ -107,7 +109,7 @@ describe('mergeUsageLimits', () => {
         expect(merged.windows).toEqual([{ id: 'plan', status: 'rejected', utilization: 100, resetsAt: null }]);
     });
 
-    it('tolerates malformed current metadata (windows not an array)', () => {
+    it('tolerates malformed current agent state (windows not an array)', () => {
         const merged = mergeUsageLimits({ capturedAt: 1, windows: 'garbage' as any }, {
             capturedAt: 2000,
             windows: [{ id: 'five_hour', utilization: 10, resetsAt: null }],

--- a/packages/happy-cli/src/claude/utils/usageLimits.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.ts
@@ -1,6 +1,6 @@
 /**
  * Normalizes plan rate-limit data from the two Claude SDK sources into the
- * backend-neutral UsageLimits shape carried in session metadata:
+ * backend-neutral UsageLimits shape carried in session agent state:
  *
  * - `rate_limit_event` (push): one window per event — whichever limit
  *   currently binds. `rateLimitType` may be absent, utilization is a 0-1
@@ -17,7 +17,7 @@ export type UnboundRateLimit = {
     resetsAt?: number | null,
 }
 
-/** A per-turn delta emitted by claudeRemote, merged into metadata by the launcher. */
+/** A per-turn delta emitted by claudeRemote, merged into agent state by the launcher. */
 export type UsageLimitsPatch = {
     capturedAt: number,
     windows: UsageLimitWindow[],
@@ -47,7 +47,7 @@ function normalizeEventUtilization(u: number | undefined): number | undefined {
     return Math.min(100, Math.max(0, Math.round(percent * 10) / 10));
 }
 
-// Event resetsAt is unix seconds; metadata carries epoch ms.
+// Event resetsAt is unix seconds; agent state carries epoch ms.
 function normalizeEventResetsAt(n: number | undefined): number | undefined {
     if (typeof n !== 'number' || !Number.isFinite(n) || n <= 0) return undefined;
     return n < 1e12 ? Math.round(n * 1000) : Math.round(n);
@@ -64,8 +64,10 @@ type GetUsageWindow = { utilization: number | null, resets_at: string | null } |
 export function windowsFromGetUsage(rateLimits: Record<string, unknown>): UsageLimitWindow[] {
     const windows: UsageLimitWindow[] = [];
     for (const [id, value] of Object.entries(rateLimits)) {
+        // Extra usage is billing/overage state, not a plan rate-limit window.
+        if (id === 'extra_usage') continue;
         if (!value || typeof value !== 'object') continue;
-        // Only entries with the window shape; skips e.g. extra_usage variants.
+        // Only entries with the rate-limit window shape.
         if (!('utilization' in value) && !('resets_at' in value)) continue;
         const w = value as Exclude<GetUsageWindow, null | undefined>;
         const utilization = typeof w.utilization === 'number' && Number.isFinite(w.utilization)
@@ -105,8 +107,8 @@ export function fromRateLimitEvent(info: RateLimitEventInfo): { window?: UsageLi
 }
 
 /**
- * Merges a patch into the current metadata value. Runs inside the launcher's
- * updateMetadata read-modify-write callback, so `current` is always the
+ * Merges a patch into the current agent-state value. Runs inside the launcher's
+ * updateAgentState read-modify-write callback, so `current` is always the
  * latest persisted value — this is what re-hydrates window state across
  * claudeRemote re-entries (mode switches, /clear, stream end).
  */

--- a/packages/happy-cli/src/claude/utils/usageLimits.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.ts
@@ -1,0 +1,157 @@
+/**
+ * Normalizes plan rate-limit data from the two Claude SDK sources into the
+ * backend-neutral UsageLimits shape carried in session metadata:
+ *
+ * - `rate_limit_event` (push): one window per event — whichever limit
+ *   currently binds. `rateLimitType` may be absent, utilization is a 0-1
+ *   fraction, `resetsAt` is unix seconds (derived from the
+ *   anthropic-ratelimit-unified-reset header).
+ * - `get_usage` (pull): all windows at once. Utilization is 0-100,
+ *   `resets_at` is an ISO 8601 string, and windows carry no status.
+ */
+import type { UsageLimits, UsageLimitWindow, UsageLimitWindowStatus } from '@/api/types';
+
+export type UnboundRateLimit = {
+    status: UsageLimitWindowStatus,
+    utilization?: number | null,
+    resetsAt?: number | null,
+}
+
+/** A per-turn delta emitted by claudeRemote, merged into metadata by the launcher. */
+export type UsageLimitsPatch = {
+    capturedAt: number,
+    windows: UsageLimitWindow[],
+    /** rate_limit_event without a rateLimitType: applies to whichever window currently binds. */
+    unbound?: UnboundRateLimit,
+    /**
+     * Set when the patch contains a full get_usage snapshot: merge starts
+     * from the patch instead of the persisted windows, so windows the
+     * backend stopped reporting don't linger with a stale status.
+     */
+    replace?: boolean,
+}
+
+export function synthesizeStatus(utilization: number | null | undefined): UsageLimitWindowStatus | undefined {
+    if (typeof utilization !== 'number' || !Number.isFinite(utilization)) return undefined;
+    if (utilization >= 100) return 'rejected';
+    if (utilization >= 90) return 'allowed_warning';
+    return 'allowed';
+}
+
+// Event utilization is a 0-1 fraction; get_usage is 0-100. The <=1 guard keeps
+// this correct if the SDK ever unifies on percent (a true percent <=1 is
+// indistinguishable, and misreading ~1% as ~100% is the safe direction).
+function normalizeEventUtilization(u: number | undefined): number | undefined {
+    if (typeof u !== 'number' || !Number.isFinite(u)) return undefined;
+    const percent = u <= 1 ? u * 100 : u;
+    return Math.min(100, Math.max(0, Math.round(percent * 10) / 10));
+}
+
+// Event resetsAt is unix seconds; metadata carries epoch ms.
+function normalizeEventResetsAt(n: number | undefined): number | undefined {
+    if (typeof n !== 'number' || !Number.isFinite(n) || n <= 0) return undefined;
+    return n < 1e12 ? Math.round(n * 1000) : Math.round(n);
+}
+
+function normalizeIsoResetsAt(iso: string | null | undefined): number | null {
+    if (!iso) return null;
+    const ms = Date.parse(iso);
+    return Number.isFinite(ms) ? ms : null;
+}
+
+type GetUsageWindow = { utilization: number | null, resets_at: string | null } | null | undefined;
+
+export function windowsFromGetUsage(rateLimits: Record<string, unknown>): UsageLimitWindow[] {
+    const windows: UsageLimitWindow[] = [];
+    for (const [id, value] of Object.entries(rateLimits)) {
+        if (!value || typeof value !== 'object') continue;
+        // Only entries with the window shape; skips e.g. extra_usage variants.
+        if (!('utilization' in value) && !('resets_at' in value)) continue;
+        const w = value as Exclude<GetUsageWindow, null | undefined>;
+        const utilization = typeof w.utilization === 'number' && Number.isFinite(w.utilization)
+            ? Math.min(100, Math.max(0, w.utilization))
+            : null;
+        windows.push({
+            id,
+            utilization,
+            resetsAt: normalizeIsoResetsAt(w.resets_at),
+            status: synthesizeStatus(utilization),
+        });
+    }
+    return windows;
+}
+
+export type RateLimitEventInfo = {
+    status: UsageLimitWindowStatus,
+    rateLimitType?: string,
+    utilization?: number,
+    resetsAt?: number,
+}
+
+export function fromRateLimitEvent(info: RateLimitEventInfo): { window?: UsageLimitWindow, unbound?: UnboundRateLimit } {
+    const utilization = normalizeEventUtilization(info.utilization);
+    const resetsAt = normalizeEventResetsAt(info.resetsAt);
+    if (info.rateLimitType) {
+        return {
+            window: {
+                id: info.rateLimitType,
+                status: info.status,
+                utilization: utilization ?? null,
+                resetsAt: resetsAt ?? null,
+            },
+        };
+    }
+    return { unbound: { status: info.status, utilization: utilization ?? null, resetsAt: resetsAt ?? null } };
+}
+
+/**
+ * Merges a patch into the current metadata value. Runs inside the launcher's
+ * updateMetadata read-modify-write callback, so `current` is always the
+ * latest persisted value — this is what re-hydrates window state across
+ * claudeRemote re-entries (mode switches, /clear, stream end).
+ */
+export function mergeUsageLimits(current: UsageLimits | null | undefined, patch: UsageLimitsPatch): UsageLimits {
+    const windows: UsageLimitWindow[] = !patch.replace && Array.isArray(current?.windows) ? [...current.windows] : [];
+    for (const incoming of patch.windows) {
+        const index = windows.findIndex(w => w.id === incoming.id);
+        if (index >= 0) {
+            windows[index] = incoming;
+        } else {
+            windows.push(incoming);
+        }
+    }
+    if (patch.unbound) {
+        // No window id on the event: apply to whichever known window is
+        // closest to its limit — dropping it would hide the rejected state.
+        let target = -1;
+        let best = -1;
+        for (let i = 0; i < windows.length; i++) {
+            const u = windows[i].utilization;
+            if (typeof u === 'number' && u > best) {
+                best = u;
+                target = i;
+            }
+        }
+        if (target < 0) {
+            // No window carries a numeric utilization: upsert the synthetic
+            // 'plan' window rather than pushing duplicates every turn.
+            target = windows.findIndex(w => w.id === 'plan');
+        }
+        if (target >= 0) {
+            windows[target] = {
+                ...windows[target],
+                status: patch.unbound.status,
+                utilization: patch.unbound.utilization ?? windows[target].utilization,
+                resetsAt: patch.unbound.resetsAt ?? windows[target].resetsAt,
+            };
+        } else {
+            windows.push({
+                id: 'plan',
+                status: patch.unbound.status,
+                utilization: patch.unbound.utilization ?? null,
+                resetsAt: patch.unbound.resetsAt ?? null,
+            });
+        }
+    }
+    return { capturedAt: patch.capturedAt, windows };
+}


### PR DESCRIPTION
Layer 1 of the two-layer design in #1442. This does not close that issue —
Layer 2 (the pull half) is still open.

### What it looks like

Both screenshots below are the same session at the same moment, with only the
setting toggled. The numbers are exact complements — 8/92 and 79/21 — because
the flip happens at render time and the stored utilisation never changes.

**Default, counting up (percent used):**

<img width="1019" height="680" alt="Google Chrome 2026-07-22 10 58 35" src="https://github.com/user-attachments/assets/0ce5e610-d964-4614-9203-dba4ad5ed61c" />


**With Show Quota Remaining enabled:**

<img width="1003" height="628" alt="Claude 2026-07-22 10 59 15" src="https://github.com/user-attachments/assets/67457c08-3ae0-4ab1-8209-f82d4d358fba" />


**The setting, in Appearance:**

<img width="843" height="349" alt="Google Chrome 2026-07-22 10 59 35" src="https://github.com/user-attachments/assets/6c7f840f-082d-4b78-9ccc-3318f2d11fbe" />


### Why this shape

#1442 left one decision to maintainers: which carrier should the snapshot ride
on — the versioned `agentState` blob (with the worry that frequent snapshot
writes would thrash its optimistic `expectedVersion`) or an ephemeral agent
message.

This PR uses **encrypted session metadata**, and removes the reason the question
was asked: `rate_limit_event` messages are buffered and flushed at most once per
`result`, skip-if-unchanged, so metadata sees **at most one CAS write per turn**
rather than one per event. `packages/happy-wire` is untouched — the field is an
additive optional inside the existing encrypted object.

Happy to move it to `agentState` or an ephemeral message if you'd rather — it is
contained in the CLI adapter plus one zod sub-schema. Worth noting why metadata
won on my side: both blobs run the identical CAS-with-backoff path, so the
difference is not the mechanism but the neighbours. `agentState`'s version
counter is shared with the permission handlers — the one write path a user is
actively waiting on — whereas metadata's other writers are all one-shot
(startup, fork, mode switch). Coalescing to one write per turn keeps this clear
of either, but metadata has more headroom if that ever stops holding.

### CLI

- Handles `rate_limit_event` in the SDK message loop, buffering and flushing per
  `result`.
- Seeds one `get_usage` on the first result of each `claudeRemote` invocation
  (the `Query` object does not exist before the first user message),
  `typeof`-gated because that method is marked experimental.
- The adapter normalises both sources: event `utilization` is a 0–1 fraction
  with unix-second `resetsAt`, `get_usage` is 0–100 with ISO strings. Windows
  merge by id inside the `updateMetadata` read-modify-write callback, which
  re-hydrates state across mode switches. An id-less event (`rateLimitType` is
  optional, including `status: rejected`) applies to the max-utilisation window
  instead of being dropped.

### App

- 5h/7d chips in the status bar's right cluster, collapsing to the binding
  window below 480px of window width. Unknown window ids render in the popover
  only.
- `usageLimitShowRemaining` (default off) switches the chips from percent-used
  to percent-remaining. Utilisation stays "percent used" throughout the data
  layer — the wire format and the warning/critical thresholds both depend on it,
  and the narrow-screen collapse still picks the window closest to its limit.
  The remaining view is a display-time flip in one pure helper. The popover
  spells it out ("58% left") because a bare "5h 58%" is ambiguous once it can
  mean either direction.
- The zod sub-schema is parse-lenient (`.catch(undefined)`, no enums) so a
  malformed value can never invalidate the whole metadata object.

### On the setting, and "one feature per PR"

CONTRIBUTING asks for one feature per PR, so let me be explicit about why the
display preference is in here rather than in a follow-up.

#1442's own sequence diagram illustrates the chip as `5h 42% left`, while the
underlying data is utilisation — percent used. Shipping a single direction would
either contradict the proposal or discard the data layer's natural units, so
both directions behind a default-off preference is this feature's finished form
rather than an addition to it. It also matches how the repo introduces new
surface area: `settings.ts` carries 27 boolean preferences today, and
`sessionStatusBarDisplay` already defaults the whole bar to `hidden`, so nobody
sees these chips without opting in first.

Happy to split it out if you would rather review the base alone.

### Scope and degradation

Claude sessions only. `rate_limit_event` and `get_usage` are Claude Agent SDK
constructs and plan rate limits are a Claude subscription concept, so the whole
capture path lives under `packages/happy-cli/src/claude/`. Codex, Gemini,
OpenClaw and agy sessions never write the field, and the app needs no branch for
them — an absent field is already the hidden case.

The same path covers everything else that cannot produce the data: API key /
Bedrock / Vertex auth, local PTY-wrapped sessions (fed by transcript scanning,
which carries no rate-limit events), and an older CLI paired with a newer app.

I hit that last one for real while developing — an app build carrying this
change paired with a CLI build that did not, and the chips simply stayed hidden
with nothing else affected.

### Tests

`packages/happy-cli/src/claude/utils/usageLimits.test.ts` covers the adapter
(both sources, normalisation, id-less events, merge-by-id).
`packages/happy-app/sources/utils/sessionStatusBar.test.ts` (10 tests) covers
chip selection, collapse, and the used/remaining flip. The CLI unit suite
(47 tests) passes and `tsc --noEmit` is clean.

### Out of scope

Layer 2 (tap → session RPC → `get_usage` → detail panel). The popover here
renders only what the snapshot already carries and issues no requests.
