### PR TITLE
fix(app): restore the readable Submit Answer button on mobile

### DIFF
--- a/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
+++ b/packages/happy-app/sources/components/tools/views/AskUserQuestionView.tsx
@@ -142,8 +142,20 @@ const styles = StyleSheet.create((theme) => ({
     submitButtonDisabled: {
         opacity: 0.5,
     },
+    // Once every question has an answer the button is genuinely actionable, so
+    // give it the same accent outline the selected radio/checkbox uses instead
+    // of leaving it on the neutral divider border.
+    submitButtonReady: {
+        borderColor: theme.colors.radio.active,
+    },
     submitButtonText: {
-        color: theme.colors.button.primary.tint,
+        // Web paints the button with button.primary.background (near-black), so
+        // the primary tint (white) is the readable foreground there. Native was
+        // switched to the neutral surfaceHighest chip without switching the
+        // foreground, leaving #FFFFFF on #f0f0f0 in the light theme — the label
+        // disappeared and the button read as permanently disabled. Same pairing
+        // the SessionView resume button uses.
+        color: Platform.select({ web: theme.colors.button.primary.tint, default: theme.colors.text }),
         fontSize: 14,
         fontWeight: '600',
     },
@@ -339,6 +351,7 @@ export const AskUserQuestionView = React.memo<ToolViewProps>(({ tool, sessionId 
                         <TouchableOpacity
                             style={[
                                 styles.submitButton,
+                                allQuestionsAnswered && !isSubmitting && styles.submitButtonReady,
                                 (!allQuestionsAnswered || isSubmitting) && styles.submitButtonDisabled,
                             ]}
                             onPress={handleSubmit}
@@ -346,7 +359,12 @@ export const AskUserQuestionView = React.memo<ToolViewProps>(({ tool, sessionId 
                             activeOpacity={0.7}
                         >
                             {isSubmitting ? (
-                                <ActivityIndicator size="small" color={theme.colors.button.primary.tint} />
+                                // Matches submitButtonText: the primary tint is only
+                                // readable on web's near-black button background.
+                                <ActivityIndicator
+                                    size="small"
+                                    color={Platform.select({ web: theme.colors.button.primary.tint, default: theme.colors.text })}
+                                />
                             ) : (
                                 <Text style={styles.submitButtonText}>{t('tools.askUserQuestion.submit')}</Text>
                             )}


### PR DESCRIPTION
## Problem

On native, the `AskUserQuestion` card's **Submit Answer** button renders as a blank grey pill — the label is invisible in the light theme, so the button reads as permanently disabled even after every question has been answered.

## Root cause

`1677fadc` ("feat: refresh mobile UI and improve session handling") made the button's **background** platform-dependent but left the **foreground** on the web-only token:

```ts
submitButton: {
    backgroundColor: Platform.select({ web: theme.colors.button.primary.background, default: theme.colors.surfaceHighest }),
    // ...
},
submitButtonText: {
    color: theme.colors.button.primary.tint,   // ← still the web pairing
},
```

`button.primary.tint` is `#FFFFFF` — the correct foreground for `button.primary.background` (`#000000`), but not for `surfaceHighest`:

| Platform / theme | Foreground | Background | Contrast |
|---|---|---|---|
| web (unchanged) | `#FFFFFF` | `#000000` | 21.00:1 |
| **native, light** | `#FFFFFF` | `#f0f0f0` | **1.14:1** ← label invisible |
| native, dark | `#FFFFFF` | `#282828` | 14.74:1 |

The submitting `ActivityIndicator` had the same problem. Dark mode was unaffected, which is why this is easy to miss.

## Fix

The label and the spinner now pair with the background the same way the codebase already does elsewhere for a button whose fill is platform-switched:

- `SessionView.tsx` resume button — `Platform.select({ web: button.primary.tint, default: theme.colors.text })` on both its `Text` and its `ActivityIndicator`
- `UserSearchResult.tsx` action button — same shape

That takes the light-theme native case from 1.14:1 to **18.43:1**; web is byte-for-byte unchanged.

While here, a fully-answered form now outlines the button with `radio.active` — the same accent this view's own selected radio/checkbox uses — so the actionable state is visually distinct from the genuinely-disabled one (the button is legitimately disabled until every question has a selection, and previously both states looked identical).

## Scope

One file, styling only. No behavior, state, or protocol change. I checked every other `button.primary.tint` usage in the app: this was the only remaining place where the background is platform-switched but the foreground is not.

## Related

Same regression family as #1582 (invisible send button) and #1598 (invisible Android settings/model/effort controls) — all three are `1677fadc` surfaces where a native repaint left a foreground token behind.
