### PR TITLE
fix(app): stop seeding ACP session defaults from Claude's table

### DIFF
--- a/packages/happy-app/sources/sync/agentDefaults.test.ts
+++ b/packages/happy-app/sources/sync/agentDefaults.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+    agentKeys,
+    getAgentDefaultOverride,
+    getCodeAgentDefaults,
+    normalizeAgentKey,
+    resolveAgentDefaultConfig,
+    setAgentDefaultOverride,
+} from './agentDefaults';
+
+// `resolveSessionFlavor()` in happy-cli (src/agent/acp/runAcp.ts) can emit exactly these three
+// values for an ACP-launched session. 'gemini' has a row in `agentKeys`; the other two do not.
+const ACP_SESSION_FLAVORS = ['gemini', 'opencode', 'acp'] as const;
+const FLAVORS_WITHOUT_PROFILE = ['opencode', 'acp'] as const;
+
+describe('agentDefaults', () => {
+    it('keeps agents that have a static profile resolving to their own row', () => {
+        for (const key of agentKeys) {
+            expect(getCodeAgentDefaults(key)).toBe(getCodeAgentDefaults(key));
+            expect(normalizeAgentKey(key)).toBe(key);
+        }
+        // Distinct agents must not share a defaults row, otherwise a collapse would go unnoticed.
+        expect(getCodeAgentDefaults('codex')).not.toEqual(getCodeAgentDefaults('claude'));
+    });
+
+    it('does not hand Claude Code defaults to flavors with no static profile', () => {
+        for (const flavor of FLAVORS_WITHOUT_PROFILE) {
+            expect(getCodeAgentDefaults(flavor)).not.toEqual(getCodeAgentDefaults('claude'));
+        }
+    });
+
+    it('gives flavors with no static profile neutral defaults', () => {
+        for (const flavor of FLAVORS_WITHOUT_PROFILE) {
+            const defaults = getCodeAgentDefaults(flavor);
+            expect(defaults.permissionMode).toBe('default');
+            expect(defaults.modelMode).toBe('default');
+            expect(defaults.effortLevel).toBeNull();
+        }
+    });
+
+    it('covers every flavor an ACP session can report', () => {
+        for (const flavor of ACP_SESSION_FLAVORS) {
+            const defaults = getCodeAgentDefaults(flavor);
+            const hasOwnProfile = (agentKeys as readonly string[]).includes(flavor);
+            if (hasOwnProfile) {
+                continue;
+            }
+            expect(defaults).not.toEqual(getCodeAgentDefaults('claude'));
+        }
+    });
+
+    it('does not read the claude override slot for flavors with no static profile', () => {
+        const overrides = { claude: { modelMode: 'sonnet' } };
+        expect(getAgentDefaultOverride(overrides, 'claude')).toEqual({ modelMode: 'sonnet' });
+        for (const flavor of FLAVORS_WITHOUT_PROFILE) {
+            expect(getAgentDefaultOverride(overrides, flavor)).toEqual({});
+            expect(resolveAgentDefaultConfig(overrides, flavor).modelMode).not.toBe('sonnet');
+        }
+    });
+
+    it('does not write into the claude override slot for flavors with no static profile', () => {
+        for (const flavor of FLAVORS_WITHOUT_PROFILE) {
+            const next = setAgentDefaultOverride({}, flavor, 'modelMode', 'something');
+            expect(next).toEqual({});
+        }
+        // An existing override must survive an unmatched-flavor write untouched.
+        const existing = { claude: { modelMode: 'sonnet' } };
+        expect(setAgentDefaultOverride(existing, 'acp', 'modelMode', 'something')).toEqual(existing);
+    });
+
+    it('still writes and clears overrides for agents that have a profile', () => {
+        const written = setAgentDefaultOverride({}, 'codex', 'modelMode', 'something');
+        expect(written.codex).toEqual({ modelMode: 'something' });
+        expect(setAgentDefaultOverride(written, 'codex', 'modelMode', null)).toEqual({});
+    });
+
+    it('leaves normalizeAgentKey falling back to claude for unknown input', () => {
+        // Kept for callers that need a concrete key. The defaults lookups deliberately do not
+        // use this fallback any more.
+        expect(normalizeAgentKey('acp')).toBe('claude');
+        expect(normalizeAgentKey(null)).toBe('claude');
+        expect(normalizeAgentKey(undefined)).toBe('claude');
+        expect(normalizeAgentKey('')).toBe('claude');
+    });
+});

