### PR TITLE
fix(cli): honor HAPPY_CLAUDE_PATH for SDK-spawned Claude sessions

### DIFF
--- a/packages/happy-cli/src/claude/sdk/claudeExecutable.test.ts
+++ b/packages/happy-cli/src/claude/sdk/claudeExecutable.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveClaudeExecutableOverride } from './claudeExecutable'
+
+describe('resolveClaudeExecutableOverride', () => {
+    it('returns undefined when HAPPY_CLAUDE_PATH is not set', () => {
+        expect(resolveClaudeExecutableOverride({})).toBeUndefined()
+        expect(resolveClaudeExecutableOverride({ HAPPY_CLAUDE_PATH: '' })).toBeUndefined()
+    })
+
+    it('returns the override when it points to an existing file', () => {
+        // process.execPath is the running node binary — guaranteed to exist.
+        expect(resolveClaudeExecutableOverride({ HAPPY_CLAUDE_PATH: process.execPath })).toBe(process.execPath)
+    })
+
+    it('falls back to the bundled executable when the override is missing on disk', () => {
+        expect(resolveClaudeExecutableOverride({ HAPPY_CLAUDE_PATH: '/nonexistent/claude-binary' })).toBeUndefined()
+    })
+})

--- a/packages/happy-cli/src/claude/sdk/claudeExecutable.ts
+++ b/packages/happy-cli/src/claude/sdk/claudeExecutable.ts
@@ -1,0 +1,38 @@
+/**
+ * Resolves the HAPPY_CLAUDE_PATH override for the Claude Code executable
+ * spawned through the agent SDK.
+ *
+ * Why this exists
+ * ---------------
+ * Local/interactive mode resolves the system-installed `claude` binary and
+ * already honors the HAPPY_CLAUDE_PATH env override (see
+ * scripts/claude_version_utils.cjs). Remote mode instead spawns the CLI build
+ * vendored inside `@anthropic-ai/claude-agent-sdk`, which can lag behind the
+ * system install — a released Happy can reject model aliases the current
+ * Claude Code accepts (e.g. `fable` / Claude 5, slopus/happy#1498), and there
+ * was no way to point remote sessions at a newer binary short of patching
+ * node_modules.
+ *
+ * Mitigation
+ * ----------
+ * Honor the same HAPPY_CLAUDE_PATH override in the SDK path by mapping it to
+ * the SDK's `pathToClaudeCodeExecutable` option, so one env var governs which
+ * `claude` both modes run. Unset — or pointing at a file that does not exist —
+ * keeps the SDK's bundled executable, so existing setups are unaffected.
+ */
+
+import { existsSync } from 'node:fs'
+
+import { logger } from '@/ui/logger'
+
+export function resolveClaudeExecutableOverride(env: NodeJS.ProcessEnv = process.env): string | undefined {
+    const override = env.HAPPY_CLAUDE_PATH
+    if (!override || override.length === 0) {
+        return undefined
+    }
+    if (!existsSync(override)) {
+        logger.debug(`[ClaudeSdk] HAPPY_CLAUDE_PATH points to a missing file, using the SDK's bundled executable instead: ${override}`)
+        return undefined
+    }
+    return override
+}

--- a/packages/happy-cli/src/claude/sdk/query.ts
+++ b/packages/happy-cli/src/claude/sdk/query.ts
@@ -7,6 +7,7 @@ import { query as sdkQuery, type Options, type Query } from '@anthropic-ai/claud
 import type { QueryOptions, QueryPrompt, SDKMessage } from './types'
 import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
 import { ensureLocalProxyBypass } from '../utils/proxyBypass'
+import { resolveClaudeExecutableOverride } from './claudeExecutable'
 import { resolveHappyEntrypoint } from './happyEntrypoint'
 
 /**
@@ -44,6 +45,9 @@ export function query(params: { prompt: QueryPrompt; options?: QueryOptions }): 
         strictMcpConfig: opts?.strictMcpConfig,
         sessionId: undefined,
         effort: opts?.effort,
+        // HAPPY_CLAUDE_PATH override — same env var the local launcher honors
+        // (undefined keeps the SDK's bundled executable).
+        pathToClaudeCodeExecutable: resolveClaudeExecutableOverride(),
     }
 
     // Map abort signal -> AbortController


### PR DESCRIPTION
Fixes #1498.

## Problem

Remote/mobile sessions spawn the CLI vendored inside `@anthropic-ai/claude-agent-sdk`, which can lag behind the system-installed `claude`. With the released happy-coder 1.1.9 (SDK 0.2.141 / CLI 2.1.141), selecting **fable** fails with:

> There's an issue with the selected model (fable). It may not exist or you may not have access to it.

while the same account and machine use `fable` fine via the up-to-date system `claude`. `opus` also silently resolves to an older model than the current CLI would pick. Full debugging trail in #1498 — replacing the bundled binary with a symlink to the system `claude` fixed it immediately, confirming the vendored CLI as the culprit.

## Fix

The local/interactive launcher already honors a `HAPPY_CLAUDE_PATH` override (`scripts/claude_version_utils.cjs`, priority: env > PATH > npm > bun > brew > native), but the SDK path ignored it — there was no way to point remote sessions at a newer binary short of patching `node_modules`.

This maps the same env var to the SDK's `pathToClaudeCodeExecutable` option, so one override governs which `claude` both modes run:

- `HAPPY_CLAUDE_PATH` unset → SDK's bundled executable, exactly as today (no behavior change)
- set to an existing file → that binary is spawned for SDK sessions too
- set but missing on disk → logged and ignored, falls back to the bundled executable

Bumping the vendored SDK also helps (main is already on ^0.3.179), but the override means users are never stuck waiting for a release when Anthropic ships new models.

## Testing

- `pnpm typecheck` clean, `pnpm build` passes
- New colocated unit tests (`claudeExecutable.test.ts`, 3 cases) pass alongside the existing sdk tests
- Verified end-to-end on the affected machine (Ubuntu 24.04, happy-coder 1.1.9): pointing the SDK spawn at the system `claude` 2.1.218 makes `--model fable` sessions work immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)