### PR TITLE
fix(app): stop an empty settings queue from resetting agent defaults

### DIFF
--- a/packages/happy-app/sources/sync/persistence.spec.ts
+++ b/packages/happy-app/sources/sync/persistence.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// react-native-mmkv needs a native/web backend; back it with a plain in-memory map.
+const store = new Map<string, string>();
+vi.mock('react-native-mmkv', () => ({
+    MMKV: class {
+        getString(key: string) { return store.get(key); }
+        set(key: string, value: string) { store.set(key, value); }
+        delete(key: string) { store.delete(key); }
+        getNumber(key: string) { const v = store.get(key); return v === undefined ? undefined : Number(v); }
+        clearAll() { store.clear(); }
+    },
+}));
+
+const { loadPendingSettings, savePendingSettings } = await import('./persistence');
+
+describe('loadPendingSettings', () => {
+    beforeEach(() => store.clear());
+
+    it('returns nothing pending for an empty queue', () => {
+        // Regression: `SettingsSchema.partial().parse({})` re-injects the fields that
+        // carry a zod `.default()`, so an empty queue used to come back as
+        // "reset schemaVersion / agentDefaultOverrides / dismissedCLIWarnings".
+        // That delta then overwrote real settings locally and on the server, which
+        // reset the agent model default on every refresh.
+        savePendingSettings({});
+        expect(loadPendingSettings()).toEqual({});
+    });
+
+    it('keeps only the keys that were actually queued', () => {
+        savePendingSettings({ viewInline: true });
+        expect(loadPendingSettings()).toEqual({ viewInline: true });
+    });
+
+    it('preserves a genuinely queued agentDefaultOverrides value', () => {
+        savePendingSettings({ agentDefaultOverrides: { claude: { modelMode: 'claude-opus-5' } } });
+        expect(loadPendingSettings()).toEqual({
+            agentDefaultOverrides: { claude: { modelMode: 'claude-opus-5' } },
+        });
+    });
+
+    it('keeps a deliberate reset to empty overrides', () => {
+        savePendingSettings({ agentDefaultOverrides: {} });
+        expect(loadPendingSettings()).toEqual({ agentDefaultOverrides: {} });
+    });
+
+    it('falls back to an empty queue on malformed json', () => {
+        store.set('pending-settings', '{not json');
+        expect(loadPendingSettings()).toEqual({});
+    });
+});

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -50,8 +50,24 @@ export function loadPendingSettings(): Partial<Settings> {
     const pending = mmkv.getString('pending-settings');
     if (pending) {
         try {
-            const parsed = JSON.parse(pending);
-            return SettingsSchema.partial().parse(parsed);
+            const raw = JSON.parse(pending);
+            if (!raw || typeof raw !== 'object') {
+                return {};
+            }
+            const parsed = SettingsSchema.partial().parse(raw) as Partial<Settings>;
+            // Keep only the keys that were actually pending. `.partial()` leaves the
+            // `.default()` wrappers intact (schemaVersion, agentDefaultOverrides,
+            // dismissedCLIWarnings), so zod re-injects those defaults for keys that
+            // were never queued. Returning them would turn "nothing is pending" into
+            // "reset these fields", which overwrites the real values on the next sync
+            // and pushes the reset to the server — wiping them on every device.
+            const result: Partial<Settings> = {};
+            for (const key of Object.keys(raw) as (keyof Settings)[]) {
+                if (key in parsed) {
+                    (result as any)[key] = parsed[key];
+                }
+            }
+            return result;
         } catch (e) {
             console.error('Failed to parse pending settings', e);
             return {};


### PR DESCRIPTION
**Two other open PRs already target this bug, and I'd rather one of them land than this one.** #1477 (@StefanGilligan) reaches the same root cause independently:

> "`partial()` makes fields optional but doesn't strip their Zod `.default()`, so the parse **re-injects** defaulted fields (`schemaVersion`, `agentDefaultOverrides`, `dismissedCLIWarnings`) that were never pending."

and #1395 (@jlixfeld) reports the symptom:

> "Configurable Agent Defaults … revert on app restart. The user sets a default, it appears to persist while the app is open, but a restart reverts it."

If either of those merges, I'll close this. Flagging the overlap up front so it isn't three PRs competing for one review.

**Reported by 6 users** — issues #648 (open), #625, #1450 (open):

> "Every new session reverts to baseline … so a user who wants a consistent default (e.g. YOLO + `xhigh` + Opus) has to reconfigure it **every single time**"
> — ay18, #1450, 2026-06-26

<details>
<summary>All reports</summary>

| Who | When | Where | Their words |
|---|---|---|---|
| omachala | 2026-02-16 | #648 (open) | "the YOLO (approve all) preference is not remembered from previous sessions" |
| ashavolian | 2026-03-24 | #648 | "every time i create a new session i have to send a message, abort, change permissions, then send another message. very annoying" |
| ashavolian | 2026-03-25 | #625 | "both the permissions setting and model preference get reset to defaults even though i had already configured them" |
| MrPhobos | 2026-04-20 | #625 | "+1, still reproducing on Happy CLI v1.1.6" |
| ay18 | 2026-06-26 | #1450 (open) | see above |
| ay18 | 2026-07-07 | #1450 | "agent defaults shows effort xhigh but every spawned session still runs at medium" |

</details>

---

## The bug

Pick a default in **Settings → Agent Defaults** (model, effort or permission). Reload the app. The pick is gone.

It is not a UI glitch — the value is destroyed on disk *and on the server*, so it also disappears from every other device on the account.

## Root cause

`loadPendingSettings()` parses the persisted outbound queue with `SettingsSchema.partial()`:

```ts
const parsed = JSON.parse(pending);
return SettingsSchema.partial().parse(parsed);
```

`.partial()` makes each key optional but leaves the `.default()` wrappers intact, and three fields carry one — `schemaVersion`, `agentDefaultOverrides` and `dismissedCLIWarnings`. So parsing the **empty** queue `{}` (the normal state right after a successful sync) does not return `{}`; it returns:

```js
{ schemaVersion: 2, agentDefaultOverrides: {}, dismissedCLIWarnings: { perMachine: {}, global: {} } }
```

"nothing is pending" has become "reset these three fields".

On the next app start `syncSettings()` layers that phantom delta over the real settings and POSTs the result to `/v1/account/settings`, so the reset is written locally **and** pushed to the server. Instrumented run, immediately after a reload:

```
POST pending={"schemaVersion":2,"agentDefaultOverrides":{},"dismissedCLIWarnings":{…}}
     storageOverrides={"claude":{"modelMode":"claude-opus-5"}}   ← the real value is still on disk
     payloadOverrides=undefined                                  ← but it is stripped from the payload
```

Two consequences beyond the visible one:

- `dismissedCLIWarnings` is wiped the same way, so dismissed CLI warnings come back.
- Every cold start issues a settings write nobody asked for, so `settingsVersion` climbs by one per app launch forever (1370 on my account).

## The fix

Keep only the keys that were actually queued. Everything else in the parse result is a zod-injected default and must not travel as a pending change.

A deliberate reset still round-trips: `savePendingSettings({ agentDefaultOverrides: {} })` writes that key into the JSON, so it survives the filter.

## Verification

Local harness (standalone server + Expo web, fresh account), same build, only `persistence.ts` swapped between the two runs:

```
before: picked=[Model → opus 5]  afterReload=[Model → Default (opus 4.8)]   ← upstream/main
after : picked=[Model → opus 5]  afterReload=[Model → opus 5]               ← this PR
```

The phantom `POST /v1/account/settings` at startup disappears entirely with the fix.

- `pnpm typecheck` clean
- `vitest` 785 passing, including 5 new cases in `sources/sync/persistence.spec.ts` covering the empty queue, a real queued value, a deliberate empty-overrides reset, and malformed JSON

