### PR TITLE
fix(app): keep unread badges when saving a draft or removing a machine

### DIFF
--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -249,7 +249,9 @@ interface StorageState {
 // Helper function to build unified list view data from sessions and machines
 function buildSessionListViewData(
     sessions: Record<string, Session>,
-    unreadSessionIds?: Set<string>,
+    // Required on purpose: an omitted set silently rebuilds the list with
+    // hasUnread=false everywhere — exactly the bug this parameter caused twice.
+    unreadSessionIds: Set<string>,
 ): SessionListViewItem[] {
     // Separate active and inactive sessions
     const activeSessions: Session[] = [];
@@ -1109,7 +1111,8 @@ export const storage = create<StorageState>()((set, get) => {
 
             // Rebuild sessionListViewData to reflect machine changes
             const sessionListViewData = buildSessionListViewData(
-                state.sessions
+                state.sessions,
+                state.unreadSessionIds
             );
 
             return {

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -1030,7 +1030,7 @@ export const storage = create<StorageState>()((set, get) => {
             return {
                 ...state,
                 sessions: updatedSessions,
-                sessionListViewData: buildSessionListViewData(updatedSessions)
+                sessionListViewData: buildSessionListViewData(updatedSessions, state.unreadSessionIds)
             };
         }),
         // Permission / model / effort picks are local mirrors of synced session
@@ -1126,7 +1126,7 @@ export const storage = create<StorageState>()((set, get) => {
             return {
                 ...state,
                 machines: remaining,
-                sessionListViewData: buildSessionListViewData(state.sessions)
+                sessionListViewData: buildSessionListViewData(state.sessions, state.unreadSessionIds)
             };
         }),
         // Artifact methods


### PR DESCRIPTION
Typing in one session's composer clears the unread marker on every other session. `buildSessionListViewData(sessions, unreadSessionIds?)` takes the unread set as an *optional* second argument, so a call site that omits it rebuilds the list with `hasUnread: false` everywhere — no type error, no warning, the markers just go until something else triggers a rebuild. `updateSessionDraft` omitted it, and the composer autosave (`useDraft.ts:28`) calls it every 2 seconds while you type. `deleteMachine` omitted it too. This threads the set through both, matching what `markSessionRead`, `markSessionUnread`, `markSessionMessageSent` and `deleteSession` already do.

### Code path

Marker is set in `applySessions` (`storage.ts:598-613`) when a session goes thinking → idle while you're viewing something else, and read at `storage.ts:146` (`hasUnread: unreadSessionIds?.has(session.id) ?? false`), which drives the solid-blue status dot and the `status.unread` label in `SessionsList.tsx:434,442`.

Two rebuild sites dropped the set:

- `updateSessionDraft` (`storage.ts:1033`) — reached from `useDraft.ts:28` on every autosave tick
- `deleteMachine` (`storage.ts:1129`) — reached from `sync.ts:2513`

Both now pass `state.unreadSessionIds`, so the set survives the rebuild.

### On visual proof

I don't have a screenshot for this one, and I'd rather say so than fake it. The marker only appears when a session finishes work while you're looking at a different one, and the visible difference is a status dot changing colour plus one word of label text — reproducing it on demand needs two live sessions and a timing window I couldn't stage cleanly. The change itself is two arguments, and the four sibling call sites in the same file already establish what correct looks like. Happy to add a capture if you'd like one before merging.

```
$ pnpm --filter happy-app typecheck
(clean)
```