### PR TITLE
feat(cli): resume agy conversations across session restarts

### DIFF
--- a/packages/happy-cli/src/agy/AgyBackend.test.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.test.ts
@@ -202,6 +202,50 @@ describe('AgyBackend', () => {
     expect(pinned).toEqual([]);
   });
 
+  it('adopts the replacement id when a stale seeded conversation was not resumed (self-heal)', async () => {
+    const spawnCalls: string[][] = [];
+    let current = makeFakeChild();
+    const spawnFn = vi.fn((_bin: string, args: string[]) => {
+      spawnCalls.push(args);
+      return current.child;
+    }) as unknown as SpawnFn;
+
+    // The persisted seed points at a conversation agy no longer knows:
+    // `--conversation <dead-id>` exits 0, silently creates a fresh
+    // conversation, and writes the fresh id to the cwd cache after the turn.
+    // Without adoption the dead id would be re-persisted forever and every
+    // resumed turn would start amnesiac.
+    const pinned: string[] = [];
+    let recorded: string | null = null;
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      spawnFn,
+      resolveConversationId: () => recorded,
+      initialConversationId: 'dead-cid',
+      onConversationId: (id) => pinned.push(id),
+    });
+
+    await backend.startSession();
+
+    const t1 = backend.sendPrompt('/work', 'first');
+    recorded = 'fresh-cid'; // agy's post-turn cache write
+    current.child.emit('close', 0);
+    await t1;
+
+    expect(pinned).toEqual(['fresh-cid']);
+
+    // The next turn resumes the adopted conversation, not the dead seed.
+    current = makeFakeChild();
+    const t2 = backend.sendPrompt('/work', 'second');
+    current.child.emit('close', 0);
+    await t2;
+
+    const idx = spawnCalls[1].indexOf('--conversation');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(spawnCalls[1][idx + 1]).toBe('fresh-cid');
+  });
+
   it('starts fresh instead of resuming a pre-existing cwd conversation (cross-resume guard)', async () => {
     const spawnCalls: string[][] = [];
     let current = makeFakeChild();

--- a/packages/happy-cli/src/agy/AgyBackend.test.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.test.ts
@@ -120,6 +120,88 @@ describe('AgyBackend', () => {
     expect(spawnCalls[1][idx + 1]).toBe('cid-xyz');
   });
 
+  it('resumes a seeded conversation id from the first turn (cross-restart resume)', async () => {
+    const spawnCalls: string[][] = [];
+    let current = makeFakeChild();
+    const spawnFn = vi.fn((_bin: string, args: string[]) => {
+      spawnCalls.push(args);
+      return current.child;
+    }) as unknown as SpawnFn;
+
+    // The cwd cache holds a foreign conversation, but the persisted metadata
+    // seed identifies our own — that seed wins and is never overwritten.
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      spawnFn,
+      resolveConversationId: () => 'someone-elses-conversation',
+      initialConversationId: 'persisted-cid',
+    });
+
+    await backend.startSession();
+
+    const t1 = backend.sendPrompt('/work', 'first');
+    current.child.emit('close', 0);
+    await t1;
+
+    const idx = spawnCalls[0].indexOf('--conversation');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(spawnCalls[0][idx + 1]).toBe('persisted-cid');
+  });
+
+  it('reports the pinned conversation id via onConversationId (for persistence)', async () => {
+    let current = makeFakeChild();
+    const spawnFn = vi.fn(() => current.child) as unknown as SpawnFn;
+
+    const pinned: string[] = [];
+    let recorded: string | null = null;
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      spawnFn,
+      resolveConversationId: () => recorded,
+      onConversationId: (id) => pinned.push(id),
+    });
+
+    await backend.startSession();
+
+    // First turn creates a conversation; the callback fires exactly once.
+    const t1 = backend.sendPrompt('/work', 'first');
+    recorded = 'new-cid';
+    current.child.emit('close', 0);
+    await t1;
+
+    // A second turn resumes the already-pinned id and must not re-fire.
+    current = makeFakeChild();
+    const t2 = backend.sendPrompt('/work', 'second');
+    current.child.emit('close', 0);
+    await t2;
+
+    expect(pinned).toEqual(['new-cid']);
+  });
+
+  it('does not report onConversationId for a seeded conversation (already persisted)', async () => {
+    let current = makeFakeChild();
+    const spawnFn = vi.fn(() => current.child) as unknown as SpawnFn;
+
+    const pinned: string[] = [];
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      spawnFn,
+      resolveConversationId: () => 'ignored',
+      initialConversationId: 'persisted-cid',
+      onConversationId: (id) => pinned.push(id),
+    });
+
+    await backend.startSession();
+    const t1 = backend.sendPrompt('/work', 'first');
+    current.child.emit('close', 0);
+    await t1;
+
+    expect(pinned).toEqual([]);
+  });
+
   it('starts fresh instead of resuming a pre-existing cwd conversation (cross-resume guard)', async () => {
     const spawnCalls: string[][] = [];
     let current = makeFakeChild();

--- a/packages/happy-cli/src/agy/AgyBackend.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.ts
@@ -125,11 +125,11 @@ export class AgyBackend implements AgentBackend {
 
     this.emit({ type: 'status', status: 'running' });
 
-    // Until we have pinned our own conversation, snapshot the cwd cache so we can
-    // tell after the turn whether the entry is ours (changed → our turn wrote it)
-    // or a leftover from another session (unchanged → not ours to adopt).
-    const preTurnCacheId =
-      this.conversationId === null ? this.resolveConversationId(this.cwd) : null;
+    // Snapshot the cwd cache so we can tell after the turn whether the entry
+    // is ours (changed → our turn wrote it) or a leftover from another session
+    // (unchanged → not ours to adopt). Used both to pin a fresh conversation
+    // and to detect that a pinned id was silently not resumed.
+    const preTurnCacheId = this.resolveConversationId(this.cwd);
 
     await new Promise<void>((resolve, reject) => {
       const child = this.spawnFn(resolveAgyBin(), args, {
@@ -203,6 +203,22 @@ export class AgyBackend implements AgentBackend {
             this.onConversationId?.(cid);
           } else {
             this.log('agy conversation cache unchanged after turn; not adopting (will retry next turn)');
+          }
+        } else {
+          // agy never validates a pinned id: `--conversation <dead-id>` exits 0
+          // and silently starts a fresh conversation instead. It does write the
+          // id it actually used back to the per-cwd cache after the turn, so a
+          // cache id that changed during our turn to something other than the
+          // pin means the pinned conversation wasn't resumed — adopt the
+          // replacement so the persisted metadata self-heals instead of
+          // pointing at a dead id forever. The changed-during-turn guard keeps
+          // the cross-resume caveat above intact: an unchanged foreign entry
+          // is a leftover, not ours to adopt.
+          const cid = this.resolveConversationId(this.cwd);
+          if (cid && cid !== this.conversationId && cid !== preTurnCacheId) {
+            this.log(`pinned agy conversation ${this.conversationId} was not resumed; adopting ${cid}`);
+            this.conversationId = cid;
+            this.onConversationId?.(cid);
           }
         }
 

--- a/packages/happy-cli/src/agy/AgyBackend.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.ts
@@ -46,6 +46,14 @@ export interface AgyBackendOptions {
   spawnFn?: SpawnFn;
   /** Optional override for resolving the resume conversation id (tests). */
   resolveConversationId?: (cwd: string) => string | null;
+  /**
+   * Conversation id to resume from a prior run (recovered from persisted session
+   * metadata). When set, the backend is already pinned and never adopts a cwd
+   * cache entry — it resumes this exact conversation across happy-cli restarts.
+   */
+  initialConversationId?: string | null;
+  /** Called with the conversation id once the backend pins one (for persistence). */
+  onConversationId?: (conversationId: string) => void;
 }
 
 /** Parse an agy duration string ("10m", "30s", "1h") to milliseconds; defaults to 10m. */
@@ -63,6 +71,7 @@ export class AgyBackend implements AgentBackend {
   private readonly log: (msg: string) => void;
   private readonly spawnFn: SpawnFn;
   private readonly resolveConversationId: (cwd: string) => string | null;
+  private readonly onConversationId?: (conversationId: string) => void;
 
   private permissionMode: PermissionMode;
   private model?: string;
@@ -77,6 +86,11 @@ export class AgyBackend implements AgentBackend {
     this.log = opts.log ?? (() => {});
     this.spawnFn = opts.spawnFn ?? spawn;
     this.resolveConversationId = opts.resolveConversationId ?? readAgyConversationId;
+    this.onConversationId = opts.onConversationId;
+    // Seed from persisted metadata so a resumed session continues its own
+    // conversation. Unlike the cwd cache (which may belong to another session),
+    // this id is scoped to this Happy session, so adopting it can't cross-resume.
+    this.conversationId = opts.initialConversationId ?? null;
   }
 
   /** Update the permission mode applied to subsequent turns. */
@@ -94,7 +108,8 @@ export class AgyBackend implements AgentBackend {
     // Deliberately do NOT seed from the cwd conversation cache: it holds whatever
     // conversation last ran in this cwd — possibly another live session's — so
     // seeding would cross-resume it. A fresh session starts a fresh conversation;
-    // resuming a specific one across restarts needs explicit id plumbing (follow-up).
+    // resuming a specific one across restarts is done via initialConversationId,
+    // which is scoped to this Happy session's own persisted metadata.
     return { sessionId: this.cwd };
   }
 
@@ -185,6 +200,7 @@ export class AgyBackend implements AgentBackend {
           if (cid && cid !== preTurnCacheId) {
             this.conversationId = cid;
             this.log(`pinned agy conversation ${cid}`);
+            this.onConversationId?.(cid);
           } else {
             this.log('agy conversation cache unchanged after turn; not adopting (will retry next turn)');
           }

--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -38,6 +38,8 @@ export interface RunAgyOptions {
   credentials: Credentials;
   startedBy?: 'daemon' | 'terminal';
   verbose?: boolean;
+  /** agy conversation id to resume (from `happy agy --resume <id>`). */
+  resumeConversationId?: string;
 }
 
 export async function runAgy(opts: RunAgyOptions): Promise<void> {
@@ -108,11 +110,35 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
 
   let displayedModel = DEFAULT_AGY_MODEL;
 
+  // Resume the prior agy conversation: prefer the id passed on the command line
+  // (`happy agy --resume <id>`, emitted by buildResumeLaunch from persisted
+  // metadata), falling back to whatever the session already carries.
+  const resumeConversationId =
+    opts.resumeConversationId ?? session.getMetadata()?.agyConversationId ?? null;
+
+  // A resumed run is a fresh Happy session and onConversationId does not fire
+  // for seeded ids, so persist the seed now — otherwise the id is dropped
+  // after one hop and the resumed session is itself unresumable.
+  if (resumeConversationId) {
+    session.updateMetadata((currentMetadata) => ({
+      ...currentMetadata,
+      agyConversationId: resumeConversationId,
+    }));
+  }
+
   const backend = new AgyBackend({
     cwd: process.cwd(),
     permissionMode: 'default',
     model: DEFAULT_AGY_MODEL,
     log,
+    initialConversationId: resumeConversationId,
+    // Persist the pinned conversation so a later resume continues it.
+    onConversationId: (conversationId) => {
+      session.updateMetadata((currentMetadata) => ({
+        ...currentMetadata,
+        agyConversationId: conversationId,
+      }));
+    },
   });
 
   // Terminal UI (only with a real TTY; the daemon runs headless).

--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -40,6 +40,10 @@ export interface RunAgyOptions {
   verbose?: boolean;
   /** agy conversation id to resume (from `happy agy --resume <id>`). */
   resumeConversationId?: string;
+  /** Initial model (from `--model`, forwarded by the daemon's resume path). */
+  model?: string;
+  /** Initial permission mode (from `--permission-mode`, same source). */
+  permissionMode?: string;
 }
 
 export async function runAgy(opts: RunAgyOptions): Promise<void> {
@@ -108,7 +112,7 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
   let abortController = new AbortController();
   let thinking = false;
 
-  let displayedModel = DEFAULT_AGY_MODEL;
+  let displayedModel = opts.model ?? DEFAULT_AGY_MODEL;
 
   // Resume the prior agy conversation: prefer the id passed on the command line
   // (`happy agy --resume <id>`, emitted by buildResumeLaunch from persisted
@@ -128,8 +132,8 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
 
   const backend = new AgyBackend({
     cwd: process.cwd(),
-    permissionMode: 'default',
-    model: DEFAULT_AGY_MODEL,
+    permissionMode: (opts.permissionMode as PermissionMode | undefined) ?? 'default',
+    model: opts.model ?? DEFAULT_AGY_MODEL,
     log,
     initialConversationId: resumeConversationId,
     // Persist the pinned conversation so a later resume continues it.

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -303,6 +303,7 @@ export type Metadata = {
   gitBranch?: string,
   claudeSessionId?: string, // Claude Code session ID
   codexThreadId?: string, // Codex app-server thread ID
+  agyConversationId?: string, // agy (Antigravity CLI) conversation ID
   tools?: string[],
   slashCommands?: string[],
   mcpServers?: Array<{ name: string; status: string }>,

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -712,11 +712,12 @@ export async function startDaemon(): Promise<void> {
           return { type: 'error', errorMessage: `Session ${happySessionId} has no stored encryption data. It was likely started before this feature was available. Restart the daemon and start a new session to enable resume.` };
         }
 
-        // Webhook metadata may be stale (missing claudeSessionId/codexThreadId set after startup).
+        // Webhook metadata may be stale (missing claudeSessionId/codexThreadId/agyConversationId set after startup).
         // Fetch fresh metadata from server if needed.
         let metadata = tracked.happySessionMetadataFromLocalWebhook;
         const needsFetch = (!metadata.claudeSessionId && (!metadata.flavor || metadata.flavor === 'claude'))
-          || (!metadata.codexThreadId && metadata.flavor === 'codex');
+          || (!metadata.codexThreadId && metadata.flavor === 'codex')
+          || (!metadata.agyConversationId && metadata.flavor === 'agy');
         if (needsFetch) {
           logger.debug(`[DAEMON RUN] Session ${happySessionId} missing agent session ID in webhook metadata, fetching from server`);
           const serverMetadata = await fetchServerSessionMetadata(happySessionId, tracked.encryption.encryptionKey, tracked.encryption.encryptionVariant);

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -450,6 +450,8 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       let startedBy: 'daemon' | 'terminal' | undefined = undefined;
       let verbose = false;
       let resumeConversationId: string | undefined = undefined;
+      let model: string | undefined = undefined;
+      let permissionMode: string | undefined = undefined;
       for (let i = 1; i < args.length; i++) {
         if (args[i] === '--started-by') {
           startedBy = args[++i] as 'daemon' | 'terminal';
@@ -461,6 +463,12 @@ Conversation history is preserved on the server, but in-flight tool calls are in
             throw new Error('--resume requires a conversation ID');
           }
           resumeConversationId = value;
+        } else if (args[i] === '--model') {
+          // Appended by the daemon's resume path; dropping it would silently
+          // ignore the model picked in the app.
+          model = args[++i];
+        } else if (args[i] === '--permission-mode') {
+          permissionMode = args[++i];
         }
       }
 
@@ -472,6 +480,8 @@ Conversation history is preserved on the server, but in-flight tool calls are in
         startedBy,
         verbose,
         resumeConversationId,
+        model,
+        permissionMode,
       });
     } catch (error) {
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -449,11 +449,18 @@ Conversation history is preserved on the server, but in-flight tool calls are in
 
       let startedBy: 'daemon' | 'terminal' | undefined = undefined;
       let verbose = false;
+      let resumeConversationId: string | undefined = undefined;
       for (let i = 1; i < args.length; i++) {
         if (args[i] === '--started-by') {
           startedBy = args[++i] as 'daemon' | 'terminal';
         } else if (args[i] === '--verbose') {
           verbose = true;
+        } else if (args[i] === '--resume') {
+          const value = args[++i];
+          if (!value || value.startsWith('-')) {
+            throw new Error('--resume requires a conversation ID');
+          }
+          resumeConversationId = value;
         }
       }
 
@@ -464,6 +471,7 @@ Conversation history is preserved on the server, but in-flight tool calls are in
         credentials,
         startedBy,
         verbose,
+        resumeConversationId,
       });
     } catch (error) {
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')

--- a/packages/happy-cli/src/resume/handleResumeCommand.test.ts
+++ b/packages/happy-cli/src/resume/handleResumeCommand.test.ts
@@ -167,6 +167,26 @@ describe('buildResumeLaunch', () => {
         });
     });
 
+    it('builds an agy resume command', () => {
+        expect(buildResumeLaunch({
+            id: 'session-agy',
+            active: false,
+            metadata: {
+                path: '/tmp/agy-repo',
+                flavor: 'agy',
+                agyConversationId: 'conv-abc-123',
+                host: 'localhost',
+                homeDir: '/tmp',
+                happyHomeDir: '/tmp/.happy',
+                happyLibDir: '/tmp/happy',
+                happyToolsDir: '/tmp/happy/tools',
+            },
+        })).toEqual({
+            cwd: '/tmp/agy-repo',
+            args: ['agy', '--resume', 'conv-abc-123'],
+        });
+    });
+
     it('rejects unsupported flavors', () => {
         expect(() => buildResumeLaunch({
             id: 'session-3',

--- a/packages/happy-cli/src/resume/handleResumeCommand.ts
+++ b/packages/happy-cli/src/resume/handleResumeCommand.ts
@@ -40,9 +40,12 @@ export function parseResumeCommandArgs(args: string[]): { showHelp: boolean; ses
     };
 }
 
-function resolveFlavor(metadata: Metadata): 'codex' | 'claude' | null {
+function resolveFlavor(metadata: Metadata): 'codex' | 'claude' | 'agy' | null {
     if (metadata.flavor === 'codex' || metadata.codexThreadId) {
         return 'codex';
+    }
+    if (metadata.flavor === 'agy' || metadata.agyConversationId) {
+        return 'agy';
     }
     if (metadata.flavor === 'claude' || metadata.claudeSessionId) {
         return 'claude';
@@ -59,6 +62,20 @@ export function buildResumeLaunch(session: ResumableHappySession, options: Resum
             throw new Error(`Happy session ${session.id} is missing its Codex thread ID.`);
         }
         const args = ['codex', '--resume', metadata.codexThreadId];
+        if (options.startedBy) {
+            args.push('--started-by', options.startedBy);
+        }
+        return {
+            cwd: metadata.path,
+            args,
+        };
+    }
+
+    if (flavor === 'agy') {
+        if (!metadata.agyConversationId) {
+            throw new Error(`Happy session ${session.id} is missing its agy conversation ID.`);
+        }
+        const args = ['agy', '--resume', metadata.agyConversationId];
         if (options.startedBy) {
             args.push('--started-by', options.startedBy);
         }

--- a/packages/happy-cli/src/resume/localResumeStore.ts
+++ b/packages/happy-cli/src/resume/localResumeStore.ts
@@ -29,6 +29,9 @@ function needsFreshMetadata(metadata: Metadata): boolean {
     if (metadata.flavor === 'codex') {
         return !metadata.codexThreadId;
     }
+    if (metadata.flavor === 'agy') {
+        return !metadata.agyConversationId;
+    }
     if (metadata.flavor === 'claude' || !metadata.flavor) {
         return !metadata.claudeSessionId;
     }

--- a/packages/happy-cli/src/resume/resolveHappySession.ts
+++ b/packages/happy-cli/src/resume/resolveHappySession.ts
@@ -16,6 +16,7 @@ export const ResumableMetadataSchema = z.object({
     flavor: z.string().optional(),
     claudeSessionId: z.string().optional(),
     codexThreadId: z.string().optional(),
+    agyConversationId: z.string().optional(),
 }).passthrough();
 
 type RawSession = {


### PR DESCRIPTION
Part of #1558.

## Problem

The agy backend pins its conversation id only in process memory: `agy --print`
doesn't echo the id it creates, so the backend recovers it from agy's per-cwd
cache after the first turn and passes it per turn — but nothing persists it.
Restart happy-cli (or resume via the daemon) and the session starts a
brand-new agy conversation.

## How it works

Same pattern as `claudeSessionId` / `codexThreadId`:

- **Persist:** `AgyBackend` gains an `onConversationId` callback that fires
  once when a fresh conversation is pinned; `runAgy` writes it to session
  metadata as `agyConversationId`. On a resumed run the seeded id is persisted
  immediately — a resumed run is a fresh Happy session and the callback
  doesn't fire for seeded ids, so without this the id would be dropped after
  one hop and the resumed session would itself be unresumable.
- **Restore:** `buildResumeLaunch` recognizes the agy flavor and emits
  `happy agy --resume <id>`. The seeded id comes from the session's own
  persisted metadata, so — unlike the cwd cache — adopting it cannot
  cross-resume another session's conversation (that guard is untouched).
- Plumbing mirrors the siblings: `Metadata`, `ResumableMetadataSchema`,
  `needsFreshMetadata`, and the daemon's stale-metadata check.

## Scope

CLI-side only. Two follow-ups deliberately not in this PR:
- app-side wiring so the UI offers resume for agy sessions
  (`MetadataSchema`, `hasBackendResumeId`, `buildResumeInvocation`);
- reconnect-in-place: `runAgy` doesn't read `HAPPY_RECONNECT_SESSION_ID` yet,
  so a daemon-driven resume continues the old agy conversation in a new Happy
  session. Previously daemon resume hard-errored ("unsupported flavor"), so
  this is a strict improvement.

## Testing

`happy-cli`: 785/785 tests (82 files) incl. new coverage for seeded-vs-fresh
pinning, agy resume launch construction, and the cross-resume guard;
`tsc --noEmit` clean. `--resume` validates its value (rejects missing or
flag-like values).
