### PR TITLE
fix(app): stop the agent default from re-modeling a running session

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -849,8 +849,14 @@ export function SessionViewLoaded({
     }, [sessionId, expImageUpload, selectedImages, clearImages, pendingCommunications]);
 
     const handleAbort = React.useCallback(() => {
-        // Stop cancels only the active turn. Permission, model, and effort are
-        // session choices and must remain sticky for the next message.
+        // Stop cancels only the active turn, so model and effort stay sticky for
+        // the next message. The permission mode cannot: both agents reset it to
+        // the launch value on abort (runClaude.ts / runCodex.ts
+        // `resetCurrentModeDefaults`), so leaving the app's synced copy in place
+        // desyncs the picker from what the next turn actually runs (#1492/#1595).
+        if (!isRig) {
+            sessionSetAgentModes(sessionId, { permissionMode: null });
+        }
         sessionAbort(sessionId);
     }, [sessionId]);
 

--- a/packages/happy-app/sources/sync/messageMeta.test.ts
+++ b/packages/happy-app/sources/sync/messageMeta.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveMessageModeMeta, UnsupportedPermissionModeError } from './messageMeta';
+import { resolveAgentDefaultPin, resolveMessageModeMeta, UnsupportedPermissionModeError } from './messageMeta';
 import { rigMetadataFixture } from './__testdata__/rigMetadata';
 
 describe('resolveMessageModeMeta', () => {
@@ -274,5 +274,90 @@ describe('resolveMessageModeMeta', () => {
         } as any);
 
         expect(meta.effort).toBe('high');
+    });
+});
+
+describe('resolveAgentDefaultPin', () => {
+    const claudeDefaults = {
+        agentDefaultOverrides: {
+            claude: {
+                permissionMode: 'bypassPermissions',
+                modelMode: 'opus',
+                effortLevel: 'medium',
+            },
+        },
+    } as any;
+
+    it('pins the settings-level defaults a session falls back to', () => {
+        const pin = resolveAgentDefaultPin({
+            permissionMode: null,
+            modelMode: null,
+            effortLevel: null,
+            metadata: { flavor: 'claude' },
+        } as any, claudeDefaults);
+
+        expect(pin).toEqual({
+            permissionMode: 'bypassPermissions',
+            modelMode: 'opus',
+            effortLevel: 'medium',
+        });
+    });
+
+    it('leaves a session that already made its own picks alone', () => {
+        const pin = resolveAgentDefaultPin({
+            permissionMode: 'default',
+            modelMode: 'sonnet',
+            effortLevel: 'xhigh',
+            metadata: { flavor: 'claude' },
+        } as any, claudeDefaults);
+
+        expect(pin).toEqual({});
+    });
+
+    it('pins only the fields the session is missing', () => {
+        const pin = resolveAgentDefaultPin({
+            permissionMode: null,
+            modelMode: 'sonnet',
+            effortLevel: null,
+            metadata: { flavor: 'claude' },
+        } as any, claudeDefaults);
+
+        expect(pin).toEqual({
+            permissionMode: 'bypassPermissions',
+            effortLevel: 'medium',
+        });
+    });
+
+    it('pins nothing when the user set no agent defaults', () => {
+        const pin = resolveAgentDefaultPin({
+            permissionMode: null,
+            modelMode: null,
+            effortLevel: null,
+            metadata: { flavor: 'claude' },
+        } as any, { agentDefaultOverrides: {} } as any);
+
+        expect(pin).toEqual({});
+    });
+
+    it('pins nothing for a different agent than the one that was configured', () => {
+        const pin = resolveAgentDefaultPin({
+            permissionMode: null,
+            modelMode: null,
+            effortLevel: null,
+            metadata: { flavor: 'codex' },
+        } as any, claudeDefaults);
+
+        expect(pin).toEqual({});
+    });
+
+    it('pins nothing for Rig sessions — the agent carries its own model state', () => {
+        const pin = resolveAgentDefaultPin({
+            permissionMode: null,
+            modelMode: null,
+            effortLevel: null,
+            metadata: rigMetadataFixture,
+        } as any, claudeDefaults);
+
+        expect(pin).toEqual({});
     });
 });

--- a/packages/happy-app/sources/sync/messageMeta.ts
+++ b/packages/happy-app/sources/sync/messageMeta.ts
@@ -1,4 +1,4 @@
-import type { Session } from './storageTypes';
+import type { Session, SessionAgentModesPatch } from './storageTypes';
 import type { Settings } from './settings';
 import { getAgentDefaultOverride, resolveAgentDefaultConfig, retirePermissionMode } from './agentDefaults';
 import { permissionModeSupportedByCli } from '@/components/modelModeOptions';
@@ -128,4 +128,44 @@ export function resolveMessageModeMeta(
     }
 
     return meta;
