### PR TITLE
fix(app): keep Stop reachable while a selection card is pending

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -976,9 +976,15 @@ export function SessionViewLoaded({
             onMicPress={(embedded || isDisconnected) ? undefined : micButtonState.onMicPress}
             isMicActive={(embedded || isDisconnected) ? false : micButtonState.isMicActive}
             onAbort={isDisconnected || !rigCanAbort(session.metadata) ? undefined : handleAbort}
-            showAbortButton={rigCanAbort(session.metadata) && (Platform.OS === 'web'
-                ? sessionStatus.state === 'thinking' || sessionStatus.state === 'waiting'
-                : sessionStatus.state === 'thinking')}
+            showAbortButton={rigCanAbort(session.metadata) && (
+                sessionStatus.state === 'thinking'
+                // A pending selection (AskUserQuestion / permission request) parks the
+                // session in 'permission_required', where the agent is blocked inside the
+                // tool call — aborting is the only way to ignore the choices and keep
+                // typing, so Stop has to stay reachable on every platform.
+                || sessionStatus.state === 'permission_required'
+                || (Platform.OS === 'web' && sessionStatus.state === 'waiting')
+            )}
             onFileViewerPress={experiments && !isTablet && rigCanBrowseFiles(session.metadata) && rigCanReadFiles(session.metadata) ? handleFileViewerPress : undefined}
             selectedImages={expImageUpload && canUseAttachments ? selectedImages : undefined}
             onPickImages={expImageUpload && canUseAttachments ? pickImages : undefined}


### PR DESCRIPTION
While an `AskUserQuestion` card or a permission request is pending, `useSessionStatus` reports `permission_required` — a state the `showAbortButton` gate in `SessionView` covers on neither platform (web checks `thinking || waiting`, native checks `thinking`). So the Stop control disappears at exactly the moment the agent is parked inside the tool call and aborting is the only way to ignore the offered choices and keep typing: on mobile the composer's primary button falls back to `idle` (`resolveAgentInputPrimaryAction` needs `showAbortButton` to return `'stop'`), and on web the Escape-to-abort handler — gated on the same prop — stops responding. This adds `permission_required` to the gate on both platforms; native still hides Stop on an idle `waiting` session, so the behaviour introduced in "refresh mobile UI and improve session handling" is otherwise unchanged.

## Proof

Before/after on an Android emulator (Pixel 5, API 30, arm64), same session parked in `permission_required` on a pending `AskUserQuestion` card: the pre-fix release build offers only the voice button, the build with this commit shows Stop. GIF and capture details in the comment below.

`pnpm typecheck` and `pnpm exec vitest run` (65 files / 779 tests) pass in `packages/happy-app`.
