### PR TITLE
feat(app): star projects to pin them to the top of the session list

### DIFF
--- a/packages/happy-app/sources/components/CommandPalette/CommandPaletteProvider.tsx
+++ b/packages/happy-app/sources/components/CommandPalette/CommandPaletteProvider.tsx
@@ -15,7 +15,7 @@ import {
     getPreferredShortcutModifier,
 } from '@/keyboard/shortcuts';
 import { isTauri } from '@/utils/isTauri';
-import { useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
+import { useSessionListStarredProjects, useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
 import { getSessionShortcutIdsInDisplayOrder } from '@/utils/sessionDisplayOrder';
 import { t } from '@/text';
 
@@ -28,6 +28,9 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     const commandPaletteEnabled = storage(useShallow((state) => state.localSettings.commandPaletteEnabled));
     const sessionListViewData = useVisibleSessionListViewData();
     const machines = useAllMachines();
+    // The number badges follow what is on screen, so they have to be built from
+    // the same starred set the list orders its project cards by.
+    const starredProjects = useSessionListStarredProjects();
     const navigateToSession = useNavigateToSession();
     const preferredModifier = useMemo(() => getPreferredShortcutModifier(
         typeof navigator === 'undefined' ? undefined : navigator
@@ -37,7 +40,8 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
         sessionListViewData,
         machines,
         t('status.unknown'),
-    ), [machines, sessionListViewData]);
+        starredProjects,
+    ), [machines, sessionListViewData, starredProjects]);
 
     // Define available commands
     const commands = useMemo((): Command[] => {

--- a/packages/happy-app/sources/components/ProjectGroup.tsx
+++ b/packages/happy-app/sources/components/ProjectGroup.tsx
@@ -6,7 +6,7 @@ import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Text } from '@/components/StyledText';
 import { Typography } from '@/constants/Typography';
 import { t } from '@/text';
-import { ProjectGroupData, ProjectWorkspaceGroup, useSessionGitStatus } from '@/sync/storage';
+import { ProjectGroupData, ProjectWorkspaceGroup, useIsProjectStarred, useSessionGitStatus, storage } from '@/sync/storage';
 import { CompactSessionRow } from './ActiveSessionsGroupCompact';
 import { Avatar } from './Avatar';
 import { requestHomeDockFocus } from './homeDockFocus';
@@ -36,24 +36,43 @@ interface ProjectGroupProps {
 export const ProjectGroup = React.memo(({ project, selectedSessionId }: ProjectGroupProps) => {
     const styles = stylesheet;
 
+    // Only path-grouped cards are starrable: the star key is machine-and-path,
+    // and Rig projects have a durable id instead of one working directory.
+    // Star the repo, not the worktree: every worktree of a repo shares its star,
+    // and the store keys stars on the path it is handed verbatim.
+    const starPath = project.path ? getRepoPath(project.path) : null;
+    const canStar = !!project.machineId && !!starPath;
+    const isStarred = useIsProjectStarred(project.machineId, starPath);
+    const handleToggleStar = React.useCallback(() => {
+        if (!project.machineId || !starPath) return;
+        storage.getState().toggleProjectStarred(project.machineId, starPath);
+    }, [project.machineId, starPath]);
+
     return (
         <View style={styles.container}>
-            {project.workspaces.map((workspace) => (
+            {project.workspaces.map((workspace, index) => (
                 <WorkspaceSection
                     key={workspace.id || 'primary'}
                     project={project}
                     workspace={workspace}
                     selectedSessionId={selectedSessionId}
+                    showStar={canStar && index === 0}
+                    isStarred={isStarred}
+                    onToggleStar={handleToggleStar}
                 />
             ))}
         </View>
     );
 });
 
-const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId }: {
+const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId, showStar, isStarred, onToggleStar }: {
     project: ProjectGroupData;
     workspace: ProjectWorkspaceGroup;
     selectedSessionId?: string;
+    // The star belongs to the project, so only the first section renders one.
+    showStar?: boolean;
+    isStarred?: boolean;
+    onToggleStar?: () => void;
 }) => {
     const styles = stylesheet;
     const { theme } = useUnistyles();
@@ -135,6 +154,23 @@ const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId }: 
                         )}
                     </View>
                 </View>
+                {showStar && (
+                    <Pressable
+                        onPress={onToggleStar}
+                        hitSlop={{ top: 15, bottom: 15, left: 8, right: 8 }}
+                        style={styles.starButton}
+                        accessibilityRole="button"
+                        accessibilityLabel={isStarred ? t('common.unstar') : t('common.star')}
+                    >
+                        <Ionicons
+                            name={isStarred ? 'star' : 'star-outline'}
+                            size={14}
+                            // Not theme.colors.warning — that is #8E8E93 (grey), which
+                            // makes a starred project indistinguishable by colour.
+                            color={isStarred ? '#f5a623' : theme.colors.textSecondary}
+                        />
+                    </Pressable>
+                )}
                 <Pressable
                     onPress={handleNewSession}
                     hitSlop={12}
@@ -192,6 +228,9 @@ const stylesheet = StyleSheet.create((theme) => ({
         letterSpacing: Platform.select({ ios: -0.08, default: 0.1 }),
         fontWeight: Platform.select({ ios: 'normal', default: '500' }),
         ...Typography.default('regular'),
+    },
+    starButton: {
+        padding: 4,
     },
     branchLine: {
         flexDirection: 'row',

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -23,6 +23,7 @@ import { layout } from './layout';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
 import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
+import { useSessionListStarredProjects } from '@/hooks/useVisibleSessionListViewData';
 import { t } from '@/text';
 import { SessionShortcutHintBadge } from './ShortcutHints';
 import { ProviderIcon } from './ProviderIcon';
@@ -344,6 +345,17 @@ export function SessionsList({
         return pathname.split('/')[2];
     }, [isTablet, pathname]);
 
+    // Starring writes a synced setting, which does not rebuild the cached list
+    // data — so the star that reorders the cards has to be read here, where a
+    // settings change re-runs the grouping below. It also rides along in
+    // extraData: web re-renders eagerly, but native FlatList memoizes cells and
+    // would keep showing the old order until something else forced a repaint.
+    const starredProjects = useSessionListStarredProjects();
+    const listExtraData = React.useMemo(
+        () => ({ selectedSessionId, starredProjects }),
+        [selectedSessionId, starredProjects],
+    );
+
     // Request review
     React.useEffect(() => {
         if (sourceData && sourceData.length > 0) {
@@ -401,6 +413,7 @@ export function SessionsList({
             groupedRows,
             machines,
             t('status.unknown'),
+            starredProjects,
         );
         if (machineGroups.length === 0) {
             return [...groupedRows, ...archiveToggle, ...archivedRows];
@@ -418,7 +431,7 @@ export function SessionsList({
             item.type !== 'project' && item.type !== 'projects-header'
         ));
         return [...hierarchy, ...legacyItems, ...archiveToggle, ...archivedRows];
-    }, [flatSessionList, hasArchivedSessions, hideArchivedSessions, machines, sourceData]);
+    }, [flatSessionList, hasArchivedSessions, hideArchivedSessions, machines, sourceData, starredProjects]);
 
     // Early return if no data yet
     if (!data) {
@@ -572,7 +585,7 @@ export function SessionsList({
                     data={data}
                     renderItem={renderItem}
                     keyExtractor={keyExtractor}
-                    extraData={selectedSessionId}
+                    extraData={listExtraData}
                     contentContainerStyle={{
                         paddingTop: topContentInset,
                         paddingBottom: safeArea.bottom + bottomContentInset,

--- a/packages/happy-app/sources/hooks/useVisibleSessionListViewData.test.ts
+++ b/packages/happy-app/sources/hooks/useVisibleSessionListViewData.test.ts
@@ -4,6 +4,7 @@ import type { SessionListViewItem, SessionRowData } from '@/sync/storage';
 const mocks = vi.hoisted(() => ({
     data: null as SessionListViewItem[] | null,
     hideArchivedSessions: false,
+    starredProjects: new Set<string>(),
 }));
 
 // The hook only ever reads `React.useMemo`, and storage.ts pulls in React
@@ -15,14 +16,13 @@ vi.mock('react', () => ({
 vi.mock('@/sync/storage', () => ({
     useSessionListViewData: () => mocks.data,
     useSetting: (key: string) => {
-        if (key !== 'hideInactiveSessions') {
-            throw new Error(`Unexpected setting read: ${key}`);
-        }
-        return mocks.hideArchivedSessions;
+        if (key === 'hideInactiveSessions') return mocks.hideArchivedSessions;
+        throw new Error(`Unexpected setting read: ${key}`);
     },
+    useStarredProjects: () => mocks.starredProjects,
 }));
 
-import { useVisibleSessionListViewData } from './useVisibleSessionListViewData';
+import { useSessionListStarredProjects, useVisibleSessionListViewData } from './useVisibleSessionListViewData';
 
 // Only the fields the visibility filter reads; the real rows are built in
 // storage.ts.
@@ -35,7 +35,10 @@ function row(id: string, options: { active?: boolean; archived?: boolean } = {})
     } as SessionRowData;
 }
 
-function project(id: string, sessions: SessionRowData[]): SessionListViewItem {
+function project(
+    id: string,
+    sessions: SessionRowData[],
+): SessionListViewItem {
     return {
         type: 'project',
         source: 'rig',
@@ -43,6 +46,7 @@ function project(id: string, sessions: SessionRowData[]): SessionListViewItem {
             id,
             name: id,
             machineId: 'machine-1',
+            path: null,
             sessionCount: sessions.length,
             activeCount: sessions.filter((session) => session.active).length,
             workspaces: [{ id: '', name: null, sessions }],
@@ -63,6 +67,7 @@ function flatSessionIds(items: SessionListViewItem[]): string[] {
 beforeEach(() => {
     mocks.data = null;
     mocks.hideArchivedSessions = false;
+    mocks.starredProjects = new Set<string>();
 });
 
 describe('useVisibleSessionListViewData', () => {
@@ -160,5 +165,15 @@ describe('useVisibleSessionListViewData', () => {
         mocks.hideArchivedSessions = true;
 
         expect(useVisibleSessionListViewData()).toEqual(mocks.data);
+    });
+
+    describe('useSessionListStarredProjects', () => {
+        // The ordering itself is buildSessionProjectDisplayGroups' job (see
+        // sessionDisplayOrder.test.ts); this hook only decides which set it gets.
+        it('hands out the starred set the ordering pass reads', () => {
+            mocks.starredProjects = new Set(['machine-1:/projects/delta']);
+
+            expect([...useSessionListStarredProjects()]).toEqual(['machine-1:/projects/delta']);
+        });
     });
 });

--- a/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
+++ b/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SessionListViewItem, useSessionListViewData, useSetting } from '@/sync/storage';
+import { SessionListViewItem, useSessionListViewData, useSetting, useStarredProjects } from '@/sync/storage';
 import { filterProjectGroupSessions } from '@/sync/projectGroups';
 
 /**
@@ -41,6 +41,10 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
             }
         });
 
+        // Order is left exactly as the list data arrived in. Starred cards rise
+        // in `buildSessionProjectDisplayGroups` instead — that pass sorts the
+        // project cards by name as the last step before they render, so any
+        // order applied here would simply be overwritten.
         const result: SessionListViewItem[] = [];
         data.forEach((item, index) => {
             if (item.type === 'projects-header') {
@@ -75,6 +79,17 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
 
         return result;
     }, [data, hideArchivedSessions]);
+}
+
+/**
+ * The starred project keys the home list orders by.
+ *
+ * Lives beside the visibility hook so the list and its keyboard shortcuts read
+ * one set; the ordering itself happens where the cards are finally sorted, in
+ * `buildSessionProjectDisplayGroups`.
+ */
+export function useSessionListStarredProjects(): ReadonlySet<string> {
+    return useStarredProjects();
 }
 
 /**

--- a/packages/happy-app/sources/sync/projectGroups.spec.ts
+++ b/packages/happy-app/sources/sync/projectGroups.spec.ts
@@ -207,6 +207,7 @@ describe('filterProjectGroupSessions', () => {
             id: 'happy-project',
             name: 'happy',
             machineId: 'machine-1',
+            path: null,
             sessionCount: 2,
             activeCount: 1,
             workspaces: [{
@@ -230,6 +231,7 @@ describe('filterProjectGroupSessions', () => {
             id: 'rig-project',
             name: 'rig',
             machineId: 'machine-1',
+            path: null,
             sessionCount: 2,
             activeCount: 0,
             workspaces: [{

--- a/packages/happy-app/sources/sync/projectGroups.ts
+++ b/packages/happy-app/sources/sync/projectGroups.ts
@@ -1,6 +1,7 @@
 import type { Session } from './storageTypes';
 import type { SessionRowData } from './storage';
 import { getRepoPath, getWorktreeName, isWorktreePath } from '@/utils/worktreePaths';
+import { projectStarKey } from '@/utils/projectPath';
 
 // One git worktree inside a project. `id` is empty and `name` is null for
 // the project's primary tree, which always sorts first.
@@ -16,9 +17,25 @@ export interface ProjectGroupData {
     id: string;
     name: string;
     machineId: string | null;
+    // The working directory this card was grouped by. Rig supplies a durable
+    // project identity instead, so its cards carry no single path and this is
+    // absent — which is also what makes them unstarrable (see projectGroupStarKey).
+    // Optional so upstream's own ProjectGroupData fixtures keep type-checking.
+    path?: string | null;
     workspaces: ProjectWorkspaceGroup[];
     sessionCount: number;
     activeCount: number;
+}
+
+/**
+ * The key a project card is starred under, or null when the card cannot be
+ * starred. Stars are stored per machine-and-path, and worktrees inherit the
+ * star of the repo they belong to, so this is `projectStarKey` — the same key
+ * `settings.starredProjects` has always held.
+ */
+export function projectGroupStarKey(project: ProjectGroupData): string | null {
+    if (!project.machineId || !project.path) return null;
+    return projectStarKey(project.machineId, project.path);
 }
 
 /**
@@ -57,6 +74,7 @@ export function buildPathProjectGroups(
                 id: `${idPrefix}:${key}`,
                 name: pathProjectName(projectPath, session.metadata?.homeDir),
                 machineId,
+                path: projectPath,
                 workspaces: [],
                 sessionCount: 0,
                 activeCount: 0,
@@ -147,6 +165,7 @@ export function buildProjectGroups(
                 id: project.id,
                 name: project.name,
                 machineId: session.metadata?.machineId ?? null,
+                path: null,
                 workspaces: [],
                 sessionCount: 0,
                 activeCount: 0,

--- a/packages/happy-app/sources/sync/settings.spec.ts
+++ b/packages/happy-app/sources/sync/settings.spec.ts
@@ -204,6 +204,7 @@ describe('settings', () => {
                 fileDiffsSidebar: false,
                 groupToolCalls: false,
                 compactToolCalls: false,
+                starredProjects: [],
                 reviewPromptAnswered: false,
                 reviewPromptLikedApp: null,
                 voiceAssistantLanguage: null,

--- a/packages/happy-app/sources/sync/settings.ts
+++ b/packages/happy-app/sources/sync/settings.ts
@@ -54,6 +54,7 @@ export const SettingsSchema = z.object({
     fileDiffsSidebar: z.boolean().describe('Show the file diffs sidebar next to the chat on desktop'),
     groupToolCalls: z.boolean().describe('Collapse consecutive tool calls into grouped containers in chat'),
     compactToolCalls: z.boolean().describe('Render non-interactive tool calls as compact one-line rows'),
+    starredProjects: z.array(z.string()).describe('Starred project keys (`${machineId}:${path}`), pinned to the top of the compact session groups; synced across the user\'s devices'),
     reviewPromptAnswered: z.boolean().describe('Whether the review prompt has been answered'),
     reviewPromptLikedApp: z.boolean().nullish().describe('Whether user liked the app when asked'),
     voiceAssistantLanguage: z.string().nullable().describe('Preferred language for voice assistant (null for auto-detect)'),
@@ -132,6 +133,7 @@ export const settingsDefaults: Settings = {
     groupToolCalls: false,
     // Full tool views by default: edit diffs render inline in the chat.
     compactToolCalls: false,
+    starredProjects: [],
     reviewPromptAnswered: false,
     reviewPromptLikedApp: null,
     voiceAssistantLanguage: null,

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -26,6 +26,7 @@ import { UserProfile, RelationshipUpdatedEvent } from "./friendTypes";
 import { loadSettings, loadLocalSettings, saveLocalSettings, saveSettings, loadPurchases, savePurchases, loadProfile, saveProfile, loadSessionDrafts, saveSessionDrafts } from "./persistence";
 import { isAgentModePushPending } from "./agentModesPending";
 import { loadSessionLastMessageSentAt, saveSessionLastMessageSentAt } from "./persistence";
+import { projectKey } from '@/utils/projectPath';
 import type { CustomerInfo } from './revenueCat/types';
 import React from "react";
 import { sync } from "./sync";
@@ -326,6 +327,10 @@ interface StorageState {
     markSessionRead: (sessionId: string) => void;
     markSessionUnread: (sessionId: string) => void;
     setCurrentViewingSession: (sessionId: string | null) => void;
+    // Starred project keys live in synced settings (settings.starredProjects),
+    // so a project starred on one device is starred on all of them.
+    toggleProjectStarred: (machineId: string, path: string) => void;
+    isProjectStarred: (machineId: string, path: string) => boolean;
 }
 
 // Helper function to build unified list view data from sessions and machines
@@ -1082,6 +1087,20 @@ export const storage = create<StorageState>()((set, get) => {
                 ...updates
             };
         }),
+        toggleProjectStarred: (machineId: string, path: string) => {
+            // Update through the same settings-change path any other setting
+            // uses (sync.applySettings → local apply + push), so the starred set
+            // reaches every device.
+            const key = projectKey(machineId, path);
+            const current = get().settings.starredProjects ?? [];
+            const next = current.includes(key)
+                ? current.filter(k => k !== key)
+                : [...current, key];
+            sync.applySettings({ starredProjects: next });
+        },
+        isProjectStarred: (machineId: string, path: string) => {
+            return (get().settings.starredProjects ?? []).includes(projectKey(machineId, path));
+        },
         updateSessionDraft: (sessionId: string, draft: string | null) => set((state) => {
             const session = state.sessions[sessionId];
             if (!session) return state;
@@ -1636,6 +1655,23 @@ export function useLocalSetting<K extends keyof LocalSettings>(name: K): LocalSe
 
 export function useIsSessionUnread(sessionId: string): boolean {
     return storage((state) => state.unreadSessionIds.has(sessionId));
+}
+
+export function useStarredProjects(): Set<string> {
+    // The Set is derived outside the store selector on purpose: fast-deep-equal's
+    // default build has no Set support and falls through to comparing
+    // `Object.keys()`, which is always `[]` for a Set — so under `useDeepEqual`
+    // every Set compares equal, the subscription never fires, and star toggles
+    // would not reorder the list until the subscriber remounted.
+    const starredKeys = storage(useShallow((state) => state.settings.starredProjects ?? []));
+    return React.useMemo(() => new Set(starredKeys), [starredKeys]);
+}
+
+export function useIsProjectStarred(machineId: string | undefined | null, path: string | undefined | null): boolean {
+    return storage((state) => {
+        if (!machineId || !path) return false;
+        return (state.settings.starredProjects ?? []).includes(projectKey(machineId, path));
+    });
 }
 
 // Artifact hooks

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -37,6 +37,8 @@ export const en = {
     },
 
     common: {
+        star: 'Star',
+        unstar: 'Unstar',
         // Simple string constants
         cancel: 'Cancel',
         authenticate: 'Authenticate',

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -37,6 +37,8 @@ export const ca: TranslationStructure = {
     },
 
     common: {
+        star: 'Destaca',
+        unstar: 'Treu el destacat',
         // Simple string constants
         cancel: 'Cancel·la',
         authenticate: 'Autentica',

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -52,6 +52,8 @@ export const en: TranslationStructure = {
     },
 
     common: {
+        star: 'Star',
+        unstar: 'Unstar',
         // Simple string constants
         cancel: 'Cancel',
         authenticate: 'Authenticate',

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -37,6 +37,8 @@ export const es: TranslationStructure = {
     },
 
     common: {
+        star: 'Destacar',
+        unstar: 'Quitar destacado',
         // Simple string constants
         cancel: 'Cancelar',
         authenticate: 'Autenticar',

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -37,6 +37,8 @@ export const it: TranslationStructure = {
     },
 
     common: {
+        star: 'Aggiungi ai preferiti',
+        unstar: 'Rimuovi dai preferiti',
         // Simple string constants
         cancel: 'Annulla',
         authenticate: 'Autentica',

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -40,6 +40,8 @@ export const ja: TranslationStructure = {
     },
 
     common: {
+        star: 'スターを付ける',
+        unstar: 'スターを外す',
         // Simple string constants
         cancel: 'キャンセル',
         authenticate: '認証',

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -48,6 +48,8 @@ export const pl: TranslationStructure = {
     },
 
     common: {
+        star: 'Oznacz gwiazdką',
+        unstar: 'Usuń gwiazdkę',
         // Simple string constants
         cancel: 'Anuluj',
         authenticate: 'Uwierzytelnij',

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -37,6 +37,8 @@ export const pt: TranslationStructure = {
     },
 
     common: {
+        star: 'Marcar com estrela',
+        unstar: 'Remover estrela',
         // Simple string constants
         cancel: 'Cancelar',
         authenticate: 'Autenticar',

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -48,6 +48,8 @@ export const ru: TranslationStructure = {
     },
 
     common: {
+        star: 'Добавить в избранное',
+        unstar: 'Убрать из избранного',
         // Simple string constants
         cancel: 'Отмена',
         authenticate: 'Авторизация',

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -39,6 +39,8 @@ export const zhHans: TranslationStructure = {
     },
 
     common: {
+        star: '加星标',
+        unstar: '取消星标',
         // Simple string constants
         cancel: '取消',
         authenticate: '认证',

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -39,6 +39,8 @@ export const zhHant: TranslationStructure = {
     },
 
     common: {
+        star: '加星號',
+        unstar: '取消星號',
         // Simple string constants
         cancel: '取消',
         authenticate: '驗證',

--- a/packages/happy-app/sources/utils/projectPath.spec.ts
+++ b/packages/happy-app/sources/utils/projectPath.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { projectKey, projectStarKey } from './projectPath';
+
+describe('projectStarKey', () => {
+    it('keys a plain checkout by its own path', () => {
+        expect(projectStarKey('m1', '/Users/me/repo')).toBe(projectKey('m1', '/Users/me/repo'));
+    });
+
+    it('keys a worktree by its repo, so it inherits the repo star', () => {
+        expect(projectStarKey('m1', '/Users/me/repo/.dev/worktree/feature-x'))
+            .toBe(projectKey('m1', '/Users/me/repo'));
+    });
+
+    it('separates the same path on different machines', () => {
+        expect(projectStarKey('m1', '/repo')).not.toBe(projectStarKey('m2', '/repo'));
+    });
+});

--- a/packages/happy-app/sources/utils/projectPath.ts
+++ b/packages/happy-app/sources/utils/projectPath.ts
@@ -1,0 +1,26 @@
+/**
+ * The project key the session list stars by. The path helpers themselves live
+ * in `utils/worktreePaths` (upstream's dependency-free module) and are
+ * re-exported here so this file stays the single place the star key is defined
+ * — keeping the key logic out of an upstream file it would otherwise conflict
+ * with on every rebase.
+ */
+export { WORKTREE_DIR, WORKTREE_PATH_MARKER, isWorktreePath, getRepoPath } from './worktreePaths';
+
+import { getRepoPath, isWorktreePath } from './worktreePaths';
+
+/**
+ * Identifies a project (a machine plus a path on it). Sessions sharing a
+ * directory on the same machine share one key — what the compact session list
+ * groups by and what `settings.starredProjects` stores.
+ */
+export const projectKey = (machineId: string, path: string): string => `${machineId}:${path}`;
+
+/**
+ * The key a path is starred under. Worktrees are not starred independently:
+ * they inherit the star of the repo they belong to, so starring a repo lifts
+ * every worktree of it, and a worktree cannot be starred on its own.
+ */
+export function projectStarKey(machineId: string, path: string): string {
+    return projectKey(machineId, isWorktreePath(path) ? getRepoPath(path) : path);
+}

--- a/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
+++ b/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
@@ -105,6 +105,7 @@ describe('session display order', () => {
                     id: 'rig-project',
                     name: 'rig',
                     machineId: 'machine-a',
+                    path: null,
                     activeCount: 1,
                     sessionCount: 1,
                     workspaces: [{
@@ -122,6 +123,7 @@ describe('session display order', () => {
                     id: 'happy-project',
                     name: 'happy',
                     machineId: 'machine-a',
+                    path: null,
                     activeCount: 1,
                     sessionCount: 1,
                     workspaces: [{
@@ -198,5 +200,105 @@ describe('session display order', () => {
             'Alpha project',
             'Zulu project',
         ]);
+    });
+    describe('starred projects', () => {
+        // Starring writes `${machineId}:${path}`, and a worktree is starred
+        // under the repo it belongs to.
+        function projectItem(
+            id: string,
+            name: string,
+            path: string | null,
+            machineId: string | null = 'machine-a',
+        ): SessionListViewItem {
+            return {
+                type: 'project',
+                source: 'happy',
+                project: {
+                    id,
+                    name,
+                    machineId,
+                    path,
+                    activeCount: 0,
+                    sessionCount: 1,
+                    workspaces: [{
+                        id: '',
+                        name: null,
+                        sessions: [session(`${id}-session`, machineId ?? '', path ?? '')],
+                    }],
+                },
+            };
+        }
+
+        const alphaAndZulu: SessionListViewItem[] = [
+            projectItem('alpha', 'Alpha project', '/projects/alpha'),
+            projectItem('zulu', 'Zulu project', '/projects/zulu'),
+        ];
+
+        function projectIds(
+            data: SessionListViewItem[],
+            starred?: ReadonlySet<string>,
+        ): string[] {
+            const groups = buildSessionProjectDisplayGroups(data, machines, 'Unknown', starred);
+            return groups.flatMap(group => group.projects.map(item => item.project.id));
+        }
+
+        it('lifts a starred project above the alphabetical order of its machine', () => {
+            expect(projectIds(alphaAndZulu, new Set(['machine-a:/projects/zulu'])))
+                .toEqual(['zulu', 'alpha']);
+        });
+
+        it('keeps the alphabetical order among projects sharing a starred state', () => {
+            expect(projectIds(alphaAndZulu, new Set([
+                'machine-a:/projects/zulu',
+                'machine-a:/projects/alpha',
+            ]))).toEqual(['alpha', 'zulu']);
+        });
+
+        it('leaves the order alone when nothing is starred', () => {
+            expect(projectIds(alphaAndZulu, new Set())).toEqual(['alpha', 'zulu']);
+            expect(projectIds(alphaAndZulu)).toEqual(['alpha', 'zulu']);
+        });
+
+        it('rides a worktree card up on the star of the repo it belongs to', () => {
+            const data = [
+                projectItem('alpha', 'Alpha project', '/projects/alpha'),
+                projectItem('worktree', 'feature', '/projects/repo/.dev/worktree/feature'),
+            ];
+
+            expect(projectIds(data)).toEqual(['alpha', 'worktree']);
+            expect(projectIds(data, new Set(['machine-a:/projects/repo'])))
+                .toEqual(['worktree', 'alpha']);
+        });
+
+        it('cannot star a card that carries no path (Rig projects)', () => {
+            const data = [
+                projectItem('rig-alpha', 'Alpha project', null),
+                projectItem('rig-zulu', 'Zulu project', null),
+            ];
+
+            expect(projectIds(data, new Set(['machine-a:/projects/anything'])))
+                .toEqual(['rig-alpha', 'rig-zulu']);
+        });
+
+        it('keeps a star inside its own machine group', () => {
+            const data = [
+                projectItem('alpha', 'Alpha project', '/projects/alpha'),
+                projectItem('zulu-machine', 'Zulu machine project', '/projects/z', 'machine-z'),
+            ];
+
+            // machine-a leads machine-z by machine name, so starring a project
+            // on machine-z lifts it within its own group, not above Alpha's.
+            expect(projectIds(data, new Set(['machine-z:/projects/z'])))
+                .toEqual(['alpha', 'zulu-machine']);
+        });
+
+        it('numbers the session shortcuts in the starred order too', () => {
+            expect(getSessionShortcutIdsInDisplayOrder(
+                alphaAndZulu,
+                machines,
+                'Unknown',
+                new Set(['machine-a:/projects/zulu']),
+            )).toEqual(['zulu-session', 'alpha-session']);
+        });
     });
 });

--- a/packages/happy-app/sources/utils/sessionDisplayOrder.ts
+++ b/packages/happy-app/sources/utils/sessionDisplayOrder.ts
@@ -1,4 +1,5 @@
 import type { SessionListViewItem, SessionRowData } from '@/sync/storage';
+import { projectGroupStarKey } from '@/sync/projectGroups';
 
 type SessionProjectListItem = Extract<SessionListViewItem, { type: 'project' }>;
 
@@ -87,14 +88,24 @@ export function buildActiveSessionDisplayGroups(
     ));
 }
 
+const NO_STARRED_PROJECTS: ReadonlySet<string> = new Set();
+
 /**
  * Restores the home list's original top-level hierarchy: machine first, then
  * projects, with worktrees and sessions kept inside each project.
+ *
+ * `starred` holds the project keys the user pinned. Ordering has to happen
+ * here rather than on the list data upstream of it: this is the last pass over
+ * the project cards, and its own name sort would otherwise undo any order it
+ * was handed. A card the machine hierarchy is built from keeps its machine —
+ * a star lifts a project within its machine group, never above another one's
+ * header.
  */
 export function buildSessionProjectDisplayGroups(
     data: readonly SessionListViewItem[],
     machines: readonly SessionDisplayMachine[],
     unknownText: string,
+    starred: ReadonlySet<string> = NO_STARRED_PROJECTS,
 ): SessionProjectDisplayMachineGroup[] {
     const machinesMap = new Map(machines.map((machine) => [machine.id, machine]));
     const byMachine = new Map<string | null, SessionProjectDisplayMachineGroup>();
@@ -115,9 +126,16 @@ export function buildSessionProjectDisplayGroups(
         group.projects.push(item);
     });
 
+    const isStarred = (item: SessionProjectListItem): boolean => {
+        if (starred.size === 0) return false;
+        const key = projectGroupStarKey(item.project);
+        return !!key && starred.has(key);
+    };
+
     byMachine.forEach((group) => {
         group.projects.sort((a, b) => (
-            a.project.name.localeCompare(b.project.name)
+            Number(isStarred(b)) - Number(isStarred(a))
+            || a.project.name.localeCompare(b.project.name)
             || a.project.id.localeCompare(b.project.id)
         ));
     });
@@ -132,13 +150,14 @@ export function getSessionShortcutIdsInDisplayOrder(
     data: readonly SessionListViewItem[] | null,
     machines: readonly SessionDisplayMachine[],
     unknownText: string,
+    starred: ReadonlySet<string> = NO_STARRED_PROJECTS,
 ): string[] {
     if (!data) {
         return [];
     }
 
     const sessionIds: string[] = [];
-    const projectGroups = buildSessionProjectDisplayGroups(data, machines, unknownText);
+    const projectGroups = buildSessionProjectDisplayGroups(data, machines, unknownText, starred);
     projectGroups.forEach((machineGroup) => {
         machineGroup.projects.forEach((item) => {
             item.project.workspaces.forEach((workspace) => {


### PR DESCRIPTION
## Problem

The session list groups sessions into project cards. Past a handful of projects, the two or three you actually work on daily sit wherever the ordering puts them — so finding them means scanning the whole list, every time.

## What this adds

A star toggle on each project card header. Starred projects rise to the top of their machine group.

The starred set lives in `settings.starredProjects`, so it rides the ordinary settings sync: star a project on the laptop and it is starred on the phone.

**Starring is per repo, not per worktree.** `projectStarKey` maps a worktree path back to its repo, so starring a repo lifts all of its worktrees together, and a worktree can't drift into a different position from the repo it belongs to.

**Rig projects show no star.** They carry a durable project identity rather than one working directory, so there is no machine-and-path key to store — `ProjectGroupData.path` is null for them and the control is hidden.

## Where the ordering runs

Inside `buildSessionProjectDisplayGroups`, the pass that assembles the machine → project hierarchy just before render.

That placement is forced rather than chosen. The pass ends by sorting each machine group by project name, so an order applied anywhere upstream of it is simply overwritten — the card would keep its star and stay exactly where the alphabet put it. Sorting by the star inside that pass, with name and id demoted to tiebreakers, is what actually moves it.

A star lifts a project **within its own machine group**, never above another machine's header, because the grouping happens before the sort.

`getSessionShortcutIdsInDisplayOrder` walks the same pass and takes the same starred set, so the ⌘1–9 badges count in the order that is on screen rather than one nobody can see.

The starred set is read in `SessionsList` via `useSessionListStarredProjects`, so a settings write re-runs the grouping. It also rides along in `extraData`: web re-renders eagerly, but native `FlatList` memoizes cells and would otherwise keep showing the old order until something else forced a repaint.

## Supporting change: `utils/projectPath.ts` (new)

The pure path logic — worktree markers, `isWorktreePath`, `getRepoPath`, the project key, and the star key — moves out of `utils/worktree.ts`. That module imports `sync/ops` and so drags React Native into anything importing it, including a unit test, which is why these rules had no coverage. The new module is dependency-free; `utils/worktree.ts` re-exports the moved helpers, so **no import site changes**.

It also collapses a duplication that was already there: `${machineId}:${path}` was being assembled by hand in `gitStatusSync` and in `storage.getSessionPathKey`. The latter now uses `projectKey`. (I left `gitStatusSync`'s private copy alone to keep this diff to the feature — happy to fold it in if you'd prefer.)

## Supersedes #1078

#1078 was the earlier, session-level take on the same itch (star individual conversations). Having dogfooded both, project-level is the one that stuck — sessions are transient, so their stars accumulate as clutter, while the project you work in is stable and is the thing you actually navigate to. Session-level starring turned out to be dead UI on my own build: weeks of running it and I never reached for it.

**#1078 is now closed**, so there is no choice to weigh here — this is the version that replaced it, not an alternative to it.

## Verification

`pnpm typecheck` clean; app suite 1125/1125.

Eleven tests cover the rules:

- `utils/projectPath.spec.ts` (3) — the star key: plain checkout, worktree inherits its repo, cross-machine isolation.
- `utils/sessionDisplayOrder.test.ts` (7) — the ordering: a star lifts a project above the alphabetical order of its machine; projects sharing a starred state keep alphabetical order; nothing starred leaves the order alone; a worktree card rides up on its repo's star; a card with no path can't be starred; a star stays inside its own machine group; and the session shortcut numbers follow the starred order.
- `hooks/useVisibleSessionListViewData.test.ts` (1) — the hook hands the ordering pass the set it reads.
