### PR TITLE
fix(cli): local mode never reports the working state on Claude Code 2.x

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
@@ -24,6 +24,14 @@ vi.mock('./utils/sessionScanner', () => ({
     createSessionScanner: mockCreateSessionScanner,
 }));
 
+// Without this mock the suite would read the developer's real
+// ~/.claude/sessions. Worse, if an assertion times out and throws, the
+// launcher's finally never runs, leaving the 500ms poll interval alive in the
+// vitest worker where it goes on scanning that real directory.
+vi.mock('./utils/claudeStatusWatcher', () => ({
+    startClaudeStatusWatcher: () => () => { },
+}));
+
 vi.mock('@/ui/logger', () => ({
     logger: {
         debug: vi.fn(),

--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -4,6 +4,7 @@ import { Session } from "./session";
 import { Future } from "@/utils/future";
 import { createSessionScanner } from "./utils/sessionScanner";
 import { launchFailureMessage } from "./utils/launchFailureMessage";
+import { startClaudeStatusWatcher } from "./utils/claudeStatusWatcher";
 
 export type LauncherResult = { type: 'switch' } | { type: 'exit', code: number };
 
@@ -36,6 +37,13 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
     };
     session.addSessionFoundCallback(scannerSessionCallback);
 
+    // Where local-mode thinking state comes from: the session status file
+    // Claude Code maintains itself. The in-process fetch patch does not work
+    // against the 2.x native binary — see claudeStatusWatcher.ts.
+    const stopStatusWatcher = startClaudeStatusWatcher({
+        getSessionId: () => session.sessionId,
+        onThinkingChange: session.onThinkingChange,
+    });
 
     // Handle abort
     let exitReason: LauncherResult | null = null;
@@ -173,6 +181,10 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
         
         // Remove session found callback
         session.removeSessionFoundCallback(scannerSessionCallback);
+
+        // Stop status tracking. This resets thinking to false internally, so
+        // shutdown cannot leave the session stuck at "working".
+        stopStatusWatcher();
 
         // Cleanup
         await scanner.cleanup();

--- a/packages/happy-cli/src/claude/utils/claudeStatusWatcher.test.ts
+++ b/packages/happy-cli/src/claude/utils/claudeStatusWatcher.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
+import { startClaudeStatusWatcher } from "./claudeStatusWatcher";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Find a pid that is definitely not running.
+ *
+ * Do not hardcode a low pid (111 and friends): on another machine, or after a
+ * reboot, it may be a real system process, which flips the liveness ordering
+ * and makes these tests flaky. Probing at runtime is deterministic.
+ */
+const findDeadPid = (): number => {
+  for (const candidate of [4194303, 999983, 888887, 777769, 666649]) {
+    try {
+      process.kill(candidate, 0);
+    } catch (error: any) {
+      // EPERM means the process exists but is not ours, so it is not dead.
+      if (error?.code !== "EPERM") {
+        return candidate;
+      }
+    }
+  }
+  throw new Error("no reliably dead pid found; cannot test liveness ordering");
+};
+
+/**
+ * These tests pin down the core semantics of claudeStatusWatcher, as observed
+ * against Claude Code 2.1.220 (see that module's header comment).
+ *
+ * The rule running through all of them: any uncertainty must resolve to false.
+ * Missing a spinner is acceptable; getting stuck showing "working" is not,
+ * because that is worse than the bug being fixed.
+ */
+describe("startClaudeStatusWatcher", () => {
+  let configDir: string;
+  let sessionsDir: string;
+  let stop: (() => void) | null = null;
+  let prevConfigDir: string | undefined;
+
+  const SESSION_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  const DEAD_PID = findDeadPid();
+
+  // Write a session status file in Claude Code's shape.
+  const writeSessionFile = (
+    pid: number,
+    status: string,
+    sessionId = SESSION_ID,
+  ) =>
+    writeFile(
+      join(sessionsDir, `${pid}.json`),
+      JSON.stringify({
+        pid,
+        sessionId,
+        status,
+        cwd: "/tmp",
+        statusUpdatedAt: Date.now(),
+      }),
+    );
+
+  beforeEach(async () => {
+    configDir = join(
+      tmpdir(),
+      `csw-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    sessionsDir = join(configDir, "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    if (stop) {
+      stop();
+      stop = null;
+    }
+    if (prevConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+    }
+    if (existsSync(configDir)) {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports thinking=true on busy and resets when it returns to idle", async () => {
+    await writeSessionFile(DEAD_PID, "idle");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 30,
+    });
+
+    await sleep(120);
+    expect(changes).toEqual([]); // steady idle must not emit any change
+
+    await writeSessionFile(DEAD_PID, "busy");
+    await sleep(150);
+    expect(changes).toEqual([true]);
+
+    // This is exactly what an ESC interrupt looks like: status returns to idle.
+    await writeSessionFile(DEAD_PID, "idle");
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("reports only on change, so sustained busy is not re-emitted", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+
+    await sleep(200);
+    expect(changes).toEqual([true]);
+  });
+
+  // `shell` is one of the four values Claude Code can write. It was observed
+  // once in a real session, holding for several minutes before returning to
+  // `busy` on its own, but its meaning is still unverified — and anything whose
+  // semantics we cannot pin down has to count as not working, or the phone
+  // risks showing "working" forever.
+  it("treats a status of unverified meaning (shell) as not working", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    await writeSessionFile(DEAD_PID, "shell");
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  // `waiting` means Claude is blocked on the user — the same file reads
+  // `waitingFor: "input needed"` while an AskUserQuestion prompt is open. It is
+  // genuinely not computing then, so false here is the semantically correct
+  // answer rather than merely the safe one.
+  it("treats waiting (blocked on the user) as not working", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    await writeFile(
+      join(sessionsDir, `${DEAD_PID}.json`),
+      JSON.stringify({
+        pid: DEAD_PID,
+        sessionId: SESSION_ID,
+        status: "waiting",
+        waitingFor: "input needed",
+        cwd: "/tmp",
+        statusUpdatedAt: Date.now(),
+      }),
+    );
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+
+    // And it resumes as soon as the user answers.
+    await writeSessionFile(DEAD_PID, "busy");
+    await sleep(150);
+    expect(changes).toEqual([true, false, true]);
+  });
+
+  it("reports nothing while the session id is unknown", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => null,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([]);
+  });
+
+  it("ignores status files belonging to other sessions", async () => {
+    await writeSessionFile(DEAD_PID, "busy", "other-session-id");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([]);
+  });
+
+  it("stays not-working when the session file never appears", async () => {
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([]);
+  });
+
+  // If "cannot read the file" meant "keep the previous state" and that state
+  // happened to be busy, we would be stuck at "working" forever. It has to
+  // reset after a few polls of grace.
+  it("resets after a grace period when the status file vanishes mid-work", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    await unlink(join(sessionsDir, `${DEAD_PID}.json`));
+    await sleep(300);
+    expect(changes).toEqual([true, false]);
+  });
+
+  // The session id changed (SessionStart hook handed us a new one, or /clear
+  // wiped it). The old session's thinking must not carry over, or a new
+  // session with no matching file would stay stuck at true.
+  it("resets immediately when the session id changes", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    let currentId: string | null = SESSION_ID;
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => currentId,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    currentId = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("resets when the session id is cleared (/clear)", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    let currentId: string | null = SESSION_ID;
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => currentId,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    currentId = null;
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("resets thinking to false on stop", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    // Also assign to `stop`, so afterEach can still clear the interval if an
+    // assertion throws. A leaked timer would otherwise go on scanning the real
+    // directory once CLAUDE_CONFIG_DIR is restored.
+    const dispose = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    stop = dispose;
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    dispose();
+    // Stopping twice must be safe.
+    dispose();
+    stop = null;
+
+    expect(changes).toEqual([true, false]);
+
+    // Nothing may be emitted after stopping.
+    await writeSessionFile(DEAD_PID, "busy");
+    await sleep(120);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("survives a half-written file with invalid JSON", async () => {
+    await writeFile(join(sessionsDir, "999.json"), '{"sessionId": "trunc');
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([true]);
+  });
+
+  // Session files are named by pid and are not cleaned up on exit: killing
+  // `claude` mid-turn leaves a file stuck at status=busy forever. After that
+  // sessionId is resumed there are two matching files in the directory, and
+  // picking the wrong one pins the phone at "working" permanently.
+  describe("multiple session files for one sessionId (leftovers from killed processes)", () => {
+    const writeAt = (
+      pid: number,
+      status: string,
+      statusUpdatedAt: number,
+      extra: Record<string, unknown> = {},
+    ) =>
+      writeFile(
+        join(sessionsDir, `${pid}.json`),
+        JSON.stringify({
+          pid,
+          sessionId: SESSION_ID,
+          status,
+          cwd: "/tmp",
+          statusUpdatedAt,
+          ...extra,
+        }),
+      );
+
+    it("prefers the newer timestamp when both processes are dead (stale busy loses to newer idle)", async () => {
+      await writeAt(DEAD_PID, "busy", 1_000);
+      await writeAt(DEAD_PID + 1, "idle", 9_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([]);
+    });
+
+    it("and the reverse holds: newer busy beats older idle", async () => {
+      await writeAt(DEAD_PID, "idle", 1_000);
+      await writeAt(DEAD_PID + 1, "busy", 9_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([true]);
+    });
+
+    // The key case: timestamps alone cannot rule out a leftover file. A live
+    // process that drops to idle stops advancing its timestamp, while another
+    // process that flipped to busy later was then SIGKILLed — the leftover
+    // busy would win forever. Hence liveness outranks the timestamp.
+    it("prefers a live process's idle over a dead process's newer busy", async () => {
+      await writeAt(DEAD_PID, "busy", 9_000); // dead, but newer timestamp
+      await writeAt(process.pid, "idle", 1_000); // alive, older timestamp
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([]);
+    });
+
+    it("prefers a live process's busy over a dead process's newer idle too", async () => {
+      await writeAt(DEAD_PID, "idle", 9_000);
+      await writeAt(process.pid, "busy", 1_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([true]);
+    });
+
+    // JSON.parse turns 1e999 into Infinity while typeof stays "number".
+    // Compared directly, Infinity > Infinity is false, which would pin the
+    // selection on the corrupt file forever.
+    it("is not pinned by a corrupt file whose timestamp parses to Infinity", async () => {
+      await writeFile(
+        join(sessionsDir, `${DEAD_PID}.json`),
+        `{"pid":${DEAD_PID},"sessionId":"${SESSION_ID}","status":"busy","statusUpdatedAt":1e999}`,
+      );
+      await writeAt(process.pid, "idle", 1_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      // The live process's idle must win instead of being pinned at busy.
+      expect(changes).toEqual([]);
+    });
+  });
+});

--- a/packages/happy-cli/src/claude/utils/claudeStatusWatcher.ts
+++ b/packages/happy-cli/src/claude/utils/claudeStatusWatcher.ts
@@ -1,0 +1,275 @@
+/**
+ * Thinking-state (is-it-working) tracking for local mode.
+ *
+ * Background: Happy used to infer busy/idle by patching `global.fetch` inside
+ * claude_local_launcher.cjs. Since Claude Code 2.x ships as a native binary,
+ * the launcher is merely its parent node process, and an in-process fetch
+ * patch cannot cross that process boundary. Local-mode `thinking` is therefore
+ * always false: the phone shows the session as online but never as working.
+ *
+ * Instead we read the session status file Claude Code maintains itself:
+ *   ~/.claude/sessions/<pid>.json → { pid, sessionId, status, statusUpdatedAt }
+ * matched by sessionId rather than pid, since `claude` is a child of the
+ * launcher and Happy never learns its pid.
+ *
+ * `status` is a closed set of four values in 2.1.220:
+ *   busy     working; flips within ~60ms of prompt submission
+ *   idle     not working
+ *   waiting  blocked on the user, so not working. The same file carries a
+ *            `waitingFor` discriminant, which reads `input needed` while an
+ *            AskUserQuestion prompt is open. In the transcript every `waiting`
+ *            interval opens with a `tool_use: AskUserQuestion` whose
+ *            `stop_reason` is already `tool_use` (so the API call had already
+ *            completed) and ends within one poll of the user's answer landing
+ *            as a `tool_result`.
+ *   shell    observed once, holding for 4m46s before returning to `busy` on
+ *            its own. Its meaning is still unverified, so it rides the
+ *            unknown-value default below. If it turns out to mark a tool
+ *            running, the spinner is absent for that span — today's behaviour
+ *            rather than a new failure.
+ *
+ * `claude agents --json` exposes `status` and `waitingFor` as public output,
+ * which is what pins those semantics down. It is a projection of this file
+ * rather than the file itself, though: it drops `statusUpdatedAt`, which the
+ * arbitration below needs. So we read the file and treat its exact shape as
+ * private — see the degradation note on the unknown-value default.
+ *
+ * Why not the Stop hook: on ESC-interrupt, Stop does not fire at all, while
+ * `status` still returns to idle correctly. Driving this from hooks would
+ * leave `thinking` stuck at true after every interrupt, so the phone would
+ * show "working forever" — strictly worse than today's "idle forever".
+ *
+ * One rule runs through this whole module: **any uncertainty must resolve to
+ * false.** Missing a spinner is acceptable; getting stuck showing "working" is
+ * not, because that is worse than the bug being fixed. The deliberately
+ * conservative choices below all follow from it: unknown status is false, a
+ * session change resets to false, a persistently unreadable status file
+ * resets to false, and a file from a live process beats a newer timestamp.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@/ui/logger";
+
+/** The only `status` value that counts as working. */
+const BUSY_STATUS = "busy";
+
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
+/**
+ * How many consecutive polls may fail to find a status file before we declare
+ * "not working". A few polls of grace, because the file may be mid atomic
+ * replace (a rename can briefly leave nothing to find) and a single failed
+ * read should not make the state flicker. But the grace cannot be unbounded,
+ * or a changed session id would pin `thinking` at true forever.
+ */
+const MISSING_FILE_GRACE_POLLS = 3;
+
+function claudeSessionsDir(): string {
+  const claudeConfigDir =
+    process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  return join(claudeConfigDir, "sessions");
+}
+
+/** Is the process still alive? EPERM means it exists but is not ours, which also counts. */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code === "EPERM";
+  }
+}
+
+/** Liveness precedence: alive > undeterminable > dead. Ties broken by timestamp. */
+function livenessRank(pid: unknown): number {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+    return 1; // no usable pid, so liveness cannot be determined
+  }
+  return isProcessAlive(pid) ? 2 : 0;
+}
+
+/**
+ * Find the `status` of the session file matching `sessionId` in
+ * ~/.claude/sessions. Returns null when there is none (not written yet, or
+ * already cleaned up).
+ *
+ * Session files are named by pid and are not removed when the process exits.
+ * If `claude` is killed mid-turn, the leftover file stays at status=busy
+ * forever; when that same sessionId is later resumed under a new pid, two
+ * files in the directory match it.
+ *
+ * Taking the largest `statusUpdatedAt` is not enough to rule the stale one
+ * out, because a newer timestamp does not imply a live process. The real
+ * counterexample: a live process drops to idle at T2 and its timestamp stops
+ * advancing, while another process flips to busy at T3 > T2 and is then
+ * SIGKILLed — the leftover busy@T3 would win forever and the phone would show
+ * "working" permanently. So rank by process liveness first, timestamp second.
+ */
+async function readStatusForSession(sessionId: string): Promise<string | null> {
+  const dir = claudeSessionsDir();
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return null;
+  }
+
+  const candidates = await Promise.all(
+    files
+      .filter((name) => name.endsWith(".json"))
+      .map(async (name) => {
+        try {
+          const raw = await readFile(join(dir, name), "utf-8");
+          const parsed = JSON.parse(raw) as {
+            pid?: unknown;
+            sessionId?: unknown;
+            status?: unknown;
+            statusUpdatedAt?: unknown;
+            updatedAt?: unknown;
+          };
+          if (
+            parsed.sessionId !== sessionId ||
+            typeof parsed.status !== "string"
+          ) {
+            return null;
+          }
+          // Number.isFinite rejects Infinity/NaN: JSON.parse turns 1e999 into
+          // Infinity while typeof stays "number", and comparing it directly
+          // would pin the selection on the first corrupt file forever, since
+          // Infinity > Infinity is false.
+          const at = Number.isFinite(parsed.statusUpdatedAt)
+            ? (parsed.statusUpdatedAt as number)
+            : Number.isFinite(parsed.updatedAt)
+              ? (parsed.updatedAt as number)
+              : -Infinity;
+          return {
+            status: parsed.status,
+            at,
+            liveness: livenessRank(parsed.pid),
+          };
+        } catch {
+          // Half-written file or invalid JSON: skip it, try again next poll.
+          return null;
+        }
+      }),
+  );
+
+  let best: { status: string; at: number; liveness: number } | null = null;
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    if (
+      best === null ||
+      candidate.liveness > best.liveness ||
+      (candidate.liveness === best.liveness && candidate.at > best.at)
+    ) {
+      best = candidate;
+    }
+  }
+  return best?.status ?? null;
+}
+
+export interface ClaudeStatusWatcherOptions {
+  /**
+   * Current Claude session id. May be unknown at startup (we are waiting on
+   * the SessionStart hook); returning null counts as not working.
+   */
+  getSessionId: () => string | null;
+  /** Called only when the state actually changes. */
+  onThinkingChange: (thinking: boolean) => void;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Poll Claude Code's session status file, mapping busy/anything-else onto
+ * thinking true/false. Returns a stop function, which forces thinking back to
+ * false so shutdown cannot leave the state stuck at "working".
+ */
+export function startClaudeStatusWatcher(
+  opts: ClaudeStatusWatcherOptions,
+): () => void {
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  let stopped = false;
+  let lastThinking = false;
+  let polling = false;
+  let lastSessionId: string | null = null;
+  let missingPolls = 0;
+
+  // Single exit point: report only on a real change, so every "reset to false"
+  // path can reuse it.
+  const applyThinking = (thinking: boolean, reason: string) => {
+    if (thinking === lastThinking) {
+      return;
+    }
+    lastThinking = thinking;
+    logger.debug(`[ClaudeStatusWatcher] ${reason} → thinking=${thinking}`);
+    opts.onThinkingChange(thinking);
+  };
+
+  const tick = async () => {
+    // Skip if the previous poll is still running, so a slow disk cannot pile
+    // them up.
+    if (stopped || polling) {
+      return;
+    }
+    polling = true;
+    try {
+      const sessionId = opts.getSessionId();
+
+      // The session changed (SessionStart hook handed us a new id) or was
+      // cleared by /clear. The old session's thinking must not carry over,
+      // or a new session with no matching file would stay stuck at true.
+      if (sessionId !== lastSessionId) {
+        lastSessionId = sessionId;
+        missingPolls = 0;
+        applyThinking(false, "session changed");
+      }
+
+      if (!sessionId) {
+        return;
+      }
+
+      const status = await readStatusForSession(sessionId);
+
+      // We may have been stopped during the await. The reset in stop() can
+      // miss this case when lastThinking happens to be false already, and
+      // continuing here would emit one final thinking=true at the very end of
+      // the launcher's life, pinning the phone at "working" permanently.
+      if (stopped) {
+        return;
+      }
+
+      if (status === null) {
+        missingPolls++;
+        if (missingPolls >= MISSING_FILE_GRACE_POLLS) {
+          applyThinking(false, "status file missing");
+        }
+        return;
+      }
+      missingPolls = 0;
+      applyThinking(status === BUSY_STATUS, `status=${status}`);
+    } catch (error) {
+      logger.debug("[ClaudeStatusWatcher] poll failed:", error);
+    } finally {
+      polling = false;
+    }
+  };
+
+  const interval = setInterval(() => {
+    void tick();
+  }, pollIntervalMs);
+  void tick();
+
+  return () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    clearInterval(interval);
+    applyThinking(false, "stopped");
+    logger.debug("[ClaudeStatusWatcher] stopped");
+  };
+}


### PR DESCRIPTION
## Summary

In local mode the phone shows a session as online but never as working — the spinner never appears, however long Claude runs. Happy infers busy/idle by patching `global.fetch` inside `claude_local_launcher.cjs`, but since Claude Code 2.x ships as a native binary the launcher is merely its **parent** process, and an in-process patch cannot cross that boundary. Local-mode `thinking` is therefore permanently `false`. Remote mode goes through the SDK and is unaffected. This reads the `status` field from the session status file Claude Code already maintains and feeds it into the existing `session.onThinkingChange` → `client.keepAlive(thinking, mode)` path.

No existing issue — consistent with the failure mode rather than evidence against it: nothing errors, nothing crashes, the session still works. It just feels unresponsive from the phone, which is not what people file. The proof below stands on its own.

## Root cause

`runClaudeCli` has two branches and only one keeps Claude in-process. #1190 documents them while fixing an unrelated orphan bug:

> - **`.js`/`.cjs` claude:** `import(importUrl)` -- runs in-process, no orphan possible.
> - **Binary claude:** `spawn(cliPath, args, { stdio: 'inherit' })` …

The patch lives in the launcher's module scope. On the `import()` path that scope is shared with Claude; on `spawn` it is a separate V8 isolate and the patch observes nothing. 2.x always takes the second branch.

The npm build does not help — I tried. It pulls a platform package via `optionalDependencies` and ends at the same binary. 2.x has no `.js` entrypoint, making `isJsFile` in `claude_version_utils.cjs` dead code. This is the same `.js`-era assumption #1140 (merged) fixed for version detection.

## The data source, and the one thing to weigh

`~/.claude/sessions/<pid>.json` holds `{ pid, sessionId, status, statusUpdatedAt }`. We poll it and match by `sessionId`, **not** pid — `claude` is a child of the launcher, so Happy never learns its pid.

**The file path is a private Claude Code detail. That is the main review consideration.** The field *semantics* are not private: `claude agents --json` publishes `status` and `waitingFor`. But that command is a projection — it drops `statusUpdatedAt`, which the liveness arbitration needs — so reading the file is deliberate and its shape is treated as unstable. Every unrecognised shape degrades to `thinking = false`, i.e. exactly today's behaviour, and nothing else depends on it. Shelling out to `claude agents --json` per poll is the documented alternative; I avoided spawning a process every 500ms, but happy to switch if the coupling is the greater cost.

### Why not hooks

`UserPromptSubmit` → true / `Stop` → false is the natural alternative, and the plumbing exists. I built it first and measured:

| Scenario | `Stop` hook | `status` field |
|---|---|---|
| Turn completes normally | fires | `busy` → `idle` |
| ESC interrupts generation | **does not fire** | `busy` → `idle` (within 200ms) |
| ESC interrupts a bash tool | **does not fire** | `busy` → `idle` |

`Stop` does not fire on interrupt, so a hook-driven version leaves `thinking` stuck at `true` after every ESC — "working forever" is strictly worse than today's "idle forever", and is the class of bug #1579 guarded against when its author noted a remembered `thinking: true` "would otherwise be immortal". Hooks also only fire at turn boundaries, so they cannot express in-turn state at all.

## Proof

**Mode is the only variable.** Across a day of real use, 20 log files contain exclusively `Iteration with mode: local`, and in every one `Thinking state changed` appears **zero** times. The only logs that do contain thinking events also contain a `remote` iteration, where the lines carry a `[claudeRemote]` prefix. Same machine, same session — the SDK path reports, the PTY path reports nothing.

After, a pure local session tracking a real day's work:

```
[21:08:34.174] [ClaudeStatusWatcher] status=busy    → thinking=true
[21:23:24.630] [ClaudeStatusWatcher] status=idle    → thinking=false
[21:34:26.104] [ClaudeStatusWatcher] status=busy    → thinking=true
[21:43:01.668] [ClaudeStatusWatcher] status=waiting → thinking=false
[21:51:42.730] [ClaudeStatusWatcher] status=busy    → thinking=true
[21:51:58.263] [ClaudeStatusWatcher] status=idle    → thinking=false
[22:35:00.887] [ClaudeStatusWatcher] stopped
```

The spinner appears and clears on the phone in step with these. Running as my daily driver since, with no instance of the state sticking at "working".

**On the values.** Aggregated over real local-mode sessions: 40 `busy`, 29 `idle`, 11 `waiting`, 1 `shell`. I did not know `waiting` existed when writing this — it appeared in logs afterwards, and the unknown-value default already handled it. It turned out to be *semantically* right, not merely safe: `waiting` means Claude is blocked on the user, confirmed by the `waitingFor: "input needed"` discriminant in the same file and by the transcript, where each `waiting` interval opens with an `AskUserQuestion` whose `stop_reason` is already `tool_use` (the API call had completed) and closes within one poll of the answer landing. Upstream has an open request for exactly this kind of state detection (anthropics/claude-code#38184). A fourth value, `shell`, occurred exactly once. It held for 4m46s and returned to `busy` on its own:

```
[02:42:39.049] status=busy  → thinking=true
[02:53:38.316] status=shell → thinking=false
[02:58:24.160] status=busy  → thinking=true
```

I still cannot say what it means, so it stays on the unknown-value default — and that single occurrence is the default doing its job rather than a hole in the evidence. If `shell` should turn out to mark a tool running, the spinner would be absent for its duration, which is today's behaviour rather than a new failure.

One limitation: anthropics/claude-code#77804 reports *background* sessions showing `busy` while blocked on `AskUserQuestion`. happy-cli drives `kind: "interactive"`, where a live capture confirms `waiting` is reported correctly.

`809 tests passed (84 files)`, including 17 new cases. `tsc --noEmit` and `pnpm --filter happy build` clean.

## Two correctness details worth flagging in review

**Any uncertainty resolves to `false`.** Missing a spinner degrades to today's behaviour; getting stuck at "working" is worse than the bug being fixed. So: only `busy` counts as working; a changed or `/clear`ed session id resets immediately; a missing file resets after three polls of grace (enough to absorb an atomic replace, bounded so a stale `true` cannot persist); `stopped` is re-checked after the `await`, since otherwise one final `thinking=true` can be emitted at the very end of the launcher's life.

**Session files are ranked by process liveness first, timestamp second.** They are named by pid and not cleaned up on exit, so killing `claude` mid-turn leaves a file stuck at `busy`; once that `sessionId` is resumed, two files match it. Comparing `statusUpdatedAt` alone does not resolve this — a live process that drops to `idle` stops advancing its timestamp, so a later-but-SIGKILLed `busy` would win forever.

## Relationship to nearby work

- **#1612** also covers the local PTY path and also makes "is it still working" visible, so the overlap deserves stating. It adds a **`background`** state for work still running *after* a turn ends, and says of itself that it "does not touch that file and does not change when `thinking` flips". This is about `thinking` **during** a turn. They compose rather than replace each other; happy to rebase behind it in either order.
- **#1587** defers `updateThinking(false)` while subagents run, in `claudeRemote.ts` only — zero overlap. It fixes an idle *misreport* on the SDK path; this fixes thinking being *entirely absent* on the PTY path.
- **#1388** proposes aborting when local Claude is idle, premised on "the CLI already tracks this state … via `onThinkingChange`". Under 2.x that premise is false, so this is arguably a prerequisite.
- **#1628** raises the same "both launch modes need the same signal" framing.

## Scope

`happy-cli` only — one new module plus wiring. It terminates at the existing `keepAlive(thinking, mode)` call, whose signature is mode-independent; that is the same channel remote mode uses. No protocol, wire-format, encryption, server or app changes.

One trade-off: each poll scans the whole sessions directory, which grows with every Claude process ever launched, and cannot short-circuit because the liveness arbitration needs all candidates. Reads are parallel. Degradation is added latency on the signal, not incorrectness — I left it unoptimised rather than add a cache whose invalidation would be a likelier source of a stuck spinner.

