### PR TITLE
fix(app): restore the home dock's agent and config pickers on Android

### DIFF
--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActivityIndicator, Keyboard, LayoutChangeEvent, Modal as RNModal, Platform, Pressable, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, Keyboard, LayoutChangeEvent, Modal as RNModal, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
@@ -17,7 +17,7 @@ import Animated, {
 import { MobileGlassSurface } from './MobileGlass';
 import { BubblePressable } from './BubblePressable';
 import { NativeOptionsPicker } from './NativeOptionsPicker';
-import { NativeSettingsMenu, type NativeSettingsMenuGroup } from './NativeSettingsMenu';
+import { NativeSettingsMenu, type NativeSettingsMenuGroup, type NativeSettingsMenuProps } from './NativeSettingsMenu';
 import { AgentInputAttachmentStrip } from './AgentInputAttachmentStrip';
 import { Typography } from '@/constants/Typography';
 import { layout } from './layout';
@@ -62,6 +62,7 @@ export const MOBILE_HOME_DOCK_CONTENT_INSET = 108;
 
 type EnvironmentSetting = 'machine' | 'project' | 'worktree';
 type AgentSetting = 'agent' | 'model' | 'permission' | 'effort';
+type PickerPage = EnvironmentSetting | AgentSetting;
 
 const CUSTOM_PROJECT_PATH_KEY = '__custom_project_path__';
 
@@ -456,6 +457,14 @@ export const HomeDock = React.memo(({
     const [isFocused, setIsFocused] = React.useState(false);
     const [focusModeVisible, setFocusModeVisible] = React.useState(false);
     const [focusedInputContentHeight, setFocusedInputContentHeight] = React.useState(0);
+    // Jetpack Compose measures a DropdownMenu.Trigger's React Native child once,
+    // at composition time, and never re-reads it — so on Android every native
+    // menu here composes before React Native has measured it and stays 0x0, i.e.
+    // an invisible control. Android drives the same pickers from the in-modal
+    // sheet below instead; iOS keeps its real native menus.
+    const useNativeMenus = Platform.OS === 'ios';
+    const [sheetPage, setSheetPage] = React.useState<PickerPage | null>(null);
+    const [sheetRootVisible, setSheetRootVisible] = React.useState(false);
     const expImageUpload = useSetting('expImageUpload');
     const { selectedImages, pickImages, removeImage, clearImages } = useImagePicker();
     const agentType = useNewSessionDraft((state) => state.agentType);
@@ -783,6 +792,9 @@ export const HomeDock = React.memo(({
     const finishCloseFocusMode = React.useCallback(() => {
         setIsFocused(false);
         setFocusModeVisible(false);
+        // The sheet lives inside the focus modal, so it must not survive it.
+        setSheetPage(null);
+        setSheetRootVisible(false);
     }, []);
 
     const closeFocusMode = React.useCallback(() => {
@@ -956,25 +968,20 @@ export const HomeDock = React.memo(({
     const modelSettingsGroup = agentSettingsGroups.find((group) => group.key === 'model');
     const effortSettingsGroup = agentSettingsGroups.find((group) => group.key === 'effort');
 
-    const renderNativePicker = (row: SettingsRow, config: PickerConfig, compact: boolean) => (
-        <NativeOptionsPicker
-            key={row.page}
-            title={config.title}
-            triggerLabel={row.value}
-            systemImage={{
-                machine: 'desktopcomputer',
-                project: 'folder',
-                worktree: 'arrow.triangle.branch',
-                agent: 'cpu',
-                model: 'cube',
-                permission: 'shield',
-                effort: 'bolt',
-            }[row.page]}
-            options={config.options.map((option) => ({ key: option.key, label: option.name }))}
-            selectedKey={config.selectedKey}
-            onSelect={config.onSelect}
-        >
-            <View style={compact ? styles.focusConfigRow : styles.option}>
+    const getPickerConfig = (page: PickerPage): PickerConfig => (
+        page === 'machine' || page === 'project' || page === 'worktree'
+            ? getEnvironmentPickerConfig(page)
+            : getAgentPickerConfig(page)
+    );
+
+    const closeSheet = () => {
+        setSheetPage(null);
+        setSheetRootVisible(false);
+    };
+    const sheetVisible = !useNativeMenus && (sheetRootVisible || sheetPage !== null);
+
+    const renderPickerRowContent = (row: SettingsRow, compact: boolean) => (
+        <View style={compact ? styles.focusConfigRow : styles.option}>
                 <View style={styles.focusConfigIcon}>
                     <Ionicons
                         name={row.icon}
@@ -991,8 +998,43 @@ export const HomeDock = React.memo(({
                     </View>
                 )}
             </View>
-        </NativeOptionsPicker>
     );
+
+    const renderPickerRow = (row: SettingsRow, config: PickerConfig, compact: boolean) => {
+        if (!useNativeMenus) {
+            return (
+                <Pressable
+                    key={row.page}
+                    onPress={() => setSheetPage(row.page as PickerPage)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${row.label}: ${row.value}`}
+                >
+                    {renderPickerRowContent(row, compact)}
+                </Pressable>
+            );
+        }
+        return (
+            <NativeOptionsPicker
+                key={row.page}
+                title={config.title}
+                triggerLabel={row.value}
+                systemImage={{
+                    machine: 'desktopcomputer',
+                    project: 'folder',
+                    worktree: 'arrow.triangle.branch',
+                    agent: 'cpu',
+                    model: 'cube',
+                    permission: 'shield',
+                    effort: 'bolt',
+                }[row.page]}
+                options={config.options.map((option) => ({ key: option.key, label: option.name }))}
+                selectedKey={config.selectedKey}
+                onSelect={config.onSelect}
+            >
+                {renderPickerRowContent(row, compact)}
+            </NativeOptionsPicker>
+        );
+    };
 
     const renderEnvironmentPickers = () => environmentRows.map((row, index) => (
         <FocusConfigRevealRow
@@ -1000,9 +1042,146 @@ export const HomeDock = React.memo(({
             progress={focusPresentation}
             index={index}
         >
-            {renderNativePicker(row, getEnvironmentPickerConfig(row.page as EnvironmentSetting), true)}
+            {renderPickerRow(row, getEnvironmentPickerConfig(row.page as EnvironmentSetting), true)}
         </FocusConfigRevealRow>
     ));
+
+    /** A composer control that opens a picker: a real native menu on iOS, the
+     *  in-modal sheet on Android. `page` is the sheet page it opens — 'root'
+     *  lists the gear's settings first, matching the iOS gear menu's grouping. */
+    const renderMenuControl = ({
+        page,
+        groups,
+        flat,
+        style,
+        accessibilityLabel,
+        triggerSystemImage,
+        triggerLabel,
+        triggerAlignment,
+        children,
+    }: {
+        page: PickerPage | 'root';
+        groups: NativeSettingsMenuGroup[];
+        flat?: boolean;
+        style: NativeSettingsMenuProps['style'];
+        accessibilityLabel: string;
+        triggerSystemImage?: NativeSettingsMenuProps['triggerSystemImage'];
+        triggerLabel?: NativeSettingsMenuProps['triggerLabel'];
+        triggerAlignment?: NativeSettingsMenuProps['triggerAlignment'];
+        children: React.ReactNode;
+    }) => {
+        if (!useNativeMenus) {
+            return (
+                <Pressable
+                    onPress={() => {
+                        if (page === 'root') {
+                            setSheetPage(null);
+                            setSheetRootVisible(true);
+                            return;
+                        }
+                        setSheetPage(page);
+                    }}
+                    style={style}
+                    accessibilityRole="button"
+                    accessibilityLabel={accessibilityLabel}
+                >
+                    {children}
+                </Pressable>
+            );
+        }
+        return (
+            <NativeSettingsMenu
+                accessibilityLabel={accessibilityLabel}
+                groups={groups}
+                flat={flat}
+                style={style}
+                triggerSystemImage={triggerSystemImage}
+                triggerLabel={triggerLabel}
+                triggerAlignment={triggerAlignment}
+            >
+                {children}
+            </NativeSettingsMenu>
+        );
+    };
+
+    const sheetRootRows = agentRows.filter((row) => (
+        row.page === 'agent' || row.page === 'permission'
+    ));
+
+    const renderSettingsSheet = () => {
+        const config = sheetPage ? getPickerConfig(sheetPage) : null;
+        // Only a page reached *through* the gear list has somewhere to go back to.
+        const canGoBack = sheetPage !== null && sheetRootVisible;
+        return (
+            <View style={styles.settingsStack}>
+                <MobileGlassSurface
+                    nativeEffect
+                    intensity={78}
+                    glassEffectStyle="regular"
+                    style={styles.settingsSurface}
+                >
+                    <View style={styles.settingsHeader}>
+                        <Pressable
+                            onPress={() => (canGoBack ? setSheetPage(null) : closeSheet())}
+                            style={styles.backButton}
+                            accessibilityRole="button"
+                            accessibilityLabel={canGoBack ? t('common.back') : t('common.cancel')}
+                        >
+                            <Ionicons
+                                name={canGoBack ? 'chevron-back' : 'close'}
+                                size={canGoBack ? 22 : 20}
+                                color={theme.colors.text}
+                            />
+                        </Pressable>
+                        <Text style={styles.settingsTitle} numberOfLines={1}>
+                            {config?.title ?? t('settings.title')}
+                        </Text>
+                    </View>
+                    <ScrollView style={styles.optionList} keyboardShouldPersistTaps="always">
+                        {config ? config.options.map((option) => (
+                            <Pressable
+                                key={option.key}
+                                onPress={() => {
+                                    config.onSelect(option.key);
+                                    closeSheet();
+                                }}
+                                style={({ pressed }) => [styles.option, pressed && styles.optionPressed]}
+                            >
+                                <View style={styles.focusConfigIcon}>
+                                    {option.key === config.selectedKey && (
+                                        <Ionicons name="checkmark" size={16} color={theme.colors.text} />
+                                    )}
+                                </View>
+                                <View style={styles.optionCopy}>
+                                    <Text style={styles.optionValue} numberOfLines={1}>{option.name}</Text>
+                                    {!!option.description && (
+                                        <Text style={styles.optionDescription} numberOfLines={2}>
+                                            {option.description}
+                                        </Text>
+                                    )}
+                                </View>
+                            </Pressable>
+                        )) : sheetRootRows.map((row) => (
+                            <Pressable
+                                key={row.page}
+                                onPress={() => setSheetPage(row.page as PickerPage)}
+                                style={({ pressed }) => [styles.option, pressed && styles.optionPressed]}
+                            >
+                                <View style={styles.focusConfigIcon}>
+                                    <Ionicons name={row.icon} size={18} color={theme.colors.text} />
+                                </View>
+                                <View style={styles.optionCopy}>
+                                    <Text style={styles.optionLabel}>{row.label}</Text>
+                                    <Text style={styles.optionValue} numberOfLines={1}>{row.value}</Text>
+                                </View>
+                                <Ionicons name="chevron-forward" size={14} color={theme.colors.textSecondary} />
+                            </Pressable>
+                        ))}
+                    </ScrollView>
+                </MobileGlassSurface>
+            </View>
+        );
+    };
 
     const renderComposer = ({
         ref,
@@ -1084,6 +1263,8 @@ export const HomeDock = React.memo(({
         if (!canSubmit) return;
         setFocusModeVisible(false);
         setIsFocused(false);
+        setSheetPage(null);
+        setSheetRootVisible(false);
         void submit();
     };
 
@@ -1147,34 +1328,38 @@ export const HomeDock = React.memo(({
                                 />
                             </BubblePressable>
                         )}
-                        <NativeSettingsMenu
-                            accessibilityLabel={t('settings.title')}
-                            groups={gearSettingsGroups}
-                            triggerSystemImage="gearshape"
-                            style={styles.nativeIconMenuFrame}
-                        >
-                            <View style={styles.nativeIconMenuContent}>
-                                <Ionicons name="settings-outline" size={20} color={theme.colors.text} />
-                            </View>
-                        </NativeSettingsMenu>
+                        {renderMenuControl({
+                            page: 'root',
+                            groups: gearSettingsGroups,
+                            style: styles.nativeIconMenuFrame,
+                            accessibilityLabel: t('settings.title'),
+                            triggerSystemImage: 'gearshape',
+                            children: (
+                                <View style={styles.nativeIconMenuContent}>
+                                    <Ionicons name="settings-outline" size={20} color={theme.colors.text} />
+                                </View>
+                            ),
+                        })}
                         {/* Pushes model/effort right so the pair sits against the
                             send button instead of drifting when a label changes. */}
                         <View style={{ flex: 1 }} />
                         {modelSettingsGroup ? (
-                            <NativeSettingsMenu
-                                accessibilityLabel={t('agentInput.model.title')}
-                                groups={[modelSettingsGroup]}
-                                flat
-                                triggerLabel={currentModel?.name ?? currentAgent.name}
-                                triggerAlignment="trailing"
-                                style={styles.nativeModeMenu}
-                            >
-                                <View style={styles.focusedModeButton}>
-                                    <Text style={styles.focusedModeText} numberOfLines={1}>
-                                        {currentModel?.name ?? currentAgent.name}
-                                    </Text>
-                                </View>
-                            </NativeSettingsMenu>
+                            renderMenuControl({
+                                page: 'model',
+                                groups: [modelSettingsGroup],
+                                flat: true,
+                                style: styles.nativeModeMenu,
+                                accessibilityLabel: t('agentInput.model.title'),
+                                triggerLabel: currentModel?.name ?? currentAgent.name,
+                                triggerAlignment: 'trailing',
+                                children: (
+                                    <View style={styles.focusedModeButton}>
+                                        <Text style={styles.focusedModeText} numberOfLines={1}>
+                                            {currentModel?.name ?? currentAgent.name}
+                                        </Text>
+                                    </View>
+                                ),
+                            })
                         ) : (
                             <View style={styles.nativeModeMenu}>
                                 <View style={styles.focusedModeButton}>
@@ -1190,22 +1375,22 @@ export const HomeDock = React.memo(({
                         {effortSettingsGroup && (
                             <Text style={styles.focusedModeSeparator}>·</Text>
                         )}
-                        {effortSettingsGroup && (
-                            <NativeSettingsMenu
-                                accessibilityLabel={t('agentInput.effort.title')}
-                                groups={[effortSettingsGroup]}
-                                flat
-                                triggerLabel={currentEffort?.name ?? t('agentInput.effort.title')}
-                                triggerAlignment="leading"
-                                style={styles.nativeEffortMenu}
-                            >
+                        {effortSettingsGroup && renderMenuControl({
+                            page: 'effort',
+                            groups: [effortSettingsGroup],
+                            flat: true,
+                            style: styles.nativeEffortMenu,
+                            accessibilityLabel: t('agentInput.effort.title'),
+                            triggerLabel: currentEffort?.name ?? t('agentInput.effort.title'),
+                            triggerAlignment: 'leading',
+                            children: (
                                 <View style={styles.focusedEffortButton}>
                                     <Text style={styles.focusedModeText} numberOfLines={1}>
                                         {currentEffort?.name ?? t('agentInput.effort.title')}
                                     </Text>
                                 </View>
-                            </NativeSettingsMenu>
-                        )}
+                            ),
+                        })}
                         <BubblePressable
                             onPress={submitFromFocusMode}
                             disabled={!canSubmit}
@@ -1274,7 +1459,7 @@ export const HomeDock = React.memo(({
                     >
                         <Pressable
                             style={styles.modalBackdrop}
-                            onPress={closeFocusMode}
+                            onPress={sheetVisible ? closeSheet : closeFocusMode}
                         />
                     </Animated.View>
                     {/* No back affordance here on purpose: tapping the backdrop
@@ -1283,9 +1468,11 @@ export const HomeDock = React.memo(({
 
                     <Animated.View style={[styles.focusDock, keyboardStyle]}>
                         <View style={styles.focusConfig}>
-                            <View style={styles.focusConfigGroup}>
-                                {renderEnvironmentPickers()}
-                            </View>
+                            {sheetVisible ? renderSettingsSheet() : (
+                                <View style={styles.focusConfigGroup}>
+                                    {renderEnvironmentPickers()}
+                                </View>
+                            )}
                         </View>
                         <View style={[
                             styles.focusComposerArea,


### PR DESCRIPTION
## Problem

On Android, tapping the session list's dock composer opens focus mode with **nothing but a send button** — no machine / project / worktree rows, no gear, no model or effort control. Every one of the dock's six pickers is unreachable, so a new session can only be started with whatever config the draft already had.

All six are React Native subtrees handed straight to a Jetpack Compose `DropdownMenu.Trigger`:

- `NativeOptionsPicker.android` for the machine / project / worktree rows
- `NativeSettingsMenu.android` for the gear, model and effort controls

`expo-modules-core` wraps such a child in `ExpoComposeAndroidView`, which pins it to `Modifier.size(view.width, view.height)` — read **once at composition** with no layout listener. A child composed before React Native has measured it therefore stays `0x0` forever: the control still occupies its slot and still accepts taps, but it paints nothing. That is why the row of controls looks empty rather than missing.

Same root cause as #1598 (the session composer's gear/model/effort), which this repo's `AgentInput` now sidesteps by gating the native menus to iOS and falling back to its own popup picker. `HomeDock` has no such fallback, so it stayed broken — and unlike `AgentInput` it also loses its three environment rows.

## Fix

Gate the native menus to iOS exactly as `AgentInput` does, and drive the same pickers from a sheet everywhere else:

- `useNativeMenus = Platform.OS === 'ios'` — iOS keeps its real native menus, untouched.
- Every trigger becomes a plain `Pressable` on other platforms, so it is measured and painted by React Native.
- The sheet reuses the option-list styles **this component already carried unused** (`settingsSurface`, `settingsHeader`, `backButton`, `settingsTitle`, `optionList`, `option*`) — they appear to be left over from a pre-native-menu picker, so no new design was invented.
- It renders **inside the focus `Modal`**, sharing that window. An app-level modal would risk landing behind the RN `Modal` on Android.
- The gear opens the agent + permission list (same grouping as the iOS gear menu) and drills into either; model, effort and each environment row open their option list directly. Selecting applies and returns to the dock; the backdrop closes the sheet before it closes focus mode; leaving focus mode resets it.

Web is also affected, though invisibly today: `NativeSettingsMenu.web` is a no-op passthrough that renders the trigger with no menu at all, so those controls were inert there. The same sheet now serves web.

## Verification

`pnpm typecheck` clean, `pnpm vitest run` 779 passed.

Rendered the non-iOS path at 393dp and exercised every control: the three environment rows are visible, the gear opens `AGENT` / `PERMISSION MODE`, the agent list shows all agents with the selected one checked, `MODEL` and `EFFORT` open their own lists (with descriptions), and picking an agent applies it and updates both the placeholder and the model label.

Since the dock is native-only in `MainView`, that render was driven by temporarily mounting `HomeDock` in the dev rig screen — so this exercises the **same JS code path Android takes** (`Platform.OS !== 'ios'`), not the Android view layer itself. The Compose boundary that caused the bug is no longer on that path, which is the point of the fix, but I have not captured it on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)