### PR TITLE
chore(app,cli): finish deprecating the remaining gemini surfaces

### DIFF
--- a/packages/happy-app/sources/app/(app)/dev/session-composer.tsx
+++ b/packages/happy-app/sources/app/(app)/dev/session-composer.tsx
@@ -48,7 +48,7 @@ const AGENTS: { key: AgentKey; label: string }[] = [
     { key: 'claude', label: 'claude code' },
     { key: 'codex', label: 'codex' },
     { key: 'openclaw', label: 'openclaw' },
-    { key: 'gemini', label: 'gemini' },
+    { key: 'gemini', label: 'gemini (deprecated)' },
 ];
 
 // Sample data for pickers

--- a/packages/happy-app/sources/app/(app)/machine/[id].tsx
+++ b/packages/happy-app/sources/app/(app)/machine/[id].tsx
@@ -545,7 +545,7 @@ export default function MachineDetailScreen() {
                             }
                         />
                         <Item
-                            title="Gemini"
+                            title="Gemini (deprecated)"
                             showChevron={false}
                             rightElement={
                                 <Text style={{ color: metadata.cliAvailability.gemini ? '#34C759' : theme.colors.textSecondary, fontSize: 14 }}>

--- a/packages/happy-app/sources/app/(app)/settings/agents.tsx
+++ b/packages/happy-app/sources/app/(app)/settings/agents.tsx
@@ -140,7 +140,10 @@ export default function AgentDefaultsSettingsScreen() {
                 />
             </ItemGroup>
 
-            {agentKeys.map((agent) => {
+            {/* The gemini backend is deprecated in favor of agy, so no defaults
+                section for it — but 'gemini' stays in the schema so stored
+                overrides and existing sessions keep resolving. */}
+            {agentKeys.filter((agent) => agent !== 'gemini').map((agent) => {
                 const codeDefaults = getCodeAgentDefaults(agent);
                 const effectiveDefaults = resolveAgentDefaultConfig(agentDefaultOverrides, agent);
                 const permissionOptions = getHardcodedPermissionModes(agent, t);

--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -52,7 +52,6 @@ const AGENTS: Array<{ key: NewSessionAgentType; name: string }> = [
     { key: 'claude', name: 'Claude Code' },
     { key: 'codex', name: 'Codex' },
     { key: 'openclaw', name: 'OpenClaw' },
-    { key: 'gemini', name: 'Gemini' },
     { key: 'agy', name: 'Agy' },
 ];
 

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -150,6 +150,11 @@ Conversation history is preserved on the server, but in-flight tool calls are in
     }
     return;
   } else if (subcommand === 'gemini') {
+    // The standalone gemini CLI is EOL; agy (Antigravity CLI) is its successor.
+    // Warn once at the branch top so every entry point — the agent itself and
+    // the model/project config subcommands — carries the deprecation signal.
+    console.warn(chalk.yellow('⚠ The gemini backend is deprecated and may be removed in a future release. Use `happy agy` (Antigravity CLI) instead.'));
+
     // Handle gemini subcommands
     const geminiSubcommand = args[1];
     
@@ -331,9 +336,6 @@ Conversation history is preserved on the server, but in-flight tool calls are in
     
     // Handle gemini command (ACP-based agent)
     try {
-      // The standalone gemini CLI is EOL; agy (Antigravity CLI) is its successor.
-      console.warn(chalk.yellow('⚠ The gemini backend is deprecated and may be removed in a future release. Use `happy agy` (Antigravity CLI) instead.'));
-
       const { runGemini } = await import('@/gemini/runGemini');
 
       // Parse startedBy argument


### PR DESCRIPTION
Part of #1540 (a further slice of step 1 — no spawn paths or backend code removed yet).

## Problem

#1541 removed gemini from the new-session picker, but several surfaces still offer it as a first-class choice with no deprecation signal:

- the home dock composer still lists Gemini for new sessions
- Settings > Agents still renders a full Gemini defaults section
- the machine page CLI-availability row and the dev session composer show plain "Gemini"
- `happy gemini model set/get` and `happy gemini project set/get` run without the deprecation warning (it only fired on the agent-run path)

## What changed

- **HomeDock**: drop gemini from the agent list. Stale drafts fall back to the first available agent — the same guard the new-session screen already has.
- **Settings > Agents**: skip the gemini section when rendering. The `gemini` key stays in `agentKeys` and the overrides schema, so stored overrides and existing gemini sessions keep resolving.
- **Machine page / dev session composer**: label the rows "(deprecated)".
- **CLI**: move the deprecation warning to the top of the gemini subcommand branch so every entry point warns exactly once.

The backend stays fully functional; this only finishes the deprecation signaling for surfaces that create or configure gemini sessions.

## Test plan

- happy-app: tsc + full suite 779/779
- happy-cli: tsc; the only behavior change is where the existing console.warn fires

## Screenshots

Settings > Agents after this change — the Gemini group is gone (Claude Code / Codex / OpenClaw / Agy only):

![Settings > Agents without the gemini section](https://raw.githubusercontent.com/charliezong18/happy/assets/pr-screenshots/settings-agents-no-gemini.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
