### PR TITLE
feat(cli,app): surface Antigravity (agy) quota in the session status bar

### DIFF
--- a/packages/happy-app/sources/utils/sessionStatusBar.test.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.test.ts
@@ -70,6 +70,22 @@ describe('usage limit helpers', () => {
         expect(chips[0].id).toBe('seven_day');
     });
 
+    it('chips the agy headline window and leaves per-model windows to the popover', () => {
+        const agyLimits = {
+            capturedAt: 1,
+            windows: [
+                { id: 'agy', label: 'agy', utilization: 50, resetsAt: 100 },
+                { id: 'agy:gemini-3.1-pro-high', label: 'Gemini 3.1 Pro', utilization: 50, resetsAt: 100 },
+                { id: 'agy:claude-sonnet-4-6', label: 'Claude Sonnet 4.6', utilization: 0, resetsAt: 200 },
+            ],
+        };
+        const chips = getUsageLimitChips(agyLimits, false);
+        expect(chips.map(c => c.id)).toEqual(['agy']);
+        expect(chips[0].shortLabel).toBe('agy');
+        // The per-model detail still reaches the popover.
+        expect(getUsageLimitRows(agyLimits).map(r => r.label)).toEqual(['agy', 'Gemini 3.1 Pro', 'Claude Sonnet 4.6']);
+    });
+
     it('hides chips for windows without numeric utilization and for absent data', () => {
         expect(getUsageLimitChips({ capturedAt: 1, windows: [{ id: 'five_hour', utilization: null }] }, false)).toEqual([]);
         expect(getUsageLimitChips(undefined, false)).toEqual([]);

--- a/packages/happy-app/sources/utils/sessionStatusBar.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.ts
@@ -60,6 +60,9 @@ export type UsageLimitStatus = 'allowed' | 'allowed_warning' | 'rejected';
 const CHIP_WINDOW_LABELS: Record<string, string> = {
     five_hour: '5h',
     seven_day: '7d',
+    // agy (Antigravity) sessions report a single headline window; per-model
+    // windows (agy:<modelId>) stay popover-only like other unknown ids.
+    agy: 'agy',
 };
 
 /**

--- a/packages/happy-cli/src/agy/agyQuotaClient.test.ts
+++ b/packages/happy-cli/src/agy/agyQuotaClient.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAgyQuotaClient, type AgyQuotaClientDeps } from './agyQuotaClient';
+
+const TOKEN_FILE = /antigravity-oauth-token$/;
+const CREDS_CACHE = /\.happy-usage-creds\.json$/;
+
+/** A binary dump with one valid client id + secret (a 35-char GOCSPX pair). */
+const GOOD_DUMP =
+  'noise 123456789-abcdefghijklmno.apps.googleusercontent.com noise ' +
+  'GOCSPX-abcdefghijklmnopqrstuvwxyz0123456789 more';
+
+type Res = { ok: boolean; status: number; json: () => Promise<unknown> };
+const ok = (data: unknown): Res => ({ ok: true, status: 200, json: async () => data });
+const err = (status: number): Res => ({ ok: false, status, json: async () => ({}) });
+
+/** Route fetch by url substring; each route is a queue drained per call (last repeats). */
+function makeFetch(routes: Record<string, Res[]>) {
+  const calls: string[] = [];
+  const fn = vi.fn(async (url: string) => {
+    calls.push(url);
+    for (const [needle, queue] of Object.entries(routes)) {
+      if (url.includes(needle)) {
+        return (queue.length > 1 ? queue.shift()! : queue[0]) as unknown as Response;
+      }
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  return { fn: fn as unknown as typeof fetch, calls };
+}
+
+function makeDeps(over: Partial<AgyQuotaClientDeps> = {}): AgyQuotaClientDeps {
+  return {
+    readTextFile: async (p) => {
+      if (TOKEN_FILE.test(p)) return JSON.stringify({ token: { refresh_token: 'RT' } });
+      throw new Error('ENOENT'); // no creds cache by default
+    },
+    writeTextFile: vi.fn(async () => {}),
+    dumpBinaryStrings: async () => GOOD_DUMP,
+    resolveBin: () => '/fake/agy',
+    now: () => 1_000_000,
+    ...over,
+  };
+}
+
+describe('createAgyQuotaClient', () => {
+  it('mints a token by scanning the binary, then fetches quota', async () => {
+    const { fn, calls } = makeFetch({
+      'oauth2.googleapis.com': [ok({ access_token: 'AT', expires_in: 3600 })],
+      retrieveUserQuota: [ok({ buckets: [{ modelId: 'x', remainingFraction: 0.5, resetTime: 't' }] })],
+    });
+    const writeTextFile = vi.fn(async () => {});
+    const client = createAgyQuotaClient(makeDeps({ fetch: fn, writeTextFile }));
+
+    const quota = await client.fetchQuota();
+
+    expect(quota).toEqual({ buckets: [{ modelId: 'x', remainingFraction: 0.5, resetTime: 't' }] });
+    // The working (clientId, secret) pair is cached for next time.
+    expect(writeTextFile).toHaveBeenCalledOnce();
+    const cached = JSON.parse((writeTextFile.mock.calls[0] as unknown[])[1] as string);
+    expect(cached.clientId).toBe('123456789-abcdefghijklmno.apps.googleusercontent.com');
+    expect(cached.clientSecret).toMatch(/^GOCSPX-/);
+    expect(cached.clientSecret).toHaveLength(35);
+    expect(calls.filter((u) => u.includes('oauth2'))).toHaveLength(1);
+  });
+
+  it('uses a cached OAuth client without scanning the binary', async () => {
+    const dumpBinaryStrings = vi.fn(async () => GOOD_DUMP);
+    const { fn } = makeFetch({
+      'oauth2.googleapis.com': [ok({ access_token: 'AT', expires_in: 3600 })],
+      retrieveUserQuota: [ok({ buckets: [] })],
+    });
+    const client = createAgyQuotaClient(
+      makeDeps({
+        fetch: fn,
+        dumpBinaryStrings,
+        readTextFile: async (p) => {
+          if (TOKEN_FILE.test(p)) return JSON.stringify({ token: { refresh_token: 'RT' } });
+          if (CREDS_CACHE.test(p)) return JSON.stringify({ clientId: 'cid', clientSecret: 'sec' });
+          throw new Error('ENOENT');
+        },
+      }),
+    );
+
+    await client.fetchQuota();
+    expect(dumpBinaryStrings).not.toHaveBeenCalled();
+  });
+
+  it('re-scans when the cached client no longer works (self-heal)', async () => {
+    const dumpBinaryStrings = vi.fn(async () => GOOD_DUMP);
+    const { fn } = makeFetch({
+      // First token exchange (cached client) fails, second (scanned) succeeds.
+      'oauth2.googleapis.com': [err(400), ok({ access_token: 'AT', expires_in: 3600 })],
+      retrieveUserQuota: [ok({ buckets: [] })],
+    });
+    const writeTextFile = vi.fn(async () => {});
+    const client = createAgyQuotaClient(
+      makeDeps({
+        fetch: fn,
+        dumpBinaryStrings,
+        writeTextFile,
+        readTextFile: async (p) => {
+          if (TOKEN_FILE.test(p)) return JSON.stringify({ token: { refresh_token: 'RT' } });
+          if (CREDS_CACHE.test(p)) return JSON.stringify({ clientId: 'stale', clientSecret: 'stale' });
+          throw new Error('ENOENT');
+        },
+      }),
+    );
+
+    await client.fetchQuota();
+    expect(dumpBinaryStrings).toHaveBeenCalledOnce();
+    expect(writeTextFile).toHaveBeenCalledOnce(); // freshly discovered pair re-cached
+  });
+
+  it('reuses the in-memory access token across polls', async () => {
+    const { fn, calls } = makeFetch({
+      'oauth2.googleapis.com': [ok({ access_token: 'AT', expires_in: 3600 })],
+      retrieveUserQuota: [ok({ buckets: [] }), ok({ buckets: [] })],
+    });
+    const client = createAgyQuotaClient(makeDeps({ fetch: fn }));
+
+    await client.fetchQuota();
+    await client.fetchQuota();
+
+    expect(calls.filter((u) => u.includes('oauth2'))).toHaveLength(1); // token minted once
+    expect(calls.filter((u) => u.includes('retrieveUserQuota'))).toHaveLength(2);
+  });
+
+  it('refreshes the token once on a 401 and retries the quota call', async () => {
+    const { fn, calls } = makeFetch({
+      'oauth2.googleapis.com': [
+        ok({ access_token: 'AT1', expires_in: 3600 }),
+        ok({ access_token: 'AT2', expires_in: 3600 }),
+      ],
+      retrieveUserQuota: [err(401), ok({ buckets: [] })],
+    });
+    const client = createAgyQuotaClient(makeDeps({ fetch: fn }));
+
+    await expect(client.fetchQuota()).resolves.toEqual({ buckets: [] });
+    expect(calls.filter((u) => u.includes('oauth2'))).toHaveLength(2); // forced re-mint
+  });
+
+  it('throws a clear error when no refresh token is present', async () => {
+    const client = createAgyQuotaClient(
+      makeDeps({ readTextFile: async () => JSON.stringify({ token: {} }) }),
+    );
+    await expect(client.fetchQuota()).rejects.toThrow(/refresh_token not found/);
+  });
+});

--- a/packages/happy-cli/src/agy/agyQuotaClient.test.ts
+++ b/packages/happy-cli/src/agy/agyQuotaClient.test.ts
@@ -64,6 +64,23 @@ describe('createAgyQuotaClient', () => {
     expect(calls.filter((u) => u.includes('oauth2'))).toHaveLength(1);
   });
 
+  it('still returns the minted token when the creds-cache write fails', async () => {
+    const { fn, calls } = makeFetch({
+      'oauth2.googleapis.com': [ok({ access_token: 'AT', expires_in: 3600 })],
+      retrieveUserQuota: [ok({ buckets: [] })],
+    });
+    const writeTextFile = vi.fn(async () => {
+      throw new Error('EACCES');
+    });
+    const client = createAgyQuotaClient(makeDeps({ fetch: fn, writeTextFile }));
+
+    // A failed cache write must not discard a successful exchange (or fall
+    // through to bogus candidate pairs / a misleading "no working client").
+    await expect(client.fetchQuota()).resolves.toEqual({ buckets: [] });
+    expect(writeTextFile).toHaveBeenCalledOnce();
+    expect(calls.filter((u) => u.includes('oauth2'))).toHaveLength(1);
+  });
+
   it('uses a cached OAuth client without scanning the binary', async () => {
     const dumpBinaryStrings = vi.fn(async () => GOOD_DUMP);
     const { fn } = makeFetch({

--- a/packages/happy-cli/src/agy/agyQuotaClient.ts
+++ b/packages/happy-cli/src/agy/agyQuotaClient.ts
@@ -1,0 +1,222 @@
+/**
+ * Fetches agy (Antigravity) usage quota from Google's cloudcode-pa backend.
+ *
+ * agy exposes no quota over its CLI stream, so this talks to the same private
+ * endpoint the CLI itself uses:
+ *   POST cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota
+ * authenticated with a short-lived access token minted from agy's stored refresh
+ * token. The OAuth client_id/secret are not published; we recover them by
+ * scanning the agy binary (self-healing across agy upgrades that rotate the
+ * client) and cache the working pair. Ported from the ai-usage SwiftBar plugin.
+ *
+ * All external effects (fs, `strings`, fetch) are injectable so the token/quota
+ * logic is unit-testable without a real binary or network.
+ */
+import os from 'node:os';
+import { join } from 'node:path';
+import { readFile, writeFile } from 'node:fs/promises';
+import { execSync, spawn } from 'node:child_process';
+import { resolveAgyBin } from './constants';
+import type { AgyQuotaResponse } from './agyUsageAdapter';
+
+const TOKEN_FILE = join(os.homedir(), '.gemini', 'antigravity-cli', 'antigravity-oauth-token');
+// Our own cache, deliberately distinct from the SwiftBar plugin's file so the
+// two never race on writes.
+const CREDS_CACHE_FILE = join(os.homedir(), '.gemini', 'antigravity-cli', '.happy-usage-creds.json');
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const QUOTA_URL = 'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota';
+const USER_AGENT = 'happy-cli/agy-usage';
+
+export interface OAuthClient {
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface AgyQuotaClientDeps {
+  readTextFile?: (path: string) => Promise<string>;
+  writeTextFile?: (path: string, data: string) => Promise<void>;
+  /** Returns the agy binary's printable strings (defaults to `strings -n 6`). */
+  dumpBinaryStrings?: (binPath: string) => Promise<string>;
+  fetch?: typeof fetch;
+  resolveBin?: () => string;
+  now?: () => number;
+  log?: (msg: string) => void;
+}
+
+export interface AgyQuotaClient {
+  fetchQuota(): Promise<AgyQuotaResponse>;
+}
+
+export function createAgyQuotaClient(deps: AgyQuotaClientDeps = {}): AgyQuotaClient {
+  const readTextFile = deps.readTextFile ?? ((p) => readFile(p, 'utf8'));
+  const writeTextFile = deps.writeTextFile ?? ((p, d) => writeFile(p, d, 'utf8'));
+  const dumpBinaryStrings = deps.dumpBinaryStrings ?? defaultDumpBinaryStrings;
+  const doFetch = deps.fetch ?? fetch;
+  const resolveBin = deps.resolveBin ?? resolveAgyBin;
+  const now = deps.now ?? Date.now;
+  const log = deps.log ?? (() => {});
+
+  let cachedToken: { accessToken: string; expiresAt: number } | null = null;
+
+  async function readRefreshToken(): Promise<string> {
+    const raw = await readTextFile(TOKEN_FILE);
+    const rt = JSON.parse(raw)?.token?.refresh_token;
+    if (typeof rt !== 'string' || !rt) {
+      throw new Error('agy refresh_token not found (run `agy` once to log in)');
+    }
+    return rt;
+  }
+
+  async function loadCachedClient(): Promise<OAuthClient | null> {
+    try {
+      const parsed = JSON.parse(await readTextFile(CREDS_CACHE_FILE));
+      if (typeof parsed?.clientId === 'string' && typeof parsed?.clientSecret === 'string') {
+        return { clientId: parsed.clientId, clientSecret: parsed.clientSecret };
+      }
+    } catch {
+      // no / invalid cache — fall back to scanning the binary
+    }
+    return null;
+  }
+
+  /** Cartesian product of client-id and secret candidates found in the binary. */
+  async function extractClients(): Promise<OAuthClient[]> {
+    const dump = await dumpBinaryStrings(toOpenablePath(resolveBin()));
+    const clientIds = [...dump.matchAll(/[0-9]+-[a-z0-9]+\.apps\.googleusercontent\.com/g)].map((m) => m[0]);
+    const secrets = [...dump.matchAll(/GOCSPX-[A-Za-z0-9_-]{28,}/g)].map((m) => m[0].slice(0, 35));
+    const seen = new Set<string>();
+    const pairs: OAuthClient[] = [];
+    for (const clientId of clientIds) {
+      for (const clientSecret of secrets) {
+        const key = `${clientId}\0${clientSecret}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          pairs.push({ clientId, clientSecret });
+        }
+      }
+    }
+    return pairs;
+  }
+
+  async function exchange(refreshToken: string, client: OAuthClient): Promise<{ accessToken: string; expiresIn: number }> {
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: client.clientId,
+      client_secret: client.clientSecret,
+    });
+    const res = await doFetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+    if (!res.ok) {
+      throw new Error(`token exchange failed: ${res.status}`);
+    }
+    const json = (await res.json()) as { access_token?: string; expires_in?: number };
+    if (!json?.access_token) {
+      throw new Error('token exchange returned no access_token');
+    }
+    return {
+      accessToken: json.access_token,
+      expiresIn: typeof json.expires_in === 'number' ? json.expires_in : 3600,
+    };
+  }
+
+  async function mintAccessToken(): Promise<{ accessToken: string; expiresIn: number }> {
+    const refreshToken = await readRefreshToken();
+    const cached = await loadCachedClient();
+    if (cached) {
+      try {
+        return await exchange(refreshToken, cached);
+      } catch (e) {
+        log(`cached agy OAuth client failed, rescanning binary: ${errMsg(e)}`);
+      }
+    }
+    for (const client of await extractClients()) {
+      try {
+        const token = await exchange(refreshToken, client);
+        await writeTextFile(
+          CREDS_CACHE_FILE,
+          JSON.stringify({ clientId: client.clientId, clientSecret: client.clientSecret }),
+        );
+        return token;
+      } catch {
+        // try the next candidate pair
+      }
+    }
+    throw new Error('no working OAuth client found in agy binary');
+  }
+
+  async function getAccessToken(forceRefresh = false): Promise<string> {
+    if (!forceRefresh && cachedToken && cachedToken.expiresAt - 60_000 > now()) {
+      return cachedToken.accessToken;
+    }
+    const { accessToken, expiresIn } = await mintAccessToken();
+    cachedToken = { accessToken, expiresAt: now() + expiresIn * 1000 };
+    return accessToken;
+  }
+
+  function requestQuota(accessToken: string): Promise<Response> {
+    return doFetch(QUOTA_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      body: '{}',
+    });
+  }
+
+  async function fetchQuota(): Promise<AgyQuotaResponse> {
+    let res = await requestQuota(await getAccessToken());
+    if (res.status === 401 || res.status === 403 || res.status === 429) {
+      // 429 too, not just auth failures: this endpoint throttles per access
+      // token, so a freshly minted one gets a clean bucket (verified against
+      // the same API from the menubar plugin, 2026-07-17).
+      res = await requestQuota(await getAccessToken(true));
+    }
+    if (!res.ok) {
+      throw new Error(`retrieveUserQuota failed: ${res.status}`);
+    }
+    return (await res.json()) as AgyQuotaResponse;
+  }
+
+  return { fetchQuota };
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * `resolveAgyBin` returns a bare command name when agy is on PATH — enough to
+ * spawn, since the OS resolves it, but `strings` needs a file it can open.
+ */
+function toOpenablePath(bin: string): string {
+  if (bin.includes('/')) return bin;
+  return execSync(`command -v ${bin}`, { encoding: 'utf8' }).trim();
+}
+
+function defaultDumpBinaryStrings(binPath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // stderr must be drained, not 'ignore': on this platform `strings` exits
+    // non-zero when its stderr is redirected to /dev/null but exits clean when
+    // it is consumed. And, like the reference plugin, we trust whatever stdout
+    // we got rather than the exit code — a partial dump still carries the
+    // OAuth client we need.
+    const child = spawn('strings', ['-n', '6', binPath], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      out += chunk;
+    });
+    child.stderr?.on('data', () => {});
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (out.length > 0) resolve(out);
+      else reject(new Error(`strings produced no output (exit ${code ?? 'null'})`));
+    });
+  });
+}

--- a/packages/happy-cli/src/agy/agyQuotaClient.ts
+++ b/packages/happy-cli/src/agy/agyQuotaClient.ts
@@ -15,7 +15,7 @@
 import os from 'node:os';
 import { join } from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
-import { execSync, spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { resolveAgyBin } from './constants';
 import type { AgyQuotaResponse } from './agyUsageAdapter';
 
@@ -49,7 +49,9 @@ export interface AgyQuotaClient {
 
 export function createAgyQuotaClient(deps: AgyQuotaClientDeps = {}): AgyQuotaClient {
   const readTextFile = deps.readTextFile ?? ((p) => readFile(p, 'utf8'));
-  const writeTextFile = deps.writeTextFile ?? ((p, d) => writeFile(p, d, 'utf8'));
+  // 0600: the cache holds the OAuth client secret, and agy's own token file
+  // next to it is 0600 — don't be the loosest file in the directory.
+  const writeTextFile = deps.writeTextFile ?? ((p, d) => writeFile(p, d, { encoding: 'utf8', mode: 0o600 }));
   const dumpBinaryStrings = deps.dumpBinaryStrings ?? defaultDumpBinaryStrings;
   const doFetch = deps.fetch ?? fetch;
   const resolveBin = deps.resolveBin ?? resolveAgyBin;
@@ -109,6 +111,7 @@ export function createAgyQuotaClient(deps: AgyQuotaClientDeps = {}): AgyQuotaCli
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
       throw new Error(`token exchange failed: ${res.status}`);
@@ -134,16 +137,23 @@ export function createAgyQuotaClient(deps: AgyQuotaClientDeps = {}): AgyQuotaCli
       }
     }
     for (const client of await extractClients()) {
+      let token: { accessToken: string; expiresIn: number };
       try {
-        const token = await exchange(refreshToken, client);
+        token = await exchange(refreshToken, client);
+      } catch {
+        continue; // try the next candidate pair
+      }
+      // Best-effort: a failed cache write must not discard the minted token —
+      // it only costs a binary rescan on the next pull.
+      try {
         await writeTextFile(
           CREDS_CACHE_FILE,
           JSON.stringify({ clientId: client.clientId, clientSecret: client.clientSecret }),
         );
-        return token;
-      } catch {
-        // try the next candidate pair
+      } catch (e) {
+        log(`could not cache agy OAuth client: ${errMsg(e)}`);
       }
+      return token;
     }
     throw new Error('no working OAuth client found in agy binary');
   }
@@ -166,6 +176,7 @@ export function createAgyQuotaClient(deps: AgyQuotaClientDeps = {}): AgyQuotaCli
         'User-Agent': USER_AGENT,
       },
       body: '{}',
+      signal: AbortSignal.timeout(10_000),
     });
   }
 
@@ -195,8 +206,11 @@ function errMsg(e: unknown): string {
  * spawn, since the OS resolves it, but `strings` needs a file it can open.
  */
 function toOpenablePath(bin: string): string {
-  if (bin.includes('/')) return bin;
-  return execSync(`command -v ${bin}`, { encoding: 'utf8' }).trim();
+  if (bin.includes('/') || bin.includes('\\')) return bin;
+  // execFile (no shell) with the platform's own lookup, mirroring
+  // resolveAgyBin's probe; `where` may print several matches — take the first.
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  return execFileSync(cmd, [bin], { encoding: 'utf8' }).trim().split(/\r?\n/)[0];
 }
 
 function defaultDumpBinaryStrings(binPath: string): Promise<string> {

--- a/packages/happy-cli/src/agy/agyUsageAdapter.test.ts
+++ b/packages/happy-cli/src/agy/agyUsageAdapter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { agyQuotaToUsageWindows, agyQuotaToPatch, AGY_HEADLINE_WINDOW_ID } from './agyUsageAdapter';
+
+describe('agyQuotaToUsageWindows', () => {
+  it('returns [] for empty / missing input', () => {
+    expect(agyQuotaToUsageWindows(undefined)).toEqual([]);
+    expect(agyQuotaToUsageWindows(null)).toEqual([]);
+    expect(agyQuotaToUsageWindows({})).toEqual([]);
+    expect(agyQuotaToUsageWindows({ buckets: [] })).toEqual([]);
+  });
+
+  it('skips buckets without a reset or a numeric remainingFraction', () => {
+    const windows = agyQuotaToUsageWindows({
+      buckets: [
+        { modelId: 'no-reset', remainingFraction: 0.5 }, // no resetTime -> unlimited
+        { modelId: 'no-fraction', resetTime: '2026-07-24T10:00:00Z' },
+        { modelId: 'ok', remainingFraction: 0.5, resetTime: '2026-07-24T10:00:00Z' },
+      ],
+    });
+    // headline + the one limited model
+    expect(windows.map((w) => w.id)).toEqual([AGY_HEADLINE_WINDOW_ID, 'agy:ok']);
+  });
+
+  it('maps remainingFraction to used% and resetTime to epoch ms', () => {
+    const windows = agyQuotaToUsageWindows({
+      buckets: [{ modelId: 'gemini-3.1-pro-high', remainingFraction: 0.77, resetTime: '2026-07-24T10:00:00Z' }],
+    });
+    const model = windows.find((w) => w.id === 'agy:gemini-3.1-pro-high')!;
+    expect(model.utilization).toBe(23); // round((1 - 0.77) * 100)
+    expect(model.label).toBe('Gemini 3.1 Pro'); // friendly label
+    expect(model.resetsAt).toBe(Date.parse('2026-07-24T10:00:00Z'));
+    expect(model.status).toBe('allowed');
+  });
+
+  it('falls back to the raw modelId when unmapped', () => {
+    const windows = agyQuotaToUsageWindows({
+      buckets: [{ modelId: 'mystery-model-x', remainingFraction: 0.1, resetTime: '2026-07-24T10:00:00Z' }],
+    });
+    expect(windows.find((w) => w.id === 'agy:mystery-model-x')!.label).toBe('mystery-model-x');
+  });
+
+  it('picks the lowest-remaining bucket as the headline', () => {
+    const windows = agyQuotaToUsageWindows({
+      buckets: [
+        { modelId: 'a', remainingFraction: 0.9, resetTime: '2026-07-24T10:00:00Z' },
+        { modelId: 'b', remainingFraction: 0.2, resetTime: '2026-07-24T12:00:00Z' },
+        { modelId: 'c', remainingFraction: 0.6, resetTime: '2026-07-24T11:00:00Z' },
+      ],
+    });
+    const headline = windows.find((w) => w.id === AGY_HEADLINE_WINDOW_ID)!;
+    expect(headline.utilization).toBe(80); // from b (0.2 remaining)
+    expect(headline.resetsAt).toBe(Date.parse('2026-07-24T12:00:00Z')); // b's reset
+    expect(windows[0].id).toBe(AGY_HEADLINE_WINDOW_ID); // headline first
+  });
+
+  it('marks a fully consumed window as rejected', () => {
+    const windows = agyQuotaToUsageWindows({
+      buckets: [{ modelId: 'x', remainingFraction: 0, resetTime: '2026-07-24T10:00:00Z' }],
+    });
+    expect(windows.find((w) => w.id === AGY_HEADLINE_WINDOW_ID)!.status).toBe('rejected');
+  });
+});
+
+describe('agyQuotaToPatch', () => {
+  it('builds a replace snapshot with the given capturedAt', () => {
+    const patch = agyQuotaToPatch(
+      { buckets: [{ modelId: 'x', remainingFraction: 0.5, resetTime: '2026-07-24T10:00:00Z' }] },
+      123456,
+    );
+    expect(patch.capturedAt).toBe(123456);
+    expect(patch.replace).toBe(true);
+    expect(patch.windows.map((w) => w.id)).toEqual([AGY_HEADLINE_WINDOW_ID, 'agy:x']);
+  });
+
+  it('emits an empty replace patch when nothing is limited (clears a stale chip)', () => {
+    const patch = agyQuotaToPatch({ buckets: [] }, 1);
+    expect(patch.replace).toBe(true);
+    expect(patch.windows).toEqual([]);
+  });
+});

--- a/packages/happy-cli/src/agy/agyUsageAdapter.ts
+++ b/packages/happy-cli/src/agy/agyUsageAdapter.ts
@@ -1,0 +1,115 @@
+/**
+ * Adapts agy's retrieveUserQuota response into the backend-neutral UsageLimits
+ * windows carried in session metadata (the same shape the Claude path produces
+ * via windowsFromGetUsage). agy quota is per-model — each bucket is one model's
+ * remaining fraction with its own reset — so there is no 5h/7d window concept
+ * like Claude. We surface:
+ *   - one synthetic `agy` headline window (the binding model, i.e. the lowest
+ *     remaining) so SessionStatusBar can render a single chip; and
+ *   - one `agy:<modelId>` window per model for the detail popover.
+ *
+ * Source shape (see the ai-usage SwiftBar plugin, which reads the same API):
+ *   { buckets: [ { modelId, remainingFraction: 0..1, resetTime: ISO 8601 } ] }
+ */
+import type { UsageLimitWindow } from '@/api/types';
+import { synthesizeStatus, type UsageLimitsPatch } from '@/claude/utils/usageLimits';
+
+/** A single model's quota bucket from retrieveUserQuota. */
+export interface AgyQuotaBucket {
+  modelId?: string;
+  /** Fraction of quota REMAINING, 0..1. */
+  remainingFraction?: number | null;
+  /** ISO 8601 timestamp when the bucket refills. */
+  resetTime?: string | null;
+}
+
+export interface AgyQuotaResponse {
+  buckets?: AgyQuotaBucket[];
+}
+
+/** Stable chip id for the agy headline window. Must match the app chip whitelist. */
+export const AGY_HEADLINE_WINDOW_ID = 'agy';
+
+/**
+ * Friendlier labels for known model ids; unknown ids fall back to the raw id.
+ * Ported from the working menubar plugin — safe to fall out of date, since an
+ * unmapped id just renders as-is in the popover.
+ */
+const AGY_MODEL_LABELS: Record<string, string> = {
+  'claude-opus-4-6-thinking': 'Claude Opus 4.6',
+  'claude-sonnet-4-6': 'Claude Sonnet 4.6',
+  'gemini-3.1-pro-high': 'Gemini 3.1 Pro',
+  'gemini-3.5-flash-low': 'Gemini 3.5 Flash',
+  'gpt-oss-120b-medium': 'GPT-OSS 120B',
+};
+
+function resetToEpochMs(resetTime: string | null | undefined): number | null {
+  if (!resetTime) return null;
+  const ms = Date.parse(resetTime);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** used% (0-100) from a 0..1 remaining fraction. */
+function usedPercent(remainingFraction: number): number {
+  return Math.min(100, Math.max(0, Math.round((1 - remainingFraction) * 100)));
+}
+
+type LimitedBucket = AgyQuotaBucket & { modelId: string; remainingFraction: number };
+
+/**
+ * Map a retrieveUserQuota response into UsageLimits windows. Only buckets that
+ * report both a numeric remainingFraction and a resetTime are "limited" and
+ * surfaced; unlimited models (no reset) are skipped. Returns [] when nothing is
+ * limited, which the poller writes as a replace patch to clear a stale chip.
+ */
+export function agyQuotaToUsageWindows(response: AgyQuotaResponse | null | undefined): UsageLimitWindow[] {
+  const buckets = Array.isArray(response?.buckets) ? response!.buckets : [];
+  const limited = buckets.filter(
+    (b): b is LimitedBucket =>
+      typeof b?.modelId === 'string' &&
+      typeof b.remainingFraction === 'number' &&
+      Number.isFinite(b.remainingFraction) &&
+      Boolean(b.resetTime),
+  );
+  if (limited.length === 0) return [];
+
+  const perModel: UsageLimitWindow[] = limited.map((b) => {
+    const utilization = usedPercent(b.remainingFraction);
+    return {
+      id: `agy:${b.modelId}`,
+      label: AGY_MODEL_LABELS[b.modelId] ?? b.modelId,
+      utilization,
+      resetsAt: resetToEpochMs(b.resetTime),
+      status: synthesizeStatus(utilization),
+    };
+  });
+
+  // Headline = the binding model (lowest remaining / highest used) so the bar
+  // shows the constraint the user hits first. It also appears in the popover as
+  // an "overall" row above the per-model breakdown.
+  const binding = limited.reduce((a, b) => (b.remainingFraction < a.remainingFraction ? b : a));
+  const headlineUtilization = usedPercent(binding.remainingFraction);
+  const headline: UsageLimitWindow = {
+    id: AGY_HEADLINE_WINDOW_ID,
+    label: 'agy',
+    utilization: headlineUtilization,
+    resetsAt: resetToEpochMs(binding.resetTime),
+    status: synthesizeStatus(headlineUtilization),
+  };
+
+  return [headline, ...perModel];
+}
+
+/** Build a full-snapshot patch (replace) for the poller to merge into metadata. */
+export function agyQuotaToPatch(
+  response: AgyQuotaResponse | null | undefined,
+  capturedAt: number,
+): UsageLimitsPatch {
+  return {
+    capturedAt,
+    windows: agyQuotaToUsageWindows(response),
+    // Full snapshot: drop models the backend stopped reporting instead of
+    // letting them linger with a stale status.
+    replace: true,
+  };
+}

--- a/packages/happy-cli/src/agy/agyUsageCollector.test.ts
+++ b/packages/happy-cli/src/agy/agyUsageCollector.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAgyUsageCollector } from './agyUsageCollector';
+import type { AgyQuotaResponse } from './agyUsageAdapter';
+
+const QUOTA: AgyQuotaResponse = {
+  buckets: [{ modelId: 'gemini-3.1-pro-high', remainingFraction: 0.5, resetTime: '2026-07-24T10:00:00Z' }],
+};
+
+/** Drain the promise chain the collector schedules its pulls on. */
+const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+function makeCollector(over: { now?: () => number, minIntervalMs?: number } = {}) {
+  const fetchQuota = vi.fn(async () => QUOTA);
+  const onPatch = vi.fn();
+  const collector = createAgyUsageCollector({
+    onPatch,
+    client: { fetchQuota },
+    now: over.now ?? (() => 1_000_000),
+    minIntervalMs: over.minIntervalMs,
+  });
+  return { collector, fetchQuota, onPatch };
+}
+
+describe('createAgyUsageCollector', () => {
+  it('emits a replace patch built from the fetched quota', async () => {
+    const { collector, onPatch } = makeCollector();
+    collector.refresh();
+    await settle();
+
+    expect(onPatch).toHaveBeenCalledOnce();
+    const patch = onPatch.mock.calls[0][0];
+    expect(patch.replace).toBe(true);
+    expect(patch.capturedAt).toBe(1_000_000);
+    expect(patch.windows.find((w: { id: string }) => w.id === 'agy')?.utilization).toBe(50);
+  });
+
+  it('collapses refreshes inside the minimum interval into one pull', async () => {
+    const { collector, fetchQuota } = makeCollector();
+    collector.refresh();
+    collector.refresh();
+    collector.refresh();
+    await settle();
+
+    expect(fetchQuota).toHaveBeenCalledOnce();
+  });
+
+  it('pulls again once the minimum interval has passed', async () => {
+    let clock = 1_000_000;
+    const { collector, fetchQuota } = makeCollector({ now: () => clock, minIntervalMs: 60_000 });
+    collector.refresh();
+    await settle();
+    clock += 60_000;
+    collector.refresh();
+    await settle();
+
+    expect(fetchQuota).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows fetch failures instead of rejecting', async () => {
+    const onPatch = vi.fn();
+    const log = vi.fn();
+    const collector = createAgyUsageCollector({
+      onPatch,
+      log,
+      client: { fetchQuota: async () => { throw new Error('boom'); } },
+    });
+    collector.refresh();
+    await settle();
+
+    expect(onPatch).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('boom'));
+  });
+
+  it('stops emitting after stop()', async () => {
+    const { collector, onPatch } = makeCollector();
+    collector.stop();
+    collector.refresh();
+    await settle();
+
+    expect(onPatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/happy-cli/src/agy/agyUsageCollector.ts
+++ b/packages/happy-cli/src/agy/agyUsageCollector.ts
@@ -1,0 +1,66 @@
+/**
+ * Pulls agy usage quota on demand and emits a metadata patch.
+ *
+ * agy exposes no per-turn usage signal, so the numbers have to be fetched from a
+ * separate endpoint — but they only move when a turn burns quota, so this is
+ * driven by turn boundaries rather than a background timer: one pull when the
+ * session opens, one after each turn. A minimum interval keeps a burst of short
+ * turns from turning into a burst of token exchanges.
+ *
+ * Calls are serialized and never awaited by the caller: a quota pull must not
+ * delay a turn, and a failure just hides the chip rather than breaking anything.
+ */
+import { createAgyQuotaClient, type AgyQuotaClient } from './agyQuotaClient';
+import { agyQuotaToPatch } from './agyUsageAdapter';
+import type { UsageLimitsPatch } from '@/claude/utils/usageLimits';
+
+const DEFAULT_MIN_INTERVAL_MS = 60_000;
+
+export interface AgyUsageCollectorOptions {
+  onPatch: (patch: UsageLimitsPatch) => void;
+  log?: (msg: string) => void;
+  /** Minimum gap between two pulls; requests inside the gap are dropped. */
+  minIntervalMs?: number;
+  client?: AgyQuotaClient;
+  now?: () => number;
+}
+
+export interface AgyUsageCollector {
+  /** Request a refresh. Fire-and-forget: never throws, never blocks the caller. */
+  refresh(): void;
+  /** Stop emitting patches (an in-flight pull is discarded, not cancelled). */
+  stop(): void;
+}
+
+export function createAgyUsageCollector(opts: AgyUsageCollectorOptions): AgyUsageCollector {
+  const log = opts.log ?? (() => {});
+  const client = opts.client ?? createAgyQuotaClient({ log });
+  const minIntervalMs = opts.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  const now = opts.now ?? Date.now;
+
+  let stopped = false;
+  let lastPullAt = Number.NEGATIVE_INFINITY;
+  let chain: Promise<void> = Promise.resolve();
+
+  const pull = async () => {
+    if (stopped) return;
+    // Checked inside the chain, not at request time: two refreshes queued back
+    // to back should collapse into one pull, not two.
+    if (now() - lastPullAt < minIntervalMs) return;
+    lastPullAt = now();
+    const response = await client.fetchQuota();
+    if (stopped) return;
+    opts.onPatch(agyQuotaToPatch(response, now()));
+  };
+
+  return {
+    refresh() {
+      chain = chain.then(pull).catch((e) => {
+        log(`agy usage refresh failed (ignored): ${e instanceof Error ? e.message : String(e)}`);
+      });
+    },
+    stop() {
+      stopped = true;
+    },
+  };
+}

--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -33,6 +33,8 @@ import type { AgentMessage } from '@/agent/core';
 import type { PermissionMode } from '@/api/types';
 import { AgyBackend } from './AgyBackend';
 import { DEFAULT_AGY_MODEL } from './constants';
+import { createAgyUsageCollector } from './agyUsageCollector';
+import { mergeUsageLimits } from '@/claude/utils/usageLimits';
 
 export interface RunAgyOptions {
   credentials: Credentials;
@@ -198,6 +200,19 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
     session.keepAlive(thinking, 'remote');
   }, 2000);
 
+  // agy reports no quota over its own stream, so usage is pulled from a separate
+  // endpoint at turn boundaries and merged into agent state the same way the
+  // Claude path does.
+  const usageCollector = createAgyUsageCollector({
+    log,
+    onPatch: (patch) => {
+      session.updateAgentState((currentAgentState) => ({
+        ...currentAgentState,
+        usageLimits: mergeUsageLimits(currentAgentState.usageLimits, patch),
+      }));
+    },
+  });
+
   async function handleAbort() {
     log('Abort requested');
     try {
@@ -221,6 +236,7 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
   try {
     await backend.startSession();
     log('Backend ready');
+    usageCollector.refresh();
 
     while (!shouldExit) {
       const waitSignal = abortController.signal;
@@ -241,12 +257,15 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
         log(`Turn ended: ${msg}`);
         sendEnvelopes(sessionManager.endTurn('failed'));
       }
+      // Also after a failed turn: a quota rejection is exactly when the chip matters.
+      usageCollector.refresh();
       thinking = false;
       session.keepAlive(false, 'remote');
       session.sendSessionEvent({ type: 'ready' });
     }
   } finally {
     clearInterval(keepAliveInterval);
+    usageCollector.stop();
     reconnectionHandle?.cancel();
 
     backend.offMessage(onBackendMessage);


### PR DESCRIPTION
Follow-up to #1430 (agy backend) and #1556 (usage limits in the status bar).

## Problem

agy sessions show no usage information: agy reports no quota over its CLI
stream, so the status bar chip and usage popover added in #1556 stay empty
for agy sessions.

## How it works

- **cli — quota client** (`agyQuotaClient.ts`): talks to the same private
  endpoint the agy CLI itself uses
  (`cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`),
  authenticated with a short-lived access token minted from agy's stored
  refresh token. The OAuth client id/secret aren't published; they are
  recovered by scanning the agy binary (self-healing across agy upgrades
  that rotate the client) and cached in a dedicated file. All external
  effects (fs, `strings`, fetch) are injectable, so the token/quota logic
  is unit-testable without a real binary or network.
- **cli — adapter** (`agyUsageAdapter.ts`): agy quota is per-model — each
  bucket is one model's remaining fraction with its own reset time; there
  is no 5h/7d concept. It maps onto the backend-neutral `UsageLimits`
  windows from #1556: one synthetic `agy` headline window (the binding
  model, i.e. lowest remaining) so the status bar renders a single chip,
  plus one `agy:<modelId>` window per model for the detail popover.
- **cli — collector** (`agyUsageCollector.ts`): turn-driven, not polled —
  one pull when the session opens and one after each turn (including
  failed turns: a quota rejection is exactly when the chip matters), with
  a 60s minimum interval so a burst of short turns doesn't become a burst
  of token exchanges. Pulls are serialized and never awaited by the turn;
  a failure just hides the chip instead of breaking anything.
- **cli — wiring** (`runAgy.ts`): patches merge into
  `agentState.usageLimits` exactly like the Claude path.
- **app**: one label entry (`agy`) in the chip whitelist; per-model
  `agy:<modelId>` windows stay popover-only like other unknown window ids.

## Before

agy sessions: no usage chip, empty usage popover.

## After

![agy quota chip in a live agy session](https://github.com/user-attachments/assets/aacddb03-857c-441d-86e5-3e9b9e9cdad5)

The `agy 100%` chip in the status bar (bottom right) of a live agy
session — same session as the screenshot in #1570.

## Testing

- 19 new unit tests across the quota client (token minting, client
  recovery from the binary, caching, error paths), the adapter (bucket
  mapping, binding-model selection, reset times), and the collector
  (turn-driven cadence, min interval, serialization).
- `happy-cli`: 800/800 tests (85 files), `tsc --noEmit` clean.
- `happy-app`: 780/780 tests (65 files) incl. the new chip-label
  coverage, `tsc --noEmit` clean.
- Verified live: chip renders in a real agy session (screenshot above).
