### PR TITLE
fix(app): make the focus backdrop and send button readable in the light theme

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -390,7 +390,10 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         marginLeft: 1,
     },
     mobilePrimaryButtonActive: {
-        backgroundColor: theme.colors.surfaceHighest,
+        // Filled like the desktop send button. surfaceHighest is nearly white
+        // in the light theme, so on the (white) composer the control had no
+        // visible edge at all.
+        backgroundColor: theme.colors.button.primary.background,
     },
     mobileStopButton: {
         backgroundColor: theme.dark ? '#F5F5F5' : theme.colors.button.primary.background,
@@ -695,7 +698,6 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     const compactMobileComposer = Platform.OS !== 'web' && !isRunningOnMac() && screenWidth <= 700;
     const glassEnabled = compactMobileComposer;
     const useNativeSettingsMenus = compactMobileComposer;
-    const activeSendIconColor = glassEnabled ? theme.colors.text : theme.colors.button.primary.tint;
     const isSendBlocked = props.blockSend ?? false;
 
     // `hasText` drives only the send-button appearance/enabled state. It's
@@ -771,6 +773,11 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     });
     const shouldShowStopButton = primaryAction === 'stop';
     const canSendMessage = primaryAction === 'send';
+    // On the filled (send-ready) button the icon must read against the primary
+    // background; the glass variant only appears while idle, over the composer.
+    const activeSendIconColor = glassEnabled && !canSendMessage
+        ? theme.colors.text
+        : theme.colors.button.primary.tint;
     const mobileCanPressSendButton = !isAborting && primaryAction !== 'idle';
     const desktopCanPressSendButton = !props.isSending
         && !props.isSendDisabled
@@ -2061,7 +2068,10 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
                         <Shaker ref={shakerRef}>
                             <MobileGlassSurface
-                                enabled={glassEnabled && !shouldShowStopButton}
+                                // Off once there is something to send: the glass layer keeps its
+                                // own shape and tint, which showed through the filled button as a
+                                // grey square corner behind the circle.
+                                enabled={glassEnabled && !shouldShowStopButton && !canSendMessage}
                                 interactive={canPressSendButton}
                                 style={[
                                     styles.sendButton,
@@ -2070,7 +2080,9 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                                         : shouldShowStopButton ? styles.mobileStopButton
                                             : canSendMessage ? styles.mobilePrimaryButtonActive
                                                 : styles.sendButtonInactive,
-                                    glassEnabled && !shouldShowStopButton && styles.sendButtonGlass,
+                                    // Glass only while there is nothing to send: the transparent
+                                    // iOS background would otherwise hide the primary action.
+                                    glassEnabled && !shouldShowStopButton && !canSendMessage && styles.sendButtonGlass,
                                     glassEnabled && !canPressSendButton && styles.sendButtonInactiveGlass,
                                 ]}
                             >

--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -252,7 +252,11 @@ const styles = StyleSheet.create((theme) => ({
         bottom: 0,
     },
     focusBackdrop: {
-        backgroundColor: 'rgba(0, 0, 0, 0.88)',
+        // Was a hard-coded near-opaque black, which only works in the dark
+        // theme: everything drawn on top of it (pickers, the back chevron)
+        // uses theme.colors.text, so in the light theme it was dark-on-black
+        // and effectively invisible.
+        backgroundColor: theme.colors.scrim,
     },
     focusBackPosition: {
         position: 'absolute',

--- a/packages/happy-app/sources/theme.ts
+++ b/packages/happy-app/sources/theme.ts
@@ -51,6 +51,10 @@ export const lightTheme = {
         surfacePressed: '#f0f0f2',
         surfaceSelected: Platform.select({ ios: '#C6C6C8', default: '#eaeaea' }),
         surfacePressedOverlay: Platform.select({ ios: '#D1D1D6', default: 'transparent' }),
+        // Dim behind a full-screen overlay. Light enough that theme-coloured
+        // content stays legible on top — a near-opaque black works only when
+        // the content above it is light, which it is not in this theme.
+        scrim: 'rgba(0, 0, 0, 0.32)',
         surfaceHigh: '#F8F8F8',
         surfaceHighest: '#f0f0f0',
         divider: Platform.select({ ios: '#eaeaea', default: '#eaeaea' }),
@@ -277,6 +281,7 @@ export const darkTheme = {
         surfacePressed: Platform.select({ web: '#2C2C2E', default: '#242424' }),
         surfaceSelected: Platform.select({ web: '#2C2C2E', default: '#242424' }),
         surfacePressedOverlay: Platform.select({ web: 'transparent', default: '#242424' }),
+        scrim: 'rgba(0, 0, 0, 0.72)',
         surfaceHigh: Platform.select({ web: '#171717', default: '#1E1E1E' }),
         surfaceHighest: Platform.select({ web: '#292929', default: '#282828' }),
         divider: Platform.select({ web: '#292929', default: '#2A2A2A' }),


### PR DESCRIPTION
Two controls are styled for the dark theme only and become invisible in the light one. Both showed up on a physical device (iPhone 17 Pro Max, iOS 26.5) rather than in the simulator.

## Focus-mode backdrop

`focusBackdrop` in `HomeDock` is a hard-coded `rgba(0, 0, 0, 0.88)`. Everything drawn on top of it — the machine / path / worktree pickers, the back chevron — uses `theme.colors.text`, so in the light theme that is dark-on-black. Opening the machine picker gave an almost entirely black screen with the rows barely discernible.

Replaced with a `scrim` colour defined per theme: `rgba(0, 0, 0, 0.32)` in light, `rgba(0, 0, 0, 0.72)` in dark — the dark theme keeps the behaviour it already had.

## Mobile send button

Worse, because two things stacked:

- `sendButtonGlass` sets `backgroundColor: 'transparent'` on iOS, which overrides whichever fill the state style picked.
- The active fill was `mobilePrimaryButtonActive` → `surfaceHighest`, which is `#f0f0f0` — nearly white on the white composer.

So with text in the field the primary action had no visible edge at all: just a faint arrow floating on the composer.

The button is now filled with `button.primary` once there is something to send, matching the desktop composer, and keeps the glass treatment only while idle.

`MobileGlassSurface` is disabled in that state too. Leaving it enabled and only dropping the style was not enough — the glass layer kept its own shape and tint under the filled circle and showed as a grey square corner behind it. `MobileGlassSurface` renders a plain `View` with the same styles when `enabled` is false, so the filled state is now a clean circle.

## Notes

`pnpm typecheck` passes with 0 errors before and after.

Both are the same class of bug: a colour or layer chosen for the dark theme and applied unconditionally. Worth a look at whether other hard-coded `rgba(0, 0, 0, 0.8+)` / near-white fills exist elsewhere — I only fixed the two I could see.