### PR TITLE
fix(mobile): stabilize native menus and composer layout

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -614,6 +614,7 @@ const ChatComposer = React.memo(function ChatComposer(props: ChatComposerProps) 
             sessionId={sessionId}
             initialValue={initialDraft}
             onChangeText={handleChangeText}
+            autoGrowInput={Platform.OS !== 'web'}
         />
     );
 });

--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -59,8 +59,14 @@ import {
 import { isRunningOnMac } from '@/utils/platform';
 import { getNewSessionSidebarLayout } from '@/utils/newSessionSidebarLayout';
 import { getAgentPickerItems, getModePickerItems } from '@/utils/newSessionPickerItems';
+import {
+    NEW_SESSION_PICKER_LAYERS,
+    cancelPendingPickerOpenState,
+    resolvePickerToggleAction,
+} from '@/utils/newSessionPickerInteraction';
 import { resolveAgentDefaultConfig } from '@/sync/agentDefaults';
 import { MobileGlassSurface } from '@/components/MobileGlass';
+import { getNativeGlassInteractivity } from '@/components/glassInteractionPolicy';
 import { BubblePressable } from '@/components/BubblePressable';
 import { Header } from '@/components/navigation/Header';
 import { MOBILE_GLASS_HEADER_HEIGHT } from '@/components/navigation/headerMetrics';
@@ -304,6 +310,7 @@ function PickerContent({
         return (
             <BubblePressable
                 key={item.key}
+                scaleFeedback={false}
                 style={(p) => [
                     pickerStyles.option,
                     embedded && pickerStyles.embeddedOption,
@@ -403,6 +410,7 @@ function ComposerSettingsContent({
                 {items.map((item) => (
                     <BubblePressable
                         key={item.key}
+                        scaleFeedback={false}
                         onPress={() => onSelect(item.key)}
                         style={(pressedState) => [
                             pickerStyles.option,
@@ -560,7 +568,7 @@ function PathPickerContent({
                             <GlassView
                                 glassEffectStyle="regular"
                                 tintColor="rgba(255,255,255,0.10)"
-                                isInteractive={true}
+                                isInteractive={getNativeGlassInteractivity(true)}
                                 style={[
                                     pickerStyles.doneButtonGlass,
                                     { borderColor: 'rgba(255,255,255,0.16)' },
@@ -633,6 +641,7 @@ function PathPickerContent({
                     return (
                         <BubblePressable
                             key={item.key}
+                            scaleFeedback={false}
                             style={(p) => [
                                 pickerStyles.option,
                                 embedded && pickerStyles.embeddedOption,
@@ -975,21 +984,24 @@ function NewSessionScreen() {
     const isDesktop = Platform.OS === 'web' || isRunningOnMac();
 
 
-    const toggleConfig = React.useCallback(() => {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-        setActivePicker(null);
-        setIsConfigExpanded(v => !v);
+    const cancelPendingPickerOpen = React.useCallback(() => {
+        cancelPendingPickerOpenState({
+            pendingPickerRef,
+            subscriptionRef: pickerKeyboardSubscriptionRef,
+            timerRef: pickerOpenTimerRef,
+        });
     }, []);
 
-    const cancelPendingPickerOpen = React.useCallback(() => {
-        pendingPickerRef.current = null;
-        pickerKeyboardSubscriptionRef.current?.remove();
-        pickerKeyboardSubscriptionRef.current = null;
-        if (pickerOpenTimerRef.current) {
-            clearTimeout(pickerOpenTimerRef.current);
-            pickerOpenTimerRef.current = null;
-        }
-    }, []);
+    const closePicker = React.useCallback(() => {
+        cancelPendingPickerOpen();
+        setActivePicker(null);
+    }, [cancelPendingPickerOpen]);
+
+    const toggleConfig = React.useCallback(() => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        closePicker();
+        setIsConfigExpanded(v => !v);
+    }, [closePicker]);
 
     React.useEffect(() => cancelPendingPickerOpen, [cancelPendingPickerOpen]);
 
@@ -998,14 +1010,20 @@ function NewSessionScreen() {
     }, [activePicker, composerSettingsPage]);
 
     const togglePicker = React.useCallback((type: PickerType) => {
-        if (activePicker === type || pendingPickerRef.current === type) {
-            cancelPendingPickerOpen();
-            setActivePicker(null);
+        const action = resolvePickerToggleAction({
+            activePicker,
+            pendingPicker: pendingPickerRef.current,
+            requestedPicker: type,
+        });
+        if (action === 'keep-pending') {
+            return;
+        }
+        if (action === 'close-active') {
+            closePicker();
             return;
         }
 
-        cancelPendingPickerOpen();
-        setActivePicker(null);
+        closePicker();
         if (isDesktop || !Keyboard.isVisible()) {
             setActivePicker(type);
             return;
@@ -1023,7 +1041,7 @@ function NewSessionScreen() {
         pickerOpenTimerRef.current = setTimeout(finishOpening, 420);
         composerInputRef.current?.blur();
         Keyboard.dismiss();
-    }, [activePicker, cancelPendingPickerOpen, isDesktop]);
+    }, [activePicker, cancelPendingPickerOpen, closePicker, isDesktop]);
 
     const isOffline = selectedMachine ? !isMachineOnline(selectedMachine) : false;
     const agent = availableAgents.find(a => a.key === selectedAgent) ?? ALL_AGENTS[0];
@@ -1178,10 +1196,11 @@ function NewSessionScreen() {
                 break;
             }
         }
-        setActivePicker(null);
+        closePicker();
     }, [
         activePicker,
         availableAgents,
+        closePicker,
         draft.setEffortLevel,
         draft.setModelMode,
         draft.setPermissionMode,
@@ -1404,7 +1423,7 @@ function NewSessionScreen() {
                 value={selectedPath}
                 homeDir={selectedHomeDir}
                 onChangeValue={setSelectedPath}
-                onDone={() => setActivePicker(null)}
+                onDone={closePicker}
                 embedded={sidebarLayout.showSidebar}
             />
         ) : pickerData ? (
@@ -1427,6 +1446,7 @@ function NewSessionScreen() {
         );
     }, [
         activePicker,
+        closePicker,
         handlePickerSelect,
         pathItems,
         pickerData,
@@ -1463,7 +1483,7 @@ function NewSessionScreen() {
             value={selectedPath}
             homeDir={selectedHomeDir}
             onChangeValue={setSelectedPath}
-            onDone={() => setActivePicker(null)}
+            onDone={closePicker}
             embedded
         />
     ) : pickerData ? (
@@ -1549,6 +1569,7 @@ function NewSessionScreen() {
                     <>
                         <View style={styles.configRowWithToggle}>
                             <BubblePressable
+                                scaleFeedback={false}
                                 style={(p) => [
                                     styles.configRow,
                                     { flex: 1 },
@@ -1591,6 +1612,7 @@ function NewSessionScreen() {
 
                         <View style={{ opacity: isOffline ? 0.4 : 1 }} pointerEvents={isOffline ? 'none' : 'auto'}>
                             <BubblePressable
+                                scaleFeedback={false}
                                 style={(p) => [styles.configRow, p.pressed && styles.configRowPressed]}
                                 onPress={() => togglePicker('path')}
                             >
@@ -1606,6 +1628,7 @@ function NewSessionScreen() {
                                 <>
                                     <View style={styles.configRow}>
                                         <BubblePressable
+                                            scaleFeedback={false}
                                             onPress={() => togglePicker('agent')}
                                             style={(p) => [styles.configInlineField, p.pressed && styles.configRowPressed]}
                                         >
@@ -1623,7 +1646,7 @@ function NewSessionScreen() {
                                         {showModel && (
                                             <>
                                                 <Text style={[styles.configLabel, { color: theme.colors.textSecondary }]}>·</Text>
-                                                <BubblePressable onPress={() => togglePicker('model')} style={(p) => [styles.configInlineField, p.pressed && styles.configRowPressed]}>
+                                                <BubblePressable scaleFeedback={false} onPress={() => togglePicker('model')} style={(p) => [styles.configInlineField, p.pressed && styles.configRowPressed]}>
                                                     <Text style={[styles.configLabel, styles.configInlineText, { color: theme.colors.textSecondary }]} numberOfLines={1}>
                                                         {currentModel.name}
                                                     </Text>
@@ -1635,7 +1658,7 @@ function NewSessionScreen() {
                                         {showEffort && (
                                             <>
                                                 <Text style={[styles.configLabel, { color: theme.colors.textSecondary }]}>·</Text>
-                                                <BubblePressable onPress={() => togglePicker('effort')} style={(p) => [styles.configInlineField, p.pressed && styles.configRowPressed]}>
+                                                <BubblePressable scaleFeedback={false} onPress={() => togglePicker('effort')} style={(p) => [styles.configInlineField, p.pressed && styles.configRowPressed]}>
                                                     <Text style={[styles.configLabel, styles.configInlineText, { color: theme.colors.textSecondary }]} numberOfLines={1}>
                                                         {currentEffort?.name}
                                                     </Text>
@@ -1650,6 +1673,7 @@ function NewSessionScreen() {
 
                                     {showPermission && (
                                         <BubblePressable
+                                            scaleFeedback={false}
                                             style={(p) => [styles.configRow, p.pressed && styles.configRowPressed]}
                                             onPress={() => togglePicker('permission')}
                                         >
@@ -1671,6 +1695,7 @@ function NewSessionScreen() {
                             {supportsWorktree && (
                                 <>
                                     <BubblePressable
+                                        scaleFeedback={false}
                                         style={(p) => [styles.configRow, p.pressed && styles.configRowPressed]}
                                         onPress={() => togglePicker('worktree')}
                                     >
@@ -1689,6 +1714,7 @@ function NewSessionScreen() {
                     <>
                         <View style={styles.configRowWithToggle}>
                             <BubblePressable
+                                scaleFeedback={false}
                                 style={(p) => [styles.collapsedRow, { flex: 1 }, p.pressed && styles.configRowPressed]}
                                 onPress={() => togglePicker('path')}
                             >
@@ -1855,6 +1881,7 @@ function NewSessionScreen() {
                 {isNativeMobile && (
                     <View style={styles.mobileComposerLeftControls}>
                         <BubblePressable
+                            scaleFeedback={false}
                             onPress={() => togglePicker('agent')}
                             style={(pressedState) => [
                                 styles.composerAgentButton,
@@ -1946,19 +1973,12 @@ function NewSessionScreen() {
                 />
             )}
 
-            {isNativeMobile && activePicker && (
-                <AnimatedClickAwayBackdrop
-                    onPress={() => setActivePicker(null)}
-                    style={styles.nativePickerBackdrop}
-                />
-            )}
-
             {sidebarLayout.showSidebar ? (
                 <View style={styles.desktopShell}>
                     {Platform.OS === 'web' && activePicker && (
                         <Pressable
                             style={styles.clickAwayBackdrop}
-                            onPress={() => setActivePicker(null)}
+                            onPress={closePicker}
                         />
                     )}
                     <View style={styles.desktopMain}>
@@ -1985,6 +2005,13 @@ function NewSessionScreen() {
                 </View>
             ) : (
                 <View style={styles.inner}>
+                    {isNativeMobile && activePicker && (
+                        <AnimatedClickAwayBackdrop
+                            exitImmediately
+                            onPress={closePicker}
+                            style={styles.nativePickerBackdrop}
+                        />
+                    )}
                     {isNativeMobile ? (
                         <>
                             <ScrollView
@@ -1992,11 +2019,17 @@ function NewSessionScreen() {
                                 contentContainerStyle={styles.mobileConfigScrollContent}
                                 keyboardDismissMode={Platform.OS === 'ios' ? 'interactive' : 'on-drag'}
                                 keyboardShouldPersistTaps="handled"
-                                onScrollBeginDrag={Keyboard.dismiss}
+                                onScrollBeginDrag={() => {
+                                    Keyboard.dismiss();
+                                    closePicker();
+                                }}
                                 showsVerticalScrollIndicator={false}
                             >
                                 <Pressable
-                                    onPress={Keyboard.dismiss}
+                                    onPress={() => {
+                                        Keyboard.dismiss();
+                                        closePicker();
+                                    }}
                                     style={styles.mobileKeyboardDismissArea}
                                 >
                                     <View
@@ -2024,7 +2057,7 @@ function NewSessionScreen() {
                             {Platform.OS === 'web' && activePicker && (
                                 <Pressable
                                     style={styles.clickAwayBackdropBehind}
-                                    onPress={() => setActivePicker(null)}
+                                    onPress={closePicker}
                                 />
                             )}
                             <View style={{ flex: 1 }} />
@@ -2046,7 +2079,7 @@ function NewSessionScreen() {
                         { top: nativePickerTop },
                     ]}
                 >
-                    <AnimatedPopup>
+                    <AnimatedPopup exitImmediately>
                         <LocalBlurHalo borderRadius={24} />
                         <MobileGlassSurface
                             nativeEffect
@@ -2079,7 +2112,7 @@ function NewSessionScreen() {
             {Platform.OS !== 'web' && !isNativeMobile && (
                 <BottomSheet
                     visible={!!activePicker}
-                    onClose={() => setActivePicker(null)}
+                    onClose={closePicker}
                 >
                     {activePicker === 'path' ? (
                         <PathPickerContent
@@ -2088,7 +2121,7 @@ function NewSessionScreen() {
                             value={selectedPath}
                             homeDir={selectedHomeDir}
                             onChangeValue={setSelectedPath}
-                            onDone={() => setActivePicker(null)}
+                            onDone={closePicker}
                         />
                     ) : pickerData ? (
                         <PickerContent {...pickerData} onSelect={handlePickerSelect} />
@@ -2174,10 +2207,11 @@ const styles = StyleSheet.create((theme) => ({
         paddingHorizontal: 20,
         paddingTop: 0,
         paddingBottom: 8,
-        zIndex: 20,
+        zIndex: NEW_SESSION_PICKER_LAYERS.config,
     },
     mobileConfigScroll: {
         flex: 1,
+        zIndex: NEW_SESSION_PICKER_LAYERS.config,
     },
     mobileConfigScrollContent: {
         flexGrow: 1,
@@ -2203,7 +2237,7 @@ const styles = StyleSheet.create((theme) => ({
         shadowOpacity: 1,
         shadowRadius: 24,
         elevation: 8,
-        zIndex: 10,
+        zIndex: NEW_SESSION_PICKER_LAYERS.composer,
     },
     mobileHeaderTitle: {
         fontSize: 16,
@@ -2227,7 +2261,7 @@ const styles = StyleSheet.create((theme) => ({
         zIndex: 1,
     },
     nativePickerBackdrop: {
-        zIndex: 150,
+        zIndex: NEW_SESSION_PICKER_LAYERS.backdrop,
     },
     clickAwayBackdropBehind: {
         position: 'absolute',
@@ -2285,7 +2319,7 @@ const styles = StyleSheet.create((theme) => ({
         position: 'absolute',
         left: 20,
         right: 20,
-        zIndex: 151,
+        zIndex: NEW_SESSION_PICKER_LAYERS.popup,
     },
     nativePopoverSurface: {
         width: '100%',

--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -35,6 +35,14 @@ import { resolveAgentInputPrimaryAction } from './agentInputPrimaryAction';
 import { NativeSettingsMenu, type NativeSettingsMenuGroup } from './NativeSettingsMenu';
 import { ProviderIcon } from './ProviderIcon';
 import { isRigMetadata } from '@/sync/rig';
+import {
+    MOBILE_COMPOSER_LAYOUT,
+    MOBILE_COMPOSER_METRICS,
+    resolveMobileComposerActionGeometry,
+    resolveMobileComposerActionRowGeometry,
+    resolveMobileComposerMenuGeometry,
+} from './agentInputLayout';
+import { shouldUseExpoNativeSettingsMenu } from './glassInteractionPolicy';
 
 interface AgentInputProps {
     // `initialValue` seeds the uncontrolled textarea once; keystrokes never
@@ -101,6 +109,8 @@ interface AgentInputProps {
     isSendDisabled?: boolean;
     isSending?: boolean;
     minHeight?: number;
+    /** Enable native multiline height propagation for chat-detail composers. */
+    autoGrowInput?: boolean;
     zenMode?: boolean;
     /** Image attachments waiting to be sent (expImageUpload feature). */
     selectedImages?: AttachmentPreview[];
@@ -116,14 +126,12 @@ function permissionKindIcon(kind: string | null | undefined): React.ComponentPro
     return 'folder-open-outline';
 }
 
-// The composer text/caret must line up with the visible leading edge of the
-// add glyph, rather than the larger 42pt touch target around it. Keeping the
-// geometry in one place prevents the two rows from drifting apart.
-const MOBILE_COMPOSER_SHELL_INSET = 10;
-const MOBILE_COMPOSER_ACTION_SIZE = 42;
-const MOBILE_COMPOSER_ADD_ICON_SIZE = 26;
-const MOBILE_COMPOSER_TEXT_INSET = MOBILE_COMPOSER_SHELL_INSET
-    + (MOBILE_COMPOSER_ACTION_SIZE - MOBILE_COMPOSER_ADD_ICON_SIZE) / 2;
+const MOBILE_ICON_MENU_GEOMETRY = resolveMobileComposerMenuGeometry('icon');
+const MOBILE_MODEL_MENU_GEOMETRY = resolveMobileComposerMenuGeometry('model');
+const MOBILE_EFFORT_MENU_GEOMETRY = resolveMobileComposerMenuGeometry('effort');
+const MOBILE_ACTION_ROW_GEOMETRY = resolveMobileComposerActionRowGeometry();
+const MOBILE_ICON_ACTION_GEOMETRY = resolveMobileComposerActionGeometry('icon');
+const MOBILE_PRIMARY_ACTION_GEOMETRY = resolveMobileComposerActionGeometry('primary');
 
 const stylesheet = StyleSheet.create((theme, runtime) => ({
     container: {
@@ -159,15 +167,15 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
             android: theme.colors.glass.backgroundStrong,
             default: theme.colors.input.background,
         }),
-        borderRadius: 30,
+        borderRadius: MOBILE_COMPOSER_METRICS.shellRadius,
         borderWidth: StyleSheet.hairlineWidth,
         borderColor: theme.colors.glass.border,
-        paddingHorizontal: MOBILE_COMPOSER_SHELL_INSET,
-        paddingTop: 8,
-        paddingBottom: 8,
+        paddingHorizontal: MOBILE_COMPOSER_METRICS.shellInset,
+        paddingTop: MOBILE_COMPOSER_METRICS.shellPaddingTop,
+        paddingBottom: MOBILE_COMPOSER_METRICS.shellPaddingBottom,
     },
     mobileUnifiedPanelShadow: {
-        borderRadius: 30,
+        borderRadius: MOBILE_COMPOSER_METRICS.shellRadius,
     },
     inputContainer: {
         flexDirection: 'row',
@@ -180,14 +188,16 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
     },
     mobileInputContainer: {
         alignItems: 'center',
-        // Keep a one-line composer compact while centering its caret between
-        // the shell and the action row. The previous 60pt slot left a full
-        // blank line below an empty input on phones.
-        minHeight: 44,
-        // 18pt from the outer edge: 10pt shell inset plus the 8pt offset to
-        // the visible edge of the 26pt add glyph inside its 42pt target.
-        paddingHorizontal: MOBILE_COMPOSER_TEXT_INSET - MOBILE_COMPOSER_SHELL_INSET,
-        paddingVertical: 4,
+        // Keep a one-line composer compact while aligning its caret with the
+        // add glyph below. The previous 60pt slot left a full blank line below
+        // an empty input on phones.
+        minHeight: MOBILE_COMPOSER_METRICS.inputMinHeight,
+        // 18pt from the outer edge: 10pt shell inset plus the 8pt inset from
+        // the add button edge to the 26pt glyph.
+        paddingLeft: MOBILE_COMPOSER_LAYOUT.inputContainerPaddingLeft,
+        paddingRight: MOBILE_COMPOSER_LAYOUT.inputContainerPaddingRight,
+        paddingTop: MOBILE_COMPOSER_METRICS.inputPaddingTop,
+        paddingBottom: MOBILE_COMPOSER_METRICS.inputPaddingBottom,
     },
 
     // Overlay styles
@@ -317,25 +327,19 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         justifyContent: 'space-between',
         paddingHorizontal: 0,
     },
-    mobileActionButtonsContainer: {
-        height: MOBILE_COMPOSER_ACTION_SIZE,
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 2,
-    },
-    mobileIconButton: {
-        width: MOBILE_COMPOSER_ACTION_SIZE,
-        height: MOBILE_COMPOSER_ACTION_SIZE,
-        borderRadius: MOBILE_COMPOSER_ACTION_SIZE / 2,
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexShrink: 0,
-    },
+    mobileActionButtonsContainer: MOBILE_ACTION_ROW_GEOMETRY,
+    mobileIconButton: MOBILE_ICON_ACTION_GEOMETRY,
+    mobileIconMenuFrame: MOBILE_ICON_MENU_GEOMETRY.frame,
+    mobileIconMenuContent: MOBILE_ICON_MENU_GEOMETRY.content,
+    mobileModelMenuFrame: MOBILE_MODEL_MENU_GEOMETRY.frame,
+    mobileModelMenuContent: MOBILE_MODEL_MENU_GEOMETRY.content,
+    mobileEffortMenuFrame: MOBILE_EFFORT_MENU_GEOMETRY.frame,
+    mobileEffortMenuContent: MOBILE_EFFORT_MENU_GEOMETRY.content,
     mobileModeButton: {
         flex: 1,
         minWidth: 0,
-        height: 40,
-        borderRadius: 20,
+        height: MOBILE_COMPOSER_METRICS.secondaryActionHeight,
+        borderRadius: MOBILE_COMPOSER_METRICS.secondaryActionHeight / 2,
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'flex-end',
@@ -344,10 +348,10 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         gap: 7,
     },
     mobileEffortButton: {
-        width: 64,
+        width: MOBILE_COMPOSER_METRICS.effortWidth,
         flexShrink: 0,
-        height: 40,
-        borderRadius: 20,
+        height: MOBILE_COMPOSER_METRICS.secondaryActionHeight,
+        borderRadius: MOBILE_COMPOSER_METRICS.secondaryActionHeight / 2,
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'flex-start',
@@ -397,12 +401,7 @@ const stylesheet = StyleSheet.create((theme, runtime) => ({
         flexShrink: 0,
         marginLeft: 8,
     },
-    mobilePrimaryButton: {
-        width: MOBILE_COMPOSER_ACTION_SIZE,
-        height: MOBILE_COMPOSER_ACTION_SIZE,
-        borderRadius: MOBILE_COMPOSER_ACTION_SIZE / 2,
-        marginLeft: 1,
-    },
+    mobilePrimaryButton: MOBILE_PRIMARY_ACTION_GEOMETRY,
     mobilePrimaryButtonActive: {
         backgroundColor: theme.colors.surfaceHighest,
     },
@@ -696,8 +695,10 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     // The compact action row is deliberately limited to the narrow native
     // layout. Desktop web, Mac Catalyst, and tablet-width canvases retain the
     // existing composer affordances rather than inheriting it.
-    const compactMobileComposer = Platform.OS !== 'web' && !isRunningOnMac() && screenWidth <= 700;
-    const useNativeSettingsMenus = compactMobileComposer;
+    const runningOnMac = isRunningOnMac();
+    const compactMobileComposer = Platform.OS !== 'web' && !runningOnMac && screenWidth <= 700;
+    const useNativeSettingsMenus = compactMobileComposer
+        || shouldUseExpoNativeSettingsMenu(Platform.OS, runningOnMac);
     const activeSendIconColor = compactMobileComposer ? theme.colors.text : theme.colors.button.primary.tint;
     const isSendBlocked = props.blockSend ?? false;
 
@@ -1083,7 +1084,11 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                     ? t('agentInput.geminiPermissionMode.title')
                     : t('agentInput.permissionMode.title'),
             systemImage: 'shield',
-            options: availableModes.map((mode) => ({ key: mode.key, label: withSandboxSuffix(mode.name, mode.key) })),
+            options: availableModes.map((mode) => ({
+                key: mode.key,
+                label: withSandboxSuffix(mode.name, mode.key),
+                disabled: mode.disabled,
+            })),
             selectedKey: permissionModeKey,
             onSelect: (key) => {
                 const mode = availableModes.find((candidate) => candidate.key === key);
@@ -1099,7 +1104,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                 key: 'model',
                 label: props.modelMode?.name ?? t('agentInput.model.title'),
                 systemImage: 'cube',
-                options: availableModels.map((model) => ({ key: model.key, label: model.name })),
+                options: availableModels.map((model) => ({ key: model.key, label: model.name, disabled: model.disabled })),
                 selectedKey: props.modelMode?.key,
                 onSelect: (key) => {
                     const model = availableModels.find((candidate) => candidate.key === key);
@@ -1114,7 +1119,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                 key: 'effort',
                 label: props.effortLevel?.name ?? t('agentInput.effort.title'),
                 systemImage: 'bolt',
-                options: availableEffortLevels.map((level) => ({ key: level.key, label: level.name })),
+                options: availableEffortLevels.map((level) => ({ key: level.key, label: level.name, disabled: level.disabled })),
                 selectedKey: props.effortLevel?.key,
                 onSelect: (key) => {
                     const level = availableEffortLevels.find((candidate) => candidate.key === key);
@@ -1223,22 +1228,34 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                     {props.zenMode && <View style={{ flex: 1 }} />}
                     {!props.zenMode && <View style={styles.actionButtonsLeft}>
                         {props.onPermissionModeChange && (
-                            <Pressable
-                                onPress={handleSettingsPress}
-                                hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
-                                style={(p) => ({
-                                    flexDirection: 'row',
-                                    alignItems: 'center',
-                                    borderRadius: Platform.select({ default: 16, android: 20 }),
-                                    paddingHorizontal: 8,
-                                    paddingVertical: 6,
-                                    justifyContent: 'center',
-                                    height: 32,
-                                    opacity: p.pressed ? 0.7 : 1,
-                                })}
-                            >
-                                <Octicons name="gear" size={16} color={theme.colors.button.secondary.tint} />
-                            </Pressable>
+                            useNativeSettingsMenus ? (
+                                <NativeSettingsMenu
+                                    accessibilityLabel={t('settings.title')}
+                                    groups={[...permissionSettingsGroups, ...modelSettingsGroups]}
+                                    style={{ width: 40, height: 40 }}
+                                >
+                                    <View style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center' }}>
+                                        <Octicons name="gear" size={16} color={theme.colors.button.secondary.tint} />
+                                    </View>
+                                </NativeSettingsMenu>
+                            ) : (
+                                <Pressable
+                                    onPress={handleSettingsPress}
+                                    hitSlop={{ top: 5, bottom: 10, left: 0, right: 0 }}
+                                    style={(p) => ({
+                                        flexDirection: 'row',
+                                        alignItems: 'center',
+                                        borderRadius: Platform.select({ default: 16, android: 20 }),
+                                        paddingHorizontal: 8,
+                                        paddingVertical: 6,
+                                        justifyContent: 'center',
+                                        height: 32,
+                                        opacity: p.pressed ? 0.7 : 1,
+                                    })}
+                                >
+                                    <Octicons name="gear" size={16} color={theme.colors.button.secondary.tint} />
+                                </Pressable>
+                            )
                         )}
 
                         {props.agentType && props.onAgentClick && (
@@ -1443,7 +1460,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
         </Pressable>
     );
 
-    const desktopSettingsOverlay = !compactMobileComposer && openPicker === 'permission' ? (
+    const desktopSettingsOverlay = !useNativeSettingsMenus && !compactMobileComposer && openPicker === 'permission' ? (
         <>
             <TouchableWithoutFeedback onPress={closePicker}>
                 <View style={styles.overlayBackdrop} />
@@ -1920,13 +1937,19 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                         <MultiTextInput
                             ref={inputRef}
                             defaultValue={props.initialValue}
-                            paddingTop={compactMobileComposer ? 4 : Platform.OS === 'web' ? 10 : 8}
-                            paddingBottom={compactMobileComposer ? 4 : Platform.OS === 'web' ? 10 : 8}
+                            paddingTop={compactMobileComposer
+                                ? MOBILE_COMPOSER_METRICS.inputPaddingTop
+                                : Platform.OS === 'web' ? 10 : 8}
+                            paddingBottom={compactMobileComposer
+                                ? MOBILE_COMPOSER_METRICS.inputPaddingBottom
+                                : Platform.OS === 'web' ? 10 : 8}
                             onChangeText={handleTextChange}
                             placeholder={props.placeholder}
                             onKeyPress={handleKeyPress}
                             onStateChange={handleInputStateChange}
-                            maxHeight={Platform.OS === 'web' ? 480 : 120}
+                            maxHeight={Platform.OS === 'web' ? 480 : MOBILE_COMPOSER_METRICS.inputMaxHeight}
+                            lineHeight={compactMobileComposer ? MOBILE_COMPOSER_METRICS.inputLineHeight : undefined}
+                            autoGrow={Platform.OS !== 'web' && props.autoGrowInput}
                         />
                     </View>
 
@@ -1947,7 +1970,7 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                             >
                                 <Ionicons
                                     name="add"
-                                    size={MOBILE_COMPOSER_ADD_ICON_SIZE}
+                                    size={MOBILE_COMPOSER_METRICS.addIconSize}
                                     color={(props.selectedImages?.length ?? 0) > 0
                                         ? theme.colors.radio.active
                                         : theme.colors.text}
@@ -1957,8 +1980,13 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
                         {!props.zenMode && permissionSettingsGroups.length > 0 && (
                             useNativeSettingsMenus ? (
-                                <NativeSettingsMenu groups={permissionSettingsGroups} flat style={styles.mobileIconButton}>
-                                    <View style={styles.mobileIconButton}>
+                                <NativeSettingsMenu
+                                    accessibilityLabel={permissionSettingsGroups[0]?.label}
+                                    groups={permissionSettingsGroups}
+                                    flat
+                                    style={styles.mobileIconMenuFrame}
+                                >
+                                    <View style={styles.mobileIconMenuContent}>
                                         <Ionicons name="settings-outline" size={20} color={theme.colors.text} />
                                     </View>
                                 </NativeSettingsMenu>
@@ -1980,8 +2008,13 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
                         {!props.zenMode ? (
                             <>
                                 {useNativeSettingsMenus && modelSettingsGroup ? (
-                                    <NativeSettingsMenu groups={[modelSettingsGroup]} flat style={styles.mobileModeButton}>
-                                        <View style={styles.mobileModeButton}>
+                                    <NativeSettingsMenu
+                                        accessibilityLabel={t('agentInput.model.title')}
+                                        groups={[modelSettingsGroup]}
+                                        flat
+                                        style={styles.mobileModelMenuFrame}
+                                    >
+                                        <View style={styles.mobileModelMenuContent}>
                                             {renderModelValue()}
                                         </View>
                                     </NativeSettingsMenu>
@@ -2003,8 +2036,13 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
                                 {effortSettingsGroup && (
                                     useNativeSettingsMenus ? (
-                                        <NativeSettingsMenu groups={[effortSettingsGroup]} flat style={styles.mobileEffortButton}>
-                                            <View style={styles.mobileEffortButton}>
+                                        <NativeSettingsMenu
+                                            accessibilityLabel={t('agentInput.effort.title')}
+                                            groups={[effortSettingsGroup]}
+                                            flat
+                                            style={styles.mobileEffortMenuFrame}
+                                        >
+                                            <View style={styles.mobileEffortMenuContent}>
                                                 {renderEffortValue()}
                                             </View>
                                         </NativeSettingsMenu>

--- a/packages/happy-app/sources/components/AnimatedOverlay.tsx
+++ b/packages/happy-app/sources/components/AnimatedOverlay.tsx
@@ -107,17 +107,20 @@ export function AnimatedBlurBackdrop({
 
 export function AnimatedClickAwayBackdrop({
     dimColor = 'transparent',
+    exitImmediately = false,
     onPress,
     style,
 }: {
     dimColor?: string;
+    /** Unmount without running the backdrop exit animation. */
+    exitImmediately?: boolean;
     onPress?: () => void;
     style?: StyleProp<ViewStyle>;
 }) {
     return (
         <Animated.View
             entering={backdropEntering}
-            exiting={backdropExiting}
+            exiting={exitImmediately ? undefined : backdropExiting}
             pointerEvents="box-none"
             style={[StyleSheet.absoluteFill, style]}
         >
@@ -206,15 +209,18 @@ export function LocalBlurHalo({
 
 export function AnimatedPopup({
     children,
+    exitImmediately = false,
     style,
 }: {
     children: React.ReactNode;
+    /** Unmount without leaving an interactive popup during its exit animation. */
+    exitImmediately?: boolean;
     style?: StyleProp<ViewStyle>;
 }) {
     return (
         <Animated.View
             entering={popupEntering}
-            exiting={popupExiting}
+            exiting={exitImmediately ? undefined : popupExiting}
             style={style}
         >
             {children}

--- a/packages/happy-app/sources/components/BubblePressable.tsx
+++ b/packages/happy-app/sources/components/BubblePressable.tsx
@@ -9,12 +9,14 @@ import {
     ViewStyle,
 } from 'react-native';
 import Animated, {
+    cancelAnimation,
     Easing,
     useAnimatedStyle,
     useSharedValue,
     withSpring,
     withTiming,
 } from 'react-native-reanimated';
+import { resolveBubblePressableFeedback } from './bubblePressableFeedback';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
@@ -22,6 +24,7 @@ type BubblePressableProps = Omit<PressableProps, 'style'> & {
     style?: StyleProp<ViewStyle> | ((state: PressableStateCallbackType) => StyleProp<ViewStyle>);
     pressedStyle?: StyleProp<ViewStyle>;
     bubbleScale?: number;
+    scaleFeedback?: boolean;
 };
 
 /**
@@ -32,6 +35,7 @@ export const BubblePressable = React.memo(({
     style,
     pressedStyle,
     bubbleScale = Platform.OS === 'web' ? 1.01 : 1.025,
+    scaleFeedback = true,
     disabled,
     onPressIn,
     onPressOut,
@@ -39,31 +43,46 @@ export const BubblePressable = React.memo(({
 }: BubblePressableProps) => {
     const scale = useSharedValue(1);
     const [pressed, setPressed] = React.useState(false);
+    const { animateScale } = resolveBubblePressableFeedback({
+        platform: Platform.OS === 'web' ? 'web' : 'native',
+        scaleFeedback,
+    });
+    React.useEffect(() => {
+        if (animateScale) {
+            return;
+        }
+        cancelAnimation(scale);
+        scale.value = 1;
+    }, [animateScale, scale]);
     const animatedStyle = useAnimatedStyle(() => ({
-        transform: [{ scale: scale.value }],
+        ...(animateScale ? { transform: [{ scale: scale.value }] } : {}),
     }));
 
     const handlePressIn = React.useCallback((event: GestureResponderEvent) => {
         if (!disabled) {
             setPressed(true);
-            scale.value = withTiming(bubbleScale, {
-                duration: 65,
-                easing: Easing.out(Easing.quad),
-            });
+            if (animateScale) {
+                scale.value = withTiming(bubbleScale, {
+                    duration: 65,
+                    easing: Easing.out(Easing.quad),
+                });
+            }
         }
         onPressIn?.(event);
-    }, [bubbleScale, disabled, onPressIn, scale]);
+    }, [animateScale, bubbleScale, disabled, onPressIn, scale]);
 
     const handlePressOut = React.useCallback((event: GestureResponderEvent) => {
         setPressed(false);
-        scale.value = withSpring(1, {
-            damping: 14,
-            stiffness: 520,
-            mass: 0.4,
-            overshootClamping: false,
-        });
+        if (animateScale) {
+            scale.value = withSpring(1, {
+                damping: 14,
+                stiffness: 520,
+                mass: 0.4,
+                overshootClamping: false,
+            });
+        }
         onPressOut?.(event);
-    }, [onPressOut, scale]);
+    }, [animateScale, onPressOut, scale]);
 
     // Bubble feedback belongs to the mobile glass controls. Keep desktop
     // interaction identical to the previous plain Pressable behavior.
@@ -91,7 +110,7 @@ export const BubblePressable = React.memo(({
             style={[
                 typeof style === 'function' ? style({ pressed } as PressableStateCallbackType) : style,
                 pressed && pressedStyle,
-                animatedStyle,
+                animateScale && animatedStyle,
             ]}
         />
     );

--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActivityIndicator, Keyboard, Modal as RNModal, Platform, Pressable, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, Keyboard, LayoutChangeEvent, Modal as RNModal, Platform, Pressable, Text, TextInput, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
@@ -40,11 +40,18 @@ import {
 import type { NewSessionAgentType } from '@/sync/persistence';
 import { useImagePicker } from '@/hooks/useImagePicker';
 import { Modal } from '@/modal';
+import { resolveMultiTextInputLayout } from './multiTextInputLayout';
+import { resolveCustomProjectPathSelection } from './homeDockInteraction';
+import {
+    MOBILE_COMPOSER_LAYOUT,
+    MOBILE_COMPOSER_METRICS,
+    resolveMobileComposerActionGeometry,
+    resolveMobileComposerActionRowGeometry,
+    resolveMobileComposerHeight,
+    resolveMobileComposerMenuGeometry,
+} from './agentInputLayout';
 
 export const MOBILE_HOME_DOCK_CONTENT_INSET = 108;
-
-const FOCUSED_COMPOSER_HEIGHT = 110;
-const FOCUSED_COMPOSER_ATTACHMENT_EXTRA_HEIGHT = 80;
 
 type EnvironmentSetting = 'machine' | 'project' | 'worktree';
 type AgentSetting = 'agent' | 'model' | 'permission' | 'effort';
@@ -58,6 +65,13 @@ const AGENTS: Array<{ key: NewSessionAgentType; name: string }> = [
     { key: 'gemini', name: 'Gemini' },
     { key: 'agy', name: 'Agy' },
 ];
+
+const MOBILE_ICON_MENU_GEOMETRY = resolveMobileComposerMenuGeometry('icon');
+const MOBILE_MODEL_MENU_GEOMETRY = resolveMobileComposerMenuGeometry('model');
+const MOBILE_EFFORT_MENU_GEOMETRY = resolveMobileComposerMenuGeometry('effort');
+const MOBILE_ACTION_ROW_GEOMETRY = resolveMobileComposerActionRowGeometry();
+const MOBILE_ICON_ACTION_GEOMETRY = resolveMobileComposerActionGeometry('icon');
+const MOBILE_PRIMARY_ACTION_GEOMETRY = resolveMobileComposerActionGeometry('primary');
 
 const styles = StyleSheet.create((theme) => ({
     keyboardFollower: {
@@ -91,13 +105,7 @@ const styles = StyleSheet.create((theme) => ({
         paddingHorizontal: 7,
         gap: 4,
     },
-    sideButton: {
-        width: 42,
-        height: 42,
-        borderRadius: 21,
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
+    sideButton: MOBILE_ICON_ACTION_GEOMETRY,
     sideButtonPressed: {
         backgroundColor: theme.colors.glass.backgroundSubtle,
     },
@@ -129,9 +137,8 @@ const styles = StyleSheet.create((theme) => ({
     focusedComposerSurface: {
         width: '100%',
         maxWidth: layout.maxWidth,
-        height: FOCUSED_COMPOSER_HEIGHT,
         alignSelf: 'center',
-        borderRadius: 30,
+        borderRadius: MOBILE_COMPOSER_METRICS.shellRadius,
         overflow: 'hidden',
         borderWidth: StyleSheet.hairlineWidth,
         borderColor: theme.colors.glass.border,
@@ -141,14 +148,11 @@ const styles = StyleSheet.create((theme) => ({
             default: theme.colors.glass.backgroundStrong,
         }),
     },
-    focusedComposerSurfaceWithAttachments: {
-        height: FOCUSED_COMPOSER_HEIGHT + FOCUSED_COMPOSER_ATTACHMENT_EXTRA_HEIGHT,
-    },
     focusedComposerAnimationShell: {
         width: '100%',
         maxWidth: layout.maxWidth,
         alignSelf: 'center',
-        borderRadius: 30,
+        borderRadius: MOBILE_COMPOSER_METRICS.shellRadius,
         overflow: 'hidden',
     },
     focusedComposerAnchored: {
@@ -159,70 +163,56 @@ const styles = StyleSheet.create((theme) => ({
     },
     focusedComposerContent: {
         flex: 1,
-        paddingHorizontal: 10,
-        paddingTop: 8,
-        paddingBottom: 8,
+        paddingHorizontal: MOBILE_COMPOSER_METRICS.shellInset,
+        paddingTop: MOBILE_COMPOSER_METRICS.shellPaddingTop,
+        paddingBottom: MOBILE_COMPOSER_METRICS.shellPaddingBottom,
     },
     focusedInput: {
         flex: 1,
-        minHeight: 44,
-        paddingHorizontal: 8,
-        paddingTop: 8,
-        paddingBottom: 4,
+        width: '100%',
+        maxHeight: MOBILE_COMPOSER_METRICS.inputMaxHeight,
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingTop: MOBILE_COMPOSER_METRICS.inputPaddingTop,
+        paddingBottom: MOBILE_COMPOSER_METRICS.inputPaddingBottom,
         color: theme.colors.text,
-        fontSize: 18,
+        fontSize: MOBILE_COMPOSER_METRICS.inputFontSize,
+        lineHeight: MOBILE_COMPOSER_METRICS.inputLineHeight,
         textAlignVertical: 'top',
         ...Typography.default(),
     },
+    focusedInputMeasurement: {
+        position: 'absolute',
+        left: MOBILE_COMPOSER_LAYOUT.inputContainerPaddingLeft,
+        right: MOBILE_COMPOSER_LAYOUT.inputContainerPaddingRight,
+        opacity: 0,
+        paddingLeft: 0,
+        paddingRight: 0,
+        paddingTop: MOBILE_COMPOSER_METRICS.inputPaddingTop,
+        paddingBottom: MOBILE_COMPOSER_METRICS.inputPaddingBottom,
+        fontSize: MOBILE_COMPOSER_METRICS.inputFontSize,
+        lineHeight: MOBILE_COMPOSER_METRICS.inputLineHeight,
+        ...Typography.default(),
+    },
     focusedInputReveal: {
-        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
         minHeight: 0,
+        paddingLeft: MOBILE_COMPOSER_LAYOUT.inputContainerPaddingLeft,
+        paddingRight: MOBILE_COMPOSER_LAYOUT.inputContainerPaddingRight,
+        paddingTop: MOBILE_COMPOSER_METRICS.inputPaddingTop,
+        paddingBottom: MOBILE_COMPOSER_METRICS.inputPaddingBottom,
     },
-    focusedComposerActions: {
-        height: 44,
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: 2,
-    },
-    focusedModeButton: {
-        width: '100%',
-        minWidth: 0,
-        height: 40,
-        paddingHorizontal: 8,
-        borderRadius: 20,
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'flex-end',
-        paddingRight: 0,
-        gap: 7,
-    },
-    nativeGearMenu: {
-        width: 42,
-        height: 42,
-    },
-    nativeModeMenu: {
-        flex: 1,
-        minWidth: 0,
-        height: 40,
-    },
-    nativeEffortMenu: {
-        width: 64,
-        flexShrink: 0,
-        height: 40,
-    },
-    focusedEffortButton: {
-        width: '100%',
-        height: 40,
-        paddingLeft: 2,
-        paddingRight: 0,
-        borderRadius: 20,
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'flex-start',
-        gap: 4,
-    },
+    focusedComposerActions: MOBILE_ACTION_ROW_GEOMETRY,
+    nativeIconMenuFrame: MOBILE_ICON_MENU_GEOMETRY.frame,
+    nativeIconMenuContent: MOBILE_ICON_MENU_GEOMETRY.content,
+    nativeModeMenu: MOBILE_MODEL_MENU_GEOMETRY.frame,
+    focusedModeButton: MOBILE_MODEL_MENU_GEOMETRY.content,
+    nativeEffortMenu: MOBILE_EFFORT_MENU_GEOMETRY.frame,
+    focusedEffortButton: MOBILE_EFFORT_MENU_GEOMETRY.content,
     focusedModeText: {
         flexShrink: 1,
+        minWidth: 0,
         color: theme.colors.text,
         fontSize: 14,
         ...Typography.default(),
@@ -233,15 +223,8 @@ const styles = StyleSheet.create((theme) => ({
         ...Typography.default(),
     },
     sendButton: {
-        width: 40,
-        height: 40,
-        borderRadius: 20,
-        alignItems: 'center',
-        justifyContent: 'center',
+        ...MOBILE_PRIMARY_ACTION_GEOMETRY,
         backgroundColor: theme.colors.surfaceHighest,
-    },
-    focusedSendButton: {
-        marginLeft: 8,
     },
     sendButtonActive: {
         backgroundColor: theme.dark ? '#F5F5F5' : theme.colors.button.primary.background,
@@ -470,10 +453,12 @@ export const HomeDock = React.memo(({
     const keyboard = useReanimatedKeyboardAnimation();
     const inputRef = React.useRef<TextInput>(null);
     const focusedInputRef = React.useRef<TextInput>(null);
+    const mountedRef = React.useRef(true);
     const focusAnimationTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
     const focusPresentation = useSharedValue(0);
     const [isFocused, setIsFocused] = React.useState(false);
     const [focusModeVisible, setFocusModeVisible] = React.useState(false);
+    const [focusedInputContentHeight, setFocusedInputContentHeight] = React.useState(0);
     const expImageUpload = useSetting('expImageUpload');
     const { selectedImages, pickImages, removeImage, clearImages } = useImagePicker();
     const agentType = useNewSessionDraft((state) => state.agentType);
@@ -627,9 +612,30 @@ export const HomeDock = React.memo(({
     const canSubmit = !isSubmitting && (
         prompt.trim().length > 0 || (expImageUpload && selectedImages.length > 0)
     );
-    const focusedComposerHeight = selectedImages.length > 0
-        ? FOCUSED_COMPOSER_HEIGHT + FOCUSED_COMPOSER_ATTACHMENT_EXTRA_HEIGHT
-        : FOCUSED_COMPOSER_HEIGHT;
+    const focusedInputLayout = resolveMultiTextInputLayout({
+        contentHeight: focusedInputContentHeight,
+        hasText: prompt.length > 0,
+        maxHeight: MOBILE_COMPOSER_METRICS.inputMaxHeight,
+        lineHeight: MOBILE_COMPOSER_METRICS.inputLineHeight,
+        paddingTop: MOBILE_COMPOSER_METRICS.inputPaddingTop,
+        paddingBottom: MOBILE_COMPOSER_METRICS.inputPaddingBottom,
+    });
+    const focusedInputContainerHeight = Math.max(
+        MOBILE_COMPOSER_METRICS.inputMinHeight,
+        focusedInputLayout.height
+            + MOBILE_COMPOSER_METRICS.inputPaddingTop
+            + MOBILE_COMPOSER_METRICS.inputPaddingBottom,
+    );
+    const focusedComposerHeight = resolveMobileComposerHeight(
+        focusedInputLayout.height,
+        selectedImages.length > 0,
+    );
+    const handleFocusedInputMeasurement = React.useCallback((event: LayoutChangeEvent) => {
+        const nextHeight = Math.ceil(event.nativeEvent.layout.height);
+        setFocusedInputContentHeight((currentHeight) => (
+            currentHeight === nextHeight ? currentHeight : nextHeight
+        ));
+    }, []);
     const keyboardStyle = useAnimatedStyle(() => ({
         // Keyboard height includes the bottom safe area on iOS. The resting
         // dock keeps that inset, then gives it back while the keyboard opens
@@ -714,10 +720,14 @@ export const HomeDock = React.memo(({
         return () => clearTimeout(timeout);
     }, [focusModeVisible]);
 
-    React.useEffect(() => () => {
-        if (focusAnimationTimerRef.current) {
-            clearTimeout(focusAnimationTimerRef.current);
-        }
+    React.useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+            if (focusAnimationTimerRef.current) {
+                clearTimeout(focusAnimationTimerRef.current);
+            }
+        };
     }, []);
 
     React.useEffect(() => {
@@ -808,24 +818,24 @@ export const HomeDock = React.memo(({
 
     const requestCustomProjectPath = () => {
         Keyboard.dismiss();
-        // Let the native menu finish dismissing before presenting the prompt.
-        setTimeout(() => {
-            void (async () => {
-                const path = await Modal.prompt(
-                    t('machineLauncher.enterCustomPath'),
-                    undefined,
-                    {
-                        placeholder: '~/path/to/project',
-                        defaultValue: selectedPath ?? '~',
-                        confirmText: t('common.ok'),
-                    },
-                );
-                const trimmedPath = path?.trim();
-                if (trimmedPath) {
-                    setPath(trimmedPath);
-                }
-            })();
-        }, 220);
+        // Native menu actions are already deferred until dismissal by the
+        // picker wrapper, so presenting another delayed task here creates a
+        // stale prompt race when HomeDock unmounts.
+        void (async () => {
+            const path = await Modal.prompt(
+                t('machineLauncher.enterCustomPath'),
+                undefined,
+                {
+                    placeholder: '~/path/to/project',
+                    defaultValue: selectedPath ?? '~',
+                    confirmText: t('common.ok'),
+                },
+            );
+            const selectedCustomPath = resolveCustomProjectPathSelection(path, mountedRef.current);
+            if (selectedCustomPath) {
+                setPath(selectedCustomPath);
+            }
+        })();
     };
 
     const getEnvironmentPickerConfig = (setting: EnvironmentSetting): PickerConfig => {
@@ -887,7 +897,11 @@ export const HomeDock = React.memo(({
                 permission: 'shield',
                 effort: 'bolt',
             }[row.page],
-            options: config.options.map((option) => ({ key: option.key, label: option.name })),
+            options: config.options.map((option) => ({
+                key: option.key,
+                label: option.name,
+                disabled: option.disabled,
+            })),
             selectedKey: config.selectedKey,
             onSelect: config.onSelect,
         };
@@ -1042,14 +1056,28 @@ export const HomeDock = React.memo(({
                 style={[
                     styles.focusedComposerSurface,
                     styles.focusedComposerAnchored,
-                    selectedImages.length > 0 && styles.focusedComposerSurfaceWithAttachments,
+                    { height: focusedComposerHeight },
                 ]}
             >
                 <View style={styles.focusedComposerContent}>
-                    <Animated.View style={[styles.focusedInputReveal, focusedInputRevealStyle]}>
-                        {expImageUpload && (
+                    {expImageUpload && selectedImages.length > 0 && (
+                        <Animated.View style={focusedInputRevealStyle}>
                             <AgentInputAttachmentStrip images={selectedImages} onRemove={removeImage} />
-                        )}
+                        </Animated.View>
+                    )}
+                    <Animated.View style={[
+                        styles.focusedInputReveal,
+                        { height: focusedInputContainerHeight },
+                        focusedInputRevealStyle,
+                    ]}>
+                        <Text
+                            accessible={false}
+                            pointerEvents="none"
+                            onLayout={handleFocusedInputMeasurement}
+                            style={styles.focusedInputMeasurement}
+                        >
+                            {prompt || ' '}
+                        </Text>
                         <TextInput
                             ref={focusedInputRef}
                             value={prompt}
@@ -1060,7 +1088,8 @@ export const HomeDock = React.memo(({
                             selectionColor={theme.colors.text}
                             autoCorrect
                             multiline
-                            style={styles.focusedInput}
+                            scrollEnabled={focusedInputLayout.scrollEnabled}
+                            style={[styles.focusedInput, { height: focusedInputLayout.height }]}
                         />
                     </Animated.View>
                     <Animated.View style={[styles.focusedComposerActions, focusedActionsRevealStyle]}>
@@ -1071,16 +1100,29 @@ export const HomeDock = React.memo(({
                                 accessibilityRole="button"
                                 accessibilityLabel="Add image"
                             >
-                                <Ionicons name="add" size={26} color={theme.colors.text} />
+                                <Ionicons
+                                    name="add"
+                                    size={MOBILE_COMPOSER_METRICS.addIconSize}
+                                    color={theme.colors.text}
+                                />
                             </BubblePressable>
                         )}
-                        <NativeSettingsMenu groups={gearSettingsGroups} style={styles.nativeGearMenu}>
-                            <View style={styles.sideButton}>
+                        <NativeSettingsMenu
+                            accessibilityLabel={t('settings.title')}
+                            groups={gearSettingsGroups}
+                            style={styles.nativeIconMenuFrame}
+                        >
+                            <View style={styles.nativeIconMenuContent}>
                                 <Ionicons name="settings-outline" size={20} color={theme.colors.text} />
                             </View>
                         </NativeSettingsMenu>
                         {modelSettingsGroup ? (
-                            <NativeSettingsMenu groups={[modelSettingsGroup]} flat style={styles.nativeModeMenu}>
+                            <NativeSettingsMenu
+                                accessibilityLabel={t('agentInput.model.title')}
+                                groups={[modelSettingsGroup]}
+                                flat
+                                style={styles.nativeModeMenu}
+                            >
                                 <View style={styles.focusedModeButton}>
                                     <Ionicons name="flash" size={18} color={theme.colors.text} />
                                     <Text style={styles.focusedModeText} numberOfLines={1}>
@@ -1099,7 +1141,12 @@ export const HomeDock = React.memo(({
                             </View>
                         )}
                         {effortSettingsGroup && (
-                            <NativeSettingsMenu groups={[effortSettingsGroup]} flat style={styles.nativeEffortMenu}>
+                            <NativeSettingsMenu
+                                accessibilityLabel={t('agentInput.effort.title')}
+                                groups={[effortSettingsGroup]}
+                                flat
+                                style={styles.nativeEffortMenu}
+                            >
                                 <View style={styles.focusedEffortButton}>
                                     <Text style={styles.focusedModeSeparator}>·</Text>
                                     <Text style={styles.focusedModeText} numberOfLines={1}>
@@ -1111,7 +1158,7 @@ export const HomeDock = React.memo(({
                         <BubblePressable
                             onPress={submitFromFocusMode}
                             disabled={!canSubmit}
-                            style={[styles.sendButton, styles.focusedSendButton, canSubmit && styles.sendButtonActive]}
+                            style={[styles.sendButton, canSubmit && styles.sendButtonActive]}
                             accessibilityRole="button"
                             accessibilityLabel="Send"
                         >

--- a/packages/happy-app/sources/components/HomeHeader.test.ts
+++ b/packages/happy-app/sources/components/HomeHeader.test.ts
@@ -1,0 +1,106 @@
+import * as React from 'react';
+// @ts-expect-error react-test-renderer has no declarations in this workspace.
+import { act, create } from 'react-test-renderer';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', async () => {
+    const ReactModule = await import('react');
+    const host = (name: string) => (props: any) => ReactModule.createElement(name, props, props.children);
+    return {
+        Platform: { OS: 'ios' },
+        Pressable: host('Pressable'),
+        Text: host('Text'),
+        View: host('View'),
+    };
+});
+
+vi.mock('./navigation/Header', async () => {
+    const ReactModule = await import('react');
+    return { Header: (props: any) => ReactModule.createElement('Header', props) };
+});
+
+vi.mock('@/sync/storage', () => ({
+    useSocketStatus: () => ({ status: 'disconnected' }),
+}));
+
+vi.mock('expo-router', () => ({
+    useRouter: () => ({ navigate: vi.fn(), push: vi.fn() }),
+    useSegments: () => [],
+}));
+
+vi.mock('@/sync/serverConfig', () => ({
+    getServerInfo: () => ({ isCustom: true, hostname: '192.168.0.108', port: 3005 }),
+}));
+
+vi.mock('expo-image', async () => {
+    const ReactModule = await import('react');
+    return { Image: (props: any) => ReactModule.createElement('Image', props) };
+});
+
+vi.mock('react-native-unistyles', () => ({
+    StyleSheet: {
+        create: (factory: any) => typeof factory === 'function' ? factory({
+            colors: {
+                groupped: { background: 'background' },
+                header: { tint: 'tint' },
+                status: {
+                    connected: 'connected',
+                    connecting: 'connecting',
+                    disconnected: 'disconnected',
+                    error: 'error',
+                    default: 'default',
+                },
+                surfaceSelected: 'selected',
+                textSecondary: 'secondary',
+            },
+        }) : factory,
+        hairlineWidth: 1,
+    },
+    useUnistyles: () => ({
+        theme: {
+            colors: {
+                groupped: { background: 'background' },
+                header: { tint: 'tint' },
+            },
+        },
+    }),
+}));
+
+vi.mock('@expo/vector-icons', async () => {
+    const ReactModule = await import('react');
+    return { Ionicons: (props: any) => ReactModule.createElement('Ionicons', props) };
+});
+
+vi.mock('@/constants/Typography', () => ({ Typography: { default: () => ({}) } }));
+vi.mock('@/text', () => ({ t: (key: string) => key }));
+vi.mock('./ShortcutHints', () => ({
+    ShortcutHintBadge: () => null,
+    useShortcutHints: () => ({ visible: false }),
+}));
+vi.mock('./StatusDot', () => ({ StatusDot: () => null }));
+
+import { HomeHeaderNotAuth } from './HomeHeader';
+
+const originalConsoleError = console.error;
+
+beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(console, 'error').mockImplementation((message?: unknown, ...args: unknown[]) => {
+        if (typeof message === 'string' && message.startsWith('react-test-renderer is deprecated')) return;
+        originalConsoleError(message, ...args);
+    });
+});
+
+afterAll(() => vi.restoreAllMocks());
+
+describe('HomeHeaderNotAuth', () => {
+    it('uses the standard plain mobile title instead of the glass title pill', () => {
+        let renderer: ReturnType<typeof create>;
+        act(() => {
+            renderer = create(React.createElement(HomeHeaderNotAuth));
+        });
+
+        const header = renderer!.root.findByType('Header' as any);
+        expect(header.props.mobileTitleSurface).toBe('plain');
+    });
+});

--- a/packages/happy-app/sources/components/HomeHeader.tsx
+++ b/packages/happy-app/sources/components/HomeHeader.tsx
@@ -123,6 +123,7 @@ export const HomeHeaderNotAuth = React.memo(() => {
             headerLeftGlass={Platform.OS !== 'web'}
             headerShadowVisible={false}
             headerBackgroundColor={theme.colors.groupped.background}
+            mobileTitleSurface="plain"
         />
     )
 });

--- a/packages/happy-app/sources/components/MobileGlass.tsx
+++ b/packages/happy-app/sources/components/MobileGlass.tsx
@@ -12,6 +12,7 @@ import Animated, {
     withSpring,
     withTiming,
 } from 'react-native-reanimated';
+import { getNativeGlassInteractivity } from './glassInteractionPolicy';
 
 type MobileGlassMaterial = 'liquid' | 'static' | 'frosted';
 
@@ -171,7 +172,7 @@ function MobileGlassSurfaceBase({
                 glassEffectStyle={glassEffectStyle}
                 colorScheme={theme.dark ? 'dark' : 'light'}
                 tintColor={tintColor ?? theme.colors.glass.tint}
-                isInteractive={interactive}
+                isInteractive={getNativeGlassInteractivity(interactive)}
                 style={style}
             >
                 {surfaceOverlay}
@@ -183,7 +184,7 @@ function MobileGlassSurfaceBase({
                 glassEffectStyle={glassEffectStyle}
                 colorScheme={theme.dark ? 'dark' : 'light'}
                 tintColor={tintColor ?? theme.colors.glass.tint}
-                isInteractive={interactive}
+                isInteractive={getNativeGlassInteractivity(interactive)}
                 style={style}
             >
                 {surfaceOverlay}

--- a/packages/happy-app/sources/components/MultiTextInput.tsx
+++ b/packages/happy-app/sources/components/MultiTextInput.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Text, TextInput, Platform, View, NativeSyntheticEvent, TextInputKeyPressEventData, TextInputSelectionChangeEventData } from 'react-native';
+import { Text, TextInput, Platform, View, NativeSyntheticEvent, TextInputKeyPressEventData, TextInputSelectionChangeEventData, LayoutChangeEvent } from 'react-native';
 import { useUnistyles } from 'react-native-unistyles';
 import { Typography } from '@/constants/Typography';
+import { resolveMultiTextInputLayout } from './multiTextInputLayout';
 
 export type SupportedKey = 'Enter' | 'Escape' | 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'Tab';
 
@@ -49,6 +50,7 @@ interface MultiTextInputProps {
     paddingLeft?: number;
     paddingRight?: number;
     multiline?: boolean;
+    autoGrow?: boolean;
     returnKeyType?: React.ComponentProps<typeof TextInput>['returnKeyType'];
     submitBehavior?: React.ComponentProps<typeof TextInput>['submitBehavior'];
     onSubmitEditing?: () => void;
@@ -67,6 +69,7 @@ export const MultiTextInput = React.memo(React.forwardRef<MultiTextInputHandle, 
         maxHeight = 120,
         lineHeight = MULTI_TEXT_INPUT_LINE_HEIGHT,
         multiline = true,
+        autoGrow = false,
         returnKeyType = 'default',
         submitBehavior = multiline ? 'newline' : 'blurAndSubmit',
         onSubmitEditing,
@@ -96,6 +99,15 @@ export const MultiTextInput = React.memo(React.forwardRef<MultiTextInputHandle, 
     // TextInput.setSelection() (Fabric's supported imperative caret API).
     const pendingSelectionRef = React.useRef<{ start: number; end: number } | null>(null);
     const [, bumpSelectionTick] = React.useReducer((c: number) => c + 1, 0);
+    const [measuredContentHeight, setMeasuredContentHeight] = React.useState(0);
+    const inputLayout = resolveMultiTextInputLayout({
+        contentHeight: measuredContentHeight,
+        hasText: text.length > 0,
+        maxHeight,
+        lineHeight,
+        paddingTop: props.paddingTop,
+        paddingBottom: props.paddingBottom,
+    });
     React.useLayoutEffect(() => {
         const sel = pendingSelectionRef.current;
         if (sel && inputRef.current) {
@@ -116,6 +128,19 @@ export const MultiTextInput = React.memo(React.forwardRef<MultiTextInputHandle, 
         paddingLeft: props.paddingLeft,
         paddingRight: props.paddingRight,
         opacity: editable ? 1 : 0.58,
+        ...Typography.default(),
+    };
+    const measurementTextStyle = {
+        position: 'absolute' as const,
+        opacity: 0,
+        width: '100%' as const,
+        fontSize: MULTI_TEXT_INPUT_FONT_SIZE,
+        lineHeight,
+        padding: 0,
+        paddingTop: props.paddingTop,
+        paddingBottom: props.paddingBottom,
+        paddingLeft: props.paddingLeft,
+        paddingRight: props.paddingRight,
         ...Typography.default(),
     };
 
@@ -249,13 +274,34 @@ export const MultiTextInput = React.memo(React.forwardRef<MultiTextInputHandle, 
     }), [onChangeText, onStateChange, onSelectionChange]);
 
     const displayText = text;
+    const handleMeasurementLayout = React.useCallback((event: LayoutChangeEvent) => {
+        if (!autoGrow || !multiline) return;
+        const nextContentHeight = Math.ceil(event.nativeEvent.layout.height);
+        setMeasuredContentHeight((previousContentHeight) => (
+            previousContentHeight === nextContentHeight ? previousContentHeight : nextContentHeight
+        ));
+    }, [autoGrow, multiline]);
+
+    const nativeTextStyle = autoGrow && multiline ? { height: inputLayout.height } : undefined;
 
     return (
-        <View style={{ width: '100%' }}>
+        <View style={autoGrow && multiline
+            ? { width: '100%', height: inputLayout.containerHeight }
+            : { width: '100%' }}>
+            {autoGrow && multiline && (
+                <Text
+                    accessible={false}
+                    pointerEvents="none"
+                    onLayout={handleMeasurementLayout}
+                    style={measurementTextStyle}
+                >
+                    {text || ' '}
+                </Text>
+            )}
             {editable ? (
                 <TextInput
                     ref={inputRef}
-                    style={textStyle}
+                    style={nativeTextStyle ? [textStyle, nativeTextStyle] : textStyle}
                     placeholder={placeholder}
                     placeholderTextColor={theme.colors.input.placeholder}
                     value={text}
@@ -272,6 +318,7 @@ export const MultiTextInput = React.memo(React.forwardRef<MultiTextInputHandle, 
                     textContentType="none"
                     submitBehavior={submitBehavior}
                     onSubmitEditing={onSubmitEditing}
+                    scrollEnabled={autoGrow && multiline ? inputLayout.scrollEnabled : undefined}
                 />
             ) : (
                 <View pointerEvents="none">

--- a/packages/happy-app/sources/components/NativeOptionsPicker.ios.tsx
+++ b/packages/happy-app/sources/components/NativeOptionsPicker.ios.tsx
@@ -10,11 +10,15 @@ import {
     Text,
 } from '@expo/ui/swift-ui';
 import {
+    accessibilityLabel,
+    contentShape,
     frame,
-    opacity,
+    foregroundColor,
+    shapes,
     tint,
 } from '@expo/ui/swift-ui/modifiers';
 import type { NativeOptionsPickerProps } from './NativeOptionsPicker';
+import { useDeferredNativeMenuAction } from './nativeMenuInteraction';
 
 const systemImage = (name: string) => (
     name as React.ComponentProps<typeof Image>['systemName']
@@ -25,12 +29,17 @@ const styles = StyleSheet.create({
         position: 'relative',
         width: '100%',
     },
+    trigger: {
+        width: '100%',
+        minWidth: 0,
+    },
     host: {
         ...StyleSheet.absoluteFillObject,
     },
 });
 
 export function NativeOptionsPicker({
+    title,
     triggerLabel,
     systemImage: triggerSystemImage,
     options,
@@ -38,24 +47,33 @@ export function NativeOptionsPicker({
     onSelect,
     children,
 }: NativeOptionsPickerProps) {
+    const deferMenuAction = useDeferredNativeMenuAction();
+
     return (
         <View style={styles.container}>
-            <View pointerEvents="none">{children}</View>
-            <Host
-                colorScheme="dark"
-                style={styles.host}
+            <View
+                pointerEvents="none"
+                accessible={false}
+                accessibilityElementsHidden
+                importantForAccessibility="no-hide-descendants"
+                style={styles.trigger}
             >
+                {children}
+            </View>
+            <Host style={styles.host}>
                 <Menu
                     modifiers={[tint('#FFFFFF')]}
                     label={(
                         <HStack
                             modifiers={[
-                                frame({ maxWidth: 10000, minHeight: 42 }),
-                                opacity(0.01),
+                                frame({ maxWidth: 10000, maxHeight: 10000, minHeight: 42 }),
+                                contentShape(shapes.rectangle()),
+                                accessibilityLabel(`${title}: ${triggerLabel}`),
+                                foregroundColor('clear'),
                             ]}
                         >
                             {!!triggerSystemImage && <Image systemName={systemImage(triggerSystemImage)} />}
-                            <Text>{triggerLabel}</Text>
+                            <Text>{`${title}: ${triggerLabel}`}</Text>
                             <Spacer minLength={8} />
                         </HStack>
                     )}
@@ -65,7 +83,7 @@ export function NativeOptionsPicker({
                             key={option.key}
                             label={option.label}
                             systemImage={option.key === selectedKey ? systemImage('checkmark') : undefined}
-                            onPress={() => onSelect(option.key)}
+                            onPress={() => deferMenuAction(() => onSelect(option.key))}
                         />
                     ))}
                 </Menu>

--- a/packages/happy-app/sources/components/NativeSettingsMenu.android.tsx
+++ b/packages/happy-app/sources/components/NativeSettingsMenu.android.tsx
@@ -11,6 +11,7 @@ export function NativeSettingsMenu({ groups, children, style, flat = false }: Na
                     {groups.flatMap((group) => group.options.map((option) => (
                         <DropdownMenuItem
                             key={`${group.key}:${option.key}`}
+                            enabled={!option.disabled}
                             onClick={() => group.onSelect(option.key)}
                         >
                             <DropdownMenuItem.Text>

--- a/packages/happy-app/sources/components/NativeSettingsMenu.ios.tsx
+++ b/packages/happy-app/sources/components/NativeSettingsMenu.ios.tsx
@@ -1,11 +1,24 @@
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Button, Host, HStack, Menu, Spacer } from '@expo/ui/swift-ui';
-import { contentShape, frame, opacity, shapes, tint } from '@expo/ui/swift-ui/modifiers';
+import { Button, Host, HStack, Image, Menu, Section, Spacer, Text } from '@expo/ui/swift-ui';
+import {
+    accessibilityLabel as accessibilityLabelModifier,
+    contentShape,
+    disabled,
+    frame,
+    foregroundColor,
+    shapes,
+    tint,
+} from '@expo/ui/swift-ui/modifiers';
 import type { NativeSettingsMenuProps } from './NativeSettingsMenu';
+import { useDeferredNativeMenuAction } from './nativeMenuInteraction';
 
 const systemImage = (name: string) => (
     name as React.ComponentProps<typeof Button>['systemImage']
+);
+
+const sectionSystemImage = (name: string) => (
+    name as React.ComponentProps<typeof Image>['systemName']
 );
 
 const styles = StyleSheet.create({
@@ -13,7 +26,6 @@ const styles = StyleSheet.create({
         position: 'relative',
     },
     trigger: {
-        flex: 1,
         minWidth: 0,
     },
     host: {
@@ -21,19 +33,37 @@ const styles = StyleSheet.create({
     },
 });
 
-export function NativeSettingsMenu({ groups, children, style, flat = false }: NativeSettingsMenuProps) {
+export function NativeSettingsMenu({
+    accessibilityLabel = 'Settings',
+    groups,
+    children,
+    style,
+    flat = false,
+}: NativeSettingsMenuProps) {
+    const deferMenuAction = useDeferredNativeMenuAction();
+
     return (
         <View style={[styles.container, style]}>
-            <View pointerEvents="none" style={styles.trigger}>{children}</View>
-            <Host colorScheme="dark" style={styles.host}>
+            <View
+                pointerEvents="none"
+                accessible={false}
+                accessibilityElementsHidden
+                importantForAccessibility="no-hide-descendants"
+                style={styles.trigger}
+            >
+                {children}
+            </View>
+            <Host style={styles.host}>
                 <Menu
                     modifiers={[tint('#FFFFFF')]}
                     label={(
                         <HStack modifiers={[
-                            frame({ maxWidth: 10000, minHeight: 40 }),
+                            frame({ maxWidth: 10000, maxHeight: 10000, minHeight: 40 }),
                             contentShape(shapes.rectangle()),
-                            opacity(0.01),
+                            accessibilityLabelModifier(accessibilityLabel),
+                            foregroundColor('clear'),
                         ]}>
+                            <Text>{accessibilityLabel}</Text>
                             <Spacer minLength={8} />
                         </HStack>
                     )}
@@ -44,25 +74,32 @@ export function NativeSettingsMenu({ groups, children, style, flat = false }: Na
                                 key={`${group.key}:${option.key}`}
                                 label={option.label}
                                 systemImage={option.key === group.selectedKey ? systemImage('checkmark') : undefined}
-                                onPress={() => group.onSelect(option.key)}
+                                modifiers={[disabled(option.disabled === true)]}
+                                onPress={() => deferMenuAction(() => group.onSelect(option.key))}
                             />
                         ))
                     )) : groups.map((group) => (
-                        <Menu
+                        <Section
                             key={group.key}
-                            label={group.label}
-                            systemImage={group.systemImage}
-                            modifiers={[tint('#FFFFFF')]}
+                            header={(
+                                <HStack spacing={6}>
+                                    {group.systemImage ? (
+                                        <Image systemName={sectionSystemImage(group.systemImage)} size={14} />
+                                    ) : null}
+                                    <Text>{group.label}</Text>
+                                </HStack>
+                            )}
                         >
                             {group.options.map((option) => (
                                 <Button
                                     key={option.key}
                                     label={option.label}
                                     systemImage={option.key === group.selectedKey ? systemImage('checkmark') : undefined}
-                                    onPress={() => group.onSelect(option.key)}
+                                    modifiers={[disabled(option.disabled === true)]}
+                                    onPress={() => deferMenuAction(() => group.onSelect(option.key))}
                                 />
                             ))}
-                        </Menu>
+                        </Section>
                     ))}
                 </Menu>
             </Host>

--- a/packages/happy-app/sources/components/NativeSettingsMenu.tsx
+++ b/packages/happy-app/sources/components/NativeSettingsMenu.tsx
@@ -4,6 +4,7 @@ import { Platform, type StyleProp, type ViewStyle } from 'react-native';
 export type NativeSettingsMenuOption = {
     key: string;
     label: string;
+    disabled?: boolean;
 };
 
 export type NativeSettingsMenuGroup = {
@@ -19,7 +20,8 @@ export type NativeSettingsMenuProps = {
     groups: NativeSettingsMenuGroup[];
     children: React.ReactNode;
     style?: StyleProp<ViewStyle>;
-    /** Render all options directly in the root menu instead of nesting by group. */
+    accessibilityLabel?: string;
+    /** Render all options directly in the root menu without native section headers. */
     flat?: boolean;
 };
 

--- a/packages/happy-app/sources/components/agentInputLayout.test.ts
+++ b/packages/happy-app/sources/components/agentInputLayout.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import * as agentInputLayout from './agentInputLayout';
+
+const { resolveAgentInputLayout } = agentInputLayout;
+
+describe('agent input compact mobile layout', () => {
+    it('aligns composer text start with the left edge of the add glyph', () => {
+        const layout = resolveAgentInputLayout({
+            shellInset: 10,
+            actionSize: 42,
+            addIconSize: 26,
+        });
+
+        expect(layout.textInset).toBe(18);
+        expect(layout.inputContainerPaddingLeft).toBe(8);
+        expect(layout.inputContainerPaddingRight).toBe(8);
+        expect(layout.textInset).toBe(layout.shellInset + (42 - 26) / 2);
+    });
+
+    it('publishes one visual metric contract for Home and Chat composers', () => {
+        expect((agentInputLayout as Record<string, unknown>).MOBILE_COMPOSER_METRICS).toEqual({
+            shellRadius: 30,
+            shellInset: 10,
+            shellPaddingTop: 8,
+            shellPaddingBottom: 8,
+            inputMinHeight: 44,
+            inputMaxHeight: 120,
+            inputFontSize: 16,
+            inputLineHeight: 22,
+            inputPaddingTop: 4,
+            inputPaddingBottom: 4,
+            actionRowHeight: 42,
+            actionSize: 42,
+            addIconSize: 26,
+            secondaryActionHeight: 40,
+            effortWidth: 64,
+            primaryActionSize: 42,
+            primaryActionMarginLeft: 8,
+            attachmentExtraHeight: 72,
+        });
+        expect((agentInputLayout as Record<string, unknown>).MOBILE_COMPOSER_BASE_HEIGHT).toBe(102);
+        expect((agentInputLayout as Record<string, unknown>).MOBILE_COMPOSER_CHROME_HEIGHT).toBe(58);
+    });
+
+    it('matches the chat shell height while the input grows and attachments appear', () => {
+        const resolveHeight = (agentInputLayout as Record<string, unknown>)
+            .resolveMobileComposerHeight as undefined | ((inputHeight: number, hasAttachments?: boolean) => number);
+
+        expect(resolveHeight?.(30)).toBe(102);
+        expect(resolveHeight?.(52)).toBe(118);
+        expect(resolveHeight?.(120)).toBe(186);
+        expect(resolveHeight?.(30, true)).toBe(174);
+    });
+
+    it.each([
+        ['icon',
+            { width: 42, height: 42, flexShrink: 0 },
+            { width: '100%', height: '100%', alignItems: 'center', justifyContent: 'center' }],
+        ['model',
+            { flex: 1, minWidth: 0, height: 40 },
+            {
+                width: '100%', minWidth: 0, height: 40, borderRadius: 20,
+                flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-end',
+                paddingLeft: 8, paddingRight: 0, gap: 7,
+            }],
+        ['effort',
+            { width: 64, flexShrink: 0, height: 40 },
+            {
+                width: '100%', minWidth: 0, height: 40, borderRadius: 20,
+                flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-start',
+                paddingLeft: 2, paddingRight: 0, gap: 4,
+            }],
+    ])('keeps %s native-menu frame geometry separate from label padding', (variant, expectedFrame, expectedContent) => {
+        const resolveGeometry = (agentInputLayout as Record<string, unknown>)
+            .resolveMobileComposerMenuGeometry as undefined | ((kind: string) => {
+                frame: Record<string, unknown>;
+                content: Record<string, unknown>;
+            });
+
+        const geometry = resolveGeometry?.(variant);
+        expect(geometry?.frame).toEqual(expectedFrame);
+        expect(geometry?.content).toEqual(expectedContent);
+        expect(geometry?.frame).not.toHaveProperty('paddingLeft');
+        expect(geometry?.frame).not.toHaveProperty('paddingRight');
+        expect(geometry?.frame).not.toHaveProperty('gap');
+    });
+
+    it('uses identical row and circular-button geometry in both composers', () => {
+        const exports = agentInputLayout as Record<string, unknown>;
+        const resolveRow = exports.resolveMobileComposerActionRowGeometry as undefined | (() => Record<string, unknown>);
+        const resolveAction = exports.resolveMobileComposerActionGeometry as undefined | ((kind: string) => Record<string, unknown>);
+
+        expect(resolveRow?.()).toEqual({
+            height: 42,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+            gap: 2,
+            paddingHorizontal: 0,
+        });
+        expect(resolveAction?.('icon')).toEqual({
+            width: 42,
+            height: 42,
+            borderRadius: 21,
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+        });
+        expect(resolveAction?.('primary')).toEqual({
+            width: 42,
+            height: 42,
+            borderRadius: 21,
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            marginLeft: 8,
+        });
+    });
+});

--- a/packages/happy-app/sources/components/agentInputLayout.ts
+++ b/packages/happy-app/sources/components/agentInputLayout.ts
@@ -1,0 +1,205 @@
+export interface AgentInputLayoutGeometry {
+    shellInset: number;
+    actionSize: number;
+    addIconSize: number;
+}
+
+export interface AgentInputLayout {
+    shellInset: number;
+    addGlyphOffset: number;
+    textInset: number;
+    inputContainerPaddingLeft: number;
+    inputContainerPaddingRight: number;
+}
+
+/**
+ * Canonical visual metrics for the compact mobile composer. Home and Chat
+ * intentionally render different controls, but their shell, input, and action
+ * geometry must stay identical.
+ */
+export const MOBILE_COMPOSER_METRICS = {
+    shellRadius: 30,
+    shellInset: 10,
+    shellPaddingTop: 8,
+    shellPaddingBottom: 8,
+    inputMinHeight: 44,
+    inputMaxHeight: 120,
+    inputFontSize: 16,
+    inputLineHeight: 22,
+    inputPaddingTop: 4,
+    inputPaddingBottom: 4,
+    actionRowHeight: 42,
+    actionSize: 42,
+    addIconSize: 26,
+    secondaryActionHeight: 40,
+    effortWidth: 64,
+    primaryActionSize: 42,
+    primaryActionMarginLeft: 8,
+    attachmentExtraHeight: 72,
+} as const;
+
+export const MOBILE_COMPOSER_BASE_HEIGHT = MOBILE_COMPOSER_METRICS.shellPaddingTop
+    + MOBILE_COMPOSER_METRICS.inputMinHeight
+    + MOBILE_COMPOSER_METRICS.actionRowHeight
+    + MOBILE_COMPOSER_METRICS.shellPaddingBottom;
+
+export const MOBILE_COMPOSER_CHROME_HEIGHT = MOBILE_COMPOSER_BASE_HEIGHT
+    - MOBILE_COMPOSER_METRICS.inputMinHeight;
+
+/** Mirrors the compact Chat structure: padded input container + action row. */
+export function resolveMobileComposerHeight(inputHeight: number, hasAttachments = false): number {
+    const inputContainerHeight = Math.max(
+        MOBILE_COMPOSER_METRICS.inputMinHeight,
+        inputHeight
+            + MOBILE_COMPOSER_METRICS.inputPaddingTop
+            + MOBILE_COMPOSER_METRICS.inputPaddingBottom,
+    );
+    return MOBILE_COMPOSER_CHROME_HEIGHT
+        + inputContainerHeight
+        + (hasAttachments ? MOBILE_COMPOSER_METRICS.attachmentExtraHeight : 0);
+}
+
+export type MobileComposerMenuVariant = 'icon' | 'model' | 'effort';
+
+export interface MobileComposerGeometryStyle {
+    width?: number | '100%';
+    height?: number | '100%';
+    minWidth?: number;
+    flex?: number;
+    flexShrink?: number;
+    flexDirection?: 'row';
+    alignItems?: 'center';
+    justifyContent?: 'center' | 'flex-start' | 'flex-end';
+    borderRadius?: number;
+    paddingLeft?: number;
+    paddingRight?: number;
+    paddingHorizontal?: number;
+    gap?: number;
+    marginLeft?: number;
+}
+
+export interface MobileComposerMenuGeometry {
+    frame: MobileComposerGeometryStyle;
+    content: MobileComposerGeometryStyle;
+}
+
+/**
+ * Keeps the Expo native-menu host frame free of visual padding. Padding and
+ * alignment belong exclusively to the visible React Native label inside it.
+ */
+export function resolveMobileComposerMenuGeometry(
+    variant: MobileComposerMenuVariant,
+): MobileComposerMenuGeometry {
+    if (variant === 'icon') {
+        return {
+            frame: {
+                width: MOBILE_COMPOSER_METRICS.actionSize,
+                height: MOBILE_COMPOSER_METRICS.actionSize,
+                flexShrink: 0,
+            },
+            content: {
+                width: '100%',
+                height: '100%',
+                alignItems: 'center',
+                justifyContent: 'center',
+            },
+        };
+    }
+
+    if (variant === 'model') {
+        return {
+            frame: {
+                flex: 1,
+                minWidth: 0,
+                height: MOBILE_COMPOSER_METRICS.secondaryActionHeight,
+            },
+            content: {
+                width: '100%',
+                minWidth: 0,
+                height: MOBILE_COMPOSER_METRICS.secondaryActionHeight,
+                borderRadius: MOBILE_COMPOSER_METRICS.secondaryActionHeight / 2,
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                paddingLeft: 8,
+                paddingRight: 0,
+                gap: 7,
+            },
+        };
+    }
+
+    return {
+        frame: {
+            width: MOBILE_COMPOSER_METRICS.effortWidth,
+            flexShrink: 0,
+            height: MOBILE_COMPOSER_METRICS.secondaryActionHeight,
+        },
+        content: {
+            width: '100%',
+            minWidth: 0,
+            height: MOBILE_COMPOSER_METRICS.secondaryActionHeight,
+            borderRadius: MOBILE_COMPOSER_METRICS.secondaryActionHeight / 2,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'flex-start',
+            paddingLeft: 2,
+            paddingRight: 0,
+            gap: 4,
+        },
+    };
+}
+
+export function resolveMobileComposerActionRowGeometry(): MobileComposerGeometryStyle {
+    return {
+        height: MOBILE_COMPOSER_METRICS.actionRowHeight,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        gap: 2,
+        paddingHorizontal: 0,
+    };
+}
+
+export function resolveMobileComposerActionGeometry(
+    variant: 'icon' | 'primary',
+): MobileComposerGeometryStyle {
+    return {
+        width: variant === 'primary'
+            ? MOBILE_COMPOSER_METRICS.primaryActionSize
+            : MOBILE_COMPOSER_METRICS.actionSize,
+        height: variant === 'primary'
+            ? MOBILE_COMPOSER_METRICS.primaryActionSize
+            : MOBILE_COMPOSER_METRICS.actionSize,
+        borderRadius: variant === 'primary'
+            ? MOBILE_COMPOSER_METRICS.primaryActionSize / 2
+            : MOBILE_COMPOSER_METRICS.actionSize / 2,
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+        ...(variant === 'primary'
+            ? { marginLeft: MOBILE_COMPOSER_METRICS.primaryActionMarginLeft }
+            : {}),
+    };
+}
+
+/** Resolves compact mobile composer geometry from the leading add glyph. */
+export function resolveAgentInputLayout({
+    shellInset,
+    actionSize,
+    addIconSize,
+}: AgentInputLayoutGeometry): AgentInputLayout {
+    const addGlyphOffset = (actionSize - addIconSize) / 2;
+    return {
+        shellInset,
+        addGlyphOffset,
+        textInset: shellInset + addGlyphOffset,
+        inputContainerPaddingLeft: addGlyphOffset,
+        inputContainerPaddingRight: addGlyphOffset,
+    };
+}
+
+export const MOBILE_COMPOSER_LAYOUT = resolveAgentInputLayout({
+    shellInset: MOBILE_COMPOSER_METRICS.shellInset,
+    actionSize: MOBILE_COMPOSER_METRICS.actionSize,
+    addIconSize: MOBILE_COMPOSER_METRICS.addIconSize,
+});

--- a/packages/happy-app/sources/components/bubblePressableFeedback.test.ts
+++ b/packages/happy-app/sources/components/bubblePressableFeedback.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBubblePressableFeedback } from './bubblePressableFeedback';
+
+describe('resolveBubblePressableFeedback', () => {
+    it('disables native scale feedback when opted out', () => {
+        expect(resolveBubblePressableFeedback({ platform: 'native', scaleFeedback: false })).toEqual({
+            animateScale: false,
+        });
+    });
+
+    it('keeps native scale feedback enabled by default', () => {
+        expect(resolveBubblePressableFeedback({ platform: 'native' })).toEqual({
+            animateScale: true,
+        });
+    });
+});

--- a/packages/happy-app/sources/components/bubblePressableFeedback.ts
+++ b/packages/happy-app/sources/components/bubblePressableFeedback.ts
@@ -1,0 +1,11 @@
+export type BubblePressablePlatform = 'native' | 'web';
+
+export function resolveBubblePressableFeedback({
+    platform,
+    scaleFeedback = true,
+}: {
+    platform: BubblePressablePlatform;
+    scaleFeedback?: boolean;
+}): { animateScale: boolean } {
+    return { animateScale: platform !== 'web' && scaleFeedback };
+}

--- a/packages/happy-app/sources/components/glassInteractionPolicy.test.ts
+++ b/packages/happy-app/sources/components/glassInteractionPolicy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import * as glassPolicy from './glassInteractionPolicy';
+
+describe('native GlassView interaction policy', () => {
+    it('keeps native GlassView interaction disabled for both requested states', () => {
+        expect(glassPolicy.getNativeGlassInteractivity(true)).toBe(false);
+        expect(glassPolicy.getNativeGlassInteractivity(false)).toBe(false);
+    });
+
+    it('uses Expo-native settings menus across iPhone and iPad but not Mac, web, or Android', () => {
+        const shouldUseExpoNativeSettingsMenu = (
+            glassPolicy as typeof glassPolicy & {
+                shouldUseExpoNativeSettingsMenu?: (platform: string, runningOnMac: boolean) => boolean;
+            }
+        ).shouldUseExpoNativeSettingsMenu;
+
+        expect(shouldUseExpoNativeSettingsMenu?.('ios', false)).toBe(true);
+        expect(shouldUseExpoNativeSettingsMenu?.('ios', true)).toBe(false);
+        expect(shouldUseExpoNativeSettingsMenu?.('web', false)).toBe(false);
+        expect(shouldUseExpoNativeSettingsMenu?.('android', false)).toBe(false);
+    });
+});

--- a/packages/happy-app/sources/components/glassInteractionPolicy.ts
+++ b/packages/happy-app/sources/components/glassInteractionPolicy.ts
@@ -1,0 +1,13 @@
+/**
+ * Native UIGlassEffect interaction is intentionally disabled. JS gesture
+ * handlers provide press feedback and action dispatch without allowing the
+ * native glass view to compete for responder ownership.
+ */
+export function getNativeGlassInteractivity(_interactive: boolean): false {
+    return false;
+}
+
+/** Expo owns menu presentation on native iOS; Mac, web, and Android keep their platform routes. */
+export function shouldUseExpoNativeSettingsMenu(platform: string, runningOnMac: boolean): boolean {
+    return platform === 'ios' && !runningOnMac;
+}

--- a/packages/happy-app/sources/components/homeDockInteraction.test.ts
+++ b/packages/happy-app/sources/components/homeDockInteraction.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCustomProjectPathSelection } from './homeDockInteraction';
+
+describe('HomeDock interaction lifecycle', () => {
+    it('ignores a custom-project prompt result after HomeDock unmounts', () => {
+        expect(resolveCustomProjectPathSelection('~/project', false)).toBeNull();
+    });
+
+    it('trims a mounted custom-project prompt result', () => {
+        expect(resolveCustomProjectPathSelection('  ~/project  ', true)).toBe('~/project');
+        expect(resolveCustomProjectPathSelection('   ', true)).toBeNull();
+    });
+});

--- a/packages/happy-app/sources/components/homeDockInteraction.ts
+++ b/packages/happy-app/sources/components/homeDockInteraction.ts
@@ -1,0 +1,10 @@
+export function resolveCustomProjectPathSelection(
+    path: string | null | undefined,
+    isMounted: boolean,
+) {
+    if (!isMounted) {
+        return null;
+    }
+    const trimmedPath = path?.trim();
+    return trimmedPath || null;
+}

--- a/packages/happy-app/sources/components/multiTextInputAutosize.test.ts
+++ b/packages/happy-app/sources/components/multiTextInputAutosize.test.ts
@@ -1,0 +1,86 @@
+import * as React from 'react';
+// @ts-expect-error react-test-renderer has no declarations in this workspace.
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', async () => {
+    const ReactModule = await import('react');
+    const host = (name: string) => ReactModule.forwardRef((props: any, ref: any) => (
+        ReactModule.createElement(name, { ...props, ref }, props.children)
+    ));
+    return {
+        Platform: { OS: 'ios' },
+        Text: host('Text'),
+        TextInput: host('TextInput'),
+        View: host('View'),
+    };
+});
+
+vi.mock('react-native-unistyles', () => ({
+    useUnistyles: () => ({
+        theme: {
+            colors: {
+                input: {
+                    placeholder: '#888888',
+                    text: '#111111',
+                },
+            },
+        },
+    }),
+}));
+
+vi.mock('@/constants/Typography', () => ({
+    Typography: { default: () => ({ fontFamily: 'System' }) },
+}));
+
+import { MultiTextInput } from './MultiTextInput';
+
+const originalConsoleError = console.error;
+
+beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(console, 'error').mockImplementation((message?: unknown, ...args: unknown[]) => {
+        if (typeof message === 'string' && message.startsWith('react-test-renderer is deprecated')) {
+            return;
+        }
+        originalConsoleError(message, ...args);
+    });
+});
+
+afterAll(() => {
+    vi.restoreAllMocks();
+});
+
+describe('native MultiTextInput autosize opt-in', () => {
+    it('keeps the legacy unconstrained wrapper when autosize is not requested', () => {
+        let renderer!: ReactTestRenderer;
+        act(() => {
+            renderer = create(React.createElement(MultiTextInput, {
+                value: 'A long value that can wrap onto another visual line',
+            }));
+        });
+
+        expect(renderer.root.findAllByType('Text' as any)).toHaveLength(0);
+        expect(renderer.root.findByType('View' as any).props.style).toEqual({ width: '100%' });
+    });
+
+    it('grows both the input and its wrapper from measured wrapped text', () => {
+        let renderer!: ReactTestRenderer;
+        act(() => {
+            renderer = create(React.createElement(MultiTextInput, {
+                value: 'A long value that wraps onto several visual lines',
+                autoGrow: true,
+            } as any));
+        });
+
+        const measurement = renderer.root.findByType('Text' as any);
+        act(() => {
+            measurement.props.onLayout({ nativeEvent: { layout: { height: 66 } } });
+        });
+
+        expect(renderer.root.findByType('View' as any).props.style).toEqual({ width: '100%', height: 66 });
+        expect(renderer.root.findByType('TextInput' as any).props.style).toEqual(expect.arrayContaining([
+            expect.objectContaining({ height: 66 }),
+        ]));
+    });
+});

--- a/packages/happy-app/sources/components/multiTextInputLayout.test.ts
+++ b/packages/happy-app/sources/components/multiTextInputLayout.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMultiTextInputLayout } from './multiTextInputLayout';
+
+describe('native multiline text input layout', () => {
+    it.each([
+        ['one line', 22, 120, 22, 0, 0, undefined, 0, { height: 22, containerHeight: 22, scrollEnabled: false }],
+        ['multiline growth', 66, 120, 22, 0, 0, undefined, 0, { height: 66, containerHeight: 66, scrollEnabled: false }],
+        ['cap enables scrolling', 180, 120, 22, 0, 0, undefined, 0, { height: 120, containerHeight: 120, scrollEnabled: true }],
+        ['shrinking below cap', 44, 120, 22, 0, 0, undefined, 0, { height: 44, containerHeight: 44, scrollEnabled: false }],
+        ['vertical padding contributes minimum', 10, 120, 22, 4, 6, undefined, 0, { height: 32, containerHeight: 32, scrollEnabled: false }],
+        ['explicit minimum keeps a compact input tall enough', 10, 120, 22, 4, 6, 44, 0, { height: 44, containerHeight: 44, scrollEnabled: false }],
+        ['composer chrome grows with multiline input', 66, 120, 22, 0, 0, 44, 66, { height: 66, containerHeight: 132, scrollEnabled: false }],
+    ])('%s', (_name, contentHeight, maxHeight, lineHeight, paddingTop, paddingBottom, minimumHeight, containerChromeHeight, expected) => {
+        expect(resolveMultiTextInputLayout({
+            contentHeight,
+            maxHeight,
+            lineHeight,
+            paddingTop,
+            paddingBottom,
+            minimumHeight,
+            containerChromeHeight,
+        })).toEqual(expected);
+    });
+
+    it('returns to the minimum height immediately when cleared text has a stale measurement', () => {
+        expect(resolveMultiTextInputLayout({
+            contentHeight: 120,
+            hasText: false,
+            maxHeight: 120,
+            lineHeight: 24,
+            paddingTop: 8,
+            paddingBottom: 4,
+            minimumHeight: 44,
+            containerChromeHeight: 66,
+        })).toEqual({
+            height: 44,
+            containerHeight: 110,
+            scrollEnabled: false,
+        });
+    });
+});

--- a/packages/happy-app/sources/components/multiTextInputLayout.ts
+++ b/packages/happy-app/sources/components/multiTextInputLayout.ts
@@ -1,0 +1,44 @@
+export interface MultiTextInputLayout {
+    height: number;
+    containerHeight: number;
+    scrollEnabled: boolean;
+}
+
+export interface MultiTextInputLayoutOptions {
+    contentHeight: number;
+    hasText?: boolean;
+    maxHeight: number;
+    lineHeight: number;
+    paddingTop?: number;
+    paddingBottom?: number;
+    minimumHeight?: number;
+    containerChromeHeight?: number;
+}
+
+export function resolveMultiTextInputLayout({
+    contentHeight,
+    hasText = true,
+    maxHeight,
+    lineHeight,
+    paddingTop = 0,
+    paddingBottom = 0,
+    minimumHeight: explicitMinimumHeight,
+    containerChromeHeight = 0,
+}: MultiTextInputLayoutOptions): MultiTextInputLayout {
+    // Native contentSize can be smaller than a line for an empty input. Keep
+    // the configured line plus vertical padding as the minimum visible size.
+    const minimumHeight = Math.max(
+        lineHeight + paddingTop + paddingBottom,
+        explicitMinimumHeight ?? 0,
+    );
+    const cap = Math.max(0, maxHeight);
+    const minimum = Math.min(minimumHeight, cap);
+    const measuredHeight = hasText && Number.isFinite(contentHeight) ? contentHeight : minimum;
+    const height = Math.min(cap, Math.max(minimum, measuredHeight));
+
+    return {
+        height,
+        containerHeight: height + Math.max(0, containerChromeHeight),
+        scrollEnabled: measuredHeight >= cap && cap > 0,
+    };
+}

--- a/packages/happy-app/sources/components/nativeExpoMenuTrigger.test.ts
+++ b/packages/happy-app/sources/components/nativeExpoMenuTrigger.test.ts
@@ -1,0 +1,230 @@
+import * as React from 'react';
+// @ts-expect-error react-test-renderer has no declarations in this workspace.
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', async () => {
+    const ReactModule = await import('react');
+    const host = (name: string) => (props: any) => ReactModule.createElement(name, props, props.children);
+    return {
+        StyleSheet: {
+            absoluteFillObject: { position: 'absolute', inset: 0 },
+            create: (styles: unknown) => styles,
+        },
+        View: host('View'),
+    };
+});
+
+vi.mock('@expo/ui/swift-ui', async () => {
+    const ReactModule = await import('react');
+    const component = (name: string) => (props: any) => ReactModule.createElement(name, props, props.children);
+    return {
+        Button: component('ExpoButton'),
+        Host: component('ExpoHost'),
+        HStack: component('ExpoHStack'),
+        Image: component('ExpoImage'),
+        Menu: component('ExpoMenu'),
+        Section: component('ExpoSection'),
+        Spacer: component('ExpoSpacer'),
+        Text: component('ExpoText'),
+    };
+});
+
+vi.mock('@expo/ui/swift-ui/modifiers', () => ({
+    accessibilityLabel: (label: string) => ({ type: 'accessibilityLabel', value: { label } }),
+    contentShape: (shape: unknown) => ({ type: 'contentShape', shape }),
+    disabled: (value: boolean) => ({ type: 'disabled', value: { disabled: value } }),
+    frame: (value: unknown) => ({ type: 'frame', value }),
+    foregroundColor: (value: string) => ({ type: 'foregroundColor', value }),
+    opacity: (value: number) => ({ type: 'opacity', value }),
+    shapes: { rectangle: () => ({ type: 'rectangle' }) },
+    tint: (value: string) => ({ type: 'tint', value }),
+}));
+
+import { NativeOptionsPicker } from './NativeOptionsPicker.ios';
+import { NativeSettingsMenu } from './NativeSettingsMenu.ios';
+
+const MENU_DISMISS_DELAY_MS = 220;
+
+const originalConsoleError = console.error;
+
+beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(console, 'error').mockImplementation((message?: unknown, ...args: unknown[]) => {
+        if (typeof message === 'string' && message.startsWith('react-test-renderer is deprecated')) return;
+        originalConsoleError(message, ...args);
+    });
+});
+
+beforeEach(() => vi.useFakeTimers());
+
+afterEach(() => vi.useRealTimers());
+
+afterAll(() => vi.restoreAllMocks());
+
+function render(element: React.ReactElement): ReactTestRenderer {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+        renderer = create(element);
+    });
+    return renderer;
+}
+
+function expectFullTriggerHitArea(label: React.ReactElement, minHeight: number) {
+    const props = label.props as { modifiers: unknown[] };
+    expect(props.modifiers).toContainEqual({
+        type: 'frame',
+        value: { maxWidth: 10000, maxHeight: 10000, minHeight },
+    });
+    expect(props.modifiers).toContainEqual({
+        type: 'contentShape',
+        shape: { type: 'rectangle' },
+    });
+    expect(props.modifiers).toContainEqual({ type: 'foregroundColor', value: 'clear' });
+    expect(props.modifiers).not.toContainEqual({ type: 'opacity', value: 0.01 });
+}
+
+describe('iOS Expo-native menu triggers', () => {
+    it('hides the pointer-disabled trigger subtree and announces the picker title and value', () => {
+        const renderer = render(React.createElement(NativeOptionsPicker, {
+            title: 'Machine',
+            triggerLabel: 'Mac',
+            options: [{ key: 'mac', label: 'Mac' }],
+            selectedKey: 'mac',
+            onSelect: vi.fn(),
+            children: React.createElement('Trigger'),
+        }));
+
+        const trigger = renderer.root.findAllByType('View' as any).find((view: any) => view.props.pointerEvents === 'none');
+        expect(trigger?.props.accessibilityElementsHidden).toBe(true);
+        expect(trigger?.props.importantForAccessibility).toBe('no-hide-descendants');
+
+        const container = renderer.root.findAllByType('View' as any).find((view: any) => view.props.style?.position === 'relative');
+        expect(container?.props.hitSlop).toBeUndefined();
+        expect(renderer.root.findByType('ExpoHost' as any).props.style).toEqual({ position: 'absolute', inset: 0 });
+
+        const menu = renderer.root.findByType('ExpoMenu' as any);
+        expect(menu.props.label.props.children[1].props.children).toBe('Machine: Mac');
+    });
+
+    it('uses the complete option-row bounds and forwards native button selection', () => {
+        const onSelect = vi.fn();
+        const renderer = render(React.createElement(NativeOptionsPicker, {
+            title: 'Machine',
+            triggerLabel: 'Mac',
+            options: [
+                { key: 'mac', label: 'Mac' },
+                { key: 'mini', label: 'Mini' },
+            ],
+            selectedKey: 'mac',
+            onSelect,
+            children: React.createElement('Trigger'),
+        }));
+
+        const menu = renderer.root.findByType('ExpoMenu' as any);
+        expectFullTriggerHitArea(menu.props.label, 42);
+        expect(renderer.root.findByType('ExpoHost' as any)).toBeDefined();
+
+        const buttons = renderer.root.findAllByType('ExpoButton' as any);
+        expect(buttons.find((button: any) => button.props.label === 'Mac')?.props.systemImage).toBe('checkmark');
+        const mini = buttons.find((button: any) => button.props.label === 'Mini');
+        act(() => mini.props.onPress());
+        expect(onSelect).not.toHaveBeenCalled();
+        act(() => vi.advanceTimersByTime(MENU_DISMISS_DELAY_MS));
+        expect(onSelect).toHaveBeenCalledOnce();
+        expect(onSelect).toHaveBeenCalledWith('mini');
+    });
+
+    it('only commits the latest selection after menu dismissal', () => {
+        const onSelect = vi.fn();
+        const renderer = render(React.createElement(NativeOptionsPicker, {
+            title: 'Machine',
+            triggerLabel: 'Mac',
+            options: [
+                { key: 'mac', label: 'Mac' },
+                { key: 'mini', label: 'Mini' },
+            ],
+            selectedKey: 'mac',
+            onSelect,
+            children: React.createElement('Trigger'),
+        }));
+        const buttons = renderer.root.findAllByType('ExpoButton' as any);
+
+        act(() => buttons[0].props.onPress());
+        act(() => buttons[1].props.onPress());
+        act(() => vi.advanceTimersByTime(MENU_DISMISS_DELAY_MS));
+
+        expect(onSelect).toHaveBeenCalledOnce();
+        expect(onSelect).toHaveBeenCalledWith('mini');
+    });
+
+    it('cancels a pending selection when the native menu unmounts', () => {
+        const onSelect = vi.fn();
+        const renderer = render(React.createElement(NativeOptionsPicker, {
+            title: 'Machine',
+            triggerLabel: 'Mac',
+            options: [{ key: 'mac', label: 'Mac' }],
+            selectedKey: 'mac',
+            onSelect,
+            children: React.createElement('Trigger'),
+        }));
+        const button = renderer.root.findByType('ExpoButton' as any);
+
+        act(() => button.props.onPress());
+        act(() => renderer.unmount());
+        act(() => vi.advanceTimersByTime(MENU_DISMISS_DELAY_MS));
+
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('renders grouped settings as sections in one native menu with full trigger bounds', () => {
+        const onSelect = vi.fn();
+        const renderer = render(React.createElement(NativeSettingsMenu, {
+            accessibilityLabel: 'Settings',
+            groups: [{
+                key: 'permission',
+                label: 'Permissions',
+                systemImage: 'shield',
+                options: [
+                    { key: 'safe', label: 'Safe mode' },
+                    { key: 'locked', label: 'Locked', disabled: true },
+                ],
+                selectedKey: 'safe',
+                onSelect,
+            }],
+            style: { width: 42, height: 42 },
+            children: React.createElement('Trigger'),
+        }));
+
+        const menus = renderer.root.findAllByType('ExpoMenu' as any);
+        expect(menus).toHaveLength(1);
+        const trigger = renderer.root.findAllByType('View' as any).find((view: any) => view.props.pointerEvents === 'none');
+        expect(trigger?.props.accessibilityElementsHidden).toBe(true);
+        expect(trigger?.props.importantForAccessibility).toBe('no-hide-descendants');
+        const container = renderer.root.findAllByType('View' as any).find((view: any) => Array.isArray(view.props.style));
+        expect(container?.props.style).toContainEqual({ width: 42, height: 42 });
+        expect(container?.props.hitSlop).toBeUndefined();
+        expect(renderer.root.findByType('ExpoHost' as any).props.style).toEqual({ position: 'absolute', inset: 0 });
+        expectFullTriggerHitArea(menus[0].props.label, 40);
+        expect(menus[0].props.label.props.children[0].props.children).toBe('Settings');
+        expect(menus[0].props.label.props.modifiers).toContainEqual({
+            type: 'accessibilityLabel',
+            value: { label: 'Settings' },
+        });
+        const sections = renderer.root.findAllByType('ExpoSection' as any);
+        expect(sections).toHaveLength(1);
+        const sectionHeader = render(sections[0].props.header);
+        expect(sectionHeader.root.findByType('ExpoHStack' as any)).toBeDefined();
+        expect(sectionHeader.root.findByType('ExpoImage' as any).props.systemName).toBe('shield');
+        expect(sectionHeader.root.findByType('ExpoText' as any).props.children).toBe('Permissions');
+
+        const safeMode = renderer.root.findAllByType('ExpoButton' as any).find((button: any) => button.props.label === 'Safe mode');
+        expect(safeMode.props.systemImage).toBe('checkmark');
+        act(() => safeMode.props.onPress());
+        act(() => vi.advanceTimersByTime(MENU_DISMISS_DELAY_MS));
+        expect(onSelect).toHaveBeenCalledWith('safe');
+
+        const locked = renderer.root.findAllByType('ExpoButton' as any).find((button: any) => button.props.label === 'Locked');
+        expect(locked.props.modifiers).toContainEqual({ type: 'disabled', value: { disabled: true } });
+    });
+});

--- a/packages/happy-app/sources/components/nativeMenuInteraction.ts
+++ b/packages/happy-app/sources/components/nativeMenuInteraction.ts
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+export const NATIVE_MENU_DISMISS_DELAY_MS = 220;
+
+type DeferredAction = () => void;
+
+/**
+ * SwiftUI dismisses a Menu after invoking its action. Deferring the callback
+ * lets that dismissal finish before React presents another surface or updates
+ * the trigger, while replacing a pending action prevents stale selections.
+ */
+export function useDeferredNativeMenuAction() {
+    const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const mountedRef = React.useRef(true);
+
+    React.useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+            if (timeoutRef.current !== null) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+            }
+        };
+    }, []);
+
+    return React.useCallback((action: DeferredAction) => {
+        if (timeoutRef.current !== null) {
+            clearTimeout(timeoutRef.current);
+        }
+        timeoutRef.current = setTimeout(() => {
+            timeoutRef.current = null;
+            if (mountedRef.current) {
+                action();
+            }
+        }, NATIVE_MENU_DISMISS_DELAY_MS);
+    }, []);
+}

--- a/packages/happy-app/sources/components/nativeSettingsMenu.android.test.ts
+++ b/packages/happy-app/sources/components/nativeSettingsMenu.android.test.ts
@@ -1,0 +1,71 @@
+import * as React from 'react';
+// @ts-expect-error react-test-renderer has no declarations in this workspace.
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-native', async () => {
+    const ReactModule = await import('react');
+    const host = (name: string) => (props: any) => ReactModule.createElement(name, props, props.children);
+    return { View: host('View') };
+});
+
+vi.mock('@expo/ui/jetpack-compose', async () => {
+    const ReactModule = await import('react');
+    const component = (name: string) => (props: any) => ReactModule.createElement(name, props, props.children);
+    const DropdownMenu = component('ExpoDropdownMenu') as any;
+    DropdownMenu.Items = component('ExpoDropdownMenuItems');
+    DropdownMenu.Trigger = component('ExpoDropdownMenuTrigger');
+    const DropdownMenuItem = component('ExpoDropdownMenuItem') as any;
+    DropdownMenuItem.Text = component('ExpoDropdownMenuItemText');
+    return { DropdownMenu, DropdownMenuItem };
+});
+
+import { NativeSettingsMenu } from './NativeSettingsMenu.android';
+
+const originalConsoleError = console.error;
+
+beforeAll(() => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.spyOn(console, 'error').mockImplementation((message?: unknown, ...args: unknown[]) => {
+        if (typeof message === 'string' && message.startsWith('react-test-renderer is deprecated')) return;
+        originalConsoleError(message, ...args);
+    });
+});
+
+afterAll(() => vi.restoreAllMocks());
+
+function render(element: React.ReactElement): ReactTestRenderer {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+        renderer = create(element);
+    });
+    return renderer;
+}
+
+describe('Android Expo-native settings menu', () => {
+    it('passes disabled state to menu items and keeps enabled selection wired', () => {
+        const onSelect = vi.fn();
+        const renderer = render(React.createElement(NativeSettingsMenu, {
+            groups: [{
+                key: 'model',
+                label: 'Model',
+                selectedKey: 'ready',
+                options: [
+                    { key: 'ready', label: 'Ready' },
+                    { key: 'unavailable', label: 'Unavailable', disabled: true },
+                ],
+                onSelect,
+            }],
+            children: React.createElement('Trigger'),
+        }));
+
+        const items = renderer.root.findAllByType('ExpoDropdownMenuItem' as any);
+        expect(items).toHaveLength(2);
+        expect(items[0].props.enabled).toBe(true);
+        expect(items[1].props.enabled).toBe(false);
+
+        act(() => items[0].props.onClick());
+        expect(onSelect).toHaveBeenCalledOnce();
+        expect(onSelect).toHaveBeenCalledWith('ready');
+    });
+});

--- a/packages/happy-app/sources/utils/newSessionPickerInteraction.test.ts
+++ b/packages/happy-app/sources/utils/newSessionPickerInteraction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+    NEW_SESSION_PICKER_LAYERS,
+    cancelPendingPickerOpenState,
+    resolvePickerToggleAction,
+} from './newSessionPickerInteraction';
+
+describe('new-session picker interaction', () => {
+    it('keeps config triggers tappable while the backdrop still guards the composer', () => {
+        expect(NEW_SESSION_PICKER_LAYERS.backdrop).toBeGreaterThan(NEW_SESSION_PICKER_LAYERS.composer);
+        expect(NEW_SESSION_PICKER_LAYERS.backdrop).toBeLessThan(NEW_SESSION_PICKER_LAYERS.config);
+        expect(NEW_SESSION_PICKER_LAYERS.popup).toBeGreaterThan(NEW_SESSION_PICKER_LAYERS.config);
+    });
+
+    it('does not cancel an opening that is only waiting for keyboard dismissal', () => {
+        expect(resolvePickerToggleAction({
+            activePicker: null,
+            pendingPicker: 'model',
+            requestedPicker: 'model',
+        })).toBe('keep-pending');
+    });
+
+    it('still closes a picker that is already visible', () => {
+        expect(resolvePickerToggleAction({
+            activePicker: 'model',
+            pendingPicker: null,
+            requestedPicker: 'model',
+        })).toBe('close-active');
+    });
+
+    it('cancels the keyboard listener and fallback timer when dismissed', () => {
+        vi.useFakeTimers();
+        const remove = vi.fn();
+        const open = vi.fn();
+        const pendingPickerRef = { current: 'model' as string | null };
+        const subscriptionRef = { current: { remove } as { remove: () => void } | null };
+        const timerRef = {
+            current: setTimeout(open, 420) as unknown as ReturnType<typeof setTimeout> | null,
+        };
+
+        cancelPendingPickerOpenState({ pendingPickerRef, subscriptionRef, timerRef });
+        vi.runAllTimers();
+
+        expect(pendingPickerRef.current).toBeNull();
+        expect(subscriptionRef.current).toBeNull();
+        expect(timerRef.current).toBeNull();
+        expect(remove).toHaveBeenCalledOnce();
+        expect(open).not.toHaveBeenCalled();
+        vi.useRealTimers();
+    });
+});

--- a/packages/happy-app/sources/utils/newSessionPickerInteraction.ts
+++ b/packages/happy-app/sources/utils/newSessionPickerInteraction.ts
@@ -1,0 +1,44 @@
+export const NEW_SESSION_PICKER_LAYERS = {
+    composer: 10,
+    backdrop: 15,
+    config: 20,
+    popup: 151,
+} as const;
+
+export type PickerToggleAction = 'close-active' | 'keep-pending' | 'open';
+
+export function cancelPendingPickerOpenState<T>({
+    pendingPickerRef,
+    subscriptionRef,
+    timerRef,
+}: {
+    pendingPickerRef: { current: T | null };
+    subscriptionRef: { current: { remove: () => void } | null };
+    timerRef: { current: ReturnType<typeof setTimeout> | null };
+}) {
+    pendingPickerRef.current = null;
+    subscriptionRef.current?.remove();
+    subscriptionRef.current = null;
+    if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+    }
+}
+
+export function resolvePickerToggleAction<T extends string>({
+    activePicker,
+    pendingPicker,
+    requestedPicker,
+}: {
+    activePicker: T | null;
+    pendingPicker: T | null;
+    requestedPicker: T;
+}): PickerToggleAction {
+    if (activePicker === requestedPicker) {
+        return 'close-active';
+    }
+    if (pendingPicker === requestedPicker) {
+        return 'keep-pending';
+    }
+    return 'open';
+}


### PR DESCRIPTION
## Summary

- stabilize native Expo menus and repeated tap handling
- align and auto-grow the Home and Chat composers
- add regression coverage for composer and menu interactions

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run`