### PR TITLE
fix(app): use full model ID for Opus 5 in the Claude model picker

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -56,7 +56,7 @@ describe('modelModeOptions', () => {
         const models = getClaudeModelModes();
         expect(models.map((model) => model.key)).toEqual([
             'default',
-            'opus-5',
+            'claude-opus-5',
             'opus',
             'fable',
             'sonnet',

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -96,7 +96,10 @@ export function getGeminiPermissionModes(translate: Translate): PermissionMode[]
 export function getClaudeModelModes(): ModelMode[] {
     return [
         { key: 'default', name: 'default model', description: null },
-        { key: 'opus-5', name: 'opus 5', description: null },
+        // Full model ID, not the `opus-5` short alias: the alias is not in the
+        // CLI's alias table yet (`claude --model opus-5` errors on 2.1.199),
+        // while the full ID passes straight through to the API.
+        { key: 'claude-opus-5', name: 'opus 5', description: null },
         { key: 'opus', name: 'opus 4.8', description: null },
         { key: 'fable', name: 'fable 5', description: null },
         { key: 'sonnet', name: 'sonnet 4.6', description: null },


### PR DESCRIPTION
Selecting "opus 5" in the Claude model picker fails at session start with "There's an issue with the selected model (opus-5)". The picker key is forwarded verbatim as `claude --model <key>`, and `opus-5` isn't in the CLI's alias table — 2.1.199 knows only `default, fable, haiku, opus, opus-4-8, opusplan, sonnet, sonnet-5`. This switches the key to the full model ID `claude-opus-5`, which the CLI passes straight through to the API, so it works on both current and future CLI builds regardless of when the short alias lands. One-line change plus the corresponding test update.

Context and the more general version of this problem (picker keys are never validated against the CLI's alias table; #1498 is the same failure with `fable`) are in #1565.

### Proof

Before — the alias the picker was sending:

```
$ claude --model opus-5 -p "say OK"
There's an issue with the selected model (opus-5). It may not exist or you may not have access to it.
```

After — the ID this PR sends:

```
$ claude --model claude-opus-5 -p "say OK"
OK
```

<!-- SCREENSHOT PLACEHOLDER: picker with "opus 5" selected + session responding -->

```
$ npx vitest run sources/components/modelModeOptions.test.ts
 ✓ sources/components/modelModeOptions.test.ts (15 tests) 4ms
 Test Files  1 passed (1)
      Tests  15 passed (15)
```
