### PR TITLE
fix(app): keep live thinking state across a full session refetch

### DIFF
--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -1000,11 +1000,18 @@ class Sync {
             // Decrypt agent state using session-specific encryption
             let agentState = await sessionEncryption.decryptAgentState(session.agentStateVersion, session.agentState);
 
-            // Put it all together
+            // Put it all together. Thinking state exists only in activity
+            // ephemerals — the server session record has no such field, so
+            // preserve whatever we already know. Hardcoding false here wipes
+            // the live state of every running session on any full refetch
+            // (notably the one `new-session` triggers), which both freezes the
+            // pulsing dot and trips the "agent just finished" unread detector
+            // in applySessions.
+            const known = storage.getState().sessions[session.id];
             const processedSession = {
                 ...session,
-                thinking: false,
-                thinkingAt: 0,
+                thinking: known?.thinking ?? false,
+                thinkingAt: known?.thinkingAt ?? 0,
                 metadata,
                 agentState
             };

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -1000,26 +1000,36 @@ class Sync {
             // Decrypt agent state using session-specific encryption
             let agentState = await sessionEncryption.decryptAgentState(session.agentStateVersion, session.agentState);
 
-            // Put it all together. Thinking state exists only in activity
-            // ephemerals — the server session record has no such field, so
-            // preserve whatever we already know. Hardcoding false here wipes
-            // the live state of every running session on any full refetch
-            // (notably the one `new-session` triggers), which both freezes the
-            // pulsing dot and trips the "agent just finished" unread detector
-            // in applySessions.
-            const known = storage.getState().sessions[session.id];
+            // Put it all together. Thinking placeholders are overwritten just
+            // before applySessions below.
             const processedSession = {
                 ...session,
-                thinking: known?.thinking ?? false,
-                thinkingAt: known?.thinkingAt ?? 0,
+                thinking: false,
+                thinkingAt: 0,
                 metadata,
                 agentState
             };
             decryptedSessions.push(processedSession);
         }
 
-        // Apply to storage
-        this.applySessions(decryptedSessions);
+        // Thinking state exists only in activity ephemerals — the server
+        // session record has no such field, so preserve whatever we already
+        // know. Hardcoding false wipes the live state of every running session
+        // on any full refetch (notably the one `new-session` triggers), which
+        // both freezes the pulsing dot and trips the "agent just finished"
+        // unread detector in applySessions. Two deliberate details:
+        // - Resolved here, synchronously with the apply, rather than inside
+        //   the decrypt loop above: the loop awaits per session, so a snapshot
+        //   taken there can be overtaken by an activity ephemeral clearing
+        //   thinking in the meantime.
+        // - Gated on `active`: a dead session can never send the clearing
+        //   ephemeral, so a preserved `true` would otherwise be immortal.
+        const current = storage.getState().sessions;
+        this.applySessions(decryptedSessions.map(s => ({
+            ...s,
+            thinking: s.active ? (current[s.id]?.thinking ?? false) : false,
+            thinkingAt: s.active ? (current[s.id]?.thinkingAt ?? 0) : 0,
+        })));
         log.log(`📥 fetchSessions completed - processed ${decryptedSessions.length} sessions`);
 
     }


### PR DESCRIPTION
## What

`fetchSessions()` hardcodes `thinking: false` on every session it decodes, and `applySessions()` overwrites rather than merges that field. The server's session record has no thinking state at all — it only ever arrives through `activity` ephemerals — so any full refetch declares every running session idle until the next heartbeat.

## Why it's visible

Creating a session triggers exactly that refetch:

`new-session` update → `sessionsSync.invalidate()` (`sync.ts:2276`) → `fetchSessions()` → `thinking: false` (`sync.ts:1006`) → `applySessions()` (`storage.ts:457`, the spread overwrites it)

Two symptoms follow, and they hit **every** running session, not just the one being created:

1. The pulsing dot in the session list freezes for a beat, until the next activity ephemeral restores `thinking`.
2. The unread detector in `applySessions` (`storage.ts:600-613`) reads the same thing as `wasActive && isNowIdle` and marks the session unread — a session that never stopped working shows the solid unread dot until you open it.

## Fix

Preserve the thinking state already held instead of resetting it. Genuine `thinking: false` transitions still arrive through the activity accumulator and `turn-end` message events, which pass an explicit value; this only stops the refetch path from inventing one.

## Notes

Complements #1567 (unread markers dropped by rebuilds that omit `unreadSessionIds`) and #1577 (unread masking a live session). Those fix how the marker is rendered and retained — this fixes a source of markers that should never have been set. No file overlap with either.

## Testing

`pnpm typecheck` and the 793-test suite pass. Verified by hand on a fork build: with several sessions running, creating a new session no longer freezes their pulsing dots or flips them to unread.

No unit test — the zustand store can't be imported under vitest (react-native flow types break the transform), which is why no existing test loads it.

No screenshot: the symptom is a one-to-two second freeze of a pulsing animation, which a still frame cannot show.