### PR TITLE
fix(cli): stop reading whole transcripts into a single string

### DIFF
--- a/packages/happy-cli/src/claude/utils/claudeCheckSession.ts
+++ b/packages/happy-cli/src/claude/utils/claudeCheckSession.ts
@@ -1,7 +1,31 @@
 import { logger } from "@/ui/logger";
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { getProjectPath } from "./path";
+
+/**
+ * A valid transcript carries an id on one of its first lines, so only the head
+ * of the file is worth reading. Reading it whole threw ERR_STRING_TOO_LONG on
+ * transcripts past Node's 512 MB string limit, and because this runs on every
+ * remote launch the exception surfaced as `[remote]: launch error` and put the
+ * whole remote mode into a retry loop.
+ */
+const HEAD_BYTES = 8 * 1024 * 1024;
+
+function readHeadLines(file: string, maxBytes: number): string[] {
+    const { size } = statSync(file);
+    const length = Math.min(size, maxBytes);
+    const fd = openSync(file, 'r');
+    try {
+        const buffer = Buffer.allocUnsafe(length);
+        const bytesRead = readSync(fd, buffer, 0, length, 0);
+        const lines = buffer.subarray(0, bytesRead).toString('utf-8').split('\n');
+        // The final line is cut off when the file is longer than the window.
+        return size > length && lines.length > 1 ? lines.slice(0, -1) : lines;
+    } finally {
+        closeSync(fd);
+    }
+}
 
 export function claudeCheckSession(sessionId: string, path: string) {
     const projectDir = getProjectPath(path);
@@ -15,7 +39,7 @@ export function claudeCheckSession(sessionId: string, path: string) {
     }
 
     // Check if session contains any messages with valid ID fields
-    const sessionData = readFileSync(sessionFile, 'utf-8').split('\n');
+    const sessionData = readHeadLines(sessionFile, HEAD_BYTES);
 
     const hasGoodMessage = !!sessionData.find((v, index) => {
         if (!v.trim()) return false;  // Skip empty lines silently (not errors)

--- a/packages/happy-cli/src/claude/utils/sessionScanner.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.ts
@@ -2,7 +2,7 @@ import { InvalidateSync } from "@/utils/sync";
 import { RawJSONLines, RawJSONLinesSchema } from "../types";
 import { parseClaudeGoalStatusTranscriptEvent, type ClaudeGoalStatusTranscriptEvent } from "../claudeGoalStatus";
 import { join } from "node:path";
-import { readFile } from "node:fs/promises";
+import { open, stat } from "node:fs/promises";
 import { logger } from "@/ui/logger";
 import { startFileWatcher } from "@/modules/watcher/startFileWatcher";
 import { getProjectPath } from "./path";
@@ -55,7 +55,7 @@ export async function createSessionScanner(opts: {
 
     // Mark existing entries as processed and start watching the initial session
     if (opts.sessionId) {
-        let entries = await readSessionEntries(projectDir, opts.sessionId);
+        let entries = await readSessionEntries(projectDir, opts.sessionId, { skipExisting: true });
         logger.debug(`[SESSION_SCANNER] Marking ${entries.length} existing entries as processed from session ${opts.sessionId}`);
         for (let entry of entries) {
             processedEntryKeys.add(entry.key);
@@ -190,7 +190,7 @@ export async function createSessionScanner(opts: {
             // file as fresh user prompts. Without this, every previous
             // user message re-appears in the chat after reconnect.
             if (options?.treatExistingAsProcessed) {
-                const existing = await readSessionEntries(projectDir, sessionId);
+                const existing = await readSessionEntries(projectDir, sessionId, { skipExisting: true });
                 logger.debug(`[SESSION_SCANNER] Pre-marking ${existing.length} existing entries as processed for new session ${sessionId}`);
                 for (const entry of existing) {
                     processedEntryKeys.add(entry.key);
@@ -232,21 +232,105 @@ function transcriptEventKey(event: ScannerTranscriptEvent): string {
 }
 
 /**
+ * Byte offset already consumed per transcript file, so each scan only parses
+ * what Claude Code appended since the previous pass.
+ */
+const consumedOffsets = new Map<string, number>();
+
+const LF = 0x0a;
+const READ_CHUNK_BYTES = 4 * 1024 * 1024;
+const MAX_BYTES_PER_SCAN = 64 * 1024 * 1024;
+const DEFAULT_BACKFILL_BYTES = 4 * 1024 * 1024;
+
+/**
+ * How much of an already-existing transcript to replay when a session is first
+ * picked up, so a device that connects mid-session still shows recent context.
+ */
+function backfillBytes(): number {
+    const configured = Number(process.env.HAPPY_BACKFILL_BYTES);
+    return Number.isFinite(configured) && configured >= 0 ? configured : DEFAULT_BACKFILL_BYTES;
+}
+
+/**
+ * Read only the lines appended since the previous call for this file.
+ *
+ * Transcripts grow without bound — reading one whole with `readFile(f, 'utf-8')`
+ * throws ERR_STRING_TOO_LONG past Node's 512 MB string limit, and the caller
+ * used to report that as a missing file, silently disabling sync for the whole
+ * session. Splitting on the 0x0a byte is safe because it never occurs inside a
+ * multi-byte UTF-8 sequence, and a trailing partial line stays unconsumed so it
+ * is re-read once Claude Code finishes writing it.
+ *
+ * `skipExisting` marks whatever is already on disk as processed without parsing
+ * it, keeping only a small tail for backfill.
+ */
+async function readAppendedLines(file: string, opts?: { skipExisting?: boolean }): Promise<string[]> {
+    const { size } = await stat(file); // throws when absent — caller reports it
+    const previous = consumedOffsets.get(file);
+    const offset = previous === undefined || size < previous ? 0 : previous;
+
+    if (opts?.skipExisting) {
+        // Re-entering must not rewind the offset, otherwise entries are resent.
+        if (consumedOffsets.has(file)) {
+            return [];
+        }
+        const tail = backfillBytes();
+        consumedOffsets.set(file, size > tail ? size - tail : 0);
+        return [];
+    }
+    if (size <= offset) {
+        return [];
+    }
+
+    const end = Math.min(size, offset + MAX_BYTES_PER_SCAN);
+    const lines: string[] = [];
+    const handle = await open(file, 'r');
+    try {
+        const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+        let position = offset;
+        let consumed = offset;
+        let leftover = Buffer.alloc(0);
+        while (position < end) {
+            const { bytesRead } = await handle.read(buffer, 0, Math.min(READ_CHUNK_BYTES, end - position), position);
+            if (bytesRead <= 0) {
+                break;
+            }
+            position += bytesRead;
+            const data = leftover.length
+                ? Buffer.concat([leftover, buffer.subarray(0, bytesRead)])
+                : Buffer.from(buffer.subarray(0, bytesRead));
+            let start = 0;
+            let lineEnd = data.indexOf(LF, start);
+            while (lineEnd !== -1) {
+                lines.push(data.subarray(start, lineEnd).toString('utf-8'));
+                consumed += (lineEnd - start) + 1;
+                start = lineEnd + 1;
+                lineEnd = data.indexOf(LF, start);
+            }
+            leftover = data.subarray(start);
+        }
+        consumedOffsets.set(file, consumed);
+    } finally {
+        await handle.close();
+    }
+    return lines;
+}
+
+/**
  * Read and parse session log file
  * Returns only valid conversation messages and recognized side-channel events,
  * silently skipping internal events.
  */
-async function readSessionEntries(projectDir: string, sessionId: string): Promise<SessionLogEntry[]> {
+async function readSessionEntries(projectDir: string, sessionId: string, opts?: { skipExisting?: boolean }): Promise<SessionLogEntry[]> {
     const expectedSessionFile = join(projectDir, `${sessionId}.jsonl`);
     logger.debug(`[SESSION_SCANNER] Reading session file: ${expectedSessionFile}`);
-    let file: string;
+    let lines: string[];
     try {
-        file = await readFile(expectedSessionFile, 'utf-8');
+        lines = await readAppendedLines(expectedSessionFile, opts);
     } catch (error) {
         logger.debug(`[SESSION_SCANNER] Session file not found: ${expectedSessionFile}`);
         return [];
     }
-    let lines = file.split('\n');
     let entries: SessionLogEntry[] = [];
     for (let l of lines) {
         try {


### PR DESCRIPTION
## Problem

`readSessionEntries()` and `claudeCheckSession()` both load an entire session JSONL with `readFile`/`readFileSync(..., 'utf-8')`. Past Node's 512 MB string limit that throws `ERR_STRING_TOO_LONG`, and both callers report it as a missing file:

```
[SESSION_SCANNER] Session file not found: /Users/.../3d2f38ec-….jsonl
```

The path exists — it was 3.01 GB. The misleading message cost a while to diagnose.

Two consequences on that session:

1. **Sync silently disabled.** The mobile client showed an empty chat and never received a message.
2. **Remote mode wedged.** `claudeCheckSession()` runs on every remote launch, so the exception surfaced as `[remote]: launch error` in a retry loop about every 0.7 s. Messages sent from the app were never processed — the app showed `online` the whole time.

```
[15:22:05.937] [remote]: launch error Error: Cannot create a string longer than 0x1fffffe8 characters
    at readFileSync (node:fs:441:20)
    at claudeCheckSession (.../claudeCheckSession.ts:18)
    at claudeRemote (.../claudeRemote.ts)
    at claudeRemoteLauncher (.../claudeRemoteLauncher.ts)
```

## Change

**`readSessionEntries`** reads only the bytes appended since the previous pass, in chunks, tracking a per-file offset. Splitting on the `0x0a` byte is safe — it never occurs inside a multi-byte UTF-8 sequence — and a trailing partial line stays unconsumed until Claude Code finishes writing it.

This also removes the full re-read and re-parse that ran every 3 s for every watched session.

**The two call sites that only mark existing entries as processed** now pass `skipExisting`, advancing the offset without parsing. It intentionally leaves a small tail (4 MB, `HAPPY_BACKFILL_BYTES`) so a device connecting mid-session still gets recent context rather than an empty chat.

**`claudeCheckSession`** looks for the first line carrying an id, so it now reads only the head of the file (8 MB).

## Measurements

On the 3.01 GB transcript:

| Operation | Before | After |
|---|---|---|
| `skipExisting` | `ERR_STRING_TOO_LONG` | 0 ms |
| nothing new | full re-parse | 0 ms |
| incremental read | throws | 15631 lines, 34 ms, RSS 229 MB |
| `claudeCheckSession` | throws | 1827 lines, 7 ms, RSS 69 MB |
| tail backfill | — | 268 lines → 126 user/assistant messages, 2 ms |

A 6.8 MB transcript is still read in full, so smaller sessions behave exactly as before.

## Notes

`typecheck` reports the same 23 pre-existing errors with and without this change (all from `@slopus/happy-wire` not being built in my environment); none are in the touched files.

Related but distinct from #834, #1163 and #1538, which are about *which* path is watched rather than transcript size.