### PR TITLE
chore(app): drop the artifacts screen's unused FAB styles

### DIFF
--- a/packages/happy-app/sources/app/(app)/artifacts/index.tsx
+++ b/packages/happy-app/sources/app/(app)/artifacts/index.tsx
@@ -105,25 +105,6 @@ const stylesheet = StyleSheet.create((theme) => ({
     artifactChevron: {
         color: theme.colors.textSecondary,
     },
-    fab: {
-        position: 'absolute',
-        bottom: 24,
-        right: 24,
-        width: 56,
-        height: 56,
-        borderRadius: 28,
-        backgroundColor: theme.colors.fab.background,
-        alignItems: 'center',
-        justifyContent: 'center',
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.2,
-        shadowRadius: 4,
-        elevation: 4,
-    },
-    fabIcon: {
-        color: '#FFFFFF',
-    },
 }));
 
 export default function ArtifactsScreen() {


### PR DESCRIPTION
The artifacts screen renders the shared `FAB` component, which carries its own positioning, glass surface and icon colour, so the local `fab` and `fabIcon` style entries have no reader — `stylesheet` is aliased exactly once to `styles` and neither name appears anywhere else in the file. Removing them also removes the last place that hardcodes a white icon against `fab.background`, which reads like a live second copy of the FAB's colour pairing while being dead code (and would have been wrong in the dark theme, where `fab.background` is white).

## Proof

Deletion-only, no runtime surface: `pnpm typecheck` is clean and `vitest run` passes 780/780 in `packages/happy-app`. No screenshot — nothing renders differently, which is the point.
