### PR TITLE
fix: keep the picked model and effort across an abort

### DIFF
--- a/packages/happy-cli/src/claude/runClaude.test.ts
+++ b/packages/happy-cli/src/claude/runClaude.test.ts
@@ -815,6 +815,35 @@ describe('runClaude remote JSONL scanner', () => {
         await harness.finish();
     });
 
+    it('keeps the picked model and effort after an abort resets the other mode defaults', async () => {
+        const harness = await startRemoteRunClaudeHarness();
+        const userMessageHandler = harness.sessionClient.onUserMessage.mock.calls[0][0];
+
+        await userMessageHandler({
+            content: { text: 'first turn' },
+            meta: { model: 'claude-fable-5-20260115', effort: 'high' },
+        });
+        expect(harness.loopOptions.messageQueue.queue[0].mode).toMatchObject({
+            model: 'claude-fable-5-20260115',
+            effort: 'high',
+        });
+
+        // Aborting the turn must not silently revert the picker's choice —
+        // the app only sends meta.model/meta.effort when the user changes them.
+        harness.loopOptions.onAbort();
+
+        await userMessageHandler({
+            content: { text: 'second turn' },
+            meta: {},
+        });
+        expect(harness.loopOptions.messageQueue.queue[1].mode).toMatchObject({
+            model: 'claude-fable-5-20260115',
+            effort: 'high',
+        });
+
+        await harness.finish();
+    });
+
     it('rejects Claude goal-action while Claude is still thinking', async () => {
         const harness = await startRemoteRunClaudeHarness();
         await vi.waitFor(() => {

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -537,14 +537,15 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     let currentEffort: 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined = options.effort ?? DEFAULT_CLAUDE_EFFORT; // Track current Claude effort (thinking depth)
 
     const resetCurrentModeDefaults = () => {
+        // Model and effort are deliberately NOT reset here. The app sends them
+        // only when the user changes the picker, so resetting them on abort
+        // silently desyncs the picker from what the next turn actually runs.
         currentPermissionMode = initialPermissionMode;
-        currentModel = options.model ?? DEFAULT_CLAUDE_MODEL;
         currentFallbackModel = undefined;
         currentCustomSystemPrompt = undefined;
         currentAppendSystemPrompt = undefined;
         currentAllowedTools = undefined;
         currentDisallowedTools = undefined;
-        currentEffort = options.effort ?? DEFAULT_CLAUDE_EFFORT;
         logger.debug('[loop] Reset current mode defaults after abort');
     };
     const currentEnhancedMode = (): EnhancedMode => ({

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -277,14 +277,16 @@ export async function runCodex(opts: {
     let currentAppendSystemPrompt: string | undefined = undefined;
 
     const resetCurrentModeDefaults = () => {
-        // Reset to the mode the session was launched with. Note this is NOT
+        // Reset permission mode and prompts to what the session was launched
+        // with. Note this is NOT
         // a safety guarantee by itself — for plain `happy codex` the launch
         // mode IS yolo; the post-abort grace window is protected by the
         // approval handler only trusting explicitly-picked modes.
+        // Model and effort are deliberately NOT reset here. The app sends them
+        // only when the user changes the picker, so resetting them on abort
+        // silently desyncs the picker from what the next turn actually runs.
         currentPermissionMode = initialPermissionMode;
         currentPermissionModeExplicitlySet = false;
-        currentModel = opts.model ?? DEFAULT_CODEX_MODEL;
-        currentEffort = opts.effort ?? DEFAULT_CODEX_EFFORT;
         currentAppendSystemPrompt = undefined;
         logger.debug('[Codex] Reset current mode defaults after abort');
     };


### PR DESCRIPTION
Fixes #1595

**Problem**

Pick a non-default model in the picker, abort a turn, then send another message — the next turn runs the session's launch default (`opus`) instead, and the picker keeps showing the model you picked. Same for reasoning effort (reverts to `medium`). Nothing in the UI indicates the switch.

**Cause**

`resetCurrentModeDefaults()` in `packages/happy-cli/src/claude/runClaude.ts` is the loop's `onAbort`. It reset `currentModel = options.model ?? DEFAULT_CLAUDE_MODEL` and `currentEffort` likewise. `options.model` is undefined for app-driven sessions, so the model landed on the `'opus'` constant.

The app sends `meta.model` / `meta.effort` only when the picker changes (the outgoing `MessageModeMeta` carries exactly `permissionMode`, `model`, `modelProviderId`, `effort` — the other fields the reset touches are never sent by the app, so resetting those is a no-op). That makes `currentModel`/`currentEffort` the only record of the user's pick — resetting them desyncs the CLI from the picker until the user re-touches it.

`packages/happy-cli/src/codex/runCodex.ts` had the identical reset and the identical bug.

**Fix**

Drop the model and effort resets from both functions. Permission mode still resets — that's deliberate post-abort safety behavior (see the comment in `runCodex.ts`); fallback model, system prompts and tool overrides also still reset.

**Proof it works (end-to-end)**

Real local happy-server (PGlite) + real seeded account + the real built CLI (`happy claude --happy-starting-mode remote`) under a sandbox `HAPPY_HOME_DIR`; the app side scripted over the same encrypted wire protocol (messages via `POST /v3/sessions/:id/messages`, abort via socket.io `rpc-call` → `<sessionId>:abort`). Scenario: message with `meta.model: claude-sonnet-4-6` → abort → message with no meta.

Before (main):

```
[21:51:35.308] [loop] Model updated from user message: claude-sonnet-4-6
[21:51:40.875] [claudeRemote] Result received
[21:51:41.336] [remote]: doAbort
[21:51:41.337] [loop] Reset current mode defaults after abort
[21:51:42.598] [loop] User message received with no model override, using current: opus
```

Turn 2's SDK subprocess ran with `--model opus`; its assistant stream reports `"model": "claude-opus-4-8"`.

After (this branch, identical scenario):

```
[21:50:28.940] [loop] Model updated from user message: claude-sonnet-4-6
[21:50:44.037] [claudeRemote] Result received
[21:50:44.534] [remote]: doAbort
[21:50:44.534] [loop] Reset current mode defaults after abort
[21:50:45.398] [loop] User message received with no model override, using current: claude-sonnet-4-6
```

Turn 2 ran with `--model claude-sonnet-4-6`; zero opus occurrences in the logs.

**Test**

Added a unit regression test in `runClaude.test.ts` on the existing `startRemoteRunClaudeHarness`: message with `meta.model` + `meta.effort` → fire `onAbort` → message with empty meta → the queued mode still carries the original model and effort. Fails on `main` with `model: 'opus', effort: 'medium'`; passes with the fix.

`runCodex` has no comparable unit harness in this package, so the Codex half is covered by the parity of the change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
