### PR TITLE
feat(cli,app): support image attachments in agy sessions

### DIFF
--- a/packages/happy-app/sources/sync/attachmentSupport.test.ts
+++ b/packages/happy-app/sources/sync/attachmentSupport.test.ts
@@ -7,11 +7,12 @@ import {
 } from './attachmentSupport';
 
 describe('supportsImageAttachmentsForFlavor', () => {
-    it('supports legacy sessions, Claude, and Codex', () => {
+    it('supports legacy sessions, Claude, Codex, and agy', () => {
         expect(supportsImageAttachmentsForFlavor(undefined)).toBe(true);
         expect(supportsImageAttachmentsForFlavor(null)).toBe(true);
         expect(supportsImageAttachmentsForFlavor('claude')).toBe(true);
         expect(supportsImageAttachmentsForFlavor('codex')).toBe(true);
+        expect(supportsImageAttachmentsForFlavor('agy')).toBe(true);
     });
 
     it('rejects Gemini, OpenClaw, and unknown explicit flavors', () => {

--- a/packages/happy-app/sources/sync/attachmentSupport.ts
+++ b/packages/happy-app/sources/sync/attachmentSupport.ts
@@ -8,7 +8,7 @@ export type ImageAttachmentSendPlan = {
 };
 
 export function supportsImageAttachmentsForFlavor(flavor: ImageAttachmentFlavor): boolean {
-    return !flavor || flavor === 'claude' || flavor === 'codex';
+    return !flavor || flavor === 'claude' || flavor === 'codex' || flavor === 'agy';
 }
 
 export function getImageAttachmentSendPlan(opts: {

--- a/packages/happy-cli/src/agy/AgyBackend.test.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.test.ts
@@ -61,6 +61,27 @@ describe('AgyBackend', () => {
     expect(messages.at(-1)).toMatchObject({ type: 'status', status: 'idle' });
   });
 
+  it('passes per-turn extra add-dirs through to the agy argv', async () => {
+    const { child } = makeFakeChild();
+    const spawnFn = vi.fn(() => child) as unknown as SpawnFn;
+
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      spawnFn,
+      resolveConversationId: () => null,
+    });
+
+    await backend.startSession();
+    const turn = backend.sendPrompt('/work', 'hi', { extraAddDirs: ['/cache/session-1'] });
+    child.emit('close', 0);
+    await turn;
+
+    const args = (spawnFn as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as string[];
+    const addDirs = args.flatMap((a, i) => (a === '--add-dir' ? [args[i + 1]] : []));
+    expect(addDirs).toEqual(['/work', '/cache/session-1']);
+  });
+
   it('emits an error status and rejects on non-zero exit', async () => {
     const { child } = makeFakeChild();
     const spawnFn = vi.fn(() => child) as unknown as SpawnFn;

--- a/packages/happy-cli/src/agy/AgyBackend.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.ts
@@ -98,13 +98,20 @@ export class AgyBackend implements AgentBackend {
     return { sessionId: this.cwd };
   }
 
-  async sendPrompt(_sessionId: SessionId, prompt: string): Promise<void> {
+  async sendPrompt(
+    _sessionId: SessionId,
+    prompt: string,
+    opts?: {
+      /** Extra dirs exposed for this turn only (e.g. the session's image cache). */
+      extraAddDirs?: string[];
+    },
+  ): Promise<void> {
     const args = buildAgyArgs({
       prompt,
       model: this.model,
       conversationId: this.conversationId,
       permissionMode: this.permissionMode,
-      addDirs: [this.cwd],
+      addDirs: [this.cwd, ...(opts?.extraAddDirs ?? [])],
       printTimeout: this.printTimeout,
     });
 

--- a/packages/happy-cli/src/agy/imageInput.test.ts
+++ b/packages/happy-cli/src/agy/imageInput.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/ui/logger', () => ({
+    logger: { debug: vi.fn() },
+}));
+
+vi.mock('@/configuration', () => ({
+    configuration: { happyHomeDir: '/home/test/.happy' },
+}));
+
+import { buildAgyImagePrompt, cleanupAgyImageCache, prepareAgyImageFiles } from './imageInput';
+
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'happy-agy-image-input-'));
+    tempDirs.push(dir);
+    return dir;
+}
+
+afterEach(async () => {
+    while (tempDirs.length > 0) {
+        const dir = tempDirs.pop()!;
+        await rm(dir, { recursive: true, force: true });
+    }
+});
+
+describe('prepareAgyImageFiles', () => {
+    it('returns empty result without touching disk when there are no attachments', async () => {
+        const result = await prepareAgyImageFiles(undefined, { sessionId: 'session-1' });
+        expect(result).toEqual({ paths: [], skipped: 0, cacheDir: null });
+    });
+
+    it('writes supported images into a session-scoped dir and skips unsupported bytes', async () => {
+        const cacheRootDir = await makeTempDir();
+        const result = await prepareAgyImageFiles(
+            [
+                { data: PNG_MAGIC, mimeType: 'image/png', name: 'shot.png' },
+                { data: new TextEncoder().encode('not an image'), mimeType: 'image/png', name: 'fake.png' },
+            ],
+            { sessionId: 'session-1', cacheRootDir },
+        );
+
+        expect(result.skipped).toBe(1);
+        expect(result.paths).toHaveLength(1);
+        // The session segment is a hash of the raw id, so only assert structure:
+        // a direct child of the cache root, stable across calls for the same id.
+        expect(result.cacheDir!.startsWith(cacheRootDir + '/')).toBe(true);
+        expect(join(result.cacheDir!, '..')).toBe(cacheRootDir);
+        expect(result.paths[0].startsWith(result.cacheDir!)).toBe(true);
+        expect(result.paths[0].endsWith('.png')).toBe(true);
+
+        const written = await readFile(result.paths[0]);
+        expect(new Uint8Array(written)).toEqual(PNG_MAGIC);
+        const dirStat = await stat(result.cacheDir!);
+        expect(dirStat.mode & 0o777).toBe(0o700);
+    });
+
+    it('maps sessions to distinct dirs even when ids collide under path sanitization', async () => {
+        const cacheRootDir = await makeTempDir();
+        const att = () => [{ data: PNG_MAGIC, mimeType: 'image/png', name: 'a.png' }];
+        const a = await prepareAgyImageFiles(att(), { sessionId: 'abc/def', cacheRootDir });
+        const b = await prepareAgyImageFiles(att(), { sessionId: 'abc_def', cacheRootDir });
+        const c = await prepareAgyImageFiles(att(), { sessionId: '///', cacheRootDir });
+        const d = await prepareAgyImageFiles(att(), { sessionId: '...', cacheRootDir });
+        const dirs = [a.cacheDir, b.cacheDir, c.cacheDir, d.cacheDir];
+        expect(new Set(dirs).size).toBe(4);
+        // Same id stays deterministic.
+        const a2 = await prepareAgyImageFiles(att(), { sessionId: 'abc/def', cacheRootDir });
+        expect(a2.cacheDir).toBe(a.cacheDir);
+    });
+
+    it('reports no cacheDir when every attachment is skipped', async () => {
+        const cacheRootDir = await makeTempDir();
+        const result = await prepareAgyImageFiles(
+            [{ data: new TextEncoder().encode('nope'), mimeType: 'image/png', name: 'fake.png' }],
+            { sessionId: 'session-1', cacheRootDir },
+        );
+        expect(result).toEqual({ paths: [], skipped: 1, cacheDir: null });
+    });
+});
+
+describe('cleanupAgyImageCache', () => {
+    it('removes the session dir and leaves other sessions alone', async () => {
+        const cacheRootDir = await makeTempDir();
+        const mine = await prepareAgyImageFiles(
+            [{ data: PNG_MAGIC, mimeType: 'image/png', name: 'a.png' }],
+            { sessionId: 'session-1', cacheRootDir },
+        );
+        const other = await prepareAgyImageFiles(
+            [{ data: PNG_MAGIC, mimeType: 'image/png', name: 'b.png' }],
+            { sessionId: 'session-2', cacheRootDir },
+        );
+
+        await cleanupAgyImageCache({ sessionId: 'session-1', cacheRootDir });
+
+        await expect(stat(mine.cacheDir!)).rejects.toMatchObject({ code: 'ENOENT' });
+        expect(await readdir(other.cacheDir!)).toHaveLength(1);
+    });
+
+    it('is a no-op for a session that never wrote images', async () => {
+        const cacheRootDir = await makeTempDir();
+        await expect(cleanupAgyImageCache({ sessionId: 'never-there', cacheRootDir })).resolves.toBeUndefined();
+    });
+});
+
+describe('buildAgyImagePrompt', () => {
+    it('passes text through untouched when there are no image paths', () => {
+        expect(buildAgyImagePrompt('hello', [])).toBe('hello');
+    });
+
+    it('prefixes the path list and isolation instruction before the user text', () => {
+        const prompt = buildAgyImagePrompt('what is this?', ['/cache/s1/a.png']);
+        expect(prompt).toContain('an image file');
+        expect(prompt).toContain('- /cache/s1/a.png');
+        expect(prompt.endsWith('what is this?')).toBe(true);
+        expect(prompt.indexOf('/cache/s1/a.png')).toBeLessThan(prompt.indexOf('what is this?'));
+    });
+
+    it('sends only the header for image-only messages and counts multiple files', () => {
+        const prompt = buildAgyImagePrompt('   ', ['/cache/s1/a.png', '/cache/s1/b.jpg']);
+        expect(prompt).toContain('2 image files');
+        expect(prompt).toContain('- /cache/s1/a.png');
+        expect(prompt).toContain('- /cache/s1/b.jpg');
+        expect(prompt.trim().endsWith('b.jpg')).toBe(true);
+    });
+});

--- a/packages/happy-cli/src/agy/imageInput.test.ts
+++ b/packages/happy-cli/src/agy/imageInput.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/configuration', () => ({
     configuration: { happyHomeDir: '/home/test/.happy' },
 }));
 
-import { buildAgyImagePrompt, cleanupAgyImageCache, prepareAgyImageFiles } from './imageInput';
+import { buildAgyImagePrompt, cleanupAgyImageCache, prepareAgyImageFiles, sweepStaleAgyImageCache } from './imageInput';
 
 const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
@@ -107,6 +107,38 @@ describe('cleanupAgyImageCache', () => {
     it('is a no-op for a session that never wrote images', async () => {
         const cacheRootDir = await makeTempDir();
         await expect(cleanupAgyImageCache({ sessionId: 'never-there', cacheRootDir })).resolves.toBeUndefined();
+    });
+});
+
+describe('sweepStaleAgyImageCache', () => {
+    it('removes only dirs older than the age gate', async () => {
+        const cacheRootDir = await makeTempDir();
+        const stale = await prepareAgyImageFiles(
+            [{ data: PNG_MAGIC, mimeType: 'image/png', name: 'a.png' }],
+            { sessionId: 'stale-session', cacheRootDir },
+        );
+        const fresh = await prepareAgyImageFiles(
+            [{ data: PNG_MAGIC, mimeType: 'image/png', name: 'b.png' }],
+            { sessionId: 'fresh-session', cacheRootDir },
+        );
+
+        // Both dirs were just written; a clock far in the future ages out both,
+        // so gate "stale" by age and protect "fresh" via maxAgeMs instead:
+        // sweep with now = real now → nothing old enough → both survive.
+        await sweepStaleAgyImageCache({ cacheRootDir });
+        expect(await readdir(stale.cacheDir!)).toHaveLength(1);
+
+        // now pushed past the gate → everything qualifies as stale.
+        const weekAndABit = 8 * 24 * 60 * 60 * 1000;
+        await sweepStaleAgyImageCache({ cacheRootDir, now: () => Date.now() + weekAndABit });
+        await expect(stat(stale.cacheDir!)).rejects.toMatchObject({ code: 'ENOENT' });
+        await expect(stat(fresh.cacheDir!)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
+    it('is a no-op when the cache root does not exist', async () => {
+        await expect(
+            sweepStaleAgyImageCache({ cacheRootDir: join(tmpdir(), 'happy-agy-no-such-root') }),
+        ).resolves.toBeUndefined();
     });
 });
 

--- a/packages/happy-cli/src/agy/imageInput.ts
+++ b/packages/happy-cli/src/agy/imageInput.ts
@@ -14,7 +14,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { rm } from 'node:fs/promises';
+import { readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { configuration } from '@/configuration';
@@ -86,6 +86,44 @@ export async function cleanupAgyImageCache(opts: {
         logger.debug('[agy] Failed to clean image cache', {
             errorName: error instanceof Error ? error.name : typeof error,
         });
+    }
+}
+
+const STALE_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Best-effort sweep of session dirs left behind by hard exits: a bare SIGTERM
+ * (the daemon's stop signal) can skip the session-end cleanup, and dirs are
+ * keyed by hashed session id, so nothing else ever revisits them. Age-gated so
+ * a concurrent live session's fresh dir is never touched.
+ */
+export async function sweepStaleAgyImageCache(opts: {
+    cacheRootDir?: string;
+    maxAgeMs?: number;
+    now?: () => number;
+} = {}): Promise<void> {
+    const root = agyImageCacheRoot(opts.cacheRootDir);
+    const maxAgeMs = opts.maxAgeMs ?? STALE_CACHE_MAX_AGE_MS;
+    const now = opts.now ?? Date.now;
+    let entries;
+    try {
+        entries = await readdir(root, { withFileTypes: true });
+    } catch {
+        return; // no cache root yet — nothing to sweep
+    }
+    for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const dir = join(root, entry.name);
+        try {
+            const info = await stat(dir);
+            if (now() - info.mtimeMs > maxAgeMs) {
+                await rm(dir, { recursive: true, force: true });
+            }
+        } catch (error) {
+            logger.debug('[agy] Failed to sweep stale image cache dir', {
+                errorName: error instanceof Error ? error.name : typeof error,
+            });
+        }
     }
 }
 

--- a/packages/happy-cli/src/agy/imageInput.ts
+++ b/packages/happy-cli/src/agy/imageInput.ts
@@ -1,0 +1,106 @@
+/**
+ * Agy image input preparation
+ *
+ * agy has no image-input flag; its only viable image path is the filesystem:
+ * decode the wire attachments into a session-scoped cache dir, expose that dir
+ * via `--add-dir`, and reference the file paths in the prompt. Decoding and
+ * cache-dir layout are reused from the Codex helpers (same magic-byte
+ * detection, same permissions), only the cache root differs.
+ *
+ * Isolation is guaranteed by directory structure, not prompt wording: given a
+ * nonexistent path agy has been observed to scan the surrounding directory and
+ * describe unrelated files, so the session dir must contain only this
+ * session's attachments and must never point at a shared location.
+ */
+
+import { createHash } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { configuration } from '@/configuration';
+import { logger } from '@/ui/logger';
+import type { PendingAttachment } from '@/utils/MessageQueue2';
+
+import { prepareCodexImageInputItems, resolveCodexImageCacheDir } from '@/codex/utils/imageInput';
+
+function agyImageCacheRoot(cacheRootDir?: string): string {
+    return cacheRootDir ?? join(configuration.happyHomeDir, 'agy-image-cache');
+}
+
+/**
+ * Collision-proof per-session directory segment. The codex sanitizer is not
+ * injective ('a/b' and 'a_b' collide) and degenerate ids collapse into fixed
+ * shared buckets — unacceptable here because the dir is handed to --add-dir
+ * and rm -rf'd at session end, so two sessions must never share a dir even
+ * for hostile server-issued ids. Hashing the raw id makes that structural.
+ */
+function sessionCacheKey(sessionId: string): string {
+    return createHash('sha256').update(sessionId).digest('hex').slice(0, 32);
+}
+
+export type PreparedAgyImages = {
+    /** Absolute paths of the decoded image files, in attachment order. */
+    paths: string[];
+    /** Attachments dropped because their bytes matched no supported format. */
+    skipped: number;
+    /** Session cache dir holding the files; null when nothing was written. */
+    cacheDir: string | null;
+};
+
+export async function prepareAgyImageFiles(
+    attachments: PendingAttachment[] | undefined,
+    opts: {
+        sessionId: string;
+        cacheRootDir?: string;
+    },
+): Promise<PreparedAgyImages> {
+    const prepared = await prepareCodexImageInputItems(attachments, {
+        sessionId: sessionCacheKey(opts.sessionId),
+        cacheRootDir: agyImageCacheRoot(opts.cacheRootDir),
+    });
+    const paths = prepared.inputItems.flatMap((item) => (item.type === 'localImage' ? [item.path] : []));
+    return {
+        paths,
+        skipped: prepared.skipped,
+        cacheDir: paths.length > 0
+            ? resolveCodexImageCacheDir({
+                sessionId: sessionCacheKey(opts.sessionId),
+                cacheRootDir: agyImageCacheRoot(opts.cacheRootDir),
+            })
+            : null,
+    };
+}
+
+/** Best-effort removal of the session's image cache dir (session end). */
+export async function cleanupAgyImageCache(opts: {
+    sessionId: string;
+    cacheRootDir?: string;
+}): Promise<void> {
+    const cacheDir = resolveCodexImageCacheDir({
+        sessionId: sessionCacheKey(opts.sessionId),
+        cacheRootDir: agyImageCacheRoot(opts.cacheRootDir),
+    });
+    try {
+        await rm(cacheDir, { recursive: true, force: true });
+    } catch (error) {
+        logger.debug('[agy] Failed to clean image cache', {
+            errorName: error instanceof Error ? error.name : typeof error,
+        });
+    }
+}
+
+/**
+ * Prefix the turn prompt with the attached file paths. The "ONLY these exact
+ * paths" instruction is belt on top of the directory-isolation suspenders —
+ * assume it may be ignored; the cache dir layout is what actually bounds agy.
+ */
+export function buildAgyImagePrompt(userText: string, paths: string[]): string {
+    if (paths.length === 0) {
+        return userText;
+    }
+    const list = paths.map((p) => `- ${p}`).join('\n');
+    const noun = paths.length === 1 ? 'an image file' : `${paths.length} image files`;
+    const header = `The user attached ${noun} to this message. Read and consider ONLY these exact file paths; if one does not exist, say so instead of searching for other files:\n${list}`;
+    const text = userText.trim();
+    return text.length > 0 ? `${header}\n\n${userText}` : header;
+}

--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -35,7 +35,7 @@ import { downloadCodexFileEventAttachment } from '@/codex/utils/attachmentEvents
 import { createSerialAsyncHandler } from '@/codex/utils/serialAsyncHandler';
 import { AgyBackend } from './AgyBackend';
 import { DEFAULT_AGY_MODEL } from './constants';
-import { buildAgyImagePrompt, cleanupAgyImageCache, prepareAgyImageFiles } from './imageInput';
+import { buildAgyImagePrompt, cleanupAgyImageCache, prepareAgyImageFiles, sweepStaleAgyImageCache } from './imageInput';
 
 export interface RunAgyOptions {
   credentials: Credentials;
@@ -103,11 +103,23 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
     }
   }
 
+  // The daemon stops sessions with a bare SIGTERM, which would skip the
+  // `finally` below and leak this session's image cache dir — nothing ever
+  // revisits it (keyed by hashed session id). Clean up on the way out, and
+  // sweep dirs older sessions left behind the same way.
+  void sweepStaleAgyImageCache();
+  const cleanupOnSignal = () => {
+    void cleanupAgyImageCache({ sessionId: session.sessionId }).finally(() => process.exit(0));
+  };
+  process.on('SIGTERM', cleanupOnSignal);
+  process.on('SIGINT', cleanupOnSignal);
+
   const sessionManager = new AcpSessionManager();
   const messageQueue = new MessageQueue2<Record<string, never>>(() => '');
   let shouldExit = false;
   let abortController = new AbortController();
   let thinking = false;
+  let imageCacheDir: string | null = null;
 
   let displayedModel = DEFAULT_AGY_MODEL;
 
@@ -250,8 +262,11 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
 
       // Decode this batch's images into the session cache dir (local disk,
       // never a shared path) and reference them from the prompt; the dir is
-      // exposed to agy via --add-dir for the turn.
+      // exposed to agy via --add-dir.
       const images = await prepareAgyImageFiles(batch.attachments, { sessionId: session.sessionId });
+      if (images.cacheDir) {
+        imageCacheDir = images.cacheDir;
+      }
       if ((batch.attachments?.length ?? 0) > 0) {
         log(`Prepared ${images.paths.length} image file(s) for turn (skipped ${images.skipped})`);
       }
@@ -264,10 +279,15 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
       log(`Incoming prompt: ${batch.message.slice(0, 200)}`);
       sendEnvelopes(sessionManager.startTurn());
       try {
+        // Latched, not per-turn: agy is spawned fresh per --print invocation,
+        // and earlier turns' image paths stay referenced by the conversation —
+        // a later text-only turn ("look at that screenshot again") still needs
+        // the sandbox grant. The files live until session end regardless, so
+        // this widens nothing.
         await backend.sendPrompt(
           process.cwd(),
           buildAgyImagePrompt(batch.message, images.paths),
-          images.cacheDir ? { extraAddDirs: [images.cacheDir] } : undefined,
+          imageCacheDir ? { extraAddDirs: [imageCacheDir] } : undefined,
         );
         sendEnvelopes(sessionManager.endTurn('completed'));
       } catch (error) {
@@ -280,6 +300,8 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
       session.sendSessionEvent({ type: 'ready' });
     }
   } finally {
+    process.off('SIGTERM', cleanupOnSignal);
+    process.off('SIGINT', cleanupOnSignal);
     clearInterval(keepAliveInterval);
     reconnectionHandle?.cancel();
 

--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -30,9 +30,12 @@ import { connectionState } from '@/utils/serverConnectionErrors';
 import { MessageBuffer } from '@/ui/ink/messageBuffer';
 import { AgyDisplay } from '@/ui/ink/AgyDisplay';
 import type { AgentMessage } from '@/agent/core';
-import type { PermissionMode } from '@/api/types';
+import type { PermissionMode, UserMessage } from '@/api/types';
+import { downloadCodexFileEventAttachment } from '@/codex/utils/attachmentEvents';
+import { createSerialAsyncHandler } from '@/codex/utils/serialAsyncHandler';
 import { AgyBackend } from './AgyBackend';
 import { DEFAULT_AGY_MODEL } from './constants';
+import { buildAgyImagePrompt, cleanupAgyImageCache, prepareAgyImageFiles } from './imageInput';
 
 export interface RunAgyOptions {
   credentials: Credentials;
@@ -175,8 +178,18 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
     process.stdin.setEncoding('utf8');
   }
 
-  session.onUserMessage((message) => {
-    if (!message.content.text) return;
+  // Decode image attachments as they arrive; the next user message claims them.
+  session.onFileEvent((fileEvent) => {
+    session.trackAttachmentDownload(downloadCodexFileEventAttachment(session, fileEvent));
+  });
+
+  // Serialized so a slow attachment drain can't reorder rapid messages.
+  session.onUserMessage(createSerialAsyncHandler<UserMessage>(async (message) => {
+    // Claim attachments before the text guard: image-only messages arrive with
+    // empty text, and an early return would leak their files into the next turn.
+    const attachments = await session.drainAttachmentsForUserMessage();
+    const text = message.content.text ?? '';
+    if (!text && attachments.length === 0) return;
 
     if (message.meta?.permissionMode) {
       backend.setPermissionMode(message.meta.permissionMode as PermissionMode);
@@ -189,9 +202,13 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
       }
     }
 
-    messageBuffer.addMessage(message.content.text, 'user');
-    messageQueue.push(message.content.text, {});
-  });
+    if (text) {
+      messageBuffer.addMessage(text, 'user');
+    }
+    messageQueue.push(text, {}, attachments.length > 0 ? attachments : undefined);
+  }, (error) => {
+    logger.debug('[agy] User message handling failed:', error);
+  }));
   session.keepAlive(thinking, 'remote');
 
   const keepAliveInterval = setInterval(() => {
@@ -231,10 +248,27 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
         break;
       }
 
+      // Decode this batch's images into the session cache dir (local disk,
+      // never a shared path) and reference them from the prompt; the dir is
+      // exposed to agy via --add-dir for the turn.
+      const images = await prepareAgyImageFiles(batch.attachments, { sessionId: session.sessionId });
+      if ((batch.attachments?.length ?? 0) > 0) {
+        log(`Prepared ${images.paths.length} image file(s) for turn (skipped ${images.skipped})`);
+      }
+      if ((batch.attachments?.length ?? 0) > 0 && images.paths.length === 0 && batch.message.trim().length === 0) {
+        session.sendSessionEvent({ type: 'message', message: 'No supported images were available to send to agy.' });
+        session.sendSessionEvent({ type: 'ready' });
+        continue;
+      }
+
       log(`Incoming prompt: ${batch.message.slice(0, 200)}`);
       sendEnvelopes(sessionManager.startTurn());
       try {
-        await backend.sendPrompt(process.cwd(), batch.message);
+        await backend.sendPrompt(
+          process.cwd(),
+          buildAgyImagePrompt(batch.message, images.paths),
+          images.cacheDir ? { extraAddDirs: [images.cacheDir] } : undefined,
+        );
         sendEnvelopes(sessionManager.endTurn('completed'));
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -252,6 +286,9 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
     backend.offMessage(onBackendMessage);
     await backend.dispose();
     inkInstance?.unmount();
+
+    // Image attachments are user content: drop the session's decoded files.
+    await cleanupAgyImageCache({ sessionId: session.sessionId });
 
     try {
       session.updateMetadata((currentMetadata) => ({

--- a/packages/happy-cli/src/utils/offlineSessionStub.test.ts
+++ b/packages/happy-cli/src/utils/offlineSessionStub.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { createOfflineSessionStub } from './offlineSessionStub';
+
+describe('createOfflineSessionStub', () => {
+    // Regression guard: runAgy/runCodex register attachment handlers
+    // unconditionally at startup, so the stub must implement them or offline
+    // startup dies with a TypeError before the reconnection loop begins.
+    it('implements the attachment surface used unconditionally at startup', async () => {
+        const stub = createOfflineSessionStub('tag-1');
+
+        expect(() => stub.onFileEvent(() => {})).not.toThrow();
+        expect(() => stub.trackAttachmentDownload(Promise.resolve(null))).not.toThrow();
+        await expect(stub.drainAttachmentsForUserMessage()).resolves.toEqual([]);
+    });
+});

--- a/packages/happy-cli/src/utils/offlineSessionStub.ts
+++ b/packages/happy-cli/src/utils/offlineSessionStub.ts
@@ -47,6 +47,9 @@ export function createOfflineSessionStub(sessionTag: string): ApiSessionClient {
         updateMetadata: () => {},
         updateAgentState: () => {},
         onUserMessage: () => {},
+        onFileEvent: () => {},
+        trackAttachmentDownload: () => {},
+        drainAttachmentsForUserMessage: async () => [],
         rpcHandlerManager: {
             registerHandler: () => {}
         }

--- a/packages/happy-cli/src/utils/offlineSessionStub.ts
+++ b/packages/happy-cli/src/utils/offlineSessionStub.ts
@@ -48,6 +48,9 @@ export function createOfflineSessionStub(sessionTag: string): ApiSessionClient {
         updateAgentState: () => {},
         onUserMessage: () => {},
         onFileEvent: () => {},
+        // Reached via sendEnvelopes on every turn; "unreachable offline" is
+        // exactly how the missing onFileEvent stub above slipped through.
+        sendSessionProtocolMessage: () => {},
         trackAttachmentDownload: () => {},
         drainAttachmentsForUserMessage: async () => [],
         rpcHandlerManager: {


### PR DESCRIPTION
Fixes #1559

## Problem

The agy backend silently drops image attachments: the app never shows the
attach button for agy sessions, and the CLI ignores any attachment payload
on incoming user messages — even though agy itself can read local image
files just fine.

## How it works

agy has no image-input flag, so the only viable path is the filesystem:

- **app**: allow the `agy` flavor in `supportsImageAttachmentsForFlavor`,
  so the existing image picker (behind the `expImageUpload` feature flag)
  appears in agy sessions.
- **cli**: decode wire attachments into a per-session cache dir under
  `~/.happy/agy-image-cache/<sha256(sessionId)>`, expose that dir for the
  turn via `--add-dir`, and prefix the prompt with the exact file paths.
  The dir is removed at session end. Decoding and cache layout are reused
  from the Codex image-input helpers (same magic-byte sniffing, same 0700
  permissions), only the cache root differs.

Session dirs are keyed by a hash of the raw session id rather than the
sanitized id: the sanitizer is not injective (`a/b` and `a_b` collide),
and since the dir is both handed to `--add-dir` and `rm -rf`'d at session
end, two sessions must never share one — even for hostile server-issued
ids.

Isolation is structural, not prompt-based: given a nonexistent path agy
has been observed to scan the surrounding directory and describe
unrelated files, so each session dir contains only that session's
attachments. The "read ONLY these exact paths" instruction in the prompt
is belt on top of those suspenders.

Also fixes a latent crash: `runAgy`/`runCodex` register attachment
handlers unconditionally at startup, but the offline session stub didn't
implement them, so offline startup died with a TypeError before the
reconnection loop began. The stub now implements the attachment surface,
with a regression test.

## Before

Dragging an image into an agy session: the attach button never appears
(flavor not whitelisted); if a message with attachments reaches the CLI,
they are silently discarded.

## After

<img width="988" height="1272" alt="Google Chrome 2026-07-24 23 03 45" src="https://github.com/user-attachments/assets/aacddb03-857c-441d-86e5-3e9b9e9cdad5" />

## Testing

- `happy-cli`: 792/792 unit tests (84 files), including new suites for
  `imageInput` (11 tests, incl. the stale-dir sweep), `AgyBackend` add-dir passthrough, and the
  offline stub regression; `tsc --noEmit` clean.
- `happy-app`: 779/779 tests (65 files) incl. the updated
  `attachmentSupport` whitelist test; `tsc --noEmit` clean.
- e2e: verified locally end to end — image attached in the web app, agy
  (`--sandbox`) reads the decoded file and describes it.

