### PR TITLE
fix(app): follow the selected agent in the home dock placeholder

### DIFF
--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -1046,7 +1046,7 @@ export const HomeDock = React.memo(({
                             value={prompt}
                             onChangeText={onPromptChange}
                             onFocus={() => setIsFocused(true)}
-                            placeholder="Ask Codex"
+                            placeholder={`Ask ${currentAgent.name}`}
                             placeholderTextColor={theme.colors.textSecondary}
                             selectionColor={theme.colors.text}
                             autoCorrect


### PR DESCRIPTION
## Problem

The session list's dock composer hardcodes `Ask Codex` as the placeholder of its focused state:

https://github.com/slopus/happy/blob/3c0155c2/packages/happy-app/sources/components/HomeDock.tsx#L1049

It names Codex regardless of which agent the new-session draft has selected, so anyone whose default is Claude Code (or Gemini, OpenClaw, Agy) is told they are about to talk to a different agent than the one that will actually start. The dock right below it shows the real agent, so the two disagree on the same screen.

## Fix

Derive the placeholder from the selected agent, the same way the first-message composer already does:

https://github.com/slopus/happy/blob/3c0155c2/packages/happy-app/sources/app/(app)/new/index.tsx#L1879

```diff
-                            placeholder="Ask Codex"
+                            placeholder={`Ask ${currentAgent.name}`}
```

`currentAgent` is already computed in this component for the model button's fallback label, so there is no new state or lookup.

Left the string hardcoded rather than routing it through `t(...)`, to match its neighbours in this component (`Plan, ask, build…`, `Machine`, `Project`, `Worktree`, `No worktree`) — happy to switch it to a translation key if you would rather fix all of them at once.

## Verification

`pnpm typecheck` clean on this branch. Rendered the dock at phone width and switched the agent between Claude Code and Codex — the placeholder follows the selection (`Ask Claude Code` ↔ `Ask Codex`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before/after emulator screenshots are in the comments below.
