### PR TITLE
fix(cli): surface API errors in the chat instead of going quiet

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -340,6 +340,15 @@ export async function claudeRemote(opts: {
                     isCompactCommand = false;
                 }
 
+                // A result carrying an error never reaches the chat, so a
+                // safeguards refusal or an API failure reads as the session
+                // simply going quiet. Surface the text as a status line.
+                const resultMessage = message as unknown as { is_error?: boolean; result?: string };
+                if (resultMessage.is_error && typeof resultMessage.result === 'string' && resultMessage.result.trim() && opts.onCompletionEvent) {
+                    const text = resultMessage.result.trim();
+                    opts.onCompletionEvent(`⚠️ ${text.length > 400 ? text.slice(0, 400) + '…' : text}`);
+                }
+
                 // Send ready event
                 opts.onReady();
 


### PR DESCRIPTION
## Problem

A `result` carrying an error never reaches the chat. The app renders regular messages, but a safeguards refusal or an API failure arrives as a result with `is_error` and the text in `result`:

```json
{
  "type": "result",
  "subtype": "success",
  "is_error": true,
  "terminal_reason": "api_error",
  "result": "API Error: Opus 5 (1M context)'s safeguards flagged this message (…)"
}
```

From the phone the session just looks broken: you send a message, the status goes back to idle, and nothing else happens. The reason exists only in the CLI log, which is not somewhere you can look at from a phone.

I hit this on a session where safeguards rejected **eight messages in a row** with no indication in the app at all. It took reading the CLI log to discover the session was answering — with a refusal — rather than hanging.

Worth noting for anyone matching on it: a flagged turn still reports `subtype: "success"`, so the condition has to key on `is_error`.

## Change

Send the text through the same channel as other status lines (`onCompletionEvent` → `sendSessionEvent`), truncated to 400 characters. It renders like "Switched to remote mode" does.

Successful results are untouched, and an `is_error` with an empty string sends nothing.

## Notes

`typecheck` reports the same 23 pre-existing errors with and without this change (all from `@slopus/happy-wire` not being built in my environment); none are in the touched file.