### PR TITLE
fix(app): tighten mobile composer spacing

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -171,11 +171,13 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         minHeight: 40,
     },
     mobileInputContainer: {
-        alignItems: 'flex-start',
-        minHeight: 60,
+        alignItems: 'center',
+        // Keep a one-line composer compact while centering its caret between
+        // the shell and the action row. The previous 60pt slot left a full
+        // blank line below an empty input on phones.
+        minHeight: 44,
         paddingHorizontal: 8,
-        paddingTop: 3,
-        paddingBottom: 7,
+        paddingVertical: 4,
     },
 
     // Overlay styles

--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -43,6 +43,9 @@ import { Modal } from '@/modal';
 
 export const MOBILE_HOME_DOCK_CONTENT_INSET = 108;
 
+const FOCUSED_COMPOSER_HEIGHT = 110;
+const FOCUSED_COMPOSER_ATTACHMENT_EXTRA_HEIGHT = 80;
+
 type EnvironmentSetting = 'machine' | 'project' | 'worktree';
 type AgentSetting = 'agent' | 'model' | 'permission' | 'effort';
 
@@ -124,7 +127,7 @@ const styles = StyleSheet.create((theme) => ({
     focusedComposerSurface: {
         width: '100%',
         maxWidth: layout.maxWidth,
-        height: 126,
+        height: FOCUSED_COMPOSER_HEIGHT,
         alignSelf: 'center',
         borderRadius: 30,
         overflow: 'hidden',
@@ -137,7 +140,7 @@ const styles = StyleSheet.create((theme) => ({
         }),
     },
     focusedComposerSurfaceWithAttachments: {
-        height: 206,
+        height: FOCUSED_COMPOSER_HEIGHT + FOCUSED_COMPOSER_ATTACHMENT_EXTRA_HEIGHT,
     },
     focusedComposerAnimationShell: {
         width: '100%',
@@ -155,14 +158,14 @@ const styles = StyleSheet.create((theme) => ({
     focusedComposerContent: {
         flex: 1,
         paddingHorizontal: 10,
-        paddingTop: 10,
+        paddingTop: 8,
         paddingBottom: 8,
     },
     focusedInput: {
         flex: 1,
-        minHeight: 58,
+        minHeight: 44,
         paddingHorizontal: 8,
-        paddingTop: 4,
+        paddingTop: 8,
         paddingBottom: 4,
         color: theme.colors.text,
         fontSize: 18,
@@ -622,7 +625,9 @@ export const HomeDock = React.memo(({
     const canSubmit = !isSubmitting && (
         prompt.trim().length > 0 || (expImageUpload && selectedImages.length > 0)
     );
-    const focusedComposerHeight = selectedImages.length > 0 ? 206 : 126;
+    const focusedComposerHeight = selectedImages.length > 0
+        ? FOCUSED_COMPOSER_HEIGHT + FOCUSED_COMPOSER_ATTACHMENT_EXTRA_HEIGHT
+        : FOCUSED_COMPOSER_HEIGHT;
     const keyboardStyle = useAnimatedStyle(() => ({
         // Keyboard height includes the bottom safe area on iOS. The resting
         // dock keeps that inset, then gives it back while the keyboard opens


### PR DESCRIPTION
Polish on top of #1562.

- `AgentInput.tsx` — mobile composer drops from a 60pt slot to 44pt and centers its content, so an empty one-line input no longer leaves a blank line below the caret on phones.
- `HomeDock.tsx` — focused composer height 126 → 110, and the magic heights are pulled into `FOCUSED_COMPOSER_HEIGHT` / `FOCUSED_COMPOSER_ATTACHMENT_EXTRA_HEIGHT` so the stylesheet and the runtime `focusedComposerHeight` calc can't drift apart.

Layout-only, no behavior change. Typecheck passes.