### PR TITLE
Add gpt-5.3-codex-spark to Codex model picker

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -43,6 +43,7 @@ describe('modelModeOptions', () => {
             'gpt-5.5',
             'gpt-5.4',
             'gpt-5.3-codex',
+            'gpt-5.3-codex-spark',
             'gpt-5.2-codex',
             'gpt-5.1-codex-max',
             'gpt-5.2',

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -116,6 +116,7 @@ export function getCodexModelModes(): ModelMode[] {
         { key: 'gpt-5.5', name: 'gpt-5.5', description: null },
         { key: 'gpt-5.4', name: 'gpt-5.4', description: null },
         { key: 'gpt-5.3-codex', name: 'gpt-5.3-codex', description: null },
+        { key: 'gpt-5.3-codex-spark', name: 'gpt-5.3-codex spark', description: null },
         { key: 'gpt-5.2-codex', name: 'gpt-5.2-codex', description: null },
         { key: 'gpt-5.1-codex-max', name: 'gpt-5.1-codex-max', description: null },
         { key: 'gpt-5.2', name: 'gpt-5.2', description: null },


### PR DESCRIPTION
## Summary

Adds `gpt-5.3-codex-spark` (OpenAI's low-latency real-time coding model, research preview, first model on Cerebras WSE-3) to the Codex model picker in the mobile/web client.

## Why

The Codex model list shown in the UI is hardcoded in `getCodexModelModes()` (`packages/happy-app/sources/components/modelModeOptions.ts`), and Codex sessions don't report a dynamic model catalog (`metadata.models` stays empty for Codex), so the fallback list is the only source for the picker. `gpt-5.3-codex` was present but the Spark variant was missing.

## How it works

The selected model key is passed straight through to `codex app-server`'s `turn/start` without validation (`runCodex.ts` → `sendTurnAndWait({ model })`), so no backend change is needed — this only makes the model selectable in the UI.

## Verification

- Added the entry to the hardcoded list and updated the exact key-list assertion in `modelModeOptions.test.ts`
- Full happy-app test suite: **811 tests passed (67 files)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)