### PR TITLE
Fix Android new-session send button layout

### DIFF
--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -2457,7 +2457,7 @@ const styles = StyleSheet.create((theme) => ({
         minHeight: Platform.select({ web: 0, default: 46 }),
     },
     mobileActionButtonsContainer: {
-        width: '100%',
+        alignSelf: 'stretch',
         minHeight: 40,
         justifyContent: 'space-between',
         gap: 2,


### PR DESCRIPTION
## Summary

Fixes the Android new-session composer so the send button stays visible beside the microphone control.

The mobile action row set `width: '100%'` inside a horizontally padded, overflow-hidden composer. On Android that percentage could resolve against the outer box rather than the padded content box, pushing the fixed-width send button past the right edge where the composer clipped it.

The row now takes its width from the parent instead of declaring one. `mobileInputBox` is a column container with `alignItems: 'stretch'`, so the explicit `alignSelf: 'stretch'` documents that the row is meant to fill the content box and leaves layout unchanged on web and iOS.

## Validation

- Built `@slopus/happy-wire`
- Ran `happy-app` TypeScript checks
- Ran `git diff --check`
