### PR TITLE
fix(app): refresh the open chat when returning from the background

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -55,7 +55,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import * as React from 'react';
 import { useMemo } from 'react';
-import { ActivityIndicator, Platform, Pressable, Text, View, useWindowDimensions } from 'react-native';
+import { ActivityIndicator, AppState, Platform, Pressable, Text, View, useWindowDimensions } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
@@ -930,6 +930,21 @@ export function SessionViewLoaded({
             }
         };
     }, [sessionId, realtimeStatus, embedded]);
+
+    // Messages are fetched when the session becomes visible, which for an
+    // already-open chat only happens on mount. Returning from the background
+    // therefore leaves it showing whatever it had before — the app-state
+    // handler in Sync refreshes the session list and friends, but nothing
+    // re-reads the open conversation, so the user has to leave the chat and
+    // come back to see what the agent did meanwhile.
+    React.useEffect(() => {
+        const subscription = AppState.addEventListener('change', (nextAppState) => {
+            if (nextAppState === 'active') {
+                sync.onSessionVisible(sessionId);
+            }
+        });
+        return () => subscription.remove();
+    }, [sessionId]);
 
     let content = (
         <>


### PR DESCRIPTION
## Problem

Background the app with a chat open, come back, and the conversation shows whatever it had before. Whatever the agent did meanwhile only appears after leaving the chat and entering it again.

The cause is a gap between two mechanisms:

- Messages are fetched lazily per session through `sync.onSessionVisible(sessionId)`, which `SessionView` calls from a `useLayoutEffect` — so effectively **on mount only**.
- The app-state handler in `Sync` invalidates ten domains when the app becomes `active` (`sessionsSync`, `machinesSync`, `profileSync`, `pushTokenSync`, `artifactsSync`, `friendsSync`, `friendRequestsSync`, `feedSync`, `purchasesSync`, `nativeUpdateSync`) — but nothing re-reads the conversation already on screen.

So the session *list* refreshes on foreground while the open chat does not, and leaving/re-entering works purely because it remounts the view.

## Change

Re-trigger `onSessionVisible` from `SessionView` when the app becomes active. It goes through `InvalidateSync`, so a foreground with nothing new costs one no-op fetch.

Putting the listener in the view rather than in the app-state handler keeps it precise — the component that is actually visible refreshes itself, and the side-chat panel keeps its own behaviour.

## Notes

`typecheck` reports the same 3 pre-existing errors with and without this change; none are in the touched file.