### PR TITLE
fix(cli): don't let rate_limit_event wipe a window's utilization

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -201,9 +201,19 @@ export async function claudeRemote(opts: {
                     const usage = await usageFn.call(response);
                     if (usage?.rate_limits_available && usage.rate_limits) {
                         for (const w of windowsFromGetUsage(usage.rate_limits)) {
-                            // Events are fresher than the seed for the same window
-                            if (!pendingUsageWindows.has(w.id)) {
+                            // Events are fresher than the seed for the same
+                            // window, but allowed events carry no utilization —
+                            // backfill the snapshot's percentage so it isn't
+                            // dropped on the floor.
+                            const pending = pendingUsageWindows.get(w.id);
+                            if (!pending) {
                                 pendingUsageWindows.set(w.id, w);
+                            } else if (pending.utilization === null || pending.utilization === undefined) {
+                                pendingUsageWindows.set(w.id, {
+                                    ...pending,
+                                    utilization: w.utilization,
+                                    resetsAt: pending.resetsAt ?? w.resetsAt,
+                                });
                             }
                         }
                         seededThisFlush = true;

--- a/packages/happy-cli/src/claude/utils/usageLimits.test.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.test.ts
@@ -89,6 +89,30 @@ describe('mergeUsageLimits', () => {
         expect(merged.windows.find(w => w.id === 'seven_day')!.utilization).toBe(70);
     });
 
+    it('keeps the last known utilization when an event window arrives without one', () => {
+        // Allowed rate_limit_events report only status + resetsAt; a full
+        // replace here would strip the percentage seeded by get_usage.
+        const merged = mergeUsageLimits(base, {
+            capturedAt: 2000,
+            windows: [{ id: 'five_hour', status: 'allowed', utilization: null, resetsAt: 5 }],
+        });
+        const fiveHour = merged.windows.find(w => w.id === 'five_hour')!;
+        expect(fiveHour.utilization).toBe(40);
+        expect(fiveHour.resetsAt).toBe(5);
+        expect(fiveHour.status).toBe('allowed');
+    });
+
+    it('keeps the last known resetsAt when an event window arrives without one', () => {
+        const merged = mergeUsageLimits(base, {
+            capturedAt: 2000,
+            windows: [{ id: 'seven_day', status: 'allowed_warning', utilization: 91, resetsAt: null }],
+        });
+        const sevenDay = merged.windows.find(w => w.id === 'seven_day')!;
+        expect(sevenDay.utilization).toBe(91);
+        expect(sevenDay.resetsAt).toBe(2);
+        expect(sevenDay.status).toBe('allowed_warning');
+    });
+
     it('applies an unbound event to the max-utilization window', () => {
         const merged = mergeUsageLimits(base, {
             capturedAt: 2000,

--- a/packages/happy-cli/src/claude/utils/usageLimits.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.ts
@@ -117,7 +117,15 @@ export function mergeUsageLimits(current: UsageLimits | null | undefined, patch:
     for (const incoming of patch.windows) {
         const index = windows.findIndex(w => w.id === incoming.id);
         if (index >= 0) {
-            windows[index] = incoming;
+            // Allowed rate_limit_events carry no utilization, so a full
+            // replace would wipe the percentage seeded by get_usage and the
+            // window would render as just a reset time. Keep the last known
+            // value; the status and reset time still come from the event.
+            windows[index] = {
+                ...incoming,
+                utilization: incoming.utilization ?? windows[index].utilization,
+                resetsAt: incoming.resetsAt ?? windows[index].resetsAt,
+            };
         } else {
             windows.push(incoming);
         }


### PR DESCRIPTION
## Problem

Follow-up to #1556. The 5h window in the status bar popover renders as just a reset time ("5-hour limit — resets 03:40 PM") with no percentage, while the 7d window shows one.

## Root cause

Allowed `rate_limit_event`s carry `status` + `resetsAt` but no `utilization`:

```json
{
  "type": "rate_limit_event",
  "rate_limit_info": {
    "status": "allowed",
    "resetsAt": 1784932800,
    "rateLimitType": "five_hour",
    ...
  }
}
```

The percentage only ever comes from the `get_usage` snapshot. But `mergeUsageLimits` replaces the whole window object on id match (`windows[index] = incoming`), so every five_hour event clears the seeded percentage back to null. seven_day survives only because no events fire for it. At seed time the same thing happens in reverse: a pending event window blocks the snapshot's window entirely.

## Fix

- `mergeUsageLimits`: on id match, keep the last known `utilization`/`resetsAt` when the incoming window lacks them (the unbound path already did this).
- `claudeRemote` seed: backfill the snapshot's percentage into a pending event window instead of skipping it.

Status and reset time still always come from the event — only missing fields fall back.

## Tests

`pnpm typecheck` clean. `usageLimits.test.ts` 15 passed (2 added: event without utilization keeps the percentage; event without resetsAt keeps the reset time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)