### PR TITLE
fix(app): clear stale draft selections when agent defaults change

### DIFF
--- a/packages/happy-app/sources/app/(app)/settings/agents.tsx
+++ b/packages/happy-app/sources/app/(app)/settings/agents.tsx
@@ -11,6 +11,7 @@ import {
     type ModeOption,
 } from '@/components/modelModeOptions';
 import { useSettingMutable } from '@/sync/storage';
+import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
 import {
     agentKeys,
     getCodeAgentDefaults,
@@ -60,6 +61,10 @@ export default function AgentDefaultsSettingsScreen() {
         value: string | null,
     ) => {
         setAgentDefaultOverrides(setAgentDefaultOverride(agentDefaultOverrides, agent, field, value));
+        // The new-session draft remembers the last manual selection and wins
+        // over defaults, so drop it — otherwise the default configured here
+        // would never take effect.
+        useNewSessionDraft.getState().clearAgentMode(agent, field);
     }, [agentDefaultOverrides, setAgentDefaultOverrides]);
 
     const renderOption = (
@@ -134,7 +139,10 @@ export default function AgentDefaultsSettingsScreen() {
                     title="Clear Overrides"
                     subtitle="Return every agent to code defaults"
                     icon={<Ionicons name="refresh-outline" size={29} color="#FF9500" />}
-                    onPress={() => setAgentDefaultOverrides({})}
+                    onPress={() => {
+                        setAgentDefaultOverrides({});
+                        useNewSessionDraft.getState().clearAllAgentModes();
+                    }}
                     disabled={Object.keys(agentDefaultOverrides).length === 0}
                     showChevron={false}
                 />

--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -760,12 +760,11 @@ export const HomeDock = React.memo(({
     }, [finishCloseFocusMode, focusPresentation]);
 
     const selectAgent = React.useCallback((agent: NewSessionAgentType) => {
-        const nextDefaults = resolveAgentDefaultConfig(defaultOverrides, agent);
+        // Mode selections live per agent in the draft, so switching agents
+        // restores the target agent's saved modes (or falls back to its
+        // defaults) instead of overwriting them.
         setAgentType(agent);
-        setPermissionMode(nextDefaults.permissionMode);
-        setModelMode(nextDefaults.modelMode);
-        if (nextDefaults.effortLevel) setEffortLevel(nextDefaults.effortLevel);
-    }, [defaultOverrides, setAgentType, setEffortLevel, setModelMode, setPermissionMode]);
+    }, [setAgentType]);
 
     React.useEffect(() => {
         if (availableAgents.length > 0 && !availableAgents.some((agent) => agent.key === agentType)) {

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
@@ -109,6 +109,49 @@ describe('useNewSessionDraft', () => {
         });
     });
 
+    it('clears a remembered selection so a new default can take effect', async () => {
+        const { useNewSessionDraft } = await import('./useNewSessionDraft');
+
+        useNewSessionDraft.getState().setModelMode('opus');
+        useNewSessionDraft.getState().setEffortLevel('high');
+
+        useNewSessionDraft.getState().clearAgentMode('claude', 'modelMode');
+
+        expect(useNewSessionDraft.getState().modelMode).toBeNull();
+        expect(useNewSessionDraft.getState().effortLevel).toBe('high');
+        expect(mockPersistence.saved.at(-1)?.agentModes).toEqual({
+            claude: { permissionMode: null, modelMode: null, effortLevel: 'high' },
+        });
+    });
+
+    it('only clears the flat view when the cleared agent is selected', async () => {
+        const { useNewSessionDraft } = await import('./useNewSessionDraft');
+
+        useNewSessionDraft.getState().setModelMode('opus');
+        useNewSessionDraft.getState().setAgentType('codex');
+        useNewSessionDraft.getState().setModelMode('gpt-5.5');
+
+        useNewSessionDraft.getState().clearAgentMode('claude', 'modelMode');
+
+        expect(useNewSessionDraft.getState().modelMode).toBe('gpt-5.5');
+        expect(mockPersistence.saved.at(-1)?.agentModes).toEqual({
+            codex: { permissionMode: null, modelMode: 'gpt-5.5', effortLevel: null },
+        });
+    });
+
+    it('clears every remembered selection when overrides are reset', async () => {
+        const { useNewSessionDraft } = await import('./useNewSessionDraft');
+
+        useNewSessionDraft.getState().setModelMode('opus');
+        useNewSessionDraft.getState().setAgentType('codex');
+        useNewSessionDraft.getState().setModelMode('gpt-5.5');
+
+        useNewSessionDraft.getState().clearAllAgentModes();
+
+        expect(useNewSessionDraft.getState().modelMode).toBeNull();
+        expect(mockPersistence.saved.at(-1)?.agentModes).toEqual({});
+    });
+
     it('keeps temporary image attachments in memory without persisting their file URIs', async () => {
         const { useNewSessionDraft } = await import('./useNewSessionDraft');
         const attachment = {

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+type AgentModes = {
+    permissionMode: string | null;
+    modelMode: string | null;
+    effortLevel: string | null;
+};
+
 type Draft = {
     input: string;
     selectedMachineId: string | null;
     selectedPath: string | null;
-    agentType: 'claude' | 'codex' | 'gemini' | 'openclaw';
-    permissionMode: string | null;
-    modelMode: string | null;
-    effortLevel: string | null;
+    agentType: 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy';
+    agentModes: Partial<Record<Draft['agentType'], AgentModes>>;
     sessionType: 'simple' | 'worktree';
     worktreeKey: string | null;
     updatedAt: number;
@@ -32,9 +36,7 @@ function persistedDraft(overrides: Partial<Draft> = {}): Draft {
         selectedMachineId: null,
         selectedPath: null,
         agentType: 'claude',
-        permissionMode: null,
-        modelMode: null,
-        effortLevel: null,
+        agentModes: {},
         sessionType: 'simple',
         worktreeKey: null,
         updatedAt: 1,
@@ -57,11 +59,11 @@ describe('useNewSessionDraft', () => {
         expect(useNewSessionDraft.getState().effortLevel).toBeNull();
     });
 
-    it('loads persisted permission, model, and effort defaults', async () => {
+    it('loads persisted permission, model, and effort defaults for the draft agent', async () => {
         mockPersistence.draft = persistedDraft({
-            permissionMode: 'yolo',
-            modelMode: 'opus',
-            effortLevel: 'xhigh',
+            agentModes: {
+                claude: { permissionMode: 'yolo', modelMode: 'opus', effortLevel: 'xhigh' },
+            },
         });
 
         const { useNewSessionDraft } = await import('./useNewSessionDraft');
@@ -77,7 +79,34 @@ describe('useNewSessionDraft', () => {
         useNewSessionDraft.getState().setEffortLevel('high');
 
         expect(useNewSessionDraft.getState().effortLevel).toBe('high');
-        expect(mockPersistence.saved.at(-1)).toMatchObject({ effortLevel: 'high' });
+        expect(mockPersistence.saved.at(-1)).toMatchObject({
+            agentModes: { claude: { effortLevel: 'high' } },
+        });
+    });
+
+    it('keeps mode selections per agent when switching agents', async () => {
+        const { useNewSessionDraft } = await import('./useNewSessionDraft');
+
+        useNewSessionDraft.getState().setModelMode('claude-opus-5');
+        useNewSessionDraft.getState().setPermissionMode('bypassPermissions');
+
+        useNewSessionDraft.getState().setAgentType('codex');
+        expect(useNewSessionDraft.getState().modelMode).toBeNull();
+        expect(useNewSessionDraft.getState().permissionMode).toBeNull();
+
+        useNewSessionDraft.getState().setModelMode('gpt-5.5');
+
+        useNewSessionDraft.getState().setAgentType('claude');
+        expect(useNewSessionDraft.getState().modelMode).toBe('claude-opus-5');
+        expect(useNewSessionDraft.getState().permissionMode).toBe('bypassPermissions');
+
+        useNewSessionDraft.getState().setAgentType('codex');
+        expect(useNewSessionDraft.getState().modelMode).toBe('gpt-5.5');
+
+        expect(mockPersistence.saved.at(-1)?.agentModes).toEqual({
+            claude: { permissionMode: 'bypassPermissions', modelMode: 'claude-opus-5', effortLevel: null },
+            codex: { permissionMode: null, modelMode: 'gpt-5.5', effortLevel: null },
+        });
     });
 
     it('keeps temporary image attachments in memory without persisting their file URIs', async () => {

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.ts
@@ -2,6 +2,11 @@
  * Zustand store for new session draft state, backed by MMKV.
  * Persists the user's last-used configuration (machine, path, agent, model, permissions, etc.)
  * so the new session screen restores the same defaults on next visit.
+ *
+ * Mode selections (permission/model/effort) are stored per agent: the flat
+ * `permissionMode`/`modelMode`/`effortLevel` fields always reflect the
+ * currently selected agent, and switching agents swaps that view instead of
+ * overwriting the selections made for another agent.
  */
 import { create } from 'zustand';
 import {
@@ -20,6 +25,7 @@ interface NewSessionDraftState {
     selectedMachineId: string | null;
     selectedPath: string | null;
     agentType: NewSessionAgentType;
+    agentModes: NewSessionDraft['agentModes'];
     permissionMode: PermissionModeKey | null;
     modelMode: string | null;
     effortLevel: string | null;
@@ -44,16 +50,34 @@ function persist(state: NewSessionDraftState) {
         selectedMachineId: state.selectedMachineId,
         selectedPath: state.selectedPath,
         agentType: state.agentType,
-        permissionMode: state.permissionMode,
-        modelMode: state.modelMode,
-        effortLevel: state.effortLevel,
+        agentModes: state.agentModes,
         sessionType: state.sessionType,
         worktreeKey: state.worktreeKey,
         updatedAt: Date.now(),
     });
 }
 
+function updateAgentMode(
+    state: NewSessionDraftState,
+    patch: Partial<Pick<NewSessionDraftState, 'permissionMode' | 'modelMode' | 'effortLevel'>>,
+): Partial<NewSessionDraftState> {
+    const current = state.agentModes[state.agentType];
+    return {
+        ...patch,
+        agentModes: {
+            ...state.agentModes,
+            [state.agentType]: {
+                permissionMode: patch.permissionMode ?? current?.permissionMode ?? null,
+                modelMode: patch.modelMode ?? current?.modelMode ?? null,
+                effortLevel: patch.effortLevel ?? current?.effortLevel ?? null,
+            },
+        },
+    };
+}
+
 const initial = loadNewSessionDraft();
+const initialAgent = initial?.agentType ?? 'claude';
+const initialModes = initial?.agentModes?.[initialAgent];
 
 export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => ({
     input: initial?.input ?? '',
@@ -62,10 +86,11 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     attachments: [],
     selectedMachineId: initial?.selectedMachineId ?? null,
     selectedPath: initial?.selectedPath ?? null,
-    agentType: initial?.agentType ?? 'claude',
-    permissionMode: initial?.permissionMode ?? null,
-    modelMode: initial?.modelMode ?? null,
-    effortLevel: initial?.effortLevel ?? null,
+    agentType: initialAgent,
+    agentModes: initial?.agentModes ?? {},
+    permissionMode: initialModes?.permissionMode ?? null,
+    modelMode: initialModes?.modelMode ?? null,
+    effortLevel: initialModes?.effortLevel ?? null,
     sessionType: initial?.sessionType ?? 'simple',
     worktreeKey: initial?.worktreeKey ?? null,
 
@@ -73,10 +98,19 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     setAttachments: (attachments) => { set({ attachments }); },
     setMachineId: (id) => { set({ selectedMachineId: id, selectedPath: null, worktreeKey: null }); persist(get()); },
     setPath: (path) => { set({ selectedPath: path, worktreeKey: null }); persist(get()); },
-    setAgentType: (agent) => { set({ agentType: agent }); persist(get()); },
-    setPermissionMode: (mode) => { set({ permissionMode: mode }); persist(get()); },
-    setModelMode: (mode) => { set({ modelMode: mode }); persist(get()); },
-    setEffortLevel: (level) => { set({ effortLevel: level }); persist(get()); },
+    setAgentType: (agent) => {
+        const modes = get().agentModes[agent];
+        set({
+            agentType: agent,
+            permissionMode: modes?.permissionMode ?? null,
+            modelMode: modes?.modelMode ?? null,
+            effortLevel: modes?.effortLevel ?? null,
+        });
+        persist(get());
+    },
+    setPermissionMode: (mode) => { set(updateAgentMode(get(), { permissionMode: mode })); persist(get()); },
+    setModelMode: (mode) => { set(updateAgentMode(get(), { modelMode: mode })); persist(get()); },
+    setEffortLevel: (level) => { set(updateAgentMode(get(), { effortLevel: level })); persist(get()); },
     setSessionType: (type) => { set({ sessionType: type }); persist(get()); },
     setWorktreeKey: (key) => { set({ worktreeKey: key }); persist(get()); },
 }));

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.ts
@@ -42,7 +42,11 @@ interface NewSessionDraftState {
     setEffortLevel: (level: string) => void;
     setSessionType: (type: NewSessionSessionType) => void;
     setWorktreeKey: (key: string | null) => void;
+    clearAgentMode: (agent: NewSessionAgentType, field: AgentModeField) => void;
+    clearAllAgentModes: () => void;
 }
+
+type AgentModeField = 'permissionMode' | 'modelMode' | 'effortLevel';
 
 function persist(state: NewSessionDraftState) {
     saveNewSessionDraft({
@@ -113,4 +117,29 @@ export const useNewSessionDraft = create<NewSessionDraftState>()((set, get) => (
     setEffortLevel: (level) => { set(updateAgentMode(get(), { effortLevel: level })); persist(get()); },
     setSessionType: (type) => { set({ sessionType: type }); persist(get()); },
     setWorktreeKey: (key) => { set({ worktreeKey: key }); persist(get()); },
+    // Drop a remembered selection so a newly configured agent default isn't
+    // shadowed by it (the draft always wins over defaults when resolving).
+    clearAgentMode: (agent, field) => {
+        const state = get();
+        const current = state.agentModes[agent];
+        if (!current) {
+            return;
+        }
+        const nextEntry = { ...current, [field]: null };
+        const agentModes = { ...state.agentModes };
+        if (nextEntry.permissionMode === null && nextEntry.modelMode === null && nextEntry.effortLevel === null) {
+            delete agentModes[agent];
+        } else {
+            agentModes[agent] = nextEntry;
+        }
+        set({
+            agentModes,
+            ...(state.agentType === agent ? { [field]: null } : {}),
+        });
+        persist(get());
+    },
+    clearAllAgentModes: () => {
+        set({ agentModes: {}, permissionMode: null, modelMode: null, effortLevel: null });
+        persist(get());
+    },
 }));

--- a/packages/happy-app/sources/sync/newSessionDraft.spec.ts
+++ b/packages/happy-app/sources/sync/newSessionDraft.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native-mmkv', () => ({
+    MMKV: class {
+        private store = new Map<string, string>();
+        getString(key: string) { return this.store.get(key); }
+        set(key: string, value: string) { this.store.set(key, value); }
+        delete(key: string) { this.store.delete(key); }
+    },
+}));
+
+import { parseNewSessionDraft } from './persistence';
+
+describe('parseNewSessionDraft', () => {
+    it('parses per-agent mode selections', () => {
+        const draft = parseNewSessionDraft({
+            input: 'hello',
+            agentType: 'codex',
+            agentModes: {
+                claude: { permissionMode: 'bypassPermissions', modelMode: 'claude-opus-5', effortLevel: null },
+                codex: { permissionMode: 'yolo', modelMode: 'gpt-5.5', effortLevel: 'high' },
+                bogus: { modelMode: 'nope' },
+            },
+            sessionType: 'simple',
+            updatedAt: 42,
+        });
+
+        expect(draft).not.toBeNull();
+        expect(draft!.agentType).toBe('codex');
+        expect(draft!.agentModes).toEqual({
+            claude: { permissionMode: 'bypassPermissions', modelMode: 'claude-opus-5', effortLevel: null },
+            codex: { permissionMode: 'yolo', modelMode: 'gpt-5.5', effortLevel: 'high' },
+        });
+    });
+
+    it('migrates legacy drafts with shared mode fields to the draft agent', () => {
+        const draft = parseNewSessionDraft({
+            input: '',
+            agentType: 'claude',
+            permissionMode: 'bypassPermissions',
+            modelMode: 'opus',
+            effortLevel: null,
+            sessionType: 'simple',
+            updatedAt: 42,
+        });
+
+        expect(draft!.agentModes).toEqual({
+            claude: { permissionMode: 'bypassPermissions', modelMode: 'opus', effortLevel: null },
+        });
+    });
+
+    it('leaves agentModes empty when a legacy draft has no mode selections', () => {
+        const draft = parseNewSessionDraft({
+            input: '',
+            agentType: 'claude',
+            sessionType: 'simple',
+            updatedAt: 42,
+        });
+
+        expect(draft!.agentModes).toEqual({});
+    });
+
+    it('returns null for non-object payloads', () => {
+        expect(parseNewSessionDraft(null)).toBeNull();
+        expect(parseNewSessionDraft('nope')).toBeNull();
+    });
+});

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -15,14 +15,22 @@ const VOICE_MESSAGE_COUNT_KEY = 'voice-message-count';
 export type NewSessionAgentType = 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy';
 export type NewSessionSessionType = 'simple' | 'worktree';
 
+const NEW_SESSION_AGENT_TYPES: NewSessionAgentType[] = ['claude', 'codex', 'gemini', 'openclaw', 'agy'];
+
+export interface NewSessionAgentModes {
+    permissionMode: PermissionModeKey | null;
+    modelMode: string | null;
+    effortLevel: string | null;
+}
+
 export interface NewSessionDraft {
     input: string;
     selectedMachineId: string | null;
     selectedPath: string | null;
     agentType: NewSessionAgentType;
-    permissionMode: PermissionModeKey | null;
-    modelMode: string | null;
-    effortLevel: string | null;
+    // Mode selections are stored per agent so switching agents doesn't
+    // overwrite the selections made for another one.
+    agentModes: Partial<Record<NewSessionAgentType, NewSessionAgentModes>>;
     sessionType: NewSessionSessionType;
     worktreeKey: string | null;
     updatedAt: number;
@@ -132,44 +140,74 @@ export function saveSessionDrafts(drafts: Record<string, string>) {
     mmkv.set('session-drafts', JSON.stringify(drafts));
 }
 
+function parseNewSessionAgentModes(value: unknown): NewSessionAgentModes | null {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const record = value as Record<string, unknown>;
+    const permissionMode: PermissionModeKey | null = typeof record.permissionMode === 'string'
+        ? record.permissionMode
+        : null;
+    const modelMode: string | null = typeof record.modelMode === 'string' ? record.modelMode : null;
+    const effortLevel: string | null = typeof record.effortLevel === 'string' ? record.effortLevel : null;
+    if (permissionMode === null && modelMode === null && effortLevel === null) {
+        return null;
+    }
+    return { permissionMode, modelMode, effortLevel };
+}
+
+export function parseNewSessionDraft(parsed: unknown): NewSessionDraft | null {
+    if (!parsed || typeof parsed !== 'object') {
+        return null;
+    }
+    const record = parsed as Record<string, unknown>;
+
+    const input = typeof record.input === 'string' ? record.input : '';
+    const selectedMachineId = typeof record.selectedMachineId === 'string' ? record.selectedMachineId : null;
+    const selectedPath = typeof record.selectedPath === 'string' ? record.selectedPath : null;
+    const agentType: NewSessionAgentType = record.agentType === 'codex' || record.agentType === 'gemini' || record.agentType === 'openclaw' || record.agentType === 'agy'
+        ? record.agentType
+        : 'claude';
+    const agentModes: NewSessionDraft['agentModes'] = {};
+    if (record.agentModes && typeof record.agentModes === 'object') {
+        const rawModes = record.agentModes as Record<string, unknown>;
+        for (const agent of NEW_SESSION_AGENT_TYPES) {
+            const modes = parseNewSessionAgentModes(rawModes[agent]);
+            if (modes) {
+                agentModes[agent] = modes;
+            }
+        }
+    } else {
+        // Migrate legacy drafts that stored a single shared mode selection:
+        // attribute it to the draft's agent.
+        const legacyModes = parseNewSessionAgentModes(record);
+        if (legacyModes) {
+            agentModes[agentType] = legacyModes;
+        }
+    }
+    const sessionType: NewSessionSessionType = record.sessionType === 'worktree' ? 'worktree' : 'simple';
+    const worktreeKey = typeof record.worktreeKey === 'string' ? record.worktreeKey : null;
+    const updatedAt = typeof record.updatedAt === 'number' ? record.updatedAt : Date.now();
+
+    return {
+        input,
+        selectedMachineId,
+        selectedPath,
+        agentType,
+        agentModes,
+        sessionType,
+        worktreeKey,
+        updatedAt,
+    };
+}
+
 export function loadNewSessionDraft(): NewSessionDraft | null {
     const raw = mmkv.getString(NEW_SESSION_DRAFT_KEY);
     if (!raw) {
         return null;
     }
     try {
-        const parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== 'object') {
-            return null;
-        }
-
-        const input = typeof parsed.input === 'string' ? parsed.input : '';
-        const selectedMachineId = typeof parsed.selectedMachineId === 'string' ? parsed.selectedMachineId : null;
-        const selectedPath = typeof parsed.selectedPath === 'string' ? parsed.selectedPath : null;
-        const agentType: NewSessionAgentType = parsed.agentType === 'codex' || parsed.agentType === 'gemini' || parsed.agentType === 'openclaw' || parsed.agentType === 'agy'
-            ? parsed.agentType
-            : 'claude';
-        const permissionMode: PermissionModeKey | null = typeof parsed.permissionMode === 'string'
-            ? parsed.permissionMode
-            : null;
-        const modelMode: string | null = typeof parsed.modelMode === 'string' ? parsed.modelMode : null;
-        const effortLevel: string | null = typeof parsed.effortLevel === 'string' ? parsed.effortLevel : null;
-        const sessionType: NewSessionSessionType = parsed.sessionType === 'worktree' ? 'worktree' : 'simple';
-        const worktreeKey = typeof parsed.worktreeKey === 'string' ? parsed.worktreeKey : null;
-        const updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now();
-
-        return {
-            input,
-            selectedMachineId,
-            selectedPath,
-            agentType,
-            permissionMode,
-            modelMode,
-            effortLevel,
-            sessionType,
-            worktreeKey,
-            updatedAt,
-        };
+        return parseNewSessionDraft(JSON.parse(raw));
     } catch (e) {
         console.error('Failed to parse new session draft', e);
         return null;


### PR DESCRIPTION
## Context

Configuring an agent default in Settings → Agents can silently do nothing. The new-session draft remembers the user's last manual mode selection and always wins over configured defaults in the resolution chain (draft → override → code default), so any older remembered pick permanently shadows a newly configured default. Concretely: set Opus 5 as the Claude default, and new sessions keep spawning with a remembered `opus` pick — with no indication why.

## What changed

- `useNewSessionDraft`: new `clearAgentMode(agent, field)` (drops one remembered selection; removes the agent's entry entirely when all fields are empty; keeps the current-agent view in sync) and `clearAllAgentModes()`.
- Settings → Agents: changing any default (including selecting "Use code default") clears the matching remembered draft selection for that agent; "Clear Overrides" clears all remembered selections.
- Net effect: the moment you configure a default, it actually takes effect for the next session.

## Notes for review

**Stacked on #1568** (per-agent draft modes) — please review only the last commit (`0302bf29`); the first commit is #1568's. I'll rebase onto main once #1568 lands.

## Tests

3 new cases in `useNewSessionDraft.test.ts`: clearing one field leaves the agent's other fields intact; clearing another agent's selection doesn't touch the current agent's view; reset clears everything. Full happy-app suite 787/787 green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)