### PR TITLE
feat(app): optional purple unread indicator + fix unread masking running state

### DIFF
--- a/packages/happy-app/sources/app/(app)/settings/appearance.tsx
+++ b/packages/happy-app/sources/app/(app)/settings/appearance.tsx
@@ -214,6 +214,7 @@ export default function AppearanceSettingsScreen() {
     const [alwaysShowContextSize, setAlwaysShowContextSize] = useSettingMutable('alwaysShowContextSize');
     const [avatarStyle, setAvatarStyle] = useSettingMutable('avatarStyle');
     const [showFlavorIcons, setShowFlavorIcons] = useSettingMutable('showFlavorIcons');
+    const [unreadIndicatorPurple, setUnreadIndicatorPurple] = useSettingMutable('unreadIndicatorPurple');
     const [userMessageBubbleColor, setUserMessageBubbleColor] = useSettingMutable('userMessageBubbleColor');
     const [sessionStatusBarDisplay, setSessionStatusBarDisplay] = useSettingMutable('sessionStatusBarDisplay');
     const [usageLimitShowRemaining, setUsageLimitShowRemaining] = useSettingMutable('usageLimitShowRemaining');
@@ -483,6 +484,17 @@ export default function AppearanceSettingsScreen() {
                         <Switch
                             value={showFlavorIcons}
                             onValueChange={setShowFlavorIcons}
+                        />
+                    }
+                />
+                <Item
+                    title={t('settingsAppearance.unreadIndicatorPurple')}
+                    subtitle={t('settingsAppearance.unreadIndicatorPurpleDescription')}
+                    icon={<Ionicons name="ellipse" size={29} color="#AF52DE" />}
+                    rightElement={
+                        <Switch
+                            value={unreadIndicatorPurple}
+                            onValueChange={setUnreadIndicatorPurple}
                         />
                     }
                 />

--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -8,7 +8,7 @@ import { type SessionState, formatPathRelativeToHome, vibingMessages, formatLast
 import { Avatar } from './Avatar';
 import { Typography } from '@/constants/Typography';
 import { StatusDot } from './StatusDot';
-import { useAllMachines, useSessionGitStatus } from '@/sync/storage';
+import { useAllMachines, useSessionGitStatus, useSetting } from '@/sync/storage';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { t } from '@/text';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
@@ -226,12 +226,15 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder }: { sessi
     const styles = stylesheet;
     const { theme } = useUnistyles();
     const baseStatus = STATUS_CONFIG[session.state];
-    // Override to solid blue when session has unread results. Only while the
-    // session is settled — if it started working again (or waits on a
-    // permission), the live state takes precedence over unread.
+    // Override to a solid color when session has unread results — blue, or
+    // purple when enabled in appearance settings. Only while the session is
+    // settled — if it started working again (or waits on a permission), the
+    // live state takes precedence over unread.
+    const unreadIndicatorPurple = useSetting('unreadIndicatorPurple');
+    const unreadColor = unreadIndicatorPurple ? '#AF52DE' : '#007AFF';
     const showUnread = session.hasUnread && session.state !== 'thinking' && session.state !== 'permission_required';
     const status = showUnread
-        ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
+        ? { ...baseStatus, color: unreadColor, dotColor: unreadColor, isPulsing: false, isConnected: baseStatus.isConnected }
         : baseStatus;
     const navigateToSession = useNavigateToSession();
     const swipeableRef = React.useRef<Swipeable | null>(null);

--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -226,8 +226,11 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder }: { sessi
     const styles = stylesheet;
     const { theme } = useUnistyles();
     const baseStatus = STATUS_CONFIG[session.state];
-    // Override to solid blue when session has unread results
-    const status = session.hasUnread
+    // Override to solid blue when session has unread results. Only while the
+    // session is settled — if it started working again (or waits on a
+    // permission), the live state takes precedence over unread.
+    const showUnread = session.hasUnread && session.state !== 'thinking' && session.state !== 'permission_required';
+    const status = showUnread
         ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
         : baseStatus;
     const navigateToSession = useNavigateToSession();
@@ -271,7 +274,7 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder }: { sessi
     const renderLeadingIndicator = () => {
         let indicator: React.ReactNode = null;
 
-        if (session.hasUnread) {
+        if (showUnread) {
             indicator = <StatusDot color={status.dotColor} isPulsing={false} />;
         } else if (session.state === 'waiting' && session.hasDraft) {
             indicator = (

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -430,8 +430,11 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
     const navigateToSession = useNavigateToSession();
     const [actionsAnchor, setActionsAnchor] = React.useState<SessionActionsAnchor | null>(null);
     const baseStatus = STATUS_CONFIG[session.state];
-    // Override to solid blue when session has unread results
-    const status = session.hasUnread
+    // Override to solid blue when session has unread results. Only while the
+    // session is settled — if it started working again (or waits on a
+    // permission), the live state takes precedence over unread.
+    const showUnread = session.hasUnread && session.state !== 'thinking' && session.state !== 'permission_required';
+    const status = showUnread
         ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
         : baseStatus;
 
@@ -439,7 +442,7 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
         return vibingMessages[Math.floor(Math.random() * vibingMessages.length)].toLowerCase() + '…';
     }, [session.state]);
 
-    const statusText = session.hasUnread
+    const statusText = showUnread
         ? t('status.unread')
         : session.state === 'thinking'
             ? vibingMessage

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -19,7 +19,7 @@ import { layout } from './layout';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
 import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
-import { useSettingMutable } from '@/sync/storage';
+import { useSetting, useSettingMutable } from '@/sync/storage';
 import { t } from '@/text';
 import { SessionShortcutHintBadge } from './ShortcutHints';
 import { ProviderIcon } from './ProviderIcon';
@@ -430,12 +430,15 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
     const navigateToSession = useNavigateToSession();
     const [actionsAnchor, setActionsAnchor] = React.useState<SessionActionsAnchor | null>(null);
     const baseStatus = STATUS_CONFIG[session.state];
-    // Override to solid blue when session has unread results. Only while the
-    // session is settled — if it started working again (or waits on a
-    // permission), the live state takes precedence over unread.
+    // Override to a solid color when session has unread results — blue, or
+    // purple when enabled in appearance settings. Only while the session is
+    // settled — if it started working again (or waits on a permission), the
+    // live state takes precedence over unread.
+    const unreadIndicatorPurple = useSetting('unreadIndicatorPurple');
+    const unreadColor = unreadIndicatorPurple ? '#AF52DE' : '#007AFF';
     const showUnread = session.hasUnread && session.state !== 'thinking' && session.state !== 'permission_required';
     const status = showUnread
-        ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
+        ? { ...baseStatus, color: unreadColor, dotColor: unreadColor, isPulsing: false, isConnected: baseStatus.isConnected }
         : baseStatus;
 
     const vibingMessage = React.useMemo(() => {

--- a/packages/happy-app/sources/sync/settings.spec.ts
+++ b/packages/happy-app/sources/sync/settings.spec.ts
@@ -188,6 +188,7 @@ describe('settings', () => {
                 agentInputEnterToSend: true,
                 avatarStyle: 'brutalist',
                 showFlavorIcons: false,
+                unreadIndicatorPurple: false,
                 userMessageBubbleColor: 'gray',
                 sessionStatusBarDisplay: 'hidden',
                 usageLimitShowRemaining: false,

--- a/packages/happy-app/sources/sync/settings.ts
+++ b/packages/happy-app/sources/sync/settings.ts
@@ -31,6 +31,7 @@ export const SettingsSchema = z.object({
     agentInputEnterToSend: z.boolean().describe('Whether pressing Enter submits/sends in the agent input (web)'),
     avatarStyle: z.string().describe('Avatar display style'),
     showFlavorIcons: z.boolean().describe('Whether to show AI provider icons in avatars'),
+    unreadIndicatorPurple: z.boolean().describe('Show the unread session indicator in purple instead of blue'),
     userMessageBubbleColor: z.string().describe('User message bubble color preset'),
     sessionStatusBarDisplay: z.enum(SESSION_STATUS_BAR_DISPLAY_MODES).describe('Whether/where to show the branch, model, effort, and context status bar'),
     usageLimitShowRemaining: z.boolean().describe('Show plan rate limits as quota remaining instead of quota used'),
@@ -106,6 +107,7 @@ export const settingsDefaults: Settings = {
     agentInputEnterToSend: true,
     avatarStyle: 'brutalist',
     showFlavorIcons: false,
+    unreadIndicatorPurple: false,
     userMessageBubbleColor: DEFAULT_USER_MESSAGE_BUBBLE_COLOR,
     // Hidden everywhere by default — the context usage indicator is still too
     // raw to roll out; users can opt back in from appearance settings.

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -209,6 +209,8 @@ export const en = {
         },
         showFlavorIcons: 'Show AI Provider Icons',
         showFlavorIconsDescription: 'Display AI provider icons on session avatars',
+        unreadIndicatorPurple: 'Purple Unread Indicator',
+        unreadIndicatorPurpleDescription: 'Show the unread dot on finished sessions in purple instead of blue',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -211,6 +211,8 @@ export const ca: TranslationStructure = {
         },
         showFlavorIcons: "Mostrar icones de proveïdors d'IA",
         showFlavorIconsDescription: "Mostrar icones del proveïdor d'IA als avatars de sessió",
+        unreadIndicatorPurple: 'Indicador de no llegits en lila',
+        unreadIndicatorPurpleDescription: 'Mostra el punt de no llegits de les sessions acabades en lila en lloc de blau',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -225,6 +225,8 @@ export const en: TranslationStructure = {
         },
         showFlavorIcons: 'Show AI Provider Icons',
         showFlavorIconsDescription: 'Display AI provider icons on session avatars',
+        unreadIndicatorPurple: 'Purple Unread Indicator',
+        unreadIndicatorPurpleDescription: 'Show the unread dot on finished sessions in purple instead of blue',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -211,6 +211,8 @@ export const es: TranslationStructure = {
         },
         showFlavorIcons: 'Mostrar íconos de proveedor de IA',
         showFlavorIconsDescription: 'Mostrar íconos del proveedor de IA en los avatares de sesión',
+        unreadIndicatorPurple: 'Indicador de no leídos en morado',
+        unreadIndicatorPurpleDescription: 'Mostrar el punto de no leídos de las sesiones terminadas en morado en lugar de azul',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -209,6 +209,8 @@ export const it: TranslationStructure = {
         },
         showFlavorIcons: 'Mostra icone provider IA',
         showFlavorIconsDescription: 'Mostra le icone del provider IA sugli avatar di sessione',
+        unreadIndicatorPurple: 'Indicatore non letti viola',
+        unreadIndicatorPurpleDescription: 'Mostra il punto non letti delle sessioni completate in viola invece che in blu',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -212,6 +212,8 @@ export const ja: TranslationStructure = {
         },
         showFlavorIcons: 'AIプロバイダーアイコンを表示',
         showFlavorIconsDescription: 'セッションアバターにAIプロバイダーアイコンを表示',
+        unreadIndicatorPurple: '未読インジケーターを紫色に',
+        unreadIndicatorPurpleDescription: '完了したセッションの未読ドットを青ではなく紫色で表示',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -228,6 +228,8 @@ export const pl: TranslationStructure = {
         },
         showFlavorIcons: 'Pokaż ikony dostawcy AI',
         showFlavorIconsDescription: 'Wyświetlaj ikony dostawcy AI na awatarach sesji',
+        unreadIndicatorPurple: 'Fioletowy wskaźnik nieprzeczytanych',
+        unreadIndicatorPurpleDescription: 'Pokazuj kropkę nieprzeczytanych w ukończonych sesjach na fioletowo zamiast na niebiesko',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -210,6 +210,8 @@ export const pt: TranslationStructure = {
         },
         showFlavorIcons: 'Mostrar ícones de provedores de IA',
         showFlavorIconsDescription: 'Exibir ícones do provedor de IA nos avatares de sessão',
+        unreadIndicatorPurple: 'Indicador de não lidos em roxo',
+        unreadIndicatorPurpleDescription: 'Exibir o ponto de não lidos das sessões concluídas em roxo em vez de azul',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -197,6 +197,8 @@ export const ru: TranslationStructure = {
         },
         showFlavorIcons: 'Показывать иконки провайдеров ИИ',
         showFlavorIconsDescription: 'Отображать иконки провайдеров ИИ на аватарах сессий',
+        unreadIndicatorPurple: 'Фиолетовый индикатор непрочитанного',
+        unreadIndicatorPurpleDescription: 'Показывать точку непрочитанного у завершённых сессий фиолетовым вместо синего',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -212,6 +212,8 @@ export const zhHans: TranslationStructure = {
         },
         showFlavorIcons: '显示 AI 提供商图标',
         showFlavorIconsDescription: '在会话头像上显示 AI 提供商图标',
+        unreadIndicatorPurple: '紫色未读指示点',
+        unreadIndicatorPurpleDescription: '已完成会话的未读点显示为紫色而非蓝色',
     },
 
     settingsFeatures: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -211,6 +211,8 @@ export const zhHant: TranslationStructure = {
         },
         showFlavorIcons: '顯示 AI 提供者圖示',
         showFlavorIconsDescription: '在工作階段頭像上顯示 AI 提供者圖示',
+        unreadIndicatorPurple: '紫色未讀指示點',
+        unreadIndicatorPurpleDescription: '已完成工作階段的未讀點以紫色而非藍色顯示',
     },
 
     settingsFeatures: {


### PR DESCRIPTION
## What

Two related changes to the session list unread indicator:

1. **Fix: unread no longer masks a running session.** A session marked unread that later resumed working kept showing the solid unread dot until opened — the unread override took precedence over the live state. The override now only applies while the session is settled; `thinking` (pulsing blue) and `permission_required` (pulsing orange) take precedence. Unread is not lost — the solid dot returns once the session settles again.

2. **Feature: optional purple unread indicator.** New synced setting `unreadIndicatorPurple` (default **off**, no visual change unless opted in). The solid blue unread dot and the pulsing blue thinking dot differ only by animation, which is hard to tell apart at a glance when scanning many concurrent sessions. With the toggle on, unread renders purple (#AF52DE): pulsing blue = still running, purple = finished with results to check. The toggle sits in Appearance below "Show AI Provider Icons"; translations added for all supported languages.

## Testing

- `tsc --noEmit` passes
- `settings.spec.ts` passes (34/34), new default covered by the defaults assertion
- Dogfooded on my fork with the toggle on: unread shows purple, and a session that resumes thinking correctly pulses blue instead of staying solid

<img width="396" height="355" alt="Google Chrome 2026-07-25 00 24 08" src="https://github.com/user-attachments/assets/9196bd22-3557-4fb2-95a1-cd428e16c867" />
<img width="937" height="228" alt="Google Chrome 2026-07-25 00 24 23" src="https://github.com/user-attachments/assets/f3b7b694-8df2-442f-adf1-bc3725a5ff39" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)