+}
+
+/**
+ * The picks a session should adopt as its own the first time it falls back to
+ * the settings-level agent defaults.
+ *
+ * `resolveMessageModeMeta` reads those defaults live, so without this a session
+ * that never got an explicit pick keeps re-resolving them on every turn — and
+ * editing the default in Settings retroactively re-models sessions that are
+ * already running. Freezing the fallback onto the session on first use keeps
+ * the default doing its job (seeding sessions that have no pick of their own)
+ * while scoping it to the moment the session first uses it.
+ *
+ * Returns only fields the session is missing; Rig sessions are excluded because
+ * their model/reasoning state is carried by the agent's own metadata.
+ */
+export function resolveAgentDefaultPin(
+    session: Pick<Session, 'permissionMode' | 'modelMode' | 'metadata' | 'effortLevel'>,
+    settings?: Pick<Settings, 'agentDefaultOverrides'>,
+): SessionAgentModesPatch {
+    if (isRigMetadataV1(session.metadata)) {
+        return {};
+    }
+
+    const agentOverrides = getAgentDefaultOverride(settings?.agentDefaultOverrides, session.metadata?.flavor);
+    const pin: SessionAgentModesPatch = {};
+
+    const isUnset = (value: string | null | undefined): boolean => value === null || value === undefined;
+
+    if (isUnset(session.permissionMode) && agentOverrides.permissionMode !== undefined) {
+        pin.permissionMode = agentOverrides.permissionMode;
+    }
+    if (isUnset(session.modelMode) && agentOverrides.modelMode !== undefined) {
+        pin.modelMode = agentOverrides.modelMode;
+    }
+    if (isUnset(session.effortLevel) && agentOverrides.effortLevel !== undefined) {
+        pin.effortLevel = agentOverrides.effortLevel;
+    }
+
+    return pin;
 }

--- a/packages/happy-app/sources/sync/sync.ts
+++ b/packages/happy-app/sources/sync/sync.ts
@@ -61,7 +61,7 @@ import { fetchFeed } from './apiFeed';
 import { FeedItem } from './feedTypes';
 import { UserProfile } from './friendTypes';
 import { resolveControlHandoffDirection } from './controlHandoff';
-import { resolveMessageModeMeta, UnsupportedPermissionModeError } from './messageMeta';
+import { resolveAgentDefaultPin, resolveMessageModeMeta, UnsupportedPermissionModeError } from './messageMeta';
 import type { AttachmentPreview, UploadedAttachment } from './attachmentTypes';
 import { requestAttachmentUpload, uploadEncryptedBlob } from './apiAttachments';
 import { encryptBlob } from '@/encryption/blob';
@@ -657,6 +657,13 @@ class Sync {
                 return;
             }
             throw error;
+        }
+        // Adopt the settings-level defaults as the session's own picks the first
+        // time it uses them, so editing the default later cannot re-model a
+        // session that is already running.
+        const defaultPin = resolveAgentDefaultPin(session, storage.getState().settings);
+        if (Object.keys(defaultPin).length > 0) {
+            sessionSetAgentModes(sessionId, defaultPin);
         }
         const { displayText, source = 'chat', attachments, awaitDelivery = false } = options ?? {};
 


### PR DESCRIPTION
The per-agent defaults in Settings are read live on every send — `resolveMessageModeMeta()` falls back to `agentDefaultOverrides` whenever a session has no explicit pick of its own — so the default is not a *new-session* default but a standing remote control over every unconfigured session. Editing the default model in Settings therefore switches the model of sessions that are already running, on their very next message, with nothing in the chat to say so. The CLI already assumes the opposite: `resetCurrentModeDefaults()` in `runClaude.ts` / `runCodex.ts` deliberately keeps the model and effort across an abort on the stated grounds that *"the app sends them only when the user changes the picker"* (#1595) — today the app also sends them when the user changes an unrelated global setting. This keeps the default doing its job (seeding a session that has no pick of its own) but scopes it to the moment the session first uses it: `resolveAgentDefaultPin()` freezes those values onto the session on first use, and `handleAbort()` no longer erases the pick — it now clears only the permission mode, which is the one field both agents actually reset on abort.

## Proof

Live end-to-end run against a standalone `happy-server` (PGlite) + Expo web + a paired `happy-cli` daemon, driven headlessly with Playwright. Identical script on both builds: send turn 1, set **Settings → Agents → Claude Code → Model = sonnet 4.6**, send turn 2, change it to **fable 5**, send turn 3. The verdict is the CLI session log, which records the model each turn actually ran with.

**Before**

```
[loop] User message received with no model override, using current: opus
[loop] Model updated from user message: sonnet
[loop] Model updated from user message: fable      ← the running session followed the setting
```

**After**

```
[loop] User message received with no model override, using current: opus
[loop] Model updated from user message: sonnet
[loop] Model updated from user message: sonnet     ← the session keeps the model it was using
```

Turn 2 is identical on both builds — the default still seeds a session that has no pick, which is the behaviour `resolveMessageModeMeta`'s settings fallback was added for. Only turn 3 differs.

Reproducing this on `main` needs an agent default that survives long enough to send a message; on current `main` the override is dropped again before the next turn (the bug #1606 / #1395 / #1477 address), which masks this one. The run above therefore has #1606's persistence fix applied on top as a harness prerequisite — it is not part of this diff.

`packages/happy-app`: `pnpm typecheck` clean, `pnpm vitest run` 817/817 across 67 files, including six new cases covering `resolveAgentDefaultPin` (pins the fallback, leaves explicit picks alone, pins only missing fields, no-op without overrides, no-op for another agent, no-op for Rig sessions).
