### PR TITLE
fix(app): restore the invisible send button on the mobile composers

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -1816,10 +1816,16 @@ function NewSessionScreen() {
                         name="arrow-up"
                         size={isNativeMobile ? 18 : 16}
                         color={sendButtonIconColor}
-                        style={[
-                            styles.sendButtonIcon,
-                            { marginTop: Platform.OS === 'web' ? 2 : 0 },
-                        ]}
+                        // The color has to travel in `style`, not just the `color`
+                        // prop: @expo/vector-icons builds `[styleDefaults, style, ...]`
+                        // (create-icon-set.js), so a `style` entry always wins over
+                        // `color`. With styles.sendButtonIcon here — it hardcodes the
+                        // primary tint (white) — the computed color was discarded and
+                        // the arrow painted white on the near-white glass composer.
+                        style={{
+                            color: sendButtonIconColor,
+                            marginTop: Platform.OS === 'web' ? 2 : 0,
+                        }}
                     />
                 )}
             </Pressable>
@@ -2525,7 +2531,12 @@ const styles = StyleSheet.create((theme) => ({
         marginLeft: 0,
         backgroundColor: Platform.select({
             ios: 'transparent',
-            android: theme.colors.glass.backgroundStrong,
+            // mobileInputBox — the composer panel directly behind this button —
+            // is itself painted glass.backgroundStrong, so reusing that token
+            // here gave the button the exact same color as its parent and the
+            // send affordance vanished into the panel. iOS stays transparent
+            // because the real glass material renders there.
+            android: theme.colors.surfaceHighest,
             default: 'transparent',
         }),
         borderWidth: StyleSheet.hairlineWidth,
@@ -2546,9 +2557,6 @@ const styles = StyleSheet.create((theme) => ({
     },
     sendButtonInnerPressed: {
         opacity: 0.7,
-    },
-    sendButtonIcon: {
-        color: theme.colors.button.primary.tint,
     },
     offlineHelp: {
         flexDirection: 'row',

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -2113,10 +2113,18 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                             name="arrow-up"
                                             size={16}
                                             color={canPressSendButton ? activeSendIconColor : theme.colors.textSecondary}
-                                            style={[
-                                                styles.sendButtonIcon,
-                                                { marginTop: Platform.OS === 'web' ? 2 : 0 },
-                                            ]}
+                                            // The color has to travel in `style`, not just the
+                                            // `color` prop: @expo/vector-icons builds
+                                            // `[styleDefaults, style, ...]` (create-icon-set.js),
+                                            // so a `style` entry always wins over `color`. With
+                                            // styles.sendButtonIcon here — it hardcodes the
+                                            // primary tint (white) — the computed color was
+                                            // discarded and the arrow painted white on the
+                                            // near-white glass composer, i.e. invisible.
+                                            style={{
+                                                color: canPressSendButton ? activeSendIconColor : theme.colors.textSecondary,
+                                                marginTop: Platform.OS === 'web' ? 2 : 0,
+                                            }}
                                         />
                                     )}
                                 </BubblePressable>


### PR DESCRIPTION
**Independently confirmed on a physical device** by @arozanov in #1597, who hit the same invisible control from the other direction:

> "So with text in the field the primary action had no visible edge at all: just a faint arrow floating on the composer." … "Both showed up on a physical device (iPhone 17 Pro Max, iOS 26.5) rather than in the simulator."

#1597 fills the send-ready button's background so a white arrow reads correctly *when there is something to send*, but it keeps `styles.sendButtonIcon` on the icon, so the idle glass state still discards its computed color. The two are orthogonal and can land in either order — happy to fold this into #1597 instead if that's simpler for you.

---

## Problem

On the compact mobile composers the send control is laid out and tappable, but paints nothing — a blind tap in the "empty" space to the right of the mic still sends the message. There is no visible send button.

This affects **both** composers, which each carry their own copy of the send button:

- the in-session composer — `sources/components/AgentInput.tsx`
- the new-session composer — `sources/app/(app)/new/index.tsx`, i.e. the composer that sends a session's *first* message

**The arrow is painted white regardless of the computed color.**

Each composer deliberately computes a non-white color for the compact mobile layout:

```ts
// AgentInput.tsx
const activeSendIconColor = compactMobileComposer ? theme.colors.text : theme.colors.button.primary.tint;
// app/(app)/new/index.tsx
const sendButtonIconColor = isNativeMobile ? theme.colors.text : theme.colors.button.primary.tint;
```

…and passes it as the icon's `color` prop — but also passes `styles.sendButtonIcon`, which hardcodes `color: theme.colors.button.primary.tint` (`#FFFFFF` in both themes). `@expo/vector-icons` applies `style` **after** the `color` prop:

```js
// node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/lib/create-icon-set.js:59
props.style = [styleDefaults, style, styleOverrides, fontStyle || {}];
```

So the computed color is always shadowed and the arrow renders white — invisible over the light glass surface. Both composers compute the right value and both discard it.

**Additionally, on the new-session composer, the button surface is the same color as the panel behind it.**

`mobileSendButton` paints its Android surface with `theme.colors.glass.backgroundStrong` — the exact token `mobileInputBox` behind it uses. Same color as the parent, so the circle disappears as well. Combined with the white arrow, the whole control vanishes in the light theme.

## Fix

- The icon carries its color in its own `style` in both composers, so the computed color is no longer shadowed by the hardcoded primary tint. `new/index.tsx`'s now-unused `sendButtonIcon` style is dropped; `AgentInput`'s is kept because the **desktop** composer still uses it, and there it is correct — that button paints a primary-background circle, so a white arrow is the right contrast.
- The new-session composer's Android surface elevates to `theme.colors.surfaceHighest` instead of reusing the panel's own background token. iOS keeps `transparent` so the real glass material still renders.

No behavior change — layout, hit target, press handling and the stop/locked/aborting/spawning states are all untouched. `pnpm typecheck` is clean.

## Rebased onto current main — what changed in this PR

The original version of this PR also elevated the **session** composer's `sendButtonGlass` surface. That half is no longer needed: #1604 replaced `sendButtonGlass` with `mobilePrimaryButton*`, and its active state already uses `surfaceHighest` — the same conclusion, reached independently. That hunk is dropped, so what remains for `AgentInput` is only the icon-color shadowing, which #1604's rework does not touch (it still passes `style={[styles.sendButtonIcon, …]}` under its new `canPressSendButton ? activeSendIconColor : textSecondary` color, so that computed color is still discarded). The fix here preserves #1604's disabled-state color and just stops it being overridden.

**Orthogonal to #1597.** That PR fills the send-ready button with `button.primary.background` so a white arrow reads correctly *when there is something to send*, but it keeps `styles.sendButtonIcon` on the icon. In the idle glass state it still resolves `activeSendIconColor` to `theme.colors.text` and still has it overwritten to white. If #1597 merges alone the invisible-arrow case returns for the idle composer; if both merge, this PR is what makes #1597's own computed colors actually take effect. No merge-order dependency either way.

## Proof — before/after on Android, both composers

Headless Android emulator (`system-images;android-30;google_apis;arm64-v8a`, Pixel 5 profile — 1080×2340 @440dpi → 393dp wide, so the compact mobile composer is active), light theme, same typed text in every frame.

`BEFORE` and `AFTER` are two **release APKs** built at this PR's then-parent commit (`0c0df93d`) and at its head, swapped in place on the one emulator — same release keystore so `adb install -r -d` preserves the account and composer state, throwaway `versionCode` 90001/90002, never published to the update channel or Obtainium. That is what makes the broken frames a real device render rather than a hand-patched mockup. Red circle marks the send control's layout box in all four frames.

### New-session composer — `app/(app)/new`

Unaffected by #1604, so these frames still show current behavior exactly. `mobileSendButton` painted the Android surface `glass.backgroundStrong`, the same token as `mobileInputBox` behind it, and the arrow took the hardcoded white `sendButtonIcon` style. Nothing paints; the mic ends up looking like the last control in the row.

![new-session composer before and after](https://github.com/chphch/happy/releases/download/proof-1582/1582-new-session-composer.png)

### Session composer — `AgentInput`

Shot on `dev/rig-preview`, one of the two places that render `<AgentInput>` (the other is the session view), so this is the component the patch touches — not `HomeDock`, which owns its own send button.

Re-captured **on top of #1604**, so this is the composer as it looks on `main` today. `BEFORE` is the shipped build with only this PR's two-file diff reverted; `AFTER` is that build as-is. With #1604's `mobilePrimaryButton*` surface in place the circle is visible in both — that half of the original report is fixed upstream — but the arrow is still white-on-near-white in `BEFORE`, because `activeSendIconColor` is still overwritten by `styles.sendButtonIcon`.

![session composer, before/after on post-#1604 main](https://github.com/chphch/happy/releases/download/proof-1582/1582-session-composer-post1604.png)

<details><summary>Original pre-#1604 capture</summary>

![session composer before and after](https://github.com/chphch/happy/releases/download/proof-1582/1582-session-composer.png)

</details>

In both BEFORE frames the control is laid out and tappable but paints nothing — which is how the bug was originally found, on a real Android device: a blind tap in the empty area right of the mic still sent the message.

