### PR TITLE
fix(app): don't let the unread marker hide a session that needs attention

### DIFF
--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -5,6 +5,7 @@ import { Text } from '@/components/StyledText';
 import { SessionRowData } from '@/sync/storage';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { type SessionState, formatPathRelativeToHome, vibingMessages, formatLastSeen } from '@/utils/sessionUtils';
+import { unreadMayOverride } from '@/utils/sessionUnread';
 import { Avatar } from './Avatar';
 import { Typography } from '@/constants/Typography';
 import { StatusDot } from './StatusDot';
@@ -226,8 +227,11 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
     const styles = stylesheet;
     const { theme } = useUnistyles();
     const baseStatus = STATUS_CONFIG[session.state];
-    // Override to solid blue when session has unread results
-    const status = session.hasUnread
+    // Override to solid blue when session has unread results — but only for
+    // states that are not themselves live. An unread marker painted over
+    // `permission_required` hides a session that is blocked on the user.
+    const showUnread = session.hasUnread && unreadMayOverride(session.state);
+    const status = showUnread
         ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
         : baseStatus;
     const navigateToSession = useNavigateToSession();
@@ -271,7 +275,7 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
     const renderLeadingIndicator = () => {
         let indicator: React.ReactNode = null;
 
-        if (session.hasUnread) {
+        if (showUnread) {
             indicator = <StatusDot color={status.dotColor} isPulsing={false} />;
         } else if (session.state === 'waiting' && session.hasDraft) {
             indicator = (

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'expo-router';
 import { SessionListViewItem, SessionRowData } from '@/sync/storage';
 import { Ionicons } from '@expo/vector-icons';
 import { type SessionState, formatLastSeen, vibingMessages } from '@/utils/sessionUtils';
+import { unreadMayOverride } from '@/utils/sessionUnread';
 import { Avatar } from './Avatar';
 import { ActiveSessionsGroupCompact } from './ActiveSessionsGroupCompact';
 import { ProjectGroup } from './ProjectGroup';
@@ -450,8 +451,11 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
     const navigateToSession = useNavigateToSession();
     const [actionsAnchor, setActionsAnchor] = React.useState<SessionActionsAnchor | null>(null);
     const baseStatus = STATUS_CONFIG[session.state];
-    // Override to solid blue when session has unread results
-    const status = session.hasUnread
+    // Override to solid blue when session has unread results — but only for
+    // states that are not themselves live. An unread marker painted over
+    // `permission_required` hides a session that is blocked on the user.
+    const showUnread = session.hasUnread && unreadMayOverride(session.state);
+    const status = showUnread
         ? { ...baseStatus, color: '#007AFF', dotColor: '#007AFF', isPulsing: false, isConnected: baseStatus.isConnected }
         : baseStatus;
 
@@ -459,7 +463,7 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
         return vibingMessages[Math.floor(Math.random() * vibingMessages.length)].toLowerCase() + '…';
     }, [session.state]);
 
-    const statusText = session.hasUnread
+    const statusText = showUnread
         ? t('status.unread')
         : session.state === 'thinking'
             ? vibingMessage

--- a/packages/happy-app/sources/utils/sessionUnread.spec.ts
+++ b/packages/happy-app/sources/utils/sessionUnread.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { unreadMayOverride } from './sessionUnread';
+import type { SessionState } from './sessionUtils';
+
+describe('unreadMayOverride', () => {
+    // The case this exists for. A session blocked on a permission prompt or an
+    // open question makes no progress until someone answers it, and unread used
+    // to paint over that: the row read "new results" while the session sat
+    // waiting, with nothing saying to open it.
+    it('does not let unread hide a session that is blocked on the user', () => {
+        expect(unreadMayOverride('permission_required')).toBe(false);
+    });
+
+    // Milder, since both render blue: unread only costs the pulse. Still a live
+    // state describing work in flight, so the live state wins.
+    it('does not let unread hide work in progress', () => {
+        expect(unreadMayOverride('thinking')).toBe(false);
+    });
+
+    it('lets unread show once the session is idle or gone', () => {
+        expect(unreadMayOverride('waiting')).toBe(true);
+        expect(unreadMayOverride('disconnected')).toBe(true);
+    });
+
+    // An allowlist, so a state added later keeps its own display until someone
+    // decides otherwise. If this fails because a state was added, decide
+    // deliberately whether unread may stand in for it.
+    it('covers every state, and defaults an unknown one to keeping its display', () => {
+        const states: SessionState[] = [
+            'disconnected',
+            'thinking',
+            'waiting',
+            'permission_required',
+        ];
+        expect(states.filter(unreadMayOverride)).toEqual(['disconnected', 'waiting']);
+        expect(unreadMayOverride('needs_input' as SessionState)).toBe(false);
+    });
+});

--- a/packages/happy-app/sources/utils/sessionUnread.ts
+++ b/packages/happy-app/sources/utils/sessionUnread.ts
@@ -1,0 +1,28 @@
+// Kept out of sessionUtils so it stays testable: that module imports React,
+// which pulls in react-native's Flow-typed entry point and cannot be loaded in
+// the node test environment. The type import below is erased at compile time.
+import type { SessionState } from './sessionUtils';
+
+/**
+ * Whether the "new results" marker may stand in for the live status of `state`.
+ *
+ * Unread is a fact about history — there is output you have not looked at yet.
+ * The states describe the present: what the session is doing right now. When the
+ * two disagree the present has to win, because it is the part that is still
+ * changing and the part that may still need you.
+ *
+ * `permission_required` is the case that matters. A session blocked on a
+ * permission prompt or an open question makes no progress until someone answers
+ * it, and letting unread paint over it hides exactly that: the row reads "new
+ * results" while the session sits waiting, and nothing says to open it.
+ * `thinking` is milder — both render blue, so unread only costs the pulse — but
+ * it still describes work in flight.
+ *
+ * Written as an allowlist rather than as an exclusion of the two attention
+ * states, so a state added later keeps its own display until someone decides
+ * otherwise. A new state is likelier to be one that needs attention than another
+ * idle one, and that is the safer way to be wrong.
+ */
+export function unreadMayOverride(state: SessionState): boolean {
+    return state === 'waiting' || state === 'disconnected';
+}


### PR DESCRIPTION
## Summary

The "new results" unread marker is applied unconditionally, so it wins over every session state — including `permission_required`. A session blocked on a permission prompt renders as the solid blue "new results" row instead of the pulsing orange one, so nothing says it is waiting on you. It makes no progress until answered, and the one signal that would tell you is painted over. This gates the override on the state: unread still shows once a session is settled, but a live state keeps its own display.

## Proof

A question is open in the terminal on the left, and the row shows orange — even though the same session had been marked unread a minute earlier:

![row shows the orange attention dot while a question is open](https://raw.githubusercontent.com/leikaiwei/happy/assets/unread-priority/unread-orange.png)

The same session a minute before, work just finished, unread showing as designed:

![row shows the solid blue unread dot once work has finished](https://raw.githubusercontent.com/leikaiwei/happy/assets/unread-priority/unread-blue.png)

Before the change (described rather than shown, per the contributing guide): the second row stayed solid blue with the "new results" label, and nothing indicated the session was waiting on an answer.

## How to reproduce on `main`

1. Leave the session list open and do not open the session — opening it clears the flag through `setCurrentViewingSession`.
2. Let an agent finish a short task. The row goes solid blue, "new results".
3. With that marker still set, trigger anything that needs approval. The row stays solid blue.

Two things worth knowing if you try it:

- `unreadSessionIds` is in-memory (`storage.ts:439`), so reloading the page clears it and step 3 shows orange for the wrong reason.
- My screenshots are from a local-mode session, where a question reaches `agentState.requests` only with a separate CLI patch I have not upstreamed. On plain `main`, reproduce in remote mode or with any ordinary tool permission prompt — the bug is in the render layer and does not care how the request got into `agentState.requests`.

Tested with `pnpm web` against a real session on a real machine.

## Why the live state should win

Unread is a fact about history: there is output you have not looked at. The states describe the present — what the session is doing right now. When the two disagree the present has to win, because it is the part that is still changing and the part that may need you.

`thinking` is affected too, though more mildly: both render blue, so the cost there is just the pulse that separates work in flight from a finished turn.

The override arrived in 4a5f91dc (#1205) as "solid blue dot when an agent finishes while the user is elsewhere" — that is, under the assumption that unread implies stopped. Coexistence with a live state was never in scope.

## Relationship to existing PRs

**#1577** proposed the same gating, bundled with an optional purple unread color. It was closed along with the declined color change, on the rationale that the gating was "largely subsumed by #1579". That holds for half of it: #1579 touches `sync/sync.ts` alone, removing a source of *spurious* unread marks on running sessions. The render-side override is untouched on `main` (`SessionsList.tsx:454`, `ActiveSessionsGroupCompact.tsx:230`), so a *legitimate* unread mark still swallows `permission_required`.

**#1374** comes at the same overloaded dot from the other direction — unread reading as *running* — by moving unread onto the title weight instead. It overlaps textually in both files. Its `expUnreadBoldTitle` setting defaults to `false` and leaves the unconditional override on that path, so the default experience is unchanged by it. If you prefer that design, I am happy to close this or reshape it as the default-path half of it.

**#1612** adds a `background` state to the same dot. If it lands first, the allowlist here needs a deliberate call on whether unread may stand in for that state.

## Notes on the change

Written as an allowlist rather than as an exclusion of the two attention states, so a state added later keeps its own display until someone decides otherwise. A new state is likelier to be one that needs attention than another idle one, and that is the safer way to be wrong.

The flag itself is untouched, so a session that finishes work while a live state was showing still surfaces its unread marker afterwards.

Both list rows carry their own copy of this logic, so both are updated, along with the compact row's leading indicator — four call sites in total.

4 unit tests on the gate, `pnpm typecheck` clean, 815 app tests passing.
