### PR TITLE
fix(app): keep new-session mode selections per agent

### DIFF
--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -760,12 +760,11 @@ export const HomeDock = React.memo(({
     }, [finishCloseFocusMode, focusPresentation]);
 
     const selectAgent = React.useCallback((agent: NewSessionAgentType) => {
-        const nextDefaults = resolveAgentDefaultConfig(defaultOverrides, agent);
+        // Mode selections live per agent in the draft, so switching agents
+        // restores the target agent's saved modes (or falls back to its
+        // defaults) instead of overwriting them.
         setAgentType(agent);
-        setPermissionMode(nextDefaults.permissionMode);
-        setModelMode(nextDefaults.modelMode);
-        if (nextDefaults.effortLevel) setEffortLevel(nextDefaults.effortLevel);
-    }, [defaultOverrides, setAgentType, setEffortLevel, setModelMode, setPermissionMode]);
+    }, [setAgentType]);
 
     React.useEffect(() => {
         if (availableAgents.length > 0 && !availableAgents.some((agent) => agent.key === agentType)) {

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+type AgentModes = {
+    permissionMode: string | null;
+    modelMode: string | null;
+    effortLevel: string | null;
+};
+
 type Draft = {
     input: string;
     selectedMachineId: string | null;
     selectedPath: string | null;
-    agentType: 'claude' | 'codex' | 'gemini' | 'openclaw';
-    permissionMode: string | null;
-    modelMode: string | null;
-    effortLevel: string | null;
+    agentType: 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy';
+    agentModes: Partial<Record<Draft['agentType'], AgentModes>>;
     sessionType: 'simple' | 'worktree';
     worktreeKey: string | null;
     updatedAt: number;
@@ -32,9 +36,7 @@ function persistedDraft(overrides: Partial<Draft> = {}): Draft {
         selectedMachineId: null,
         selectedPath: null,
         agentType: 'claude',
-        permissionMode: null,
-        modelMode: null,
-        effortLevel: null,
+        agentModes: {},
         sessionType: 'simple',
         worktreeKey: null,
         updatedAt: 1,
@@ -57,11 +59,11 @@ describe('useNewSessionDraft', () => {
         expect(useNewSessionDraft.getState().effortLevel).toBeNull();
     });
 
-    it('loads persisted permission, model, and effort defaults', async () => {
+    it('loads persisted permission, model, and effort defaults for the draft agent', async () => {
         mockPersistence.draft = persistedDraft({
-            permissionMode: 'yolo',
-            modelMode: 'opus',
-            effortLevel: 'xhigh',
+            agentModes: {
+                claude: { permissionMode: 'yolo', modelMode: 'opus', effortLevel: 'xhigh' },
+            },
         });
 
         const { useNewSessionDraft } = await import('./useNewSessionDraft');
@@ -77,7 +79,34 @@ describe('useNewSessionDraft', () => {
         useNewSessionDraft.getState().setEffortLevel('high');
 
         expect(useNewSessionDraft.getState().effortLevel).toBe('high');
-        expect(mockPersistence.saved.at(-1)).toMatchObject({ effortLevel: 'high' });
+        expect(mockPersistence.saved.at(-1)).toMatchObject({
+            agentModes: { claude: { effortLevel: 'high' } },
+        });
+    });
+
+    it('keeps mode selections per agent when switching agents', async () => {
+        const { useNewSessionDraft } = await import('./useNewSessionDraft');
+
+        useNewSessionDraft.getState().setModelMode('claude-opus-5');
+        useNewSessionDraft.getState().setPermissionMode('bypassPermissions');
+
+        useNewSessionDraft.getState().setAgentType('codex');
+        expect(useNewSessionDraft.getState().modelMode).toBeNull();
+        expect(useNewSessionDraft.getState().permissionMode).toBeNull();
+
+        useNewSessionDraft.getState().setModelMode('gpt-5.5');
+
+        useNewSessionDraft.getState().setAgentType('claude');
+        expect(useNewSessionDraft.getState().modelMode).toBe('claude-opus-5');
+        expect(useNewSessionDraft.getState().permissionMode).toBe('bypassPermissions');
+
+        useNewSessionDraft.getState().setAgentType('codex');
+        expect(useNewSessionDraft.getState().modelMode).toBe('gpt-5.5');
+
+        expect(mockPersistence.saved.at(-1)?.agentModes).toEqual({
+            claude: { permissionMode: 'bypassPermissions', modelMode: 'claude-opus-5', effortLevel: null },
+            codex: { permissionMode: null, modelMode: 'gpt-5.5', effortLevel: null },
+        });
     });
 
     it('keeps temporary image attachments in memory without persisting their file URIs', async () => {

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.ts
@@ -2,6 +2,11 @@
  * Zustand store for new session draft state, backed by MMKV.
  * Persists the user's last-used configuration (machine, path, agent, model, permissions, etc.)
  * so the new session screen restores the same defaults on next visit.
+ *
+ * Mode selections (permission/model/effort) are stored per agent: the flat
+ * `permissionMode`/`modelMode`/`effortLevel` fields always reflect the
+ * currently selected agent, and switching agents swaps that view instead of
+ * overwriting the selections made for another agent.
  */
 import { create } from 'zustand';
 import {
@@ -20,6 +25,7 @@ interface NewSessionDraftState {
     selectedMachineId: string | null;
     selectedPath: string | null;
     agentType: NewSessionAgentType;
+    agentModes: NewSessionDraft['agentModes'];
     permissionMode: PermissionModeKey | null;
     modelMode: string | null;
     effortLevel: string | null;
@@ -44,16 +50,34 @@ function persist(state: NewSessionDraftState) {
         selectedMachineId: state.selectedMachineId,
         selectedPath: state.selectedPath,
         agentType: state.agentType,
-        permissionMode: state.permissionMode,
-        modelMode: state.modelMode,
-        effortLevel: state.effortLevel,
+        agentModes: state.agentModes,
         sessionType: state.sessionType,
         worktreeKey: state.worktreeKey,
         updatedAt: Date.now(),
     });
 }
 
+function updateAgentMode(
+    state: NewSessionDraftState,
+    patch: Partial<Pick<NewSessionDraftState, 'permissionMode' | 'modelMode' | 'effortLevel'>>,
+): Partial<NewSessionDraftState> {
+    const current = state.agentModes[state.agentType];
+    return {
+        ...patch,
+        agentModes: {
+            ...state.agentModes,
+            [state.agentType]: {
+                permissionMode: patch.permissionMode ?? current?.permissionMode ?? null,
+                modelMode: patch.modelMode ?? current?.modelMode ?? null,
+                effortLevel: patch.effortLevel ?? current?.effortLevel ?? null,
+            },
+        },
+    };
+}
+
 const initial = loadNewSessionDraft();
+const initialAgent = initial?.agentType ?? 'claude';
+const initialModes = initial?.agentModes?.[initialAgent];
 
 export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => ({
     input: initial?.input ?? '',
@@ -62,10 +86,11 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     attachments: [],
     selectedMachineId: initial?.selectedMachineId ?? null,
     selectedPath: initial?.selectedPath ?? null,
-    agentType: initial?.agentType ?? 'claude',
-    permissionMode: initial?.permissionMode ?? null,
-    modelMode: initial?.modelMode ?? null,
-    effortLevel: initial?.effortLevel ?? null,
+    agentType: initialAgent,
+    agentModes: initial?.agentModes ?? {},
+    permissionMode: initialModes?.permissionMode ?? null,
+    modelMode: initialModes?.modelMode ?? null,
+    effortLevel: initialModes?.effortLevel ?? null,
     sessionType: initial?.sessionType ?? 'simple',
     worktreeKey: initial?.worktreeKey ?? null,
 
@@ -73,10 +98,19 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     setAttachments: (attachments) => { set({ attachments }); },
     setMachineId: (id) => { set({ selectedMachineId: id, selectedPath: null, worktreeKey: null }); persist(get()); },
     setPath: (path) => { set({ selectedPath: path, worktreeKey: null }); persist(get()); },
-    setAgentType: (agent) => { set({ agentType: agent }); persist(get()); },
-    setPermissionMode: (mode) => { set({ permissionMode: mode }); persist(get()); },
-    setModelMode: (mode) => { set({ modelMode: mode }); persist(get()); },
-    setEffortLevel: (level) => { set({ effortLevel: level }); persist(get()); },
+    setAgentType: (agent) => {
+        const modes = get().agentModes[agent];
+        set({
+            agentType: agent,
+            permissionMode: modes?.permissionMode ?? null,
+            modelMode: modes?.modelMode ?? null,
+            effortLevel: modes?.effortLevel ?? null,
+        });
+        persist(get());
+    },
+    setPermissionMode: (mode) => { set(updateAgentMode(get(), { permissionMode: mode })); persist(get()); },
+    setModelMode: (mode) => { set(updateAgentMode(get(), { modelMode: mode })); persist(get()); },
+    setEffortLevel: (level) => { set(updateAgentMode(get(), { effortLevel: level })); persist(get()); },
     setSessionType: (type) => { set({ sessionType: type }); persist(get()); },
     setWorktreeKey: (key) => { set({ worktreeKey: key }); persist(get()); },
 }));

--- a/packages/happy-app/sources/sync/newSessionDraft.spec.ts
+++ b/packages/happy-app/sources/sync/newSessionDraft.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native-mmkv', () => ({
+    MMKV: class {
+        private store = new Map<string, string>();
+        getString(key: string) { return this.store.get(key); }
+        set(key: string, value: string) { this.store.set(key, value); }
+        delete(key: string) { this.store.delete(key); }
+    },
+}));
+
+import { parseNewSessionDraft } from './persistence';
+
+describe('parseNewSessionDraft', () => {
+    it('parses per-agent mode selections', () => {
+        const draft = parseNewSessionDraft({
+            input: 'hello',
+            agentType: 'codex',
+            agentModes: {
+                claude: { permissionMode: 'bypassPermissions', modelMode: 'claude-opus-5', effortLevel: null },
+                codex: { permissionMode: 'yolo', modelMode: 'gpt-5.5', effortLevel: 'high' },
+                bogus: { modelMode: 'nope' },
+            },
+            sessionType: 'simple',
+            updatedAt: 42,
+        });
+
+        expect(draft).not.toBeNull();
+        expect(draft!.agentType).toBe('codex');
+        expect(draft!.agentModes).toEqual({
+            claude: { permissionMode: 'bypassPermissions', modelMode: 'claude-opus-5', effortLevel: null },
+            codex: { permissionMode: 'yolo', modelMode: 'gpt-5.5', effortLevel: 'high' },
+        });
+    });
+
+    it('migrates legacy drafts with shared mode fields to the draft agent', () => {
+        const draft = parseNewSessionDraft({
+            input: '',
+            agentType: 'claude',
+            permissionMode: 'bypassPermissions',
+            modelMode: 'opus',
+            effortLevel: null,
+            sessionType: 'simple',
+            updatedAt: 42,
+        });
+
+        expect(draft!.agentModes).toEqual({
+            claude: { permissionMode: 'bypassPermissions', modelMode: 'opus', effortLevel: null },
+        });
+    });
+
+    it('leaves agentModes empty when a legacy draft has no mode selections', () => {
+        const draft = parseNewSessionDraft({
+            input: '',
+            agentType: 'claude',
+            sessionType: 'simple',
+            updatedAt: 42,
+        });
+
+        expect(draft!.agentModes).toEqual({});
+    });
+
+    it('returns null for non-object payloads', () => {
+        expect(parseNewSessionDraft(null)).toBeNull();
+        expect(parseNewSessionDraft('nope')).toBeNull();
+    });
+});

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -15,14 +15,22 @@ const VOICE_MESSAGE_COUNT_KEY = 'voice-message-count';
 export type NewSessionAgentType = 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy';
 export type NewSessionSessionType = 'simple' | 'worktree';
 
+const NEW_SESSION_AGENT_TYPES: NewSessionAgentType[] = ['claude', 'codex', 'gemini', 'openclaw', 'agy'];
+
+export interface NewSessionAgentModes {
+    permissionMode: PermissionModeKey | null;
+    modelMode: string | null;
+    effortLevel: string | null;
+}
+
 export interface NewSessionDraft {
     input: string;
     selectedMachineId: string | null;
     selectedPath: string | null;
     agentType: NewSessionAgentType;
-    permissionMode: PermissionModeKey | null;
-    modelMode: string | null;
-    effortLevel: string | null;
+    // Mode selections are stored per agent so switching agents doesn't
+    // overwrite the selections made for another one.
+    agentModes: Partial<Record<NewSessionAgentType, NewSessionAgentModes>>;
     sessionType: NewSessionSessionType;
     worktreeKey: string | null;
     updatedAt: number;
@@ -132,44 +140,74 @@ export function saveSessionDrafts(drafts: Record<string, string>) {
     mmkv.set('session-drafts', JSON.stringify(drafts));
 }
 
+function parseNewSessionAgentModes(value: unknown): NewSessionAgentModes | null {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const permissionMode: PermissionModeKey | null = typeof record.permissionMode === 'string'
+        ? record.permissionMode
+        : null;
+    const modelMode: string | null = typeof record.modelMode === 'string' ? record.modelMode : null;
+    const effortLevel: string | null = typeof record.effortLevel === 'string' ? record.effortLevel : null;
+    if (permissionMode === null && modelMode === null && effortLevel === null) {
+        return null;
+    }
+    return { permissionMode, modelMode, effortLevel };
+}
+
+export function parseNewSessionDraft(parsed: unknown): NewSessionDraft | null {
+    if (!parsed || typeof parsed !== 'object') {
+        return null;
+    }
+    const record = parsed as Record<string, unknown>;
+
+    const input = typeof record.input === 'string' ? record.input : '';
+    const selectedMachineId = typeof record.selectedMachineId === 'string' ? record.selectedMachineId : null;
+    const selectedPath = typeof record.selectedPath === 'string' ? record.selectedPath : null;
+    const agentType: NewSessionAgentType = record.agentType === 'codex' || record.agentType === 'gemini' || record.agentType === 'openclaw' || record.agentType === 'agy'
+        ? record.agentType
+        : 'claude';
+    const agentModes: NewSessionDraft['agentModes'] = {};
+    if (record.agentModes && typeof record.agentModes === 'object') {
+        const rawModes = record.agentModes as Record<string, unknown>;
+        for (const agent of NEW_SESSION_AGENT_TYPES) {
+            const modes = parseNewSessionAgentModes(rawModes[agent]);
+            if (modes) {
+                agentModes[agent] = modes;
+            }
+        }
+    } else {
+        // Migrate legacy drafts that stored a single shared mode selection:
+        // attribute it to the draft's agent.
+        const legacyModes = parseNewSessionAgentModes(record);
+        if (legacyModes) {
+            agentModes[agentType] = legacyModes;
+        }
+    }
+    const sessionType: NewSessionSessionType = record.sessionType === 'worktree' ? 'worktree' : 'simple';
+    const worktreeKey = typeof record.worktreeKey === 'string' ? record.worktreeKey : null;
+    const updatedAt = typeof record.updatedAt === 'number' ? record.updatedAt : Date.now();
+
+    return {
+        input,
+        selectedMachineId,
+        selectedPath,
+        agentType,
+        agentModes,
+        sessionType,
+        worktreeKey,
+        updatedAt,
+    };
+}
+
 export function loadNewSessionDraft(): NewSessionDraft | null {
     const raw = mmkv.getString(NEW_SESSION_DRAFT_KEY);
     if (!raw) {
         return null;
     }
     try {
-        const parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== 'object') {
-            return null;
-        }
-
-        const input = typeof parsed.input === 'string' ? parsed.input : '';
-        const selectedMachineId = typeof parsed.selectedMachineId === 'string' ? parsed.selectedMachineId : null;
-        const selectedPath = typeof parsed.selectedPath === 'string' ? parsed.selectedPath : null;
-        const agentType: NewSessionAgentType = parsed.agentType === 'codex' || parsed.agentType === 'gemini' || parsed.agentType === 'openclaw' || parsed.agentType === 'agy'
-            ? parsed.agentType
-            : 'claude';
-        const permissionMode: PermissionModeKey | null = typeof parsed.permissionMode === 'string'
-            ? parsed.permissionMode
-            : null;
-        const modelMode: string | null = typeof parsed.modelMode === 'string' ? parsed.modelMode : null;
-        const effortLevel: string | null = typeof parsed.effortLevel === 'string' ? parsed.effortLevel : null;
-        const sessionType: NewSessionSessionType = parsed.sessionType === 'worktree' ? 'worktree' : 'simple';
-        const worktreeKey = typeof parsed.worktreeKey === 'string' ? parsed.worktreeKey : null;
-        const updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now();
-
-        return {
-            input,
-            selectedMachineId,
-            selectedPath,
-            agentType,
-            permissionMode,
-            modelMode,
-            effortLevel,
-            sessionType,
-            worktreeKey,
-            updatedAt,
-        };
+        return parseNewSessionDraft(JSON.parse(raw));
     } catch (e) {
         console.error('Failed to parse new session draft', e);
         return null;


### PR DESCRIPTION
## Context

Switching agents in HomeDock silently resets the user's model/permission/effort choices. `selectAgent()` overwrites the shared draft fields with the new agent's defaults, so e.g. picking a non-default Claude model, toggling to Codex to run something, and coming back leaves the Claude picker back on its default — every time. The new-session screen (`new/index.tsx`) doesn't clobber, so the two entry points also disagree about what an agent switch does.

## What changed

- The new-session draft now stores mode selections per agent (`agentModes` map in `persistence.ts`), instead of one shared `permissionMode`/`modelMode`/`effortLevel` triple.
- `useNewSessionDraft` still exposes the flat fields, but they are a view of the currently selected agent; `setAgentType` swaps the view. Consumers (`new/index.tsx`, `useStartSessionFromDraft`) needed no changes.
- `HomeDock.selectAgent` no longer writes the target agent's defaults into the draft — saved selections restore, and agents without saved selections fall back to their defaults as before (via the existing `resolveOption`/`resolveAgentDefaultConfig` chain).
- Legacy drafts (single shared triple) migrate on load: the stored values are attributed to the draft's agent. Same storage key, no data loss.

## Tests

- `useNewSessionDraft.test.ts`: updated for the new shape; new case covering claude → codex → claude round-trip keeping each agent's model choice.
- `newSessionDraft.spec.ts` (new): draft parsing — per-agent shape, legacy migration, empty/garbage payloads.
- Full happy-app suite 784/784 green, `tsc --noEmit` clean.

(Screenshots of the agent-switch round-trip coming shortly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)