### PR TITLE
fix(app): make the mobile FAB's plus icon visible again

### DIFF
--- a/packages/happy-app/sources/components/FAB.tsx
+++ b/packages/happy-app/sources/components/FAB.tsx
@@ -69,7 +69,16 @@ export const FAB = React.memo(({ onPress }: { onPress: () => void }) => {
                     <Ionicons name="add" size={24} color={theme.colors.fab.icon} />
                 ) : (
                     <MobileGlassSurface interactive intensity={76} style={styles.glass}>
-                        <Ionicons name="add" size={24} color={theme.colors.fab.icon} />
+                        {/*
+                          `fab.icon` is the inverse of `fab.background` (white on
+                          black in light, black on white in dark), so it only reads
+                          against that opaque fill — which is the web path. Native
+                          replaces the fill with a glass surface tinted like the page
+                          behind it, where the same token lands white-on-near-white
+                          in light and black-on-near-black in dark. Follow the text
+                          color there instead, as the glass composer already does.
+                        */}
+                        <Ionicons name="add" size={24} color={theme.colors.text} />
                     </MobileGlassSurface>
                 )}
             </Pressable>


### PR DESCRIPTION
The floating action button paints its icon with `fab.icon`, which the theme defines as the inverse of `fab.background` — white on black in the light theme, black on white in the dark one. That pairing only holds against the opaque fill, and the fill is now the web path only: on native the button's interior became a glass surface tinted like the page behind it, so the same token lands white-on-`rgba(255,255,255,0.84)` in light and black-on-`rgba(28,28,28,0.68)` in dark, and the plus is invisible in both themes. This points the native icon at `theme.colors.text` instead, which is what the glass composer already does for its own send arrow. The web path keeps `fab.icon` and its opaque fill unchanged.

## Proof

Captured on an Android emulator (Pixel 5, API 30, arm64), same device, same account, same screen (Artifacts) — the FAB's only render site. The change is a single colour value, so the frames differ only in the JS that produced them.
