### PR TITLE
fix(cli): stop dropping messages while background subagents run

### DIFF
--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.test.ts
@@ -536,6 +536,152 @@ describe('mapClaudeLogMessageToSessionEnvelopes', () => {
         expect(result.envelopes).toHaveLength(0);
     });
 
+    it('does not attribute a main-loop message to a subagent via the parent uuid chain', () => {
+        const state = { currentTurnId: null };
+
+        // Main loop spawns a background Agent.
+        mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'main-spawn-1',
+            message: {
+                role: 'assistant',
+                content: [{
+                    type: 'tool_use',
+                    id: 'agent-chain-1',
+                    name: 'Agent',
+                    input: { description: 'background work', prompt: 'go' },
+                }],
+            },
+        } as any, state);
+
+        // The subagent streams a message of its own.
+        const side = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'side-chain-1',
+            isSidechain: true,
+            parent_tool_use_id: 'agent-chain-1',
+            message: {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'subagent working' }],
+            },
+        } as any, state);
+        expect(side.envelopes.length).toBeGreaterThan(0);
+
+        // SDKToLogConverter advances lastUuid for sidechain messages too, so the
+        // next main-loop message gets a parentUuid pointing into subagent history.
+        // It must still be mapped as a main-loop message.
+        const main = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'main-reply-1',
+            isSidechain: false,
+            parentUuid: 'side-chain-1',
+            message: {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'answer for the user' }],
+            },
+        } as any, state);
+
+        expect(main.envelopes).toHaveLength(1);
+        expect(main.envelopes[0].subagent).toBeUndefined();
+        expect(main.envelopes[0].ev).toEqual({ t: 'text', text: 'answer for the user' });
+    });
+
+    it('keeps mapping background subagent messages after the spawning turn closed', () => {
+        const state: any = { currentTurnId: null };
+
+        mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'main-spawn-2',
+            message: {
+                role: 'assistant',
+                content: [{
+                    type: 'tool_use',
+                    id: 'agent-outlives-1',
+                    name: 'Agent',
+                    input: { description: 'long job', prompt: 'go' },
+                }],
+            },
+        } as any, state);
+
+        // The turn ends while the background subagent is still running.
+        const closed = closeClaudeTurnWithStatus(state, 'completed');
+        state.currentTurnId = closed.currentTurnId;
+
+        const late = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'side-late-1',
+            isSidechain: true,
+            parent_tool_use_id: 'agent-outlives-1',
+            message: {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'still running' }],
+            },
+        } as any, state);
+
+        expect(late.envelopes.some((envelope) => {
+            return envelope.ev.t === 'text' && envelope.ev.text === 'still running';
+        })).toBe(true);
+    });
+
+    it('still emits a main-loop reply while background subagents keep streaming', () => {
+        const state: any = { currentTurnId: null };
+
+        mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'main-spawn-3',
+            message: {
+                role: 'assistant',
+                content: [{
+                    type: 'tool_use',
+                    id: 'agent-live-1',
+                    name: 'Agent',
+                    input: { description: 'long job', prompt: 'go' },
+                }],
+            },
+        } as any, state);
+
+        const closed = closeClaudeTurnWithStatus(state, 'completed');
+        state.currentTurnId = closed.currentTurnId;
+
+        // Subagent keeps streaming across the turn boundary.
+        mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'side-live-1',
+            isSidechain: true,
+            parent_tool_use_id: 'agent-live-1',
+            message: {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'progress' }],
+            },
+        } as any, state);
+
+        // New user turn, then the agent's reply - chained off the subagent message.
+        mapClaudeLogMessageToSessionEnvelopes({
+            type: 'user',
+            uuid: 'user-ask-1',
+            isSidechain: false,
+            parentUuid: 'side-live-1',
+            message: { role: 'user', content: 'how is it going?' },
+        } as any, state);
+
+        const reply = mapClaudeLogMessageToSessionEnvelopes({
+            type: 'assistant',
+            uuid: 'main-reply-3',
+            isSidechain: false,
+            parentUuid: 'user-ask-1',
+            message: {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'going well' }],
+            },
+        } as any, state);
+
+        expect(reply.envelopes.some((envelope) => {
+            return envelope.ev.t === 'text' && envelope.ev.text === 'going well';
+        })).toBe(true);
+        const replyText = reply.envelopes.find((envelope) => envelope.ev.t === 'text');
+        expect(replyText?.subagent).toBeUndefined();
+    });
+
     it('does not emit envelopes for compact summary assistant messages', () => {
         const result = mapClaudeLogMessageToSessionEnvelopes({
             type: 'assistant',

--- a/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
+++ b/packages/happy-cli/src/claude/utils/sessionProtocolMapper.ts
@@ -257,16 +257,16 @@ function resolveProviderSubagent(message: RawJSONLines, state: ClaudeSessionProt
         return explicitSubagent;
     }
 
+    if (!isSidechainMessage(message)) {
+        return undefined;
+    }
+
     const parentUuid = pickParentUuid(message);
     if (parentUuid) {
         const inheritedSubagent = getUuidToProviderSubagent(state).get(parentUuid);
         if (inheritedSubagent) {
             return inheritedSubagent;
         }
-    }
-
-    if (!isSidechainMessage(message)) {
-        return undefined;
     }
 
     const prompt = pickSidechainRootPrompt(message);
@@ -388,12 +388,15 @@ function emitActiveSubagentStops(
 function clearSubagentTracking(state: ClaudeSessionProtocolState): void {
     getUuidToProviderSubagent(state).clear();
     getTaskPromptToSubagents(state).clear();
-    getProviderSubagentToSessionSubagent(state).clear();
-    getSubagentTitles(state).clear();
     getBufferedSubagentMessages(state).clear();
     getHiddenParentToolCalls(state).clear();
     getStartedSubagents(state).clear();
     getActiveSubagents(state).clear();
+    // providerSubagentToSessionSubagent and subagentTitles are deliberately kept:
+    // background subagents outlive the turn that spawned them, and a wiped
+    // registration makes every later message from them fail the
+    // `providerSubagent && !subagent` check and get buffered forever.
+    // The ids are a pure hash of the provider id, so keeping them is free.
 }
 
 function ensureTurn(state: ClaudeSessionProtocolState, envelopes: SessionEnvelope[]): string {


### PR DESCRIPTION
Fixes #1626.

## Problem

Once a session has background subagents running, `mapClaudeLogMessageToSessionEnvelopes` starts silently discarding messages — including the agent's replies to direct user questions. The app receives `turn-start` → `turn-end` with nothing in between, and refreshing does not help because the envelopes never reached the server. Nothing is logged and nothing errors.

Two problems compose:

**1. `resolveProviderSubagent` applied the uuid-chain inheritance before the sidechain guard.**

`SDKToLogConverter.convert()` advances `lastUuid` for *every* converted message, sidechain included, and main-loop messages get `parentUuid = lastUuid`. With subagents streaming concurrently, the message converted immediately before a main-loop message is usually a subagent message — so main-loop messages arrive carrying a `parentUuid` that points into subagent history and get claimed by that subagent.

**2. `clearSubagentTracking` wiped `providerSubagentToSessionSubagent` on every turn close.**

Background subagents outlive the turn that spawned them. Once the registration is gone, every later message from them fails the `providerSubagent && !subagent` check and lands in `bufferSubagentMessage`, which is only drained when the matching tool-call id is emitted again — it never is for an already-started subagent. The messages are parked forever.

## Fix

- Move the `isSidechainMessage` guard ahead of the `parentUuid → subagent` inheritance, so a non-sidechain message can never be claimed via the uuid chain. (`parentUuid` is still in scope for the `if (!parentUuid)` check further down.)
- Keep `providerSubagentToSessionSubagent` and `subagentTitles` across turn boundaries. `deterministicSessionSubagentId()` is a pure hash of the provider tool-use id, so retaining them costs nothing, and the map is what answers "do we already know this subagent?".

Buffering is deliberately left intact for the case it was written for — subagent messages arriving before their parent tool call is known — and the existing `buffers subagent messages until parent Task registration is known` test still covers it.

## Tests

Three regression tests in `sessionProtocolMapper.test.ts`:

| test | fails before |
|---|---|
| `does not attribute a main-loop message to a subagent via the parent uuid chain` | `expected 'c4ba425e5edee819d268c2c1' to be undefined` |
| `keeps mapping background subagent messages after the spawning turn closed` | `expected false to be true` |
| `still emits a main-loop reply while background subagents keep streaming` | `expected false to be true` |

All three fail on `main` and pass with the fix. `sessionProtocolMapper.test.ts` is 21/21 green; `tsc --noEmit` clean.

Full `vitest run --project unit`, same tree, before vs after:

```
before:  40 failed | 752 passed (792)
after:   40 failed | 755 passed (795)
```

The 40 pre-existing failures are unrelated — `getProjectPath` / `claudeVersionUtils` tests that assume POSIX paths and fail on Windows. The failure set is byte-identical before and after; the delta is exactly the 3 new tests.

## How this was found

Replayed the 4512 SDK messages recorded in a real session's happy debug log back through the shipped mapper, reproducing the converter's `parentUuid` chain and calling `closeClaudeTurnWithStatus` on `result` messages:

```
                              before      after
envelopes emitted             733         2760
main-loop messages swallowed  9           0
subagent messages swallowed   1938        0
structural violations         2           0
```

733 matches exactly what that session's server-side message log actually contained (fetched via `GET /v3/sessions/{id}/messages` and decrypted), which is how the drop was confirmed rather than inferred. Structural validation checks that every envelope's turn was opened by a `turn-start`, every subagent envelope is preceded by a `start`, no duplicate `start`, and every `tool-call-end` has a matching `tool-call-start` — the patched output is clean on all four and also fixes two orphan `tool-call-end` envelopes the current code emits.

## Note

The silent-swallow path deserves a `logger.debug` regardless of this fix — the total absence of any log line is what made this hard to track down. Happy to add it here or separately, whichever you prefer.
