### PR TITLE
feat(app): attach images from the new-session composer

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -43,6 +43,9 @@ import { resolveAbsolutePath } from '@/utils/pathUtils';
 import { formatPathRelativeToHome, formatLastSeen } from '@/utils/sessionUtils';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
+import { useImagePicker } from '@/hooks/useImagePicker';
+import { useWebImagePaste } from '@/hooks/useWebImagePaste';
+import { AgentInputAttachmentStrip } from '@/components/AgentInputAttachmentStrip';
 import { useShallow } from 'zustand/react/shallow';
 import type { MultiTextInputHandle } from '@/components/MultiTextInput';
 import { Modal } from '@/modal';
@@ -769,6 +772,34 @@ function NewSessionScreen() {
         setWorktreeKey: s.setWorktreeKey,
     })));
     const draftAgent = draft.agentType;
+
+    // Image/file attachments for the first message.
+    // useImagePicker owns the pick/camera/file/paste mechanics; the draft store
+    // stays the single source the spawn handler reads, so the two are mirrored.
+    // Attachments deliberately live in memory only (see useNewSessionDraft).
+    const {
+        selectedImages,
+        pickImages,
+        removeImage,
+        clearImages,
+        addImages,
+    } = useImagePicker();
+    // Seed the picker once from whatever the draft already holds — HomeDock
+    // stages attachments there before routing here, so without this the strip
+    // would render empty even though the spawn would still send them.
+    const attachmentsSeededRef = React.useRef(false);
+    React.useEffect(() => {
+        if (attachmentsSeededRef.current) return;
+        attachmentsSeededRef.current = true;
+        const staged = useNewSessionDraft.getState().attachments;
+        if (staged.length > 0) addImages(staged);
+    }, [addImages]);
+    // Mirror every later picker change back into the draft store.
+    React.useEffect(() => {
+        if (!attachmentsSeededRef.current) return;
+        useNewSessionDraft.getState().setAttachments(selectedImages);
+    }, [selectedImages]);
+    useWebImagePaste(addImages);
     const setSelectedAgent = draft.setAgentType;
     const selectedMachineId = draft.selectedMachineId;
     const setSelectedMachineId = draft.setMachineId;
