### PR TITLE
fix(app): don't treat an undecryptable settings blob as "all defaults"

### DIFF
--- a/packages/happy-app/sources/sync/settings.spec.ts
+++ b/packages/happy-app/sources/sync/settings.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SettingsSchema, settingsParse, applySettings, settingsDefaults, settingsToSyncPayload, type Settings } from './settings';
+import { SettingsSchema, settingsParse, settingsParseFromServer, applySettings, settingsDefaults, settingsToSyncPayload, type Settings } from './settings';
 
 describe('settings', () => {
     describe('settingsParse', () => {
@@ -469,6 +469,26 @@ describe('settings', () => {
 
             expect(merged.experiments).toBe(true);
             expect(merged.dismissedCLIWarnings).toEqual(pendingChanges.dismissedCLIWarnings);
+        });
+    });
+
+    describe('settingsParseFromServer', () => {
+        it('parses a decrypted blob like settingsParse', () => {
+            const blob = { experiments: true, agentDefaultOverrides: { claude: { modelMode: 'opus' } } };
+            expect(settingsParseFromServer(blob)).toEqual(settingsParse(blob));
+        });
+
+        it('throws instead of returning defaults when the blob failed to decrypt', () => {
+            // `decryptRaw` returns null on any failure. Falling through to
+            // `settingsParse(null)` would yield a full set of defaults, which the
+            // caller applies over the real settings and then pushes to the server —
+            // silently resetting the account on every device.
+            expect(() => settingsParseFromServer(null)).toThrow(/Failed to decrypt/);
+            expect(() => settingsParseFromServer(undefined)).toThrow(/Failed to decrypt/);
+        });
+
+        it('throws on a non-object payload', () => {
+            expect(() => settingsParseFromServer('not settings')).toThrow(/Failed to decrypt/);
         });
     });
 });

--- a/packages/happy-app/sources/sync/settings.ts
+++ b/packages/happy-app/sources/sync/settings.ts
@@ -181,6 +181,23 @@ export function settingsParse(settings: unknown): Settings {
     return { ...settingsDefaults, ...parsed.data, ...unknownFields };
 }
 
+/**
+ * Parse a settings blob that came off the wire, refusing anything we failed to decrypt.
+ *
+ * `decryptRaw` swallows every failure and returns null, and `settingsParse(null)`
+ * returns the full defaults — so a single failed decrypt is indistinguishable from
+ * "the server says every setting is at its default". Applying that overwrites the
+ * local copy, and the client then pushes those defaults back up, resetting the
+ * account on every other device. Throw instead, so the caller keeps what it has and
+ * retries on the next sync.
+ */
+export function settingsParseFromServer(decrypted: unknown): Settings {
+    if (decrypted === null || decrypted === undefined || typeof decrypted !== 'object') {
+        throw new Error('Failed to decrypt account settings from server');
+    }
+    return settingsParse(decrypted);
+}
+
 //
 // Applying changes
 // NOTE: May be something more sophisticated here around defaults and merging, but for now this is fine.

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -27,7 +27,7 @@ import { syncCurrentPushToken } from './pushRegistration';
 import { Platform, AppState, type AppStateStatus } from 'react-native';
 import { isRunningOnMac } from '@/utils/platform';
 import { NormalizedMessage, normalizeRawMessage, RawRecord } from './typesRaw';
-import { applySettings, Settings, settingsDefaults, settingsParse, settingsToSyncPayload, SUPPORTED_SCHEMA_VERSION } from './settings';
+import { applySettings, Settings, settingsDefaults, settingsParseFromServer, settingsToSyncPayload, SUPPORTED_SCHEMA_VERSION } from './settings';
 import { Profile, profileParse } from './profile';
 import { loadPendingSettings, savePendingSettings } from './persistence';
 import {
@@ -1811,7 +1811,7 @@ class Sync {
                 if (data.error === 'version-mismatch') {
                     // Parse server settings
                     const serverSettings = data.currentSettings
-                        ? settingsParse(await this.encryption.decryptRaw(data.currentSettings))
+                        ? settingsParseFromServer(await this.encryption.decryptRaw(data.currentSettings))
                         : { ...settingsDefaults };
 
                     // Merge: server base + our pending changes (our changes win)
@@ -1863,7 +1863,7 @@ class Sync {
         // Parse response
         let parsedSettings: Settings;
         if (data.settings) {
-            parsedSettings = settingsParse(await this.encryption.decryptRaw(data.settings));
+            parsedSettings = settingsParseFromServer(await this.encryption.decryptRaw(data.settings));
         } else {
             parsedSettings = { ...settingsDefaults };
         }
@@ -2617,7 +2617,7 @@ class Sync {
             if (accountUpdate.settings?.value) {
                 try {
                     const decryptedSettings = await this.encryption.decryptRaw(accountUpdate.settings.value);
-                    const parsedSettings = settingsParse(decryptedSettings);
+                    const parsedSettings = settingsParseFromServer(decryptedSettings);
 
                     // Version compatibility check
                     const settingsSchemaVersion = parsedSettings.schemaVersion ?? 1;


### PR DESCRIPTION
## The problem

`decryptRaw` never throws — it catches everything and returns `null`:

```ts
async decryptRaw(encrypted: string): Promise<any | null> {
    try { … } catch (error) { return null; }
}
```

and `settingsParse` treats a null/non-object input as "empty settings", returning the full defaults:

```ts
export function settingsParse(settings: unknown): Settings {
    if (!settings || typeof settings !== 'object') {
        return { ...settingsDefaults };
    }
```

Composed, `settingsParse(await decryptRaw(blob))` cannot distinguish **"I could not decrypt this"** from **"the server says every setting is at its default"**. All three places where account settings arrive from the server compose them exactly that way:

- `fetchSettings` — the startup GET
- the `version-mismatch` retry branch inside `syncSettings`
- the `update-account` socket handler

Whichever fires first hands those defaults to `applyServerSettings`, which overwrites the local copy; `syncSettings` then POSTs the result back. A decrypt failure on one device therefore resets the account **on every device**, and nothing surfaces an error — the `catch` in the socket path logs, but the other two paths look like a perfectly ordinary sync.

## The change

A single guarded entry point for wire data:

```ts
export function settingsParseFromServer(decrypted: unknown): Settings {
    if (decrypted === null || decrypted === undefined || typeof decrypted !== 'object') {
        throw new Error('Failed to decrypt account settings from server');
    }
    return settingsParse(decrypted);
}
```

The three call sites use it instead of `settingsParse`. Throwing is the safe direction here: `fetchSettings` and `syncSettings` run under `InvalidateSync`, so the throw becomes a backoff-and-retry with local settings untouched, and the socket handler already wraps its body in a `try/catch` that logs and moves on.

`settingsParse` itself is unchanged — its lenient behaviour is still correct for local storage, where an absent value genuinely does mean "use defaults".

## Notes

- This is a latent failure path, not one I have a reproduction for; I found it while chasing a different settings-reset bug (#1606) whose visible symptom was identical. The two are independent — different files, no conflict — and this one is the more destructive of the pair, since it wipes *every* synced setting rather than the three with a zod `.default()`.
- `pnpm typecheck` clean; `vitest` 783 passing, including 3 new cases asserting the guard throws on `null` / `undefined` / a non-object and otherwise matches `settingsParse`.
