### PR TITLE
fix(cli): title a resumed chat from the session hook

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -466,6 +466,9 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Used by hook server to notify Session when Claude changes session ID
     let currentSession: Session | null = null;
 
+    // Last title pushed from a session hook, so repeated hooks stay quiet
+    let appliedSessionTitle: string | null = null;
+
     // Start Hook server for receiving Claude session notifications
     const hookServer = await startHookServer({
         onSessionHook: (sessionId, data) => {
@@ -485,6 +488,25 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             // *future* JSONL writes from a parallel `claude --resume`
             // terminal, which the file watcher will pick up.
             remoteScanner.onNewSession(sessionId, { treatExistingAsProcessed: true });
+
+            // A chat is titled only when the model calls mcp__happy__change_title,
+            // which it skips on `--resume` because it does not consider that a new
+            // chat — leaving the session as "New chat" forever. Claude Code already
+            // tells us the real title here, so use it. Same mechanism the MCP tool
+            // uses: a summary message.
+            if (data.session_title && data.session_title !== appliedSessionTitle && process.env.HAPPY_TITLE_FROM_SESSION !== '0') {
+                appliedSessionTitle = data.session_title;
+                logger.debug(`[START] Applying session title from hook: ${data.session_title}`);
+                try {
+                    session.sendClaudeSessionMessage({
+                        type: 'summary',
+                        summary: data.session_title,
+                        leafUuid: randomUUID()
+                    });
+                } catch (error) {
+                    logger.debug('[START] Failed to apply session title', error);
+                }
+            }
 
             // Update session ID in the Session instance
             if (currentSession) {

--- a/packages/happy-cli/src/claude/utils/startHookServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHookServer.ts
@@ -70,6 +70,8 @@ export interface SessionHookData {
     cwd?: string;
     hook_event_name?: string;
     source?: string;
+    /** Title Claude Code already assigned to the session, if any. */
+    session_title?: string;
     [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Problem

A chat gets a title only when the model calls `mcp__happy__change_title`. The injected prompt asks for that *"when you start a new chat"*, and on `--resume` the model does not treat it as one — so a resumed session stays **New chat** indefinitely. That hits exactly the sessions most worth finding again later.

Claude Code already hands us the real title. SessionStart hooks arrive like this:

```json
{
  "session_id": "3d2f38ec-…",
  "transcript_path": "/Users/…/3d2f38ec-….jsonl",
  "cwd": "/Users/…/vaonline",
  "hook_event_name": "SessionStart",
  "source": "resume",
  "session_title": "sdtable-php-go-migration-fix"
}
```

`session_title` does not appear anywhere in `packages/happy-cli/src` — the value was received and dropped on the floor.

## Change

Apply it through the same mechanism the MCP tool already uses — a `summary` message via `sendClaudeSessionMessage` — deduped so repeated hooks stay quiet. `session_title` is added to `SessionHookData` rather than left to the index signature, and `HAPPY_TITLE_FROM_SESSION=0` opts out.

Verified on a resumed session: the chat went from `New chat` to `sdtable-php-go-migration-fix` on the next start.

## Notes

`typecheck` reports the same 23 pre-existing errors with and without this change (all from `@slopus/happy-wire` not being built in my environment); none are in the touched files.