@@ -1529,6 +1560,7 @@ function NewSessionScreen() {
                     const attachments = draftState.attachments;
                     draftState.setInput('');
                     draftState.setAttachments([]);
+                    clearImages();
 
                     // Send initial message if provided
                     if (trimmedPrompt || attachments.length > 0) {
@@ -1569,7 +1601,7 @@ function NewSessionScreen() {
         } finally {
             if (isMountedRef.current) setIsSpawning(false);
         }
-    }, [allMachines, canPickWorktree, currentEffort?.key, currentModelKey, currentPermission?.key, effectiveAgentDefaults.effortLevel, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.permissionMode, navigateToSession, picksWorkspaces, router, selectedAgent, selectedMachineId, selectedPath, worktreeKey]);
+    }, [allMachines, canPickWorktree, clearImages, currentEffort?.key, currentModelKey, currentPermission?.key, effectiveAgentDefaults.effortLevel, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.permissionMode, navigateToSession, picksWorkspaces, router, selectedAgent, selectedMachineId, selectedPath, worktreeKey]);
 
     const canSend = selectedMachineId && selectedMachine && isMachineOnline(selectedMachine) && !isSpawning;
     React.useEffect(() => {
@@ -2074,6 +2106,58 @@ function NewSessionScreen() {
         </MobileGlassSurface>
     );
 
+    // Attach-image button. Shared by the desktop action row
+    // and the native-mobile left controls so both composers can stage files.
+    // On native mobile it mirrors the session composer's "+" bubble (see
+    // AgentInput's compact mobile row) so the attach affordance is identical
+    // before and after the first message; desktop keeps the outline glyph that
+    // matches the rest of its own action row.
+    const attachButtonNode = isNativeMobile ? (
+        <BubblePressable
+            onPress={pickImages}
+            hitSlop={6}
+            style={(pressedState) => [
+                styles.composerActionButton,
+                pressedState.pressed && styles.configRowPressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Attach image"
+        >
+            <Ionicons
+                name="add"
+                size={24}
+                color={selectedImages.length > 0
+                    ? theme.colors.radio.active
+                    : theme.colors.textSecondary}
+            />
+        </BubblePressable>
+    ) : (
+        <Pressable
+            onPress={pickImages}
+            hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
+            style={(p) => ({
+                flexDirection: 'row',
+                alignItems: 'center',
+                borderRadius: Platform.select({ default: 16, android: 20 }),
+                paddingHorizontal: 8,
+                paddingVertical: 6,
+                justifyContent: 'center',
+                height: 32,
+                opacity: p.pressed ? 0.7 : 1,
+            })}
+            accessibilityRole="button"
+            accessibilityLabel="Attach image"
+        >
+            <Ionicons
+                name="image-outline"
+                size={16}
+                color={selectedImages.length > 0
+                    ? theme.colors.radio.active
+                    : theme.colors.button.secondary.tint}
+            />
+        </Pressable>
+    );
+
     const composerNode = (
         <MobileGlassSurface
             enabled={isNativeMobile}
@@ -2084,6 +2168,12 @@ function NewSessionScreen() {
                 : undefined}
             style={[styles.inputBox, isNativeMobile && styles.mobileInputBox]}
         >
+            {selectedImages.length > 0 && (
+                <AgentInputAttachmentStrip
+                    images={selectedImages}
+                    onRemove={removeImage}
+                />
+            )}
             <View style={[styles.inputField, isNativeMobile && styles.mobileInputField]}>
                 <PromptInput
                     ref={composerInputRef}
@@ -2096,9 +2186,14 @@ function NewSessionScreen() {
                 styles.actionButtonsContainer,
                 isNativeMobile && styles.mobileActionButtonsContainer,
             ]}>
-                {!isNativeMobile && <View style={styles.actionButtonsLeft} />}
+                {!isNativeMobile && (
+                    <View style={styles.actionButtonsLeft}>
+                        {attachButtonNode}
+                    </View>
+                )}
                 {isNativeMobile && (
                     <View style={styles.mobileComposerLeftControls}>
+                        {attachButtonNode}
                         <BubblePressable
                             scaleFeedback={false}
                             onPress={() => togglePicker('agent')}

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -5,7 +5,7 @@ import { Keyboard, View, Platform, useWindowDimensions, Text, ActivityIndicator,
 import { Image } from 'expo-image';
 import { AgentInputAttachmentStrip } from './AgentInputAttachmentStrip';
 import type { AttachmentPreview } from '@/sync/attachmentTypes';
-import { generateThumbhash } from '@/utils/thumbhash';
+import { useWebImagePaste } from '@/hooks/useWebImagePaste';
 import { layout } from './layout';
 import { MultiTextInput, KeyPressEvent } from './MultiTextInput';
 import { Typography } from '@/constants/Typography';
@@ -968,81 +968,8 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     React.useImperativeHandle(ref, () => inputRef.current!, []);
 
     // Web paste/drag — intercept image pastes and file drops for the
-    // attachment feature. Both handlers funnel through props.onAddImages.
-    React.useEffect(() => {
-        if (Platform.OS !== 'web' || !props.onAddImages) return;
-
-        const handlePaste = async (e: ClipboardEvent) => {
-            // Only handle pastes targeted at a focused text-editable element.
-            // The listener is attached to document, so without this guard a
-            // paste in the URL bar, another modal, or any focused-elsewhere
-            // input would steal images intended for somewhere else.
-            const active = document.activeElement;
-            const isEditableTarget = active instanceof HTMLInputElement
-                || active instanceof HTMLTextAreaElement
-                || (active instanceof HTMLElement && active.isContentEditable);
-            if (!isEditableTarget) return;
-
-            const { getImagesFromClipboard, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
-            const files = getImagesFromClipboard(e);
-            if (!files.length) return;
-            e.preventDefault();
-            const previews = (await Promise.all(
-                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
-            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
-            if (previews.length) {
-                props.onAddImages!(previews.map((p) => ({
-                    ...p,
-                    id: `paste_${Date.now()}_${Math.random().toString(36).slice(2)}`,
-                })));
-            }
-        };
-
-        // dragover must call preventDefault for drop to fire; we gate on
-        // `types.includes('Files')` so we don't hijack drag-text/HTML in the
-        // rest of the app.
-        const isFileDrag = (e: DragEvent) => {
-            const types = e.dataTransfer?.types;
-            if (!types) return false;
-            // DataTransferItemList vs DOMStringList — both expose .includes-ish.
-            for (let i = 0; i < types.length; i++) {
-                if (types[i] === 'Files') return true;
-            }
-            return false;
-        };
-
-        const handleDragOver = (e: DragEvent) => {
-            if (!isFileDrag(e)) return;
-            e.preventDefault();
-            if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
-        };
-
-        const handleDrop = async (e: DragEvent) => {
-            if (!isFileDrag(e)) return;
-            e.preventDefault();
-            const { getImagesFromDrop, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
-            const files = getImagesFromDrop(e);
-            if (!files.length) return;
-            const previews = (await Promise.all(
-                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
-            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
-            if (previews.length) {
-                props.onAddImages!(previews.map((p) => ({
-                    ...p,
-                    id: `drop_${Date.now()}_${Math.random().toString(36).slice(2)}`,
-                })));
-            }
-        };
-
-        document.addEventListener('paste', handlePaste as any);
-        document.addEventListener('dragover', handleDragOver);
-        document.addEventListener('drop', handleDrop);
-        return () => {
-            document.removeEventListener('paste', handlePaste as any);
-            document.removeEventListener('dragover', handleDragOver);
-            document.removeEventListener('drop', handleDrop);
-        };
-    }, [props.onAddImages]);
+    // attachment feature. Shared with the new-session composer.
+    useWebImagePaste(props.onAddImages);
 
     // Autocomplete state — text + selection. Updated via startTransition so
     // typing renders the character immediately and the autocomplete pipeline

--- a/packages/happy-app/sources/hooks/useWebImagePaste.ts
+++ b/packages/happy-app/sources/hooks/useWebImagePaste.ts
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { generateThumbhash } from '@/utils/thumbhash';
+import type { AttachmentPreview } from '@/sync/attachmentTypes';
+
+/**
+ * Web-only: intercept image clipboard pastes and file drops anywhere in the
+ * document and funnel them into an attachment handler.
+ *
+ * Why a document-level listener (not an element handler): React Native Web's
+ * text input doesn't surface raw `paste`/`drop` clipboard files, so we listen
+ * on `document` and gate paste on a focused editable target — otherwise a paste
+ * in the URL bar or another input would steal images meant for elsewhere.
+ *
+ * Shared by AgentInput (in-session composer) and the new-session composer so
+ * both get identical paste/drag behavior. No-op on native and when no handler
+ * is provided.
+ */
+export function useWebImagePaste(onAddImages?: (images: AttachmentPreview[]) => void) {
+    React.useEffect(() => {
+        if (Platform.OS !== 'web' || !onAddImages) return;
+
+        const handlePaste = async (e: ClipboardEvent) => {
+            const active = document.activeElement;
+            const isEditableTarget = active instanceof HTMLInputElement
+                || active instanceof HTMLTextAreaElement
+                || (active instanceof HTMLElement && active.isContentEditable);
+            if (!isEditableTarget) return;
+
+            const { getImagesFromClipboard, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
+            const files = getImagesFromClipboard(e);
+            if (!files.length) return;
+            e.preventDefault();
+            const previews = (await Promise.all(
+                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
+            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
+            if (previews.length) {
+                onAddImages(previews.map((p) => ({
+                    ...p,
+                    id: `paste_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+                })));
+            }
+        };
+
+        // dragover must call preventDefault for drop to fire; we gate on
+        // `types.includes('Files')` so we don't hijack drag-text/HTML elsewhere.
+        const isFileDrag = (e: DragEvent) => {
+            const types = e.dataTransfer?.types;
+            if (!types) return false;
+            for (let i = 0; i < types.length; i++) {
+                if (types[i] === 'Files') return true;
+            }
+            return false;
+        };
+
+        const handleDragOver = (e: DragEvent) => {
+            if (!isFileDrag(e)) return;
+            e.preventDefault();
+            if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+        };
+
+        const handleDrop = async (e: DragEvent) => {
+            if (!isFileDrag(e)) return;
+            e.preventDefault();
+            const { getImagesFromDrop, fileToAttachmentPreview } = await import('@/utils/pasteImages.web');
+            const files = getImagesFromDrop(e);
+            if (!files.length) return;
+            const previews = (await Promise.all(
+                files.map((f) => fileToAttachmentPreview(f, generateThumbhash))
+            )).filter(Boolean) as Omit<AttachmentPreview, 'id'>[];
+            if (previews.length) {
+                onAddImages(previews.map((p) => ({
+                    ...p,
+                    id: `drop_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+                })));
+            }
+        };
+
+        document.addEventListener('paste', handlePaste as any);
+        document.addEventListener('dragover', handleDragOver);
+        document.addEventListener('drop', handleDrop);
+        return () => {
+            document.removeEventListener('paste', handlePaste as any);
+            document.removeEventListener('dragover', handleDragOver);
+            document.removeEventListener('drop', handleDrop);
+        };
+    }, [onAddImages]);
+}


### PR DESCRIPTION
The new-session screen already sends whatever attachments the draft store holds, but nothing on that screen could put them there — only `HomeDock` stages an image before routing here, so starting a session from `/new` had no way to include a picture with the first message. This adds the missing staging surface: an attach button in both composer rows, the shared `AgentInputAttachmentStrip` for staged previews, and web paste support. The clipboard listener moves out of `AgentInput` into a reusable `useWebImagePaste` hook so both composers share one implementation. Attachments stay in memory only, matching the existing comment in `useNewSessionDraft` — picker URIs are temporary, so nothing new is persisted. On native mobile the button mirrors the session composer's `+` bubble so the attach affordance is identical before and after the first message; the desktop row keeps the outline glyph that matches its own action row.

### Continues #1461

This is @jlixfeld's PR #1461 rebased onto current `main`, with authorship preserved on the commit. That PR has been CONFLICTING since late June and another fork user [asked for it downstream](https://github.com/slopus/happy/pull/1461#issuecomment-5077466875), so this carries it forward rather than duplicating it. **If @jlixfeld rebases #1461, close this one** — no ownership claimed.

Two things changed while rebasing:

- `main` has since added `attachments` to `useNewSessionDraft` and the send-on-spawn path, so those parts of #1461 are dropped as already-landed.
- #1461 also persisted attachments to MMKV via a new `attachmentDraft` parser. `main`'s store comments say picker URIs are intentionally *not* persisted, so that half is dropped too and this PR keeps the in-memory behaviour.

### Proof

`pnpm typecheck` clean; `pnpm exec vitest run` 778 passed (the one failure is `blob.test.ts`'s 1MB case timing out under parallel load — passes when run alone, untouched by this diff).

Running on the self-hosted fork build: the attach control appears on the `/new` composer, picking a file stages it in the strip, and sending spawns the session with the image as the first message.

### Note on overlap

#1582 touches the same composer's send button in `app/(app)/new/index.tsx`. The hunks are adjacent but independent — the two PRs merge cleanly against main in either order, and whichever lands second I'll rebase and resolve the trivial conflict the same day. No sequencing decision needed on your side.