### PR TITLE
feat(cli,app): show when a session still has background work running

### DIFF
--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -27,6 +27,8 @@ import { ProviderIcon } from './ProviderIcon';
 const STATUS_CONFIG: Record<SessionState, { color: string; dotColor: string; isPulsing: boolean; isConnected: boolean }> = {
     disconnected: { color: '#999', dotColor: '#999', isPulsing: false, isConnected: false },
     thinking: { color: '#007AFF', dotColor: '#007AFF', isPulsing: true, isConnected: true },
+    // Lighter blue than `thinking`: still working, but not on your turn.
+    background: { color: '#5AC8FA', dotColor: '#5AC8FA', isPulsing: true, isConnected: true },
     waiting: { color: '#34C759', dotColor: '#34C759', isPulsing: false, isConnected: true },
     permission_required: { color: '#FF9500', dotColor: '#FF9500', isPulsing: true, isConnected: true },
 };
@@ -281,7 +283,7 @@ const CompactSessionRow = React.memo(({ session, selected, showBorder }: { sessi
                     color={theme.colors.textSecondary}
                 />
             );
-        } else if (session.state === 'permission_required' || session.state === 'thinking') {
+        } else if (session.state === 'permission_required' || session.state === 'thinking' || session.state === 'background') {
             indicator = <StatusDot color={status.dotColor} isPulsing={status.isPulsing} />;
         } else if (session.state === 'waiting') {
             indicator = <StatusDot color={theme.colors.textSecondary} isPulsing={false} />;

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -415,6 +415,8 @@ export function SessionsList({
 const STATUS_CONFIG: Record<SessionState, { color: string; dotColor: string; isPulsing: boolean; isConnected: boolean }> = {
     disconnected: { color: '#999', dotColor: '#999', isPulsing: false, isConnected: false },
     thinking: { color: '#007AFF', dotColor: '#007AFF', isPulsing: true, isConnected: true },
+    // Lighter blue than `thinking`: still working, but not on your turn.
+    background: { color: '#5AC8FA', dotColor: '#5AC8FA', isPulsing: true, isConnected: true },
     waiting: { color: '#34C759', dotColor: '#34C759', isPulsing: false, isConnected: true },
     permission_required: { color: '#FF9500', dotColor: '#FF9500', isPulsing: true, isConnected: true },
 };
@@ -447,7 +449,9 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
                 ? t('status.lastSeen', { time: formatLastSeen(session.activeAt!, false) })
                 : session.state === 'permission_required'
                     ? t('status.permissionRequired')
-                    : t('status.online');
+                    : session.state === 'background'
+                        ? t('status.backgroundWork', { count: session.backgroundCount })
+                        : t('status.online');
 
     const handlePress = React.useCallback(() => {
         navigateToSession(session.id);

--- a/packages/happy-app/sources/sync/rig.ts
+++ b/packages/happy-app/sources/sync/rig.ts
@@ -178,8 +178,14 @@ export function rigCanUseShell(metadata: Metadata | null | undefined): boolean {
         || (metadata?.capabilities?.shell === true && rigHasRpcMethod(metadata, 'bash'));
 }
 
+/**
+ * Activity indicators for any client that reports `metadata.activity` — Rig
+ * reports it natively, and happy-cli derives it from Claude Code's Stop hook.
+ * Gating this on Rig would hide background shells and subagents for every
+ * Claude session, which is where most of that work actually happens.
+ */
 export function getRigActivityIndicators(metadata: Metadata | null | undefined): RigActivityIndicator[] {
-    if (!isRigMetadata(metadata) || !metadata?.activity) return [];
+    if (!metadata?.activity) return [];
     const indicators: RigActivityIndicator[] = [];
     const { activity } = metadata;
     if (activity.subagents.running > 0 || activity.subagents.queued > 0) {
@@ -196,6 +202,37 @@ export function getRigActivityIndicators(metadata: Metadata | null | undefined):
         indicators.push({ key: 'tasks', count: activity.tasks.inProgress, queued: activity.tasks.pending });
     }
     return indicators;
+}
+
+/**
+ * Whether the session has background work in flight. Cheaper than building the
+ * indicator list, and used on the session-list hot path to decide whether an
+ * idle session should still read as busy.
+ */
+export function hasBackgroundActivity(metadata: Metadata | null | undefined): boolean {
+    const activity = metadata?.activity;
+    if (!activity) return false;
+    return activity.subagents.running > 0
+        || activity.subagents.queued > 0
+        || activity.workflows.running > 0
+        || activity.processes.running > 0
+        || activity.tasks.pending > 0
+        || activity.tasks.inProgress > 0;
+}
+
+/**
+ * Total in-flight background items, for the one-line "N running" status text.
+ * Queued work counts too — it is why the session is still busy.
+ */
+export function backgroundWorkCount(metadata: Metadata | null | undefined): number {
+    const activity = metadata?.activity;
+    if (!activity) return 0;
+    return activity.subagents.running
+        + activity.subagents.queued
+        + activity.workflows.running
+        + activity.processes.running
+        + activity.tasks.pending
+        + activity.tasks.inProgress;
 }
 
 export function getRigReasoningLevels(metadata: Metadata | null | undefined, modelKey: string | null | undefined): string[] {

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -32,7 +32,7 @@ import { getCurrentRealtimeSessionId, getVoiceSession } from '@/realtime/Realtim
 import { isMutableTool } from "@/components/tools/knownTools";
 import { DecryptedArtifact } from "./artifactTypes";
 import { FeedItem } from "./feedTypes";
-import { getRigActivityIndicators, getRigIdentity } from './rig';
+import { backgroundWorkCount, getRigActivityIndicators, getRigIdentity, hasBackgroundActivity } from './rig';
 import { indexSessionsById } from './sessionIdentity';
 
 // Debounce timer for realtimeMode changes
@@ -89,6 +89,8 @@ export interface SessionRowData {
     providerKind: string | null;
     modelName: string | null;
     activitySummary: string | null;
+    /** In-flight background items, for the "N running in background" status line. */
+    backgroundCount: number;
     state: SessionState;
     // Only present on inactive sessions — active sessions never show "last seen"
     // and activeAt updates on every heartbeat, causing needless deep-equal diffs
@@ -115,6 +117,10 @@ function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): 
         state = 'permission_required';
     } else if (session.thinking) {
         state = 'thinking';
+    } else if (hasBackgroundActivity(session.metadata)) {
+        // The turn ended but a background shell / subagent / workflow is still
+        // running, so the session is not actually idle.
+        state = 'background';
     } else {
         state = 'waiting';
     }
@@ -134,6 +140,7 @@ function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): 
         activitySummary: rigActivity.length > 0
             ? rigActivity.map((item) => `${item.count}${item.queued ? `+${item.queued}` : ''} ${item.key}`).join(' · ')
             : null,
+        backgroundCount: backgroundWorkCount(session.metadata),
         state,
         ...(!session.active && { activeAt: session.activeAt, createdAt: session.createdAt }),
         hasDraft: !!session.draft,

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -83,6 +83,7 @@ export const en = {
         activeNow: 'Active now',
         unknown: 'unknown',
         unread: 'new results',
+        backgroundWork: ({ count }: { count: number }) => `${count} running in background`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -84,6 +84,7 @@ export const ca: TranslationStructure = {
         activeNow: 'Actiu ara',
         unknown: 'desconegut',
         unread: 'nous resultats',
+        backgroundWork: ({ count }: { count: number }) => `${count} en segon pla`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -99,6 +99,7 @@ export const en: TranslationStructure = {
         activeNow: 'Active now',
         unknown: 'unknown',
         unread: 'new results',
+        backgroundWork: ({ count }: { count: number }) => `${count} running in background`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -84,6 +84,7 @@ export const es: TranslationStructure = {
         activeNow: 'Activo ahora',
         unknown: 'desconocido',
         unread: 'nuevos resultados',
+        backgroundWork: ({ count }: { count: number }) => `${count} en segundo plano`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -83,6 +83,7 @@ export const it: TranslationStructure = {
         activeNow: 'Attivo ora',
         unknown: 'sconosciuto',
         unread: 'nuovi risultati',
+        backgroundWork: ({ count }: { count: number }) => `${count} in background`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -86,6 +86,7 @@ export const ja: TranslationStructure = {
         activeNow: 'アクティブ',
         unknown: '不明',
         unread: '新しい結果',
+        backgroundWork: ({ count }: { count: number }) => `バックグラウンドで${count}件実行中`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -95,6 +95,7 @@ export const pl: TranslationStructure = {
         activeNow: 'Aktywny teraz',
         unknown: 'nieznane',
         unread: 'nowe wyniki',
+        backgroundWork: ({ count }: { count: number }) => `${count} w tle`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -84,6 +84,7 @@ export const pt: TranslationStructure = {
         activeNow: 'Ativo agora',
         unknown: 'desconhecido',
         unread: 'novos resultados',
+        backgroundWork: ({ count }: { count: number }) => `${count} em segundo plano`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -428,6 +428,7 @@ export const ru: TranslationStructure = {
         activeNow: 'Активен сейчас',
         unknown: 'неизвестно',
         unread: 'новые результаты',
+        backgroundWork: ({ count }: { count: number }) => `${count} в фоне`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -86,6 +86,7 @@ export const zhHans: TranslationStructure = {
         activeNow: '当前活跃',
         unknown: '未知',
         unread: '新结果',
+        backgroundWork: ({ count }: { count: number }) => `后台运行 ${count} 项`,
     },
 
     time: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -85,6 +85,7 @@ export const zhHant: TranslationStructure = {
         activeNow: '目前活躍',
         unknown: '未知',
         unread: '新結果',
+        backgroundWork: ({ count }: { count: number }) => `背景執行 ${count} 項`,
     },
 
     time: {

--- a/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
+++ b/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
@@ -22,6 +22,7 @@ function session(
         providerKind: null,
         modelName: null,
         activitySummary: null,
+        backgroundCount: 0,
         state: 'waiting',
         createdAt,
         hasDraft: false,

--- a/packages/happy-app/sources/utils/sessionUtils.ts
+++ b/packages/happy-app/sources/utils/sessionUtils.ts
@@ -2,8 +2,14 @@ import * as React from 'react';
 import { Session } from '@/sync/storageTypes';
 import { t } from '@/text';
 import { buildResumeCommand, buildResumeCommandBlock, ResumeCommandBlock } from './resumeCommand';
+import { backgroundWorkCount, hasBackgroundActivity } from '@/sync/rig';
 
-export type SessionState = 'disconnected' | 'thinking' | 'waiting' | 'permission_required';
+/**
+ * `background` means the turn is over but the session still has work in flight
+ * — a background shell, a subagent, a workflow. It sits between `thinking` and
+ * `waiting`: nothing is being generated, yet the session is not done either.
+ */
+export type SessionState = 'disconnected' | 'thinking' | 'background' | 'waiting' | 'permission_required';
 
 export interface SessionStatus {
     state: SessionState;
@@ -59,6 +65,21 @@ export function useSessionStatus(session: Session): SessionStatus {
             shouldShowStatus: true,
             statusColor: '#007AFF',
             statusDotColor: '#007AFF',
+            isPulsing: true
+        };
+    }
+
+    // Turn is over, but a background shell / subagent / workflow is still
+    // running — a lighter blue than `thinking` to read as "related activity,
+    // not the main thread".
+    if (hasBackgroundActivity(session.metadata)) {
+        return {
+            state: 'background',
+            isConnected: true,
+            statusText: t('status.backgroundWork', { count: backgroundWorkCount(session.metadata) }),
+            shouldShowStatus: true,
+            statusColor: '#5AC8FA',
+            statusDotColor: '#5AC8FA',
             isPulsing: true
         };
     }

--- a/packages/happy-cli/scripts/session_hook_forwarder.cjs
+++ b/packages/happy-cli/scripts/session_hook_forwarder.cjs
@@ -1,16 +1,24 @@
 #!/usr/bin/env node
 /**
  * Session Hook Forwarder
- * 
- * This script is executed by Claude's SessionStart hook.
+ *
+ * This script is executed by Claude's SessionStart / Stop / SessionEnd hooks.
  * It reads JSON data from stdin and forwards it to Happy's hook server.
- * 
- * Usage: echo '{"session_id":"..."}' | node session_hook_forwarder.cjs <port>
+ *
+ * Usage: echo '{"session_id":"..."}' | node session_hook_forwarder.cjs <port> [path]
+ *
+ * `path` defaults to /hook/session-start so existing SessionStart hook settings
+ * files written by an older happy-cli keep working after an upgrade.
  */
 
 const http = require('http');
 
 const port = parseInt(process.argv[2], 10);
+// Only the paths this forwarder is allowed to target — a settings file is
+// user-editable, and this script is spawned by Claude on every hook.
+const ALLOWED_PATHS = ['/hook/session-start', '/hook/stop', '/hook/session-end'];
+const requestedPath = process.argv[3] || '/hook/session-start';
+const path = ALLOWED_PATHS.includes(requestedPath) ? requestedPath : '/hook/session-start';
 
 if (!port || isNaN(port)) {
     process.exit(1);
@@ -29,7 +37,7 @@ process.stdin.on('end', () => {
         host: '127.0.0.1',
         port: port,
         method: 'POST',
-        path: '/hook/session-start',
+        path: path,
         headers: {
             'Content-Type': 'application/json',
             'Content-Length': body.length

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import type { Update, UpdateMachineBody } from '@slopus/happy-wire';
 import { UsageSchema } from '@/claude/types'
 import type { SandboxConfig } from '@/persistence'
+import type { SessionActivity } from '@/claude/utils/backgroundActivity'
 
 export {
   SessionMessageContentSchema,
@@ -331,6 +332,13 @@ export type Metadata = {
    * inside the parent session's sidebar panel.
    */
   isSideChat?: boolean
+  /**
+   * In-flight background work for this session (background shells, subagents,
+   * workflows), refreshed from Claude Code's Stop hook. Lets the app show that
+   * a session is idle-but-still-busy, which `thinking` cannot express because
+   * it only describes the current turn.
+   */
+  activity?: SessionActivity
 };
 
 export type UsageLimitWindowStatus = 'allowed' | 'allowed_warning' | 'rejected'

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -18,6 +18,7 @@ import { initialMachineMetadata } from '@/daemon/run';
 import { startHappyServer } from '@/claude/utils/startHappyServer';
 import { startHookServer } from '@/claude/utils/startHookServer';
 import { generateHookSettingsFile, cleanupHookSettingsFile } from '@/claude/utils/generateHookSettings';
+import { activityEquals, isActivityEmpty, summarizeBackgroundTasks, type SessionActivity } from '@/claude/utils/backgroundActivity';
 import { registerKillSessionHandler } from './registerKillSessionHandler';
 import { projectPath } from '../projectPath';
 import { resolve } from 'node:path';
@@ -466,6 +467,11 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
     // Used by hook server to notify Session when Claude changes session ID
     let currentSession: Session | null = null;
 
+    // Last background-activity summary pushed to metadata. The Stop hook fires
+    // on every turn, and most turns start no background work at all, so this
+    // keeps idle turns from re-sending an identical metadata update.
+    let lastReportedActivity: SessionActivity | undefined = undefined;
+
     // Start Hook server for receiving Claude session notifications
     const hookServer = await startHookServer({
         onSessionHook: (sessionId, data) => {
@@ -494,6 +500,17 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
                     currentSession.onSessionFound(sessionId);
                 }
             }
+        },
+        onBackgroundActivity: (tasks) => {
+            const activity = summarizeBackgroundTasks(tasks);
+            if (activityEquals(activity, lastReportedActivity)) {
+                return;
+            }
+            lastReportedActivity = activity;
+            // Absent rather than an all-zero object once nothing is running, so
+            // a session with no background work carries no activity field at all.
+            const next = isActivityEmpty(activity) ? undefined : activity;
+            session.updateMetadata((metadata) => ({ ...metadata, activity: next }));
         }
     });
     logger.debug(`[START] Hook server started on port ${hookServer.port}`);

--- a/packages/happy-cli/src/claude/utils/backgroundActivity.test.ts
+++ b/packages/happy-cli/src/claude/utils/backgroundActivity.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+    activityEquals,
+    EMPTY_ACTIVITY,
+    isActivityEmpty,
+    parseBackgroundTasks,
+    summarizeBackgroundTasks,
+    type BackgroundTaskSummary,
+} from './backgroundActivity';
+
+const shell = (status = 'running'): BackgroundTaskSummary => ({
+    id: `shell-${status}`,
+    type: 'shell',
+    status,
+    description: 'Build and deploy webapp',
+    command: 'pnpm build',
+});
+
+describe('parseBackgroundTasks', () => {
+    it('keeps well-formed entries', () => {
+        const tasks = parseBackgroundTasks([
+            { id: 'b1', type: 'shell', status: 'running', description: 'x' },
+            { id: 'a1', type: 'subagent', status: 'running', subagent_type: 'general-purpose' },
+        ]);
+        expect(tasks.map((t) => t.id)).toEqual(['b1', 'a1']);
+    });
+
+    it('drops malformed entries instead of throwing', () => {
+        // A hook payload shape we do not recognize must never take the session down.
+        expect(parseBackgroundTasks([
+            { id: 'ok', type: 'shell', status: 'running' },
+            { type: 'shell', status: 'running' },
+            { id: 'no-type', status: 'running' },
+            null,
+            'nope',
+            42,
+        ]).map((t) => t.id)).toEqual(['ok']);
+    });
+
+    it('returns empty for a missing or non-array field', () => {
+        expect(parseBackgroundTasks(undefined)).toEqual([]);
+        expect(parseBackgroundTasks(null)).toEqual([]);
+        expect(parseBackgroundTasks({ nope: true })).toEqual([]);
+    });
+});
+
+describe('summarizeBackgroundTasks', () => {
+    it('counts nothing when there are no tasks', () => {
+        expect(summarizeBackgroundTasks([])).toEqual(EMPTY_ACTIVITY);
+        expect(isActivityEmpty(summarizeBackgroundTasks([]))).toBe(true);
+    });
+
+    it('routes each task type into its own bucket', () => {
+        const activity = summarizeBackgroundTasks([
+            shell(),
+            shell(),
+            { id: 'a1', type: 'subagent', status: 'running' },
+            { id: 'w1', type: 'workflow', status: 'running' },
+        ]);
+        expect(activity.processes.running).toBe(2);
+        expect(activity.subagents).toEqual({ running: 1, queued: 0, total: 1 });
+        expect(activity.workflows).toEqual({ running: 1, total: 1 });
+        expect(isActivityEmpty(activity)).toBe(false);
+    });
+
+    it('separates queued subagents from running ones', () => {
+        const activity = summarizeBackgroundTasks([
+            { id: 'a1', type: 'subagent', status: 'running' },
+            { id: 'a2', type: 'subagent', status: 'pending' },
+            { id: 'a3', type: 'subagent', status: 'pending' },
+        ]);
+        // A fan-out should read as "1 running +2 queued", not "3 running".
+        expect(activity.subagents).toEqual({ running: 1, queued: 2, total: 3 });
+    });
+
+    it('treats an unknown task type as a generic process rather than dropping it', () => {
+        const activity = summarizeBackgroundTasks([
+            { id: 'm1', type: 'monitor', status: 'running' },
+            { id: 'x1', type: 'some_future_kind', status: 'running' },
+        ]);
+        expect(activity.processes.running).toBe(2);
+        expect(isActivityEmpty(activity)).toBe(false);
+    });
+
+    it('matches the task type and status case-insensitively', () => {
+        const activity = summarizeBackgroundTasks([
+            { id: 'a1', type: 'Subagent', status: 'RUNNING' },
+        ]);
+        expect(activity.subagents).toEqual({ running: 1, queued: 0, total: 1 });
+    });
+});
+
+describe('activityEquals', () => {
+    it('is true for structurally identical summaries', () => {
+        const tasks = [shell(), { id: 'a1', type: 'subagent', status: 'running' }];
+        expect(activityEquals(summarizeBackgroundTasks(tasks), summarizeBackgroundTasks(tasks))).toBe(true);
+    });
+
+    it('is false once a count moves', () => {
+        expect(activityEquals(
+            summarizeBackgroundTasks([shell()]),
+            summarizeBackgroundTasks([shell(), shell()]),
+        )).toBe(false);
+    });
+
+    it('distinguishes a running task from a queued one of the same type', () => {
+        expect(activityEquals(
+            summarizeBackgroundTasks([{ id: 'a1', type: 'subagent', status: 'running' }]),
+            summarizeBackgroundTasks([{ id: 'a1', type: 'subagent', status: 'pending' }]),
+        )).toBe(false);
+    });
+
+    it('treats undefined as equal only to undefined', () => {
+        expect(activityEquals(undefined, undefined)).toBe(true);
+        expect(activityEquals(EMPTY_ACTIVITY, undefined)).toBe(false);
+    });
+});

--- a/packages/happy-cli/src/claude/utils/backgroundActivity.ts
+++ b/packages/happy-cli/src/claude/utils/backgroundActivity.ts
@@ -1,0 +1,145 @@
+/**
+ * Summarize Claude Code's in-flight background work for session metadata.
+ *
+ * Claude Code reports every registered background task on the `Stop` hook
+ * payload as `background_tasks: [{ id, type, status, description, ... }]`,
+ * where `type` is a friendly label — 'shell', 'subagent', 'workflow',
+ * 'monitor', … — falling back to the raw discriminant for unknown kinds.
+ *
+ * This is the only signal that survives BOTH happy-cli launch modes: the local
+ * launcher drives the `claude` binary through a PTY and the remote launcher
+ * drives it through the SDK, but the binary runs its hooks either way. Reading
+ * it here means the app learns about background work without happy-cli having
+ * to reconstruct task lifecycles from transcript records.
+ *
+ * Why it matters: `thinking` is turn-scoped, so a session drops to "waiting"
+ * the moment the turn ends — even when a 20-minute build or a still-running
+ * subagent is the whole reason the session is still alive. The counts produced
+ * here let the session list say "idle, but N things are still running".
+ */
+
+/** One entry of the Stop hook's `background_tasks` array. */
+export interface BackgroundTaskSummary {
+    id: string;
+    /** 'shell' | 'subagent' | 'workflow' | 'monitor' | raw discriminant. */
+    type: string;
+    status: string;
+    description?: string;
+    command?: string;
+    subagent_type?: string;
+}
+
+/**
+ * Session activity counts, shaped to the app's `metadata.activity` schema.
+ * Every bucket is always present so the app's Zod object schema parses it
+ * whether or not a given kind of work is running.
+ */
+export interface SessionActivity {
+    subagents: { running: number; queued: number; total: number };
+    workflows: { running: number; total: number };
+    processes: { running: number };
+    tasks: { pending: number; inProgress: number; completed: number; total: number };
+}
+
+export const EMPTY_ACTIVITY: SessionActivity = {
+    subagents: { running: 0, queued: 0, total: 0 },
+    workflows: { running: 0, total: 0 },
+    processes: { running: 0 },
+    tasks: { pending: 0, inProgress: 0, completed: 0, total: 0 },
+};
+
+/**
+ * A task Claude Code still lists is in flight by definition, but only some of
+ * them have actually started. Anything not explicitly 'running' is counted as
+ * queued so a large fan-out reads as "2 running +6 queued" rather than "8 running".
+ */
+function isRunning(status: string): boolean {
+    return status.toLowerCase() === 'running';
+}
+
+function isBackgroundTask(value: unknown): value is BackgroundTaskSummary {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false;
+    }
+    const task = value as Record<string, unknown>;
+    return typeof task.id === 'string' && typeof task.type === 'string' && typeof task.status === 'string';
+}
+
+/**
+ * Pull the well-formed entries out of a raw hook payload's `background_tasks`.
+ * Malformed entries are dropped rather than throwing — a hook payload shape we
+ * do not recognize must never take the session down.
+ */
+export function parseBackgroundTasks(value: unknown): BackgroundTaskSummary[] {
+    return Array.isArray(value) ? value.filter(isBackgroundTask) : [];
+}
+
+/**
+ * Fold background tasks into the counts the app renders.
+ *
+ * 'shell' and every unrecognized kind land in `processes`, which is the app's
+ * generic "something is running on the machine" bucket — an unknown future task
+ * type is still worth showing as activity, just without a specific icon.
+ */
+export function summarizeBackgroundTasks(tasks: BackgroundTaskSummary[]): SessionActivity {
+    const activity: SessionActivity = {
+        subagents: { running: 0, queued: 0, total: 0 },
+        workflows: { running: 0, total: 0 },
+        processes: { running: 0 },
+        tasks: { pending: 0, inProgress: 0, completed: 0, total: 0 },
+    };
+
+    for (const task of tasks) {
+        const running = isRunning(task.status);
+        switch (task.type.toLowerCase()) {
+            case 'subagent':
+                activity.subagents.total += 1;
+                if (running) {
+                    activity.subagents.running += 1;
+                } else {
+                    activity.subagents.queued += 1;
+                }
+                break;
+            case 'workflow':
+                activity.workflows.total += 1;
+                if (running) {
+                    activity.workflows.running += 1;
+                }
+                break;
+            default:
+                activity.processes.running += 1;
+                break;
+        }
+    }
+
+    return activity;
+}
+
+/** Whether an activity summary carries no in-flight work at all. */
+export function isActivityEmpty(activity: SessionActivity): boolean {
+    return activity.subagents.total === 0
+        && activity.workflows.total === 0
+        && activity.processes.running === 0
+        && activity.tasks.total === 0;
+}
+
+/**
+ * Structural equality, used to skip redundant metadata writes. Metadata updates
+ * are read-modify-write against the server under optimistic concurrency, so
+ * re-sending an identical `activity` on every idle turn is pure churn.
+ */
+export function activityEquals(a: SessionActivity | undefined, b: SessionActivity | undefined): boolean {
+    if (!a || !b) {
+        return a === b;
+    }
+    return a.subagents.running === b.subagents.running
+        && a.subagents.queued === b.subagents.queued
+        && a.subagents.total === b.subagents.total
+        && a.workflows.running === b.workflows.running
+        && a.workflows.total === b.workflows.total
+        && a.processes.running === b.processes.running
+        && a.tasks.pending === b.tasks.pending
+        && a.tasks.inProgress === b.tasks.inProgress
+        && a.tasks.completed === b.tasks.completed
+        && a.tasks.total === b.tasks.total;
+}

--- a/packages/happy-cli/src/claude/utils/generateHookSettings.ts
+++ b/packages/happy-cli/src/claude/utils/generateHookSettings.ts
@@ -27,21 +27,30 @@ export function generateHookSettingsFile(port: number): string {
 
     // Path to the hook forwarder script
     const forwarderScript = resolve(projectPath(), 'scripts', 'session_hook_forwarder.cjs');
-    const hookCommand = `node "${forwarderScript}" ${port}`;
-
-    const settings = {
-        hooks: {
-            SessionStart: [
+    const hookEntry = (path: string) => [
+        {
+            matcher: "*",
+            hooks: [
                 {
-                    matcher: "*",
-                    hooks: [
-                        {
-                            type: "command",
-                            command: hookCommand
-                        }
-                    ]
+                    type: "command",
+                    command: `node "${forwarderScript}" ${port} ${path}`
                 }
             ]
+        }
+    ];
+
+    // Stop carries `background_tasks` — the background work (shells, subagents,
+    // workflows) still in flight when the turn ends. It is what distinguishes
+    // "the turn ended and the session is idle" from "the turn ended but a build
+    // is still running", and it arrives in both launch modes because the
+    // `claude` binary runs its hooks whether it is driven through the PTY or
+    // through the SDK. SessionEnd clears the counts, so a session that exits
+    // mid-build leaves no stale activity behind.
+    const settings = {
+        hooks: {
+            SessionStart: hookEntry('/hook/session-start'),
+            Stop: hookEntry('/hook/stop'),
+            SessionEnd: hookEntry('/hook/session-end')
         }
     };
 

--- a/packages/happy-cli/src/claude/utils/startHookServer.ts
+++ b/packages/happy-cli/src/claude/utils/startHookServer.ts
@@ -1,9 +1,10 @@
 /**
  * Dedicated HTTP server for receiving Claude session hooks
- * 
+ *
  * This server receives notifications from Claude when sessions change
- * (new session, resume, compact, fork, etc.) via the SessionStart hook.
- * 
+ * (new session, resume, compact, fork, etc.) via the SessionStart hook, and
+ * the session's in-flight background work via the Stop / SessionEnd hooks.
+ *
  * Separate from the MCP server to keep concerns isolated.
  * 
  * ## Control Flow
@@ -59,6 +60,7 @@
 
 import { createServer, IncomingMessage, ServerResponse, Server } from 'node:http';
 import { logger } from '@/ui/logger';
+import { parseBackgroundTasks, type BackgroundTaskSummary } from './backgroundActivity';
 
 /**
  * Data received from Claude's SessionStart hook
@@ -70,12 +72,20 @@ export interface SessionHookData {
     cwd?: string;
     hook_event_name?: string;
     source?: string;
+    /** Stop hook only: background work still in flight for this session. */
+    background_tasks?: unknown;
     [key: string]: unknown;
 }
 
 export interface HookServerOptions {
     /** Called when a session hook is received with a valid session ID */
     onSessionHook: (sessionId: string, data: SessionHookData) => void;
+    /**
+     * Called on every Stop hook with the background work still in flight, and
+     * on SessionEnd with an empty list. `thinking` only describes the current
+     * turn, so this is what tells the app a session is idle-but-still-busy.
+     */
+    onBackgroundActivity?: (tasks: BackgroundTaskSummary[]) => void;
 }
 
 export interface HookServer {
@@ -92,12 +102,36 @@ export interface HookServer {
  * @returns Promise resolving to the server instance with port info
  */
 export async function startHookServer(options: HookServerOptions): Promise<HookServer> {
-    const { onSessionHook } = options;
+    const { onSessionHook, onBackgroundActivity } = options;
+
+    const handlers: Record<string, (data: SessionHookData) => void> = {
+        '/hook/session-start': (data) => {
+            // Support both snake_case (from Claude) and camelCase
+            const sessionId = data.session_id || data.sessionId;
+            if (sessionId) {
+                logger.debug(`[hookServer] Session hook received session ID: ${sessionId}`);
+                onSessionHook(sessionId, data);
+            } else {
+                logger.debug('[hookServer] Session hook received but no session_id found in data');
+            }
+        },
+        '/hook/stop': (data) => {
+            const tasks = parseBackgroundTasks(data.background_tasks);
+            logger.debug(`[hookServer] Stop hook: ${tasks.length} background task(s) in flight`);
+            onBackgroundActivity?.(tasks);
+        },
+        // The session is gone, so whatever it had in flight is no longer ours to
+        // report — clear it rather than leaving the last Stop's counts frozen.
+        '/hook/session-end': () => {
+            logger.debug('[hookServer] SessionEnd hook: clearing background activity');
+            onBackgroundActivity?.([]);
+        },
+    };
 
     return new Promise((resolve, reject) => {
         const server: Server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-            // Only handle POST to /hook/session-start
-            if (req.method === 'POST' && req.url === '/hook/session-start') {
+            const handler = req.method === 'POST' && req.url ? handlers[req.url] : undefined;
+            if (handler) {
                 // Set timeout to prevent hanging if Claude doesn't close stdin
                 const timeout = setTimeout(() => {
                     if (!res.headersSent) {
@@ -112,9 +146,9 @@ export async function startHookServer(options: HookServerOptions): Promise<HookS
                         chunks.push(chunk as Buffer);
                     }
                     clearTimeout(timeout);
-                    
+
                     const body = Buffer.concat(chunks).toString('utf-8');
-                    logger.debug('[hookServer] Received session hook:', body);
+                    logger.debug(`[hookServer] Received hook ${req.url}:`, body);
 
                     let data: SessionHookData = {};
                     try {
@@ -123,14 +157,7 @@ export async function startHookServer(options: HookServerOptions): Promise<HookS
                         logger.debug('[hookServer] Failed to parse hook data as JSON:', parseError);
                     }
 
-                    // Support both snake_case (from Claude) and camelCase
-                    const sessionId = data.session_id || data.sessionId;
-                    if (sessionId) {
-                        logger.debug(`[hookServer] Session hook received session ID: ${sessionId}`);
-                        onSessionHook(sessionId, data);
-                    } else {
-                        logger.debug('[hookServer] Session hook received but no session_id found in data');
-                    }
+                    handler(data);
 
                     res.writeHead(200, { 'Content-Type': 'text/plain' }).end('ok');
                 } catch (error) {


### PR DESCRIPTION
Implements #1628.

A session drops to "waiting" the moment its turn ends, so a twenty-minute build, a background subagent or a workflow — the whole reason the session is still alive — is invisible from the session list. `thinking` cannot express this because it only describes the current turn, and from the list there is no way to tell "this finished" from "this handed off to something that is still running", which is exactly when you want to leave it alone. This adds a `background` session state fed by the background work Claude Code already reports.

## How

Every `Stop` hook payload carries `background_tasks` — one entry per in-flight item, `{ id, type, status, description, command? }`, where `type` is `shell`, `subagent`, `workflow`, `monitor`, or the raw discriminant for kinds added later. happy-cli already registers a `SessionStart` hook to track session ids, so this registers `Stop` and `SessionEnd` alongside it, folds the array into counts, and publishes them as `metadata.activity`.

Reading it from the hook rather than from the SDK stream is what makes it work in both launch modes: the `claude` binary runs its hooks whether happy-cli drives it through the PTY (`claudeLocal`) or through the SDK (`claudeRemote`).

`metadata.activity` is a shape the app already parses — `MetadataSchema` defines it and the session info screen already renders it for any client. The only thing missing was a producer; on the app side this un-gates the list-level indicators (they were restricted to Rig sessions) and adds the dot state:

- `background` — a lighter blue than `thinking`, so it reads as "still working, but not on your turn", with the existing activity summary spelling out what is running.
- `SessionEnd` clears the counts, so a session that exits mid-build leaves nothing stale behind.
- Identical summaries are not re-sent, so idle turns cost no metadata writes.

Server and wire format are untouched — `activity` rides inside the existing encrypted metadata.

## Proof

Captured live end-to-end: a real `happy-cli` daemon against a standalone `happy-server`, a real Claude session that starts a background shell, screenshotted after the turn ended. Before/after is the same session with the same shell still running — only the app bundle differs. GIF in the first comment.

happy-cli: `typecheck` clean, 804 unit tests pass (12 new, covering the summarizer's type routing, queued-vs-running split, unknown task kinds and the dedupe comparison). happy-app: `typecheck` clean, 780 tests pass. The hook pipeline itself was additionally exercised against a real `claude` process — `SessionStart` still routes as before, `Stop` delivers the running shell, and `SessionEnd` clears it.

## Relationship to #1587

#1587 addresses the same underlying annoyance from the other end: it defers `updateThinking(false)` in `claudeRemote.ts` until the SDK's background-task set empties, so the turn is not reported idle while a subagent runs. This PR does not touch that file and does not change when `thinking` flips — it adds the counts and a separate visual state for the idle-but-still-busy case, and covers the local PTY path too. They compose: with both, a subagent keeps the session `thinking`, and anything still running past turn end shows as `background`. Happy to rebase behind #1587 if it lands first.

