### PR TITLE
fix: detect native-installer claude binary in PATH resolution instead of treating it as an npm shim

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -105,6 +105,44 @@ function isPlainTextWithoutShebang(filePath) {
 }
 
 /**
+ * Detect a native executable: an extensionless file whose leading bytes are
+ * not plain text (Mach-O/ELF), e.g. the native-installer binaries at
+ * ~/.local/share/claude/versions/<version>. These must not be treated as
+ * npm text shims.
+ */
+function isNativeBinaryFile(filePath) {
+    try {
+        const fd = fs.openSync(filePath, 'r');
+        try {
+            const buffer = Buffer.alloc(128);
+            const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
+            if (bytesRead === 0) {
+                return false;
+            }
+            // Shebang scripts are text executables, not native binaries
+            if (bytesRead >= 2 && buffer[0] === 0x23 && buffer[1] === 0x21) {
+                return false;
+            }
+            for (let i = 0; i < bytesRead; i++) {
+                const byte = buffer[i];
+                const isPrintableAscii = byte >= 0x20 && byte <= 0x7e;
+                const isCommonWhitespace = byte === 0x09 || byte === 0x0a || byte === 0x0d;
+                if (!isPrintableAscii && !isCommonWhitespace) {
+                    // Non-text byte found (e.g. Mach-O 0xcf 0xfa, ELF 0x7f 'ELF')
+                    return true;
+                }
+            }
+            // All bytes are plain text — likely an npm shim script
+            return false;
+        } finally {
+            fs.closeSync(fd);
+        }
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
  * Find path to npm globally installed Claude Code CLI
  * @returns {string|null} Path to cli.js or native binary, or null if not found
  */
@@ -152,6 +190,15 @@ function findClaudeInPath() {
                 return null;
             }
             if (!isExecutable) {
+                // Extensionless native binary (e.g. native installer >= 2.1.113:
+                // ~/.local/bin/claude -> ~/.local/share/claude/versions/<version>).
+                // Must be handled before the npm text-shim fallback below.
+                if (isNativeBinaryFile(resolvedPath)) {
+                    const originalSource = detectSourceFromPath(claudePath);
+                    const resolvedSource = detectSourceFromPath(resolvedPath);
+                    const source = originalSource !== 'PATH' ? originalSource : resolvedSource;
+                    return { path: resolvedPath, source };
+                }
                 const shimDir = path.dirname(claudePath);
                 const pkgDir = path.join(shimDir, 'node_modules', '@anthropic-ai', 'claude-code');
                 const entrypoint = resolveClaudeEntrypoint(pkgDir);
@@ -687,6 +734,7 @@ module.exports = {
     resolveClaudeEntrypoint,
     findGlobalClaudeCliPath,
     findClaudeInPath,
+    isNativeBinaryFile,
     detectSourceFromPath,
     findNpmGlobalCliPath,
     findBunGlobalCliPath,

--- a/packages/happy-cli/scripts/claude_version_utils.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.test.ts
@@ -6,6 +6,7 @@ import {
   resolveClaudeEntrypoint,
   findGlobalClaudeCliPath,
   findClaudeInPath,
+  isNativeBinaryFile,
   detectSourceFromPath,
   findNpmGlobalCliPath,
   findBunGlobalCliPath,
@@ -318,6 +319,53 @@ describe('Claude Version Utils - Cross-Platform Detection', () => {
         process.env.PATH = originalPath;
         fs.rmSync(root, { recursive: true, force: true });
       }
+    });
+  });
+
+  describe('isNativeBinaryFile', () => {
+    let binaryDir: string;
+
+    beforeEach(() => {
+      binaryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'happy-claude-native-binary-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(binaryDir, { recursive: true, force: true });
+    });
+
+    it('detects Mach-O-like leading bytes as a native binary', () => {
+      const filePath = path.join(binaryDir, 'claude');
+      fs.writeFileSync(filePath, Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+
+      expect(isNativeBinaryFile(filePath)).toBe(true);
+    });
+
+    it('detects ELF leading bytes as a native binary', () => {
+      const filePath = path.join(binaryDir, 'claude');
+      fs.writeFileSync(filePath, Buffer.from([0x7f, 0x45, 0x4c, 0x46]));
+
+      expect(isNativeBinaryFile(filePath)).toBe(true);
+    });
+
+    it('does not treat a shebang script as a native binary', () => {
+      const filePath = path.join(binaryDir, 'claude');
+      fs.writeFileSync(filePath, '#!/bin/sh\necho "not a binary"\n');
+
+      expect(isNativeBinaryFile(filePath)).toBe(false);
+    });
+
+    it('does not treat plain text as a native binary', () => {
+      const filePath = path.join(binaryDir, 'claude');
+      fs.writeFileSync(filePath, 'echo "npm shim script"\n');
+
+      expect(isNativeBinaryFile(filePath)).toBe(false);
+    });
+
+    it('does not treat an empty file as a native binary', () => {
+      const filePath = path.join(binaryDir, 'claude');
+      fs.writeFileSync(filePath, '');
+
+      expect(isNativeBinaryFile(filePath)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Problem

Claude Code's native installer (>= 2.1.113) installs `~/.local/bin/claude` as a symlink to an extensionless Mach-O/ELF binary at `~/.local/share/claude/versions/<version>`.

In `packages/happy-cli/scripts/claude_version_utils.cjs`, `findClaudeInPath()` treats any resolved PATH hit that doesn't end in `.js`/`.cjs`/`.exe` as an npm text shim (the `!isExecutable` branch), tries to resolve a `@anthropic-ai/claude-code` package next to it, and returns `null` when none exists. A native-installer binary therefore gets misclassified as a shim and the launch fails.

The existing `isPlainTextWithoutShebang` helper is not a usable inverse here — it returns `false` for both shebang scripts and binaries — so a dedicated check was needed.

## Fix

Add an `isNativeBinaryFile()` helper that sniffs the leading bytes of an extensionless file: shebang scripts and all-printable-text files (npm shims) are not native binaries; anything with non-text bytes (Mach-O `0xcf 0xfa`, ELF `0x7f 'ELF'`, etc.) is. In `findClaudeInPath()`, this check runs before the npm text-shim fallback, and a detected native binary is returned directly with the source derived via `detectSourceFromPath()`.

## Testing

- Added unit tests in `claude_version_utils.test.ts` covering Mach-O-like and ELF leading bytes (true), shebang scripts, plain text, and empty files (false).
- Full `claude_version_utils.test.ts` suite passes (55 tests).
- Verified locally on macOS against a native-installer setup (`~/.local/bin/claude` symlinked to the versioned native binary), where the previous behavior failed the launch.