--- a/packages/happy-app/sources/sync/agentDefaults.ts
+++ b/packages/happy-app/sources/sync/agentDefaults.ts
@@ -37,22 +37,41 @@ const codeAgentDefaults: Record<AgentKey, AgentDefaultConfig> = {
     agy: { permissionMode: 'default', modelMode: 'Gemini 3.1 Pro (High)', effortLevel: null },
 };
 
-export function normalizeAgentKey(flavor: string | null | undefined): AgentKey {
-    if (flavor === 'codex' || flavor === 'gemini' || flavor === 'openclaw' || flavor === 'agy') {
-        return flavor;
+// Flavors outside `agentKeys` have no static config profile of their own. `resolveSessionFlavor()`
+// in happy-cli emits 'opencode' for OpenCode and 'acp' for every other ACP binary, and generic ACP
+// agents advertise their models and modes at runtime (`available_models`, operating modes), so there
+// is nothing meaningful to hardcode for them. Falling back to Claude's row would hand them
+// Claude-only keys such as `bypassPermissions` and `opus`, which their agent never advertises.
+const NEUTRAL_AGENT_DEFAULTS: AgentDefaultConfig = {
+    permissionMode: 'default',
+    modelMode: 'default',
+    effortLevel: null,
+};
+
+// Returns the matching key, or null when the flavor has no static profile. Membership is derived
+// from `agentKeys` rather than an if-chain so adding an agent cannot silently miss this path.
+function matchAgentKey(flavor: string | null | undefined): AgentKey | null {
+    if (!flavor) {
+        return null;
     }
-    return 'claude';
+    return (agentKeys as readonly string[]).includes(flavor) ? flavor as AgentKey : null;
+}
+
+export function normalizeAgentKey(flavor: string | null | undefined): AgentKey {
+    return matchAgentKey(flavor) ?? 'claude';
 }
 
 export function getCodeAgentDefaults(flavor: string | null | undefined): AgentDefaultConfig {
-    return codeAgentDefaults[normalizeAgentKey(flavor)];
+    const key = matchAgentKey(flavor);
+    return key ? codeAgentDefaults[key] : NEUTRAL_AGENT_DEFAULTS;
 }
 
 export function getAgentDefaultOverride(
     overrides: AgentDefaultOverrides | null | undefined,
     flavor: string | null | undefined,
 ): AgentDefaultOverride {
-    return overrides?.[normalizeAgentKey(flavor)] ?? {};
+    const key = matchAgentKey(flavor);
+    return (key ? overrides?.[key] : undefined) ?? {};
 }
 
 export function resolveAgentDefaultConfig(
@@ -90,7 +109,13 @@ export function setAgentDefaultOverride(
     field: AgentDefaultField,
     value: string | null | undefined,
 ): AgentDefaultOverrides {
-    const key = normalizeAgentKey(flavor);
+    const key = matchAgentKey(flavor);
+    if (!key) {
+        // No slot to write to. Writing under `normalizeAgentKey`'s 'claude' fallback would edit
+        // the user's Claude Code defaults instead. The Agent Defaults screen iterates `agentKeys`
+        // so it never reaches this, but the read paths above are called with live session flavors.
+        return { ...(overrides ?? {}) };
+    }
     const next: AgentDefaultOverrides = { ...(overrides ?? {}) };
     const current: AgentDefaultOverride = { ...(next[key] ?? {}) };
 


### PR DESCRIPTION
Fixes #1583.

## The bug

`agentKeys` in `sources/sync/agentDefaults.ts` omits `'acp'` and `'opencode'`, two flavors `happy-cli` actively reports (`agent/acp/runAcp.ts:439` `resolveSessionFlavor`, both first-class in `BackendFlavor`). `normalizeAgentKey()` collapsed anything unrecognised to `'claude'`, so those sessions were seeded from Claude Code's row:

```ts
claude: { permissionMode: 'bypassPermissions', modelMode: 'opus', effortLevel: 'medium' },
```

`opus` and `bypassPermissions` are Claude-specific keys. An ACP agent advertises its own models and modes over the wire, so for an ACP session the seeded default is not merely the wrong choice, it is unmatchable. `'opencode'` ships today via `happy acp opencode`, so this is a released integration, not a hypothetical one.

Confirmed read paths in #1583: `-session/SessionView.tsx:667-669` (`resolveAgentDefaultConfig` with the live flavor) and `components/modelModeOptions.ts:323-329` (`getDefaultModelKey` / `getDefaultPermissionModeKey`).

## The fix

`matchAgentKey()` does exact membership against `agentKeys` and returns `null` for anything else. Unrecognised flavors then get neutral defaults instead of falling through to claude:

```ts
const NEUTRAL_AGENT_DEFAULTS: AgentDefaultConfig = {
    permissionMode: 'default', modelMode: 'default', effortLevel: null,
};
```

`getAgentDefaultOverride` and `setAgentDefaultOverride` stop touching the `claude` slot for a flavor that has no row of its own. `normalizeAgentKey()` keeps its claude fallback, so nothing that depends on getting an `AgentKey` back changes behaviour.

**`agentKeys` is deliberately unchanged.** That array drives `settings/agents.tsx:143`, which renders a Permission field for every entry from `getHardcodedPermissionModes(agent, t)` — and that function *also* falls through to `getClaudePermissionModes()` (`modelModeOptions.ts:146-160`). Adding `'acp'` there would put Claude's permission modes under an ACP heading in the settings screen, with no session metadata available to correct them. That is the fix I started with and abandoned; this narrower one has no UI surface.

On the values: #1583 said I'd wait for a maintainer to name the defaults, and that is still your call. I'm sending the patch anyway because the two halves separate cleanly — the wrong lookup isn't a taste question, and the values are one object literal to change. `'default'` / `'default'` / `null` is the most conservative option available and matches the existing `openclaw` row rather than inventing a convention; #1329's reasoning (static fallback stays empty because the model picker is populated at runtime from ACP `available_models`) is the precedent. Say the word and I'll change them.

## Relation to #1322 / #1329

Complementary, no overlap. Those add a *named* `hermes` flavor; this fixes the *generic* path, which survives them — after both land, `happy acp -- <any other agent>` still resolves through the `'claude'` branch. No file touched here is touched there.

## Tests

8 new tests in `sources/sync/agentDefaults.test.ts`, following the conventions of the sibling `modelModeOptions.test.ts`.

They are not vacuous. With the test file present and `agentDefaults.ts` reverted to `3c0155c`, **5 of the 8 fail** with exactly the bug's signature:

```
✓ keeps agents that have a static profile resolving to their own row
× does not hand Claude Code defaults to flavors with no static profile
  → expected { …(3) } to not deeply equal { …(3) }
× gives flavors with no static profile neutral defaults
  → expected 'bypassPermissions' to be 'default'
× covers every flavor an ACP session can report
  → expected { …(3) } to not deeply equal { …(3) }
× does not read the claude override slot for flavors with no static profile
  → expected { modelMode: 'sonnet' } to deeply equal {}
× does not write into the claude override slot for flavors with no static profile
  → expected { claude: { modelMode: 'something' } } to deeply equal {}
✓ still writes and clears overrides for agents that have a profile
✓ leaves normalizeAgentKey falling back to claude for unknown input

Tests  5 failed | 3 passed (8)
```

With the fix: 8 passed.

- `pnpm --filter happy-app typecheck` → **0 errors** (this is what `typecheck.yml` runs on the PR).
- Full `happy-app` suite: 786 passed, 1 failed. The failure is `sources/encryption/blob.test.ts > should encrypt and decrypt a large blob (1MB)`, `Test timed out in 5000ms` — it also fails on unmodified `3c0155c`, and passes in 2.3s when that file is run alone. Pre-existing flakiness under parallel load, unrelated to this change. Flagging it rather than quietly reporting green.

`happy-app` tests aren't run by CI (`typecheck.yml` only runs `tsc`), so the above are local runs: macOS 15 arm64, Node 20, vitest via the workspace binary.

## Scope

Two files, +117/−7, no dependencies, no UI change, no behaviour change for `claude` / `codex` / `gemini` / `openclaw` / `agy` (first and seventh tests pin that). I did not touch `AgentDefaultOverridesSchema`; adding slots there is only needed if you also want these flavors editable in settings, which is the UI question above and a separate decision.
