### PR TITLE
fix(app): keep composer native menus tappable while the keyboard is open

### DIFF
--- a/packages/happy-app/sources/components/NativeSettingsMenu.ios.tsx
+++ b/packages/happy-app/sources/components/NativeSettingsMenu.ios.tsx
@@ -25,7 +25,12 @@ export function NativeSettingsMenu({ groups, children, style, flat = false }: Na
     return (
         <View style={[styles.container, style]}>
             <View pointerEvents="none" style={styles.trigger}>{children}</View>
-            <Host colorScheme="dark" style={styles.host}>
+            {/* The host must not perform keyboard avoidance: it is pinned over a
+                composer chip whose position React Native already manages. Left on,
+                SwiftUI shifts the menu's invisible trigger up by the keyboard
+                height while the host's RN frame stays put, so the chip becomes
+                untappable whenever the keyboard is open. */}
+            <Host colorScheme="dark" ignoreSafeArea="keyboard" style={styles.host}>
                 <Menu
                     modifiers={[tint('#FFFFFF')]}
                     label={(


### PR DESCRIPTION
## What's broken

On the compact mobile composer (iOS), tapping the model chip does nothing
while the keyboard is open. It works normally once the keyboard is dismissed.

Repro:
1. Open a session on an iPhone and tap into the composer so the keyboard shows.
2. Tap the model chip.
3. Nothing opens. Dismiss the keyboard, tap it again — the menu appears.

The permission and effort chips share the same component, so they should be
affected identically.

## Why

`NativeSettingsMenu.ios.tsx` renders the chip as a SwiftUI `Menu` inside an
`@expo/ui` `Host`. The `Host` is `position: absolute` over the chip, and the
visible content sits underneath it as a `pointerEvents="none"` RN view — so the
`Host` is the only thing that can receive the tap.

`Host` performs keyboard safe-area avoidance by default. When the keyboard
opens, SwiftUI shifts the hosted content — including the menu's invisible
trigger — up by the keyboard height, while the `Host`'s RN frame stays put. The
trigger leaves the chip's bounds, so taps on the chip hit nothing.

This is consistent with the "+" attachment button still working with the
keyboard open: it is a plain RN pressable and never goes through a `Host`.

## Fix

Set `ignoreSafeArea="keyboard"` on the `Host`. Its position is already managed
by React Native, so it never wanted keyboard avoidance in the first place.

## Testing

**Not verified on device or simulator** — I don't have an iOS build of this app
to test against, so please treat the mechanism as reasoned rather than proven.

What it rests on:
- `HostProps.ignoreSafeArea` is documented as controlling exactly this, and
  keyboard avoidance is the default when it is unset (`@expo/ui` ~55.0.5).
- The reporter's observation is deterministic, not intermittent: keyboard open
  always fails, keyboard closed always works.
- The one composer button that is not `Host`-backed is unaffected.

The quickest confirmation is that the ⚙️ permission and effort chips should be
dead under the same conditions, and live again after this change.

