### PR TITLE
docs(cli): disclose that the agy backend never prompts for tool approval

### DIFF
--- a/packages/happy-cli/README.md
+++ b/packages/happy-cli/README.md
@@ -41,6 +41,15 @@ happy acp opencode
 happy acp -- custom-agent --flag
 ```
 
+> **Note on agy permissions:** the agy backend runs `agy --print`, which is
+> one-shot and has no interactive approval surface — tool calls proceed
+> automatically without ever prompting you. The permission mode you pick in
+> Happy only chooses which flag is passed to agy: the default modes use
+> `--sandbox`, and the bypass/yolo-style modes (including `acceptEdits`) use
+> `--dangerously-skip-permissions`. Neither adds a per-tool approval gate
+> inside Happy, so selecting "default" for an agy session does **not** give
+> you an approval prompt the way it does for Claude Code.
+
 ## Daemon
 
 The daemon is a background service that stays running on your machine. It lets you spawn and manage coding sessions remotely — from your phone or the web app — without needing an open terminal.


### PR DESCRIPTION
## Problem

The agy backend runs `agy --print`, which is one-shot and has no interactive
approval surface — tool calls proceed automatically without ever prompting the
user. The permission mode picked in Happy only selects which flag is passed to
agy: the default modes use `--sandbox`, and the bypass/yolo-style modes
(including `acceptEdits`) use `--dangerously-skip-permissions`. Neither adds a
per-tool approval gate inside Happy, so selecting "default" for an agy session
does not behave the way it does for Claude Code — and nothing documents this
today. Discussed in the #1430 review thread but never made it into the docs.

## Change

One note in `packages/happy-cli/README.md`, right after the "More agents"
section where `happy agy` is introduced, as a
`> **Note:**` blockquote. Docs-only; no behavior change.

## Testing

Docs-only; `tsc --noEmit` clean in happy-cli. Claims verified against
`src/agy/cliArgs.ts` (mode→flag mapping) and `AgyBackend.ts` (no tool-call or
permission events in print mode).

