### PR TITLE
fix(cli): session never syncs if first prompt comes >60s after launch

### DIFF
--- a/packages/happy-cli/src/claude/claudeRemote.ts
+++ b/packages/happy-cli/src/claude/claudeRemote.ts
@@ -295,13 +295,14 @@ export async function claudeRemote(opts: {
                     const found = await awaitFileExist(join(projectDir, `${systemInit.session_id}.jsonl`), 30000);
                     logger.debug(`[claudeRemote] Session file found: ${systemInit.session_id} ${found}`);
                     if (!found) {
-                        // The transcript never landed on disk within the grace
-                        // window. We still register the id so the (now
-                        // bounded) scanner watcher can pick it up if it shows
-                        // up late and otherwise drops it cleanly instead of
-                        // wedging — but surface the anomaly so a stuck remote
-                        // launch is visible in the app rather than a silent
-                        // "dead instance".
+                        // The transcript has not landed on disk yet. We still
+                        // register the id: the scanner's watcher waits for the
+                        // file indefinitely (it no longer gives up on a
+                        // deadline — see startFileWatcher), so a late
+                        // transcript is still picked up cleanly. This wait is
+                        // therefore only about surfacing the anomaly, so a
+                        // genuinely stuck remote launch is visible in the app
+                        // rather than a silent "dead instance".
                         logger.debug(`[claudeRemote] WARNING: session transcript ${systemInit.session_id} never appeared after 30s`);
                         opts.onCompletionEvent?.('⚠️ Claude session did not produce a transcript — the agent may be unresponsive. Try sending your message again.');
                     }

--- a/packages/happy-cli/src/claude/utils/sessionScanner.test.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.test.ts
@@ -10,14 +10,25 @@ import { getProjectPath } from './path'
 
 describe('sessionScanner', () => {
   let testDir: string
+  let configDir: string
   let projectDir: string
   let collectedMessages: RawJSONLines[]
   let collectedTranscriptEvents: ClaudeGoalStatusTranscriptEvent[]
   let scanner: Awaited<ReturnType<typeof createSessionScanner>> | null = null
-  
+  let prevConfigDir: string | undefined
+
   beforeEach(async () => {
-    testDir = join(tmpdir(), `scanner-test-${Date.now()}`)
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    testDir = join(tmpdir(), `scanner-test-${unique}`)
     await mkdir(testDir, { recursive: true })
+
+    // Isolate CLAUDE_CONFIG_DIR *before* deriving projectDir, since
+    // getProjectPath() reads it. Otherwise these tests create directories
+    // under the developer's real ~/.claude/projects and rm -rf them in
+    // afterEach.
+    configDir = join(tmpdir(), `scanner-config-${unique}`)
+    prevConfigDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.CLAUDE_CONFIG_DIR = configDir
 
     // Use the same path calculation as the scanner to ensure paths match
     projectDir = getProjectPath(testDir)
@@ -26,19 +37,25 @@ describe('sessionScanner', () => {
     collectedMessages = []
     collectedTranscriptEvents = []
   })
-  
+
   afterEach(async () => {
     // Clean up scanner
     if (scanner) {
       await scanner.cleanup()
       scanner = null
     }
-    
+
+    if (prevConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = prevConfigDir
+    }
+
     if (existsSync(testDir)) {
       await rm(testDir, { recursive: true, force: true })
     }
-    if (existsSync(projectDir)) {
-      await rm(projectDir, { recursive: true, force: true })
+    if (existsSync(configDir)) {
+      await rm(configDir, { recursive: true, force: true })
     }
   })
   
@@ -319,11 +336,14 @@ describe('sessionScanner', () => {
     // }
   })
 
-  it('drops a phantom session whose transcript never appears and keeps serving real ones', async () => {
-    // Reproduces the "dead Happy instance" bug: a session id is announced
-    // (e.g. a remote launch) but its .jsonl is never written. The scanner
-    // must give up on it instead of spinning forever, and must still process
-    // a real session that arrives afterwards.
+  it('keeps serving real sessions while a phantom session has no transcript', async () => {
+    // A session id is announced (e.g. a remote launch) but its .jsonl is
+    // never written. The watcher now waits for that file indefinitely via
+    // the parent directory instead of giving up on a deadline — a transcript
+    // Claude Code creates lazily must never be abandoned (that dropped real
+    // sessions whose first prompt came late). The phantom therefore stays
+    // watched, costing one idle directory watch and no CPU, and must not
+    // leak messages or disturb a real session arriving afterwards.
     scanner = await createSessionScanner({
       sessionId: null,
       workingDirectory: testDir,

--- a/packages/happy-cli/src/claude/utils/sessionScanner.ts
+++ b/packages/happy-cli/src/claude/utils/sessionScanner.ts
@@ -30,9 +30,14 @@ export async function createSessionScanner(opts: {
     onMessage: (message: RawJSONLines) => void
     onTranscriptEvent?: (event: ScannerTranscriptEvent) => void
     /**
-     * How long a session transcript may stay absent before its watcher gives
-     * up and the session is dropped. Defaults to the startFileWatcher default
-     * (60s). Exposed mainly so tests can exercise the drop path quickly.
+     * How long the transcript's parent directory may stay continuously
+     * unwatchable before the watcher gives up and the session is dropped.
+     * Defaults to the startFileWatcher default (60s). Exposed mainly so tests
+     * can exercise the drop path quickly.
+     *
+     * Note this no longer bounds how long we wait for the transcript *file* —
+     * that wait is unbounded on purpose, because Claude Code creates it lazily
+     * on the first prompt. See startFileWatcher for the full rationale.
      */
     missingFileTimeoutMs?: number
 }) {
@@ -46,11 +51,17 @@ export async function createSessionScanner(opts: {
     let currentSessionId: string | null = null;
     let watchers = new Map<string, (() => void)>();
     let processedEntryKeys = new Set<string>();
-    // Sessions whose transcript file never appeared. Their watcher gave up,
-    // so we must stop re-reading them and never re-create a watcher for them
-    // — otherwise a phantom session id (e.g. a remote launch whose .jsonl is
-    // never written) keeps itself alive forever via the watchers map below
-    // and spins the CPU / floods the log (the "dead Happy instance" bug).
+    // Sessions whose watcher gave up because the project directory itself
+    // stayed unwatchable (missing, EACCES). Once dropped we must stop
+    // re-reading them and never re-create a watcher, or the id keeps itself
+    // alive forever via the watchers map below and floods the log (the
+    // "dead Happy instance" bug).
+    //
+    // A merely absent transcript no longer lands here: Claude Code creates it
+    // lazily on the first prompt, so the watcher waits for it indefinitely.
+    // That makes this set rare in practice — a phantom id now costs one idle
+    // directory watch for the lifetime of the process instead of being
+    // blacklisted after 60s. See startFileWatcher for why that trade is right.
     let deadSessions = new Set<string>();
 
     // Mark existing entries as processed and start watching the initial session
@@ -132,12 +143,14 @@ export async function createSessionScanner(opts: {
                     {
                         missingFileTimeoutMs: opts.missingFileTimeoutMs,
                         onGaveUp: () => {
-                            // The transcript for this session never appeared.
-                            // Tear the watcher down and blacklist the session
-                            // so the collection loop above stops resurrecting
-                            // it. Without this the phantom session would keep
-                            // itself in `watchers` forever.
-                            logger.debug(`[SESSION_SCANNER] Session ${p} transcript never appeared — dropping it`);
+                            // The project directory itself stayed unwatchable,
+                            // so we can never observe this transcript. Tear the
+                            // watcher down and blacklist the session so the
+                            // collection loop above stops resurrecting it.
+                            // Without this it would keep itself in `watchers`
+                            // forever. Note a merely late transcript does NOT
+                            // reach here — that wait is unbounded by design.
+                            logger.debug(`[SESSION_SCANNER] Session ${p} transcript unreachable (directory unwatchable) — dropping it`);
                             watchers.get(p)?.();
                             watchers.delete(p);
                             deadSessions.add(p);
@@ -157,12 +170,24 @@ export async function createSessionScanner(opts: {
     return {
         cleanup: async () => {
             clearInterval(intervalId);
+            // Order matters. `invalidateAndAwait` really does run the sync body
+            // once more, and that body ends by creating a watcher for every
+            // session that lacks one. Disposing before the final flush would
+            // let that last sync re-create them all, and the following
+            // `sync.stop()` only sets a stopped flag — it does not touch
+            // `watchers`, which we already cleared, so nothing can reach those
+            // persistent OS watches again. Hence: flush and stop the sync
+            // first, dispose the watchers second.
+            //
+            // Before this change the leak was bounded: a watcher on a
+            // non-existent file terminated itself via onGaveUp after 60s. Now
+            // that watchers wait indefinitely, it would last until exit.
+            await sync.invalidateAndAwait();
+            sync.stop();
             for (let w of watchers.values()) {
                 w();
             }
             watchers.clear();
-            await sync.invalidateAndAwait();
-            sync.stop();
         },
         onNewSession: async (sessionId: string, options?: { treatExistingAsProcessed?: boolean }) => {
             if (currentSessionId === sessionId) {

--- a/packages/happy-cli/src/modules/watcher/startFileWatcher.test.ts
+++ b/packages/happy-cli/src/modules/watcher/startFileWatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { startFileWatcher } from './startFileWatcher'
-import { mkdir, writeFile, appendFile, rm } from 'node:fs/promises'
+import { mkdir, writeFile, appendFile, rm, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { existsSync } from 'node:fs'
@@ -26,7 +26,11 @@ describe('startFileWatcher', () => {
     }
   })
 
-  it('gives up exactly once when the file never appears', async () => {
+  // Regression test. Claude Code creates the transcript lazily: it does not
+  // exist until the user submits their first prompt. The previous
+  // implementation bounded total absence by time and gave up, which
+  // blacklisted the session permanently — its content never synced again.
+  it('does not give up while the file has simply not been created yet', async () => {
     const missing = join(testDir, 'never.jsonl')
     let changes = 0
     let gaveUp = 0
@@ -36,30 +40,33 @@ describe('startFileWatcher', () => {
       onGaveUp: () => { gaveUp++ },
     })
 
-    // First retry backoff is ~1s, so give-up lands a little after that.
-    await sleep(2500)
+    // Far past missingFileTimeoutMs: that timeout only bounds a parent
+    // directory that cannot be watched at all.
+    await sleep(1200)
 
-    expect(gaveUp).toBe(1)
+    expect(gaveUp).toBe(0)
     expect(changes).toBe(0)
   })
 
-  it('recovers when the file appears within the grace window', async () => {
+  // The real-world case: the user types their first prompt 90 seconds in.
+  // A short timeout here proves waiting for creation is independent of it.
+  it('attaches to a file created long after the timeout would have fired', async () => {
     const file = join(testDir, 'late.jsonl')
     let changes = 0
     let gaveUp = 0
 
     stop = startFileWatcher(file, () => { changes++ }, {
-      missingFileTimeoutMs: 10_000,
+      missingFileTimeoutMs: 100,
       onGaveUp: () => { gaveUp++ },
     })
 
-    // Create the transcript after the watcher has already failed once.
-    await sleep(300)
+    await sleep(900)
+    expect(gaveUp).toBe(0)
+
     await writeFile(file, 'line-1\n')
-    await sleep(1500)
+    await sleep(400)
     await appendFile(file, 'line-2\n')
-    await appendFile(file, 'line-3\n')
-    await sleep(800)
+    await sleep(400)
 
     expect(gaveUp).toBe(0)
     expect(changes).toBeGreaterThan(0)
@@ -84,6 +91,49 @@ describe('startFileWatcher', () => {
     expect(changes).toBeGreaterThan(0)
   })
 
+  it('re-arms when the file is deleted and later recreated', async () => {
+    const file = join(testDir, 'recreated.jsonl')
+    await writeFile(file, 'init\n')
+
+    let changes = 0
+    let gaveUp = 0
+    stop = startFileWatcher(file, () => { changes++ }, {
+      missingFileTimeoutMs: 100,
+      onGaveUp: () => { gaveUp++ },
+    })
+
+    await sleep(200)
+    await unlink(file)
+    await sleep(600)
+
+    await writeFile(file, 'reborn\n')
+    await sleep(300)
+    await appendFile(file, 'again\n')
+    await sleep(400)
+
+    expect(gaveUp).toBe(0)
+    expect(changes).toBeGreaterThan(0)
+  })
+
+  // The only remaining give-up path: the parent directory itself stays
+  // unwatchable (missing, or permissions deny it). This is what the original
+  // timeout was actually there to guard.
+  it('gives up exactly once when the parent directory stays unwatchable', async () => {
+    const missing = join(testDir, 'no-such-dir', 'ghost.jsonl')
+    let changes = 0
+    let gaveUp = 0
+
+    stop = startFileWatcher(missing, () => { changes++ }, {
+      missingFileTimeoutMs: 100,
+      onGaveUp: () => { gaveUp++ },
+    })
+
+    await sleep(2500)
+
+    expect(gaveUp).toBe(1)
+    expect(changes).toBe(0)
+  })
+
   it('stops on dispose without giving up', async () => {
     const missing = join(testDir, 'aborted.jsonl')
     let changes = 0
@@ -100,7 +150,11 @@ describe('startFileWatcher', () => {
     dispose()
     stop = null
 
-    await sleep(2000)
+    await sleep(600)
+
+    // Creating the file after dispose must not fire the callback either.
+    await writeFile(missing, 'after-dispose\n')
+    await sleep(300)
 
     expect(gaveUp).toBe(0)
     expect(changes).toBe(0)

--- a/packages/happy-cli/src/modules/watcher/startFileWatcher.ts
+++ b/packages/happy-cli/src/modules/watcher/startFileWatcher.ts
@@ -1,40 +1,76 @@
 import { logger } from "@/ui/logger";
 import { watch } from "fs/promises";
+import { existsSync } from "node:fs";
+import { basename, dirname } from "node:path";
+
+/** How often we re-check existence while waiting for a file to be created. */
+const CREATION_POLL_INTERVAL_MS = 2000;
 
 export interface FileWatcherOptions {
     /**
-     * Invoked exactly once when the watcher permanently gives up because the
-     * target file never appeared within `missingFileTimeoutMs`. The watcher
-     * loop exits right after; the caller owns any follow-up cleanup (e.g.
-     * dropping the dead session so it is never re-watched).
+     * Invoked exactly once when the watcher permanently gives up. This only
+     * happens when the file's parent directory stays unwatchable for
+     * `missingFileTimeoutMs` (e.g. it does not exist, or permissions deny
+     * watching) — never merely because the file itself has not been created
+     * yet. The watcher loop exits right after; the caller owns any follow-up
+     * cleanup (e.g. dropping the dead session so it is never re-watched).
      */
     onGaveUp?: () => void;
     /**
-     * How long the file may stay continuously absent before we give up.
-     * Defaults to 60s — comfortably longer than a legitimately slow Claude
-     * session start (claudeRemote waits ~10s for the transcript), but bounded
-     * so a session id that never produces a file cannot wedge the process.
+     * How long the parent directory may stay *continuously* unwatchable before
+     * we give up. Defaults to 60s. This does NOT bound how long we wait for the
+     * file itself — see the module docs below for why.
      */
     missingFileTimeoutMs?: number;
 }
 
+type CreationOutcome =
+    /** The file now exists. */
+    | 'created'
+    /** We were disposed. */
+    | 'aborted'
+    /** The parent directory could not be watched at all (missing, EACCES, ...). */
+    | 'unwatchable'
+    /** Nothing conclusive; the caller should simply loop and try again. */
+    | 'retry';
+
 /**
- * Watch a single file for changes.
+ * Watch a single file for changes, tolerating a file that does not exist yet.
  *
- * `fs.watch()` throws `ENOENT` synchronously for a path that does not exist,
- * so the previous implementation (tight `while (true)` + flat `delay(1000)`)
- * turned a never-created session transcript into an infinite 1-per-second
- * spin. Combined with the session scanner re-adding the watcher every sync
- * cycle, that produced the pegged-CPU / multi-MB-log "dead Happy instance"
- * where the terminal agent kept working but the bridge never recovered.
+ * `fs.watch()` throws `ENOENT` synchronously for a path that does not exist.
+ * An earlier implementation (tight `while (true)` + flat `delay(1000)`) turned
+ * a never-created session transcript into an infinite 1-per-second spin, which
+ * pegged the CPU and flooded the log — the "dead Happy instance" bug. That was
+ * fixed by bounding total absence with a 60s timeout and giving up.
+ *
+ * Bounding by time is the wrong cure, because "not created yet" and "never
+ * going to be created" are indistinguishable by elapsed time. Claude Code
+ * creates `<uuid>.jsonl` lazily — not at launch, but when the user submits
+ * their first prompt. A user who starts Happy, reads some code, and types
+ * their first prompt 90 seconds later would trip the timeout, and the watcher
+ * would give up ~an instant before the file appeared. The session then stays
+ * registered (the phone shows it as online with a title) but no message is
+ * ever uploaded, and it cannot recover for the rest of its lifetime.
+ *
+ * So instead of racing a timer, wait for the file to be *created*: when it is
+ * absent, watch the parent directory and block until the entry shows up.
+ *
+ * That wait races a low-frequency existence poll. Pure event-driven waiting
+ * would hang forever on filesystems that do not deliver watch events at all
+ * (NFS, SMB, some container bind mounts) — reproducing the very bug above,
+ * only quieter. The poll is the safety net; events remain the fast path, so
+ * there is no per-second spin and no log flood.
  *
  * This version:
- *  - backs off exponentially between retries (1s → 15s, capped),
- *  - distinguishes "file absent" (ENOENT) from transient watch errors,
- *  - gives up — instead of spinning forever — when the file stays absent
- *    past `missingFileTimeoutMs`, signalling the caller via `onGaveUp`,
- *  - resets all failure state as soon as the file is observed, so a slow
- *    session start that eventually writes its transcript heals cleanly.
+ *  - waits indefinitely for a not-yet-created file, via directory events
+ *    raced against a slow poll,
+ *  - backs off exponentially (1s → 15s, capped) on transient watch errors,
+ *  - gives up only if the parent directory itself stays continuously
+ *    unwatchable past `missingFileTimeoutMs`, signalling via `onGaveUp`,
+ *  - resets failure state only on observed progress, so a persistent error
+ *    (EACCES, EMFILE) escalates to the 15s cap instead of retrying every
+ *    second forever,
+ *  - re-arms if the file is deleted later, waiting for it to reappear.
  */
 export function startFileWatcher(
     file: string,
@@ -43,6 +79,8 @@ export function startFileWatcher(
 ) {
     const abortController = new AbortController();
     const missingFileTimeoutMs = options.missingFileTimeoutMs ?? 60_000;
+    const directory = dirname(file);
+    const filename = basename(file);
 
     // Timeout/abort-aware wait so a long backoff does not delay cleanup.
     const wait = (ms: number) => new Promise<void>((resolve) => {
@@ -61,54 +99,180 @@ export function startFileWatcher(
         abortController.signal.addEventListener('abort', onAbort, { once: true });
     });
 
+    /**
+     * Block until `file` exists, by watching its parent directory while also
+     * polling for existence.
+     *
+     * The two are raced deliberately: the event path reacts instantly on
+     * healthy filesystems, the poll guarantees eventual progress on ones that
+     * never deliver events. Distinguishing 'unwatchable' from 'retry' matters
+     * — only the former may start the give-up countdown, and a directory
+     * iterator ending on its own (a rename, or Node closing it) is benign.
+     */
+    const awaitFileCreation = async (): Promise<CreationOutcome> => {
+        // Own abort controller for the directory watch so every exit path
+        // (file found, abort, throw) releases it. Returning straight out of a
+        // `for await` — or never iterating it at all, as happens when the
+        // existence re-check below wins the race — would otherwise leave the
+        // underlying OS watch armed until GC: one leaked watch per session.
+        const directoryAbort = new AbortController();
+        const forwardAbort = () => directoryAbort.abort();
+        abortController.signal.addEventListener('abort', forwardAbort, { once: true });
+
+        // Wakes the loop below on a timer even if no event ever arrives.
+        let pollTimer: NodeJS.Timeout | null = null;
+        const startPoll = () => {
+            pollTimer = setTimeout(() => {
+                if (existsSync(file)) {
+                    directoryAbort.abort();
+                } else {
+                    startPoll();
+                }
+            }, CREATION_POLL_INTERVAL_MS);
+        };
+
+        try {
+            const directoryWatcher = watch(directory, { persistent: true, signal: directoryAbort.signal });
+
+            // The file may have been created between the caller's existence
+            // check and this watch being armed — re-check before blocking, or
+            // we would wait for an event that has already happened.
+            if (existsSync(file)) {
+                return 'created';
+            }
+
+            startPoll();
+
+            for await (const event of directoryWatcher) {
+                if (abortController.signal.aborted) {
+                    return 'aborted';
+                }
+                // `filename` is null on some platforms/events; re-check on any
+                // directory activity rather than trusting the name.
+                if (!event.filename || event.filename === filename) {
+                    if (existsSync(file)) {
+                        logger.debug(`[FILE_WATCHER] File appeared: ${file}`);
+                        return 'created';
+                    }
+                }
+            }
+
+            // Iterator ended. Either our poll found the file and aborted the
+            // watch, or the directory went away / Node closed it. Existence
+            // decides which — never report 'unwatchable' on a guess, because
+            // that is what arms the give-up countdown.
+            if (abortController.signal.aborted) {
+                return 'aborted';
+            }
+            if (existsSync(file)) {
+                logger.debug(`[FILE_WATCHER] File appeared (poll): ${file}`);
+                return 'created';
+            }
+            return 'retry';
+        } catch (e: any) {
+            if (abortController.signal.aborted) {
+                return 'aborted';
+            }
+            // The directory itself cannot be watched — this, and only this, is
+            // what `missingFileTimeoutMs` guards.
+            logger.debug(`[FILE_WATCHER] Cannot watch directory ${directory}: ${e?.message}`);
+            return 'unwatchable';
+        } finally {
+            if (pollTimer) {
+                clearTimeout(pollTimer);
+            }
+            abortController.signal.removeEventListener('abort', forwardAbort);
+            directoryAbort.abort();
+        }
+    };
+
     void (async () => {
-        // When the target file first went missing (null = currently present
-        // or never-yet-missing). Used to bound total absence time.
-        let missingSince: number | null = null;
+        // When the parent directory first became unwatchable (null = fine, or
+        // never-yet-failed). Reset the moment the directory is watchable again,
+        // so an early transient failure cannot make a much later, unrelated
+        // failure trip the deadline with zero grace.
+        let directoryUnwatchableSince: number | null = null;
         let failureCount = 0;
 
+        const backoff = async () => {
+            failureCount++;
+            const backoffMs = Math.min(1000 * 2 ** Math.min(failureCount - 1, 4), 15_000);
+            await wait(backoffMs);
+            return backoffMs;
+        };
+
         while (true) {
+            if (abortController.signal.aborted) {
+                return;
+            }
             try {
+                // Wait for a not-yet-created transcript instead of failing on
+                // ENOENT and racing a deadline.
+                if (!existsSync(file)) {
+                    logger.debug(`[FILE_WATCHER] Waiting for ${file} to be created`);
+                    const outcome = await awaitFileCreation();
+                    if (abortController.signal.aborted || outcome === 'aborted') {
+                        return;
+                    }
+                    if (outcome === 'unwatchable') {
+                        const now = Date.now();
+                        if (directoryUnwatchableSince === null) {
+                            directoryUnwatchableSince = now;
+                        }
+                        const unwatchableMs = now - directoryUnwatchableSince;
+                        if (unwatchableMs >= missingFileTimeoutMs) {
+                            logger.debug(`[FILE_WATCHER] Giving up on ${file}: directory ${directory} unwatchable for ${Math.round(unwatchableMs / 1000)}s`);
+                            options.onGaveUp?.();
+                            return;
+                        }
+                        await backoff();
+                        continue;
+                    }
+                    // Watchable again (created or benign retry): clear the
+                    // give-up clock so it only ever measures a continuous
+                    // unwatchable stretch.
+                    directoryUnwatchableSince = null;
+                    if (outcome === 'retry') {
+                        continue;
+                    }
+                }
+
+                // Directory is demonstrably fine at this point.
+                directoryUnwatchableSince = null;
+
                 logger.debug(`[FILE_WATCHER] Starting watcher for ${file}`);
                 const watcher = watch(file, { persistent: true, signal: abortController.signal });
                 for await (const event of watcher) {
                     if (abortController.signal.aborted) {
                         return;
                     }
-                    // The file exists and is being watched — clear failure state.
-                    missingSince = null;
+                    // Only an actually delivered event proves the watch works.
+                    // Resetting before arming would pin a persistently failing
+                    // watch (EACCES, EMFILE) at the 1s floor forever.
                     failureCount = 0;
                     logger.debug(`[FILE_WATCHER] File changed: ${file}`);
                     onFileChange(file);
                 }
-                // Iterator ended without an abort (rare); fall through to retry.
+                // Iterator ended without an abort (rare, e.g. the file was
+                // replaced); fall through and re-arm.
             } catch (e: any) {
                 if (abortController.signal.aborted) {
                     return;
                 }
 
-                const isMissing = e?.code === 'ENOENT';
-                if (isMissing) {
-                    const now = Date.now();
-                    if (missingSince === null) {
-                        missingSince = now;
-                    }
-                    const absentMs = now - missingSince;
-                    if (absentMs >= missingFileTimeoutMs) {
-                        logger.debug(`[FILE_WATCHER] Giving up on ${file}: never appeared after ${Math.round(absentMs / 1000)}s`);
-                        options.onGaveUp?.();
-                        return;
-                    }
+                // ENOENT here means the file vanished after we started
+                // watching it. The loop re-arms and waits for it to reappear,
+                // so this is not a give-up condition either.
+                if (e?.code !== 'ENOENT') {
+                    const backoffMs = await backoff();
+                    logger.debug(`[FILE_WATCHER] Watch error: ${e?.message}, retried after ${backoffMs}ms`);
                 } else {
-                    // Transient error on an (assumed) existing file: back off
-                    // and keep retrying, but do not count it as "missing".
-                    missingSince = null;
+                    logger.debug(`[FILE_WATCHER] File disappeared, waiting for it to return: ${file}`);
+                    // Normally the next loop blocks in awaitFileCreation, but if
+                    // existsSync() and watch() disagree (a delete racing us) we
+                    // could spin hot. A short pause bounds that to a slow poll.
+                    await wait(200);
                 }
-
-                failureCount++;
-                const backoffMs = Math.min(1000 * 2 ** Math.min(failureCount - 1, 4), 15_000);
-                logger.debug(`[FILE_WATCHER] Watch error: ${e.message}, retrying in ${backoffMs}ms`);
-                await wait(backoffMs);
             }
         }
     })();


### PR DESCRIPTION
## Summary

Claude Code creates a session transcript lazily — `~/.claude/projects/<slug>/<uuid>.jsonl` does not exist at launch, only once the user submits their first prompt. `startFileWatcher` arms `fs.watch()` immediately, gets `ENOENT`, backs off, and after 60s calls `onGaveUp`; `sessionScanner` then adds the session to `deadSessions` and never reads it again. The session stays registered server-side, so the phone shows the entry, the title updates and RPC works — but no message body is ever uploaded, and it cannot recover for the rest of that session's lifetime. Anyone who starts Happy, reads some code, and types their first prompt more than 60 seconds later hits this. This PR stops bounding "file has not appeared yet" by time and instead waits for the file to be created, narrowing the give-up condition to what it should always have been: the parent directory itself being unwatchable.

Fixes #1538.

## Why the timeout is the wrong tool here

"Not created yet" and "never going to be created" are indistinguishable by elapsed time, so no value of `missingFileTimeoutMs` separates them. The bound arrived in 0efede47 (part of #1332), which records no rationale for it — the commit message and PR description do not mention the watcher, and the code comments describe only what the timeout does. Whatever it was reaching for, it cannot tell a permanently wrong path from a transcript that simply has not been written yet, and it resolves both by discarding the session.

The fix removes the need for the bound rather than tuning it. When the file is absent, watch its **parent directory** and block until the entry appears. That is event driven, so the per-second spin that motivated the timeout is gone on its own.

Events alone are not sufficient. NFS, SMB and some container bind mounts deliver no `inotify` events at all, so a pure event wait would block forever — the same bug in a quieter form, with the phone online and a title showing while nothing syncs. The directory watch therefore **races a 2s existence poll**: events are the fast path, the poll is the safety net.

`missingFileTimeoutMs` keeps its name and default but now bounds only one thing: the parent directory staying *continuously* unwatchable (missing, `EACCES`). That is the condition the original timeout was actually guarding.

## Proof

Before, from a machine running Happy through a normal working day. **9 distinct sessions** were dropped this way in that single day:

```
[11:05:59.296] [FILE_WATCHER] Giving up on /Users/kelvin/.claude/projects/-Users-kelvin-code-hoperun-litellm--/d674e55c-….jsonl: never appeared after 60s
[11:05:59.296] [SESSION_SCANNER] Session d674e55c-… transcript never appeared — dropping it
```

Each of those sessions was live and healthy in the terminal; the phone showed it online, with its title, and synced nothing for the rest of its life.

After, same machine, `Iteration with mode: local`. The transcript took **3 minutes 22 seconds** to appear — the user was reading code before typing anything — and the watcher picked it up cleanly:

```
[22:15:20.213] [SESSION_SCANNER] Starting watcher for session: c4f6d2ff-…
[22:15:20.213] [FILE_WATCHER] Waiting for /Users/kelvin/.claude/projects/-Users-kelvin-github-happy/c4f6d2ff-….jsonl to be created
[22:18:42.426] [FILE_WATCHER] File appeared: /Users/kelvin/.claude/projects/-Users-kelvin-github-happy/c4f6d2ff-….jsonl
[22:18:42.427] [FILE_WATCHER] Starting watcher for /Users/kelvin/.claude/projects/-Users-kelvin-github-happy/c4f6d2ff-….jsonl
```

On the old code that session was already blacklisted at 22:16:20, 2m22s before its transcript existed. A second run in the same session shows the shorter, more common case (57s — still under the old limit only by luck):

```
[21:07:37.103] [FILE_WATCHER] Waiting for …/e351cc52-….jsonl to be created
[21:08:34.113] [FILE_WATCHER] File appeared: …/e351cc52-….jsonl
```

I have been running this patch as my daily driver since, across both local and remote sessions, with no dropped session and no recurrence of the give-up path.

`794 tests passed (83 files)`, `tsc --noEmit` and `pnpm --filter happy build` all clean.

## Also in this change

Each of these is a consequence of the watcher now waiting indefinitely; they are not drive-by cleanups:

- Distinguish "directory iterator ended normally" from "directory is unwatchable". Only the latter arms the give-up countdown — reporting `unwatchable` on a guess would reintroduce the bug through the back door.
- Reset `failureCount` only after an event is actually delivered. Resetting before arming pins a persistently failing watch (`EACCES`, `EMFILE`) at the 1s floor forever.
- Clear `directoryUnwatchableSince` once the directory is watchable again, so an early transient failure cannot make a much later, unrelated failure trip the deadline with zero grace.
- Release the directory watcher when the existence re-check wins the race and the iterator is never entered, which otherwise leaks one OS watch per session.
- Re-arm if the file is deleted and later recreated.
- Flush and stop the sync **before** disposing watchers in `cleanup()`. `invalidateAndAwait` really does run the sync body once more, and that body re-creates a watcher for every session lacking one; the old order let that final sync resurrect them all with no remaining path to dispose them. Harmless while watchers self-terminated after 60s, a leak until process exit now that they wait indefinitely.
- Isolate `CLAUDE_CONFIG_DIR` in `sessionScanner.test.ts`, which until now created directories under the developer's real `~/.claude/projects` and `rm -rf`'d them in `afterEach`.

## Relationship to nearby issues and PRs

Same file or same symptom, different root causes — this PR does not subsume or conflict with any of them:

- **#1359** (watcher loops on `ENOENT` for a ghost session id) and **#1111** (`-w` worktree deriving the wrong transcript path) are both about a path that is *permanently* wrong — the case a bounded give-up genuinely serves, which is why this PR keeps one. Worth noting that #1359 was filed two weeks *after* 0efede47, so the existing bound did not resolve it. This PR addresses the opposite case: a path that is correct but simply not written yet.
- **#1528** (draft) touches `startFileWatcher.ts` but only threads `initialRetryDelayMs`/`maxRetryDelayMs` through for test determinism; it does not change the give-up branch. Its substance is in `sessionScanner.ts`, recovering ghost ids from an explicit `SessionStart` `transcript_path`. That cannot fix this case: at `SessionStart` the file does not exist yet, the hook's path equals the one already being watched, and `SessionStart` fires once — before the 60s deadline, with no later chance to re-attach.
- **#1586** shares the symptom (blank session, shown online) but the cause is a 3 GB transcript hitting `ERR_STRING_TOO_LONG`, surfaced as `Session file not found`. Unrelated mechanism.
- **#846** is server-side `metadata = null` on Windows; #1538 already notes the two are distinct.

## Scope

`happy-cli` only. No protocol, encryption, server or app changes; no change to what gets uploaded or how. The sync engine's behaviour is untouched apart from when a watcher decides to stop trying.

