### PR TITLE
feat(cli): surface a local-mode question on the phone and route the answer back

### DIFF
--- a/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.test.ts
@@ -24,6 +24,14 @@ vi.mock('./utils/sessionScanner', () => ({
     createSessionScanner: mockCreateSessionScanner,
 }));
 
+// Without this mock the suite would read the developer's real
+// ~/.claude/sessions. Worse, if an assertion times out and throws, the
+// launcher's finally never runs, leaving the 500ms poll interval alive in the
+// vitest worker where it goes on scanning that real directory.
+vi.mock('./utils/claudeStatusWatcher', () => ({
+    startClaudeStatusWatcher: () => () => { },
+}));
+
 vi.mock('@/ui/logger', () => ({
     logger: {
         debug: vi.fn(),

--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -5,6 +5,7 @@ import { Future } from "@/utils/future";
 import { createSessionScanner } from "./utils/sessionScanner";
 import { launchFailureMessage } from "./utils/launchFailureMessage";
 import { startClaudeStatusWatcher } from "./utils/claudeStatusWatcher";
+import { startLocalQuestionBridge } from "./utils/localQuestionBridge";
 
 export type LauncherResult = { type: 'switch' } | { type: 'exit', code: number };
 
@@ -37,12 +38,18 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
     };
     session.addSessionFoundCallback(scannerSessionCallback);
 
+    // Surfaces a question the terminal is blocked on, and takes the answer back
+    // from the phone — see localQuestionBridge.ts for why the answer becomes a
+    // handoff to remote mode rather than a tool result.
+    const questionBridge = startLocalQuestionBridge(session);
+
     // Where local-mode thinking state comes from: the session status file
     // Claude Code maintains itself. The in-process fetch patch does not work
     // against the 2.x native binary — see claudeStatusWatcher.ts.
     const stopStatusWatcher = startClaudeStatusWatcher({
         getSessionId: () => session.sessionId,
         onThinkingChange: session.onThinkingChange,
+        onWaitingForInputChange: questionBridge.onWaitingForInputChange,
     });
 
     // Handle abort
@@ -183,8 +190,12 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
         session.removeSessionFoundCallback(scannerSessionCallback);
 
         // Stop status tracking. This resets thinking to false internally, so
-        // shutdown cannot leave the session stuck at "working".
+        // shutdown cannot leave the session stuck at "working". It also emits a
+        // final waitingForInput=false, which withdraws any published question
+        // through the bridge — so stop it before disposing the bridge, or one
+        // last poll could republish what we just withdrew.
         stopStatusWatcher();
+        questionBridge.dispose();
 
         // Cleanup
         await scanner.cleanup();

--- a/packages/happy-cli/src/claude/claudeLocalLauncher.ts
+++ b/packages/happy-cli/src/claude/claudeLocalLauncher.ts
@@ -4,6 +4,7 @@ import { Session } from "./session";
 import { Future } from "@/utils/future";
 import { createSessionScanner } from "./utils/sessionScanner";
 import { launchFailureMessage } from "./utils/launchFailureMessage";
+import { startClaudeStatusWatcher } from "./utils/claudeStatusWatcher";
 
 export type LauncherResult = { type: 'switch' } | { type: 'exit', code: number };
 
@@ -36,6 +37,13 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
     };
     session.addSessionFoundCallback(scannerSessionCallback);
 
+    // Where local-mode thinking state comes from: the session status file
+    // Claude Code maintains itself. The in-process fetch patch does not work
+    // against the 2.x native binary — see claudeStatusWatcher.ts.
+    const stopStatusWatcher = startClaudeStatusWatcher({
+        getSessionId: () => session.sessionId,
+        onThinkingChange: session.onThinkingChange,
+    });
 
     // Handle abort
     let exitReason: LauncherResult | null = null;
@@ -173,6 +181,10 @@ export async function claudeLocalLauncher(session: Session): Promise<LauncherRes
         
         // Remove session found callback
         session.removeSessionFoundCallback(scannerSessionCallback);
+
+        // Stop status tracking. This resets thinking to false internally, so
+        // shutdown cannot leave the session stuck at "working".
+        stopStatusWatcher();
 
         // Cleanup
         await scanner.cleanup();

--- a/packages/happy-cli/src/claude/loop.ts
+++ b/packages/happy-cli/src/claude/loop.ts
@@ -43,6 +43,11 @@ interface LoopOptions {
     sandboxConfig?: SandboxConfig
     onSessionReady?: (session: Session) => void
     onAbort?: () => void
+    /**
+     * Current model / permission mode / effort. Needed when the CLI enqueues a
+     * message on the user's behalf — see Session.getEnhancedMode.
+     */
+    getEnhancedMode?: () => EnhancedMode
     /** Path to temporary settings file with SessionStart hook (required for session tracking) */
     hookSettingsPath: string
     /** JavaScript runtime to use for spawning Claude Code (default: 'node') */
@@ -67,6 +72,7 @@ export async function loop(opts: LoopOptions): Promise<number> {
         sandboxConfig: opts.sandboxConfig,
         onModeChange: opts.onModeChange,
         onAbort: opts.onAbort,
+        getEnhancedMode: opts.getEnhancedMode,
         hookSettingsPath: opts.hookSettingsPath,
         jsRuntime: opts.jsRuntime
     });

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -947,6 +947,7 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
             currentSession = sessionInstance;
         },
         onAbort: resetCurrentModeDefaults,
+        getEnhancedMode: currentEnhancedMode,
         mcpServers: {
             'happy': {
                 type: 'http' as const,

--- a/packages/happy-cli/src/claude/session.ts
+++ b/packages/happy-cli/src/claude/session.ts
@@ -18,6 +18,13 @@ export class Session {
     readonly sandboxConfig?: SandboxConfig;
     readonly _onModeChange: (mode: 'local' | 'remote') => void;
     readonly _onAbort?: () => void;
+    /**
+     * Current model, permission mode and effort, as assembled by runClaude.
+     * Needed to enqueue a message on the user's behalf: the queue keys its
+     * batches by a hash of this, so pushing a hardcoded default would restart
+     * remote mode with a different model than the one the user selected.
+     */
+    readonly getEnhancedMode?: () => EnhancedMode;
     /** Path to temporary settings file with SessionStart hook (required for session tracking) */
     readonly hookSettingsPath: string;
     /** JavaScript runtime to use for spawning Claude Code (default: 'node') */
@@ -45,6 +52,7 @@ export class Session {
         messageQueue: MessageQueue2<EnhancedMode>,
         onModeChange: (mode: 'local' | 'remote') => void,
         onAbort?: () => void,
+        getEnhancedMode?: () => EnhancedMode,
         allowedTools?: string[],
         sandboxConfig?: SandboxConfig,
         /** Path to temporary settings file with SessionStart hook (required for session tracking) */
@@ -65,6 +73,7 @@ export class Session {
         this.sandboxConfig = opts.sandboxConfig;
         this._onModeChange = opts.onModeChange;
         this._onAbort = opts.onAbort;
+        this.getEnhancedMode = opts.getEnhancedMode;
         this.hookSettingsPath = opts.hookSettingsPath;
         this.jsRuntime = opts.jsRuntime ?? 'node';
 

--- a/packages/happy-cli/src/claude/utils/claudeStatusWatcher.test.ts
+++ b/packages/happy-cli/src/claude/utils/claudeStatusWatcher.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
+import { startClaudeStatusWatcher } from "./claudeStatusWatcher";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Find a pid that is definitely not running.
+ *
+ * Do not hardcode a low pid (111 and friends): on another machine, or after a
+ * reboot, it may be a real system process, which flips the liveness ordering
+ * and makes these tests flaky. Probing at runtime is deterministic.
+ */
+const findDeadPid = (): number => {
+  for (const candidate of [4194303, 999983, 888887, 777769, 666649]) {
+    try {
+      process.kill(candidate, 0);
+    } catch (error: any) {
+      // EPERM means the process exists but is not ours, so it is not dead.
+      if (error?.code !== "EPERM") {
+        return candidate;
+      }
+    }
+  }
+  throw new Error("no reliably dead pid found; cannot test liveness ordering");
+};
+
+/**
+ * These tests pin down the core semantics of claudeStatusWatcher, as observed
+ * against Claude Code 2.1.220 (see that module's header comment).
+ *
+ * The rule running through all of them: any uncertainty must resolve to false.
+ * Missing a spinner is acceptable; getting stuck showing "working" is not,
+ * because that is worse than the bug being fixed.
+ */
+describe("startClaudeStatusWatcher", () => {
+  let configDir: string;
+  let sessionsDir: string;
+  let stop: (() => void) | null = null;
+  let prevConfigDir: string | undefined;
+
+  const SESSION_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  const DEAD_PID = findDeadPid();
+
+  // Write a session status file in Claude Code's shape.
+  const writeSessionFile = (
+    pid: number,
+    status: string,
+    sessionId = SESSION_ID,
+  ) =>
+    writeFile(
+      join(sessionsDir, `${pid}.json`),
+      JSON.stringify({
+        pid,
+        sessionId,
+        status,
+        cwd: "/tmp",
+        statusUpdatedAt: Date.now(),
+      }),
+    );
+
+  beforeEach(async () => {
+    configDir = join(
+      tmpdir(),
+      `csw-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    sessionsDir = join(configDir, "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    if (stop) {
+      stop();
+      stop = null;
+    }
+    if (prevConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+    }
+    if (existsSync(configDir)) {
+      await rm(configDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports thinking=true on busy and resets when it returns to idle", async () => {
+    await writeSessionFile(DEAD_PID, "idle");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 30,
+    });
+
+    await sleep(120);
+    expect(changes).toEqual([]); // steady idle must not emit any change
+
+    await writeSessionFile(DEAD_PID, "busy");
+    await sleep(150);
+    expect(changes).toEqual([true]);
+
+    // This is exactly what an ESC interrupt looks like: status returns to idle.
+    await writeSessionFile(DEAD_PID, "idle");
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("reports only on change, so sustained busy is not re-emitted", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+
+    await sleep(200);
+    expect(changes).toEqual([true]);
+  });
+
+  // `shell` is one of the four values Claude Code can write. It was observed
+  // once in a real session, holding for several minutes before returning to
+  // `busy` on its own, but its meaning is still unverified — and anything whose
+  // semantics we cannot pin down has to count as not working, or the phone
+  // risks showing "working" forever.
+  it("treats a status of unverified meaning (shell) as not working", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    await writeSessionFile(DEAD_PID, "shell");
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  // `waiting` means Claude is blocked on the user — the same file reads
+  // `waitingFor: "input needed"` while an AskUserQuestion prompt is open. It is
+  // genuinely not computing then, so false here is the semantically correct
+  // answer rather than merely the safe one.
+  it("treats waiting (blocked on the user) as not working", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    await writeFile(
+      join(sessionsDir, `${DEAD_PID}.json`),
+      JSON.stringify({
+        pid: DEAD_PID,
+        sessionId: SESSION_ID,
+        status: "waiting",
+        waitingFor: "input needed",
+        cwd: "/tmp",
+        statusUpdatedAt: Date.now(),
+      }),
+    );
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+
+    // And it resumes as soon as the user answers.
+    await writeSessionFile(DEAD_PID, "busy");
+    await sleep(150);
+    expect(changes).toEqual([true, false, true]);
+  });
+
+  it("reports nothing while the session id is unknown", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => null,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([]);
+  });
+
+  it("ignores status files belonging to other sessions", async () => {
+    await writeSessionFile(DEAD_PID, "busy", "other-session-id");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([]);
+  });
+
+  it("stays not-working when the session file never appears", async () => {
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([]);
+  });
+
+  // If "cannot read the file" meant "keep the previous state" and that state
+  // happened to be busy, we would be stuck at "working" forever. It has to
+  // reset after a few polls of grace.
+  it("resets after a grace period when the status file vanishes mid-work", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    await unlink(join(sessionsDir, `${DEAD_PID}.json`));
+    await sleep(300);
+    expect(changes).toEqual([true, false]);
+  });
+
+  // The session id changed (SessionStart hook handed us a new one, or /clear
+  // wiped it). The old session's thinking must not carry over, or a new
+  // session with no matching file would stay stuck at true.
+  it("resets immediately when the session id changes", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    let currentId: string | null = SESSION_ID;
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => currentId,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    currentId = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("resets when the session id is cleared (/clear)", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    let currentId: string | null = SESSION_ID;
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => currentId,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    currentId = null;
+    await sleep(150);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("resets thinking to false on stop", async () => {
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    // Also assign to `stop`, so afterEach can still clear the interval if an
+    // assertion throws. A leaked timer would otherwise go on scanning the real
+    // directory once CLAUDE_CONFIG_DIR is restored.
+    const dispose = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    stop = dispose;
+    await sleep(120);
+    expect(changes).toEqual([true]);
+
+    dispose();
+    // Stopping twice must be safe.
+    dispose();
+    stop = null;
+
+    expect(changes).toEqual([true, false]);
+
+    // Nothing may be emitted after stopping.
+    await writeSessionFile(DEAD_PID, "busy");
+    await sleep(120);
+    expect(changes).toEqual([true, false]);
+  });
+
+  it("survives a half-written file with invalid JSON", async () => {
+    await writeFile(join(sessionsDir, "999.json"), '{"sessionId": "trunc');
+    await writeSessionFile(DEAD_PID, "busy");
+    const changes: boolean[] = [];
+    stop = startClaudeStatusWatcher({
+      getSessionId: () => SESSION_ID,
+      onThinkingChange: (t) => {
+        changes.push(t);
+      },
+      pollIntervalMs: 20,
+    });
+    await sleep(150);
+    expect(changes).toEqual([true]);
+  });
+
+  // Session files are named by pid and are not cleaned up on exit: killing
+  // `claude` mid-turn leaves a file stuck at status=busy forever. After that
+  // sessionId is resumed there are two matching files in the directory, and
+  // picking the wrong one pins the phone at "working" permanently.
+  describe("multiple session files for one sessionId (leftovers from killed processes)", () => {
+    const writeAt = (
+      pid: number,
+      status: string,
+      statusUpdatedAt: number,
+      extra: Record<string, unknown> = {},
+    ) =>
+      writeFile(
+        join(sessionsDir, `${pid}.json`),
+        JSON.stringify({
+          pid,
+          sessionId: SESSION_ID,
+          status,
+          cwd: "/tmp",
+          statusUpdatedAt,
+          ...extra,
+        }),
+      );
+
+    it("prefers the newer timestamp when both processes are dead (stale busy loses to newer idle)", async () => {
+      await writeAt(DEAD_PID, "busy", 1_000);
+      await writeAt(DEAD_PID + 1, "idle", 9_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([]);
+    });
+
+    it("and the reverse holds: newer busy beats older idle", async () => {
+      await writeAt(DEAD_PID, "idle", 1_000);
+      await writeAt(DEAD_PID + 1, "busy", 9_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([true]);
+    });
+
+    // The key case: timestamps alone cannot rule out a leftover file. A live
+    // process that drops to idle stops advancing its timestamp, while another
+    // process that flipped to busy later was then SIGKILLed — the leftover
+    // busy would win forever. Hence liveness outranks the timestamp.
+    it("prefers a live process's idle over a dead process's newer busy", async () => {
+      await writeAt(DEAD_PID, "busy", 9_000); // dead, but newer timestamp
+      await writeAt(process.pid, "idle", 1_000); // alive, older timestamp
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([]);
+    });
+
+    it("prefers a live process's busy over a dead process's newer idle too", async () => {
+      await writeAt(DEAD_PID, "idle", 9_000);
+      await writeAt(process.pid, "busy", 1_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      expect(changes).toEqual([true]);
+    });
+
+    // JSON.parse turns 1e999 into Infinity while typeof stays "number".
+    // Compared directly, Infinity > Infinity is false, which would pin the
+    // selection on the corrupt file forever.
+    it("is not pinned by a corrupt file whose timestamp parses to Infinity", async () => {
+      await writeFile(
+        join(sessionsDir, `${DEAD_PID}.json`),
+        `{"pid":${DEAD_PID},"sessionId":"${SESSION_ID}","status":"busy","statusUpdatedAt":1e999}`,
+      );
+      await writeAt(process.pid, "idle", 1_000);
+      const changes: boolean[] = [];
+      stop = startClaudeStatusWatcher({
+        getSessionId: () => SESSION_ID,
+        onThinkingChange: (t) => {
+          changes.push(t);
+        },
+        pollIntervalMs: 20,
+      });
+      await sleep(150);
+      // The live process's idle must win instead of being pinned at busy.
+      expect(changes).toEqual([]);
+    });
+  });
+});

--- a/packages/happy-cli/src/claude/utils/claudeStatusWatcher.test.ts
+++ b/packages/happy-cli/src/claude/utils/claudeStatusWatcher.test.ts
@@ -187,6 +187,115 @@ describe("startClaudeStatusWatcher", () => {
     expect(changes).toEqual([true, false, true]);
   });
 
+  // A question that is no longer open must never stay published, so this signal
+  // has to fall back to false from every path the thinking signal does.
+  describe("waitingForInput", () => {
+    const writeWaiting = (waitingFor: string | null) =>
+      writeFile(
+        join(sessionsDir, `${DEAD_PID}.json`),
+        JSON.stringify({
+          pid: DEAD_PID,
+          sessionId: SESSION_ID,
+          status: "waiting",
+          ...(waitingFor === null ? {} : { waitingFor }),
+          cwd: "/tmp",
+          statusUpdatedAt: Date.now(),
+        }),
+      );
+
+    const track = (getSessionId: () => string | null = () => SESSION_ID) => {
+      const waiting: boolean[] = [];
+      const dispose = startClaudeStatusWatcher({
+        getSessionId,
+        onThinkingChange: () => {},
+        onWaitingForInputChange: (w) => {
+          waiting.push(w);
+        },
+        pollIntervalMs: 20,
+      });
+      stop = dispose;
+      return { waiting, dispose };
+    };
+
+    it("reports true only while an answer is awaited", async () => {
+      await writeSessionFile(DEAD_PID, "busy");
+      const { waiting } = track();
+      await sleep(120);
+      expect(waiting).toEqual([]);
+
+      await writeWaiting("input needed");
+      await sleep(150);
+      expect(waiting).toEqual([true]);
+
+      // The user answered, so Claude is computing again.
+      await writeSessionFile(DEAD_PID, "busy");
+      await sleep(150);
+      expect(waiting).toEqual([true, false]);
+    });
+
+    // The other documented `waitingFor` values also mean "blocked on the user",
+    // but they are not questions we can forward. Publishing one would leave the
+    // phone offering to answer something Claude never asked.
+    it("ignores a waiting state that is not a question", async () => {
+      const { waiting } = track();
+      await writeWaiting("permission prompt");
+      await sleep(150);
+      expect(waiting).toEqual([]);
+
+      await writeWaiting("dialog open");
+      await sleep(150);
+      expect(waiting).toEqual([]);
+    });
+
+    it("ignores waiting with no discriminant at all", async () => {
+      const { waiting } = track();
+      await writeWaiting(null);
+      await sleep(150);
+      expect(waiting).toEqual([]);
+    });
+
+    it("does not re-report while the same question stays open", async () => {
+      const { waiting } = track();
+      await writeWaiting("input needed");
+      await sleep(200);
+      expect(waiting).toEqual([true]);
+    });
+
+    it("resets when the session id changes", async () => {
+      let currentId: string | null = SESSION_ID;
+      const { waiting } = track(() => currentId);
+      await writeWaiting("input needed");
+      await sleep(150);
+      expect(waiting).toEqual([true]);
+
+      currentId = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+      await sleep(150);
+      expect(waiting).toEqual([true, false]);
+    });
+
+    it("resets when the status file vanishes", async () => {
+      const { waiting } = track();
+      await writeWaiting("input needed");
+      await sleep(150);
+      expect(waiting).toEqual([true]);
+
+      await unlink(join(sessionsDir, `${DEAD_PID}.json`));
+      await sleep(300);
+      expect(waiting).toEqual([true, false]);
+    });
+
+    it("resets on stop", async () => {
+      const { waiting, dispose } = track();
+      await writeWaiting("input needed");
+      await sleep(150);
+      expect(waiting).toEqual([true]);
+
+      dispose();
+      stop = null;
+      expect(waiting).toEqual([true, false]);
+    });
+  });
+
   it("reports nothing while the session id is unknown", async () => {
     await writeSessionFile(DEAD_PID, "busy");
     const changes: boolean[] = [];

--- a/packages/happy-cli/src/claude/utils/claudeStatusWatcher.ts
+++ b/packages/happy-cli/src/claude/utils/claudeStatusWatcher.ts
@@ -55,6 +55,9 @@ import { logger } from "@/ui/logger";
 /** The only `status` value that counts as working. */
 const BUSY_STATUS = "busy";
 
+/** `status` value Claude Code writes while it is blocked on the user. */
+const WAITING_STATUS = "waiting";
+
 const DEFAULT_POLL_INTERVAL_MS = 500;
 
 /**
@@ -65,6 +68,21 @@ const DEFAULT_POLL_INTERVAL_MS = 500;
  * or a changed session id would pin `thinking` at true forever.
  */
 const MISSING_FILE_GRACE_POLLS = 3;
+
+/**
+ * `waitingFor` value Claude Code writes while it is blocked on an answer to a
+ * question (an open AskUserQuestion prompt). Other documented values —
+ * `permission prompt`, `sandbox request`, `worker request`, `dialog open` —
+ * also mean "blocked on the user", but only this one is a question we can
+ * forward, so we match it exactly rather than treating every `waiting` alike.
+ */
+const WAITING_FOR_INPUT = "input needed";
+
+/** The parts of a session status file we act on. */
+interface SessionStatusSnapshot {
+  status: string;
+  waitingFor: string | null;
+}
 
 function claudeSessionsDir(): string {
   const claudeConfigDir =
@@ -107,7 +125,9 @@ function livenessRank(pid: unknown): number {
  * SIGKILLed — the leftover busy@T3 would win forever and the phone would show
  * "working" permanently. So rank by process liveness first, timestamp second.
  */
-async function readStatusForSession(sessionId: string): Promise<string | null> {
+async function readStatusForSession(
+  sessionId: string,
+): Promise<SessionStatusSnapshot | null> {
   const dir = claudeSessionsDir();
   let files: string[];
   try {
@@ -126,6 +146,7 @@ async function readStatusForSession(sessionId: string): Promise<string | null> {
             pid?: unknown;
             sessionId?: unknown;
             status?: unknown;
+            waitingFor?: unknown;
             statusUpdatedAt?: unknown;
             updatedAt?: unknown;
           };
@@ -146,6 +167,8 @@ async function readStatusForSession(sessionId: string): Promise<string | null> {
               : -Infinity;
           return {
             status: parsed.status,
+            waitingFor:
+              typeof parsed.waitingFor === "string" ? parsed.waitingFor : null,
             at,
             liveness: livenessRank(parsed.pid),
           };
@@ -156,7 +179,12 @@ async function readStatusForSession(sessionId: string): Promise<string | null> {
       }),
   );
 
-  let best: { status: string; at: number; liveness: number } | null = null;
+  let best: {
+    status: string;
+    waitingFor: string | null;
+    at: number;
+    liveness: number;
+  } | null = null;
   for (const candidate of candidates) {
     if (!candidate) {
       continue;
@@ -169,7 +197,9 @@ async function readStatusForSession(sessionId: string): Promise<string | null> {
       best = candidate;
     }
   }
-  return best?.status ?? null;
+  return best === null
+    ? null
+    : { status: best.status, waitingFor: best.waitingFor };
 }
 
 export interface ClaudeStatusWatcherOptions {
@@ -180,6 +210,14 @@ export interface ClaudeStatusWatcherOptions {
   getSessionId: () => string | null;
   /** Called only when the state actually changes. */
   onThinkingChange: (thinking: boolean) => void;
+  /**
+   * Called only on change, with true while Claude is blocked waiting for an
+   * answer to a question. This is the authority on whether a question is
+   * *still* open: a transcript alone cannot tell a pending `AskUserQuestion`
+   * from one that was abandoned, and the file selection below discards
+   * leftovers from processes that are gone.
+   */
+  onWaitingForInputChange?: (waitingForInput: boolean) => void;
   pollIntervalMs?: number;
 }
 
@@ -194,6 +232,7 @@ export function startClaudeStatusWatcher(
   const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   let stopped = false;
   let lastThinking = false;
+  let lastWaitingForInput = false;
   let polling = false;
   let lastSessionId: string | null = null;
   let missingPolls = 0;
@@ -207,6 +246,20 @@ export function startClaudeStatusWatcher(
     lastThinking = thinking;
     logger.debug(`[ClaudeStatusWatcher] ${reason} → thinking=${thinking}`);
     opts.onThinkingChange(thinking);
+  };
+
+  // Same shape as applyThinking, and reset from all the same paths: a question
+  // that is no longer open must never stay published, or the phone keeps
+  // offering to answer something Claude has stopped waiting for.
+  const applyWaitingForInput = (waitingForInput: boolean, reason: string) => {
+    if (waitingForInput === lastWaitingForInput) {
+      return;
+    }
+    lastWaitingForInput = waitingForInput;
+    logger.debug(
+      `[ClaudeStatusWatcher] ${reason} → waitingForInput=${waitingForInput}`,
+    );
+    opts.onWaitingForInputChange?.(waitingForInput);
   };
 
   const tick = async () => {
@@ -226,13 +279,14 @@ export function startClaudeStatusWatcher(
         lastSessionId = sessionId;
         missingPolls = 0;
         applyThinking(false, "session changed");
+        applyWaitingForInput(false, "session changed");
       }
 
       if (!sessionId) {
         return;
       }
 
-      const status = await readStatusForSession(sessionId);
+      const snapshot = await readStatusForSession(sessionId);
 
       // We may have been stopped during the await. The reset in stop() can
       // miss this case when lastThinking happens to be false already, and
@@ -242,15 +296,28 @@ export function startClaudeStatusWatcher(
         return;
       }
 
-      if (status === null) {
+      if (snapshot === null) {
         missingPolls++;
         if (missingPolls >= MISSING_FILE_GRACE_POLLS) {
           applyThinking(false, "status file missing");
+          applyWaitingForInput(false, "status file missing");
         }
         return;
       }
       missingPolls = 0;
-      applyThinking(status === BUSY_STATUS, `status=${status}`);
+      applyThinking(
+        snapshot.status === BUSY_STATUS,
+        `status=${snapshot.status}`,
+      );
+      // Only `waiting` + `input needed` is a question we can forward. Every
+      // other combination — including the other `waitingFor` values, which are
+      // also "blocked on the user" — resolves to false, so nothing downstream
+      // can be left waiting on an answer that will never be asked for.
+      applyWaitingForInput(
+        snapshot.status === WAITING_STATUS &&
+          snapshot.waitingFor === WAITING_FOR_INPUT,
+        `status=${snapshot.status} waitingFor=${snapshot.waitingFor ?? "-"}`,
+      );
     } catch (error) {
       logger.debug("[ClaudeStatusWatcher] poll failed:", error);
     } finally {
@@ -270,6 +337,7 @@ export function startClaudeStatusWatcher(
     stopped = true;
     clearInterval(interval);
     applyThinking(false, "stopped");
+    applyWaitingForInput(false, "stopped");
     logger.debug("[ClaudeStatusWatcher] stopped");
   };
 }

--- a/packages/happy-cli/src/claude/utils/claudeStatusWatcher.ts
+++ b/packages/happy-cli/src/claude/utils/claudeStatusWatcher.ts
@@ -1,0 +1,275 @@
+/**
+ * Thinking-state (is-it-working) tracking for local mode.
+ *
+ * Background: Happy used to infer busy/idle by patching `global.fetch` inside
+ * claude_local_launcher.cjs. Since Claude Code 2.x ships as a native binary,
+ * the launcher is merely its parent node process, and an in-process fetch
+ * patch cannot cross that process boundary. Local-mode `thinking` is therefore
+ * always false: the phone shows the session as online but never as working.
+ *
+ * Instead we read the session status file Claude Code maintains itself:
+ *   ~/.claude/sessions/<pid>.json → { pid, sessionId, status, statusUpdatedAt }
+ * matched by sessionId rather than pid, since `claude` is a child of the
+ * launcher and Happy never learns its pid.
+ *
+ * `status` is a closed set of four values in 2.1.220:
+ *   busy     working; flips within ~60ms of prompt submission
+ *   idle     not working
+ *   waiting  blocked on the user, so not working. The same file carries a
+ *            `waitingFor` discriminant, which reads `input needed` while an
+ *            AskUserQuestion prompt is open. In the transcript every `waiting`
+ *            interval opens with a `tool_use: AskUserQuestion` whose
+ *            `stop_reason` is already `tool_use` (so the API call had already
+ *            completed) and ends within one poll of the user's answer landing
+ *            as a `tool_result`.
+ *   shell    observed once, holding for 4m46s before returning to `busy` on
+ *            its own. Its meaning is still unverified, so it rides the
+ *            unknown-value default below. If it turns out to mark a tool
+ *            running, the spinner is absent for that span — today's behaviour
+ *            rather than a new failure.
+ *
+ * `claude agents --json` exposes `status` and `waitingFor` as public output,
+ * which is what pins those semantics down. It is a projection of this file
+ * rather than the file itself, though: it drops `statusUpdatedAt`, which the
+ * arbitration below needs. So we read the file and treat its exact shape as
+ * private — see the degradation note on the unknown-value default.
+ *
+ * Why not the Stop hook: on ESC-interrupt, Stop does not fire at all, while
+ * `status` still returns to idle correctly. Driving this from hooks would
+ * leave `thinking` stuck at true after every interrupt, so the phone would
+ * show "working forever" — strictly worse than today's "idle forever".
+ *
+ * One rule runs through this whole module: **any uncertainty must resolve to
+ * false.** Missing a spinner is acceptable; getting stuck showing "working" is
+ * not, because that is worse than the bug being fixed. The deliberately
+ * conservative choices below all follow from it: unknown status is false, a
+ * session change resets to false, a persistently unreadable status file
+ * resets to false, and a file from a live process beats a newer timestamp.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "@/ui/logger";
+
+/** The only `status` value that counts as working. */
+const BUSY_STATUS = "busy";
+
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
+/**
+ * How many consecutive polls may fail to find a status file before we declare
+ * "not working". A few polls of grace, because the file may be mid atomic
+ * replace (a rename can briefly leave nothing to find) and a single failed
+ * read should not make the state flicker. But the grace cannot be unbounded,
+ * or a changed session id would pin `thinking` at true forever.
+ */
+const MISSING_FILE_GRACE_POLLS = 3;
+
+function claudeSessionsDir(): string {
+  const claudeConfigDir =
+    process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  return join(claudeConfigDir, "sessions");
+}
+
+/** Is the process still alive? EPERM means it exists but is not ours, which also counts. */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: any) {
+    return error?.code === "EPERM";
+  }
+}
+
+/** Liveness precedence: alive > undeterminable > dead. Ties broken by timestamp. */
+function livenessRank(pid: unknown): number {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+    return 1; // no usable pid, so liveness cannot be determined
+  }
+  return isProcessAlive(pid) ? 2 : 0;
+}
+
+/**
+ * Find the `status` of the session file matching `sessionId` in
+ * ~/.claude/sessions. Returns null when there is none (not written yet, or
+ * already cleaned up).
+ *
+ * Session files are named by pid and are not removed when the process exits.
+ * If `claude` is killed mid-turn, the leftover file stays at status=busy
+ * forever; when that same sessionId is later resumed under a new pid, two
+ * files in the directory match it.
+ *
+ * Taking the largest `statusUpdatedAt` is not enough to rule the stale one
+ * out, because a newer timestamp does not imply a live process. The real
+ * counterexample: a live process drops to idle at T2 and its timestamp stops
+ * advancing, while another process flips to busy at T3 > T2 and is then
+ * SIGKILLed — the leftover busy@T3 would win forever and the phone would show
+ * "working" permanently. So rank by process liveness first, timestamp second.
+ */
+async function readStatusForSession(sessionId: string): Promise<string | null> {
+  const dir = claudeSessionsDir();
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return null;
+  }
+
+  const candidates = await Promise.all(
+    files
+      .filter((name) => name.endsWith(".json"))
+      .map(async (name) => {
+        try {
+          const raw = await readFile(join(dir, name), "utf-8");
+          const parsed = JSON.parse(raw) as {
+            pid?: unknown;
+            sessionId?: unknown;
+            status?: unknown;
+            statusUpdatedAt?: unknown;
+            updatedAt?: unknown;
+          };
+          if (
+            parsed.sessionId !== sessionId ||
+            typeof parsed.status !== "string"
+          ) {
+            return null;
+          }
+          // Number.isFinite rejects Infinity/NaN: JSON.parse turns 1e999 into
+          // Infinity while typeof stays "number", and comparing it directly
+          // would pin the selection on the first corrupt file forever, since
+          // Infinity > Infinity is false.
+          const at = Number.isFinite(parsed.statusUpdatedAt)
+            ? (parsed.statusUpdatedAt as number)
+            : Number.isFinite(parsed.updatedAt)
+              ? (parsed.updatedAt as number)
+              : -Infinity;
+          return {
+            status: parsed.status,
+            at,
+            liveness: livenessRank(parsed.pid),
+          };
+        } catch {
+          // Half-written file or invalid JSON: skip it, try again next poll.
+          return null;
+        }
+      }),
+  );
+
+  let best: { status: string; at: number; liveness: number } | null = null;
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+    if (
+      best === null ||
+      candidate.liveness > best.liveness ||
+      (candidate.liveness === best.liveness && candidate.at > best.at)
+    ) {
+      best = candidate;
+    }
+  }
+  return best?.status ?? null;
+}
+
+export interface ClaudeStatusWatcherOptions {
+  /**
+   * Current Claude session id. May be unknown at startup (we are waiting on
+   * the SessionStart hook); returning null counts as not working.
+   */
+  getSessionId: () => string | null;
+  /** Called only when the state actually changes. */
+  onThinkingChange: (thinking: boolean) => void;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Poll Claude Code's session status file, mapping busy/anything-else onto
+ * thinking true/false. Returns a stop function, which forces thinking back to
+ * false so shutdown cannot leave the state stuck at "working".
+ */
+export function startClaudeStatusWatcher(
+  opts: ClaudeStatusWatcherOptions,
+): () => void {
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  let stopped = false;
+  let lastThinking = false;
+  let polling = false;
+  let lastSessionId: string | null = null;
+  let missingPolls = 0;
+
+  // Single exit point: report only on a real change, so every "reset to false"
+  // path can reuse it.
+  const applyThinking = (thinking: boolean, reason: string) => {
+    if (thinking === lastThinking) {
+      return;
+    }
+    lastThinking = thinking;
+    logger.debug(`[ClaudeStatusWatcher] ${reason} → thinking=${thinking}`);
+    opts.onThinkingChange(thinking);
+  };
+
+  const tick = async () => {
+    // Skip if the previous poll is still running, so a slow disk cannot pile
+    // them up.
+    if (stopped || polling) {
+      return;
+    }
+    polling = true;
+    try {
+      const sessionId = opts.getSessionId();
+
+      // The session changed (SessionStart hook handed us a new id) or was
+      // cleared by /clear. The old session's thinking must not carry over,
+      // or a new session with no matching file would stay stuck at true.
+      if (sessionId !== lastSessionId) {
+        lastSessionId = sessionId;
+        missingPolls = 0;
+        applyThinking(false, "session changed");
+      }
+
+      if (!sessionId) {
+        return;
+      }
+
+      const status = await readStatusForSession(sessionId);
+
+      // We may have been stopped during the await. The reset in stop() can
+      // miss this case when lastThinking happens to be false already, and
+      // continuing here would emit one final thinking=true at the very end of
+      // the launcher's life, pinning the phone at "working" permanently.
+      if (stopped) {
+        return;
+      }
+
+      if (status === null) {
+        missingPolls++;
+        if (missingPolls >= MISSING_FILE_GRACE_POLLS) {
+          applyThinking(false, "status file missing");
+        }
+        return;
+      }
+      missingPolls = 0;
+      applyThinking(status === BUSY_STATUS, `status=${status}`);
+    } catch (error) {
+      logger.debug("[ClaudeStatusWatcher] poll failed:", error);
+    } finally {
+      polling = false;
+    }
+  };
+
+  const interval = setInterval(() => {
+    void tick();
+  }, pollIntervalMs);
+  void tick();
+
+  return () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    clearInterval(interval);
+    applyThinking(false, "stopped");
+    logger.debug("[ClaudeStatusWatcher] stopped");
+  };
+}

--- a/packages/happy-cli/src/claude/utils/localQuestionBridge.ts
+++ b/packages/happy-cli/src/claude/utils/localQuestionBridge.ts
@@ -1,0 +1,193 @@
+/**
+ * Surfaces a local-mode question on the phone, and routes the answer back.
+ *
+ * In local mode Claude runs as its own binary in the terminal, so Happy has no
+ * `canUseTool` hook to intercept an `AskUserQuestion` with — `permissionHandler`
+ * is wired only into remote mode. The phone therefore shows the session as
+ * merely online while the terminal sits blocked on a question, and the answer
+ * sheet it already renders cannot submit: `AskUserQuestionView` only calls
+ * `sessionAllow` when `tool.permission` exists, and that is derived from
+ * `agentState.requests`, which nothing populates here. The button spins and
+ * sends nothing.
+ *
+ * This publishes the open question into `agentState.requests`, which is the one
+ * input the app's session state derives "needs attention" from, and registers
+ * the `permission` RPC so the answer has somewhere to land.
+ *
+ * The answer cannot be returned as a `tool_result`: that would require being
+ * inside the tool call, which is exactly what local mode is not. It is enqueued
+ * as a user message instead, which the queue's existing handler turns into a
+ * handoff to remote mode — the same thing the user does by hand today when they
+ * type into the app to take over. So the turn is interrupted rather than
+ * resumed, and Claude reads the answer as text. That is a real semantic
+ * difference from remote mode, and the reason this is not simply "local mode
+ * now supports questions".
+ */
+
+import { logger } from "@/ui/logger";
+import type { Session } from "../session";
+import { findPendingQuestion } from "./pendingQuestion";
+
+/** Formats the app's answer map into the message Claude will read. */
+function formatAnswer(answers: Record<string, unknown>): string {
+  const lines = Object.entries(answers)
+    .filter(([, value]) => typeof value === "string" && value.length > 0)
+    .map(([question, value]) => `- ${question}: ${value as string}`);
+  return lines.length === 0
+    ? "(the question was answered with no selection)"
+    : `Answering your question from the phone:\n${lines.join("\n")}`;
+}
+
+export interface LocalQuestionBridge {
+  /** Feed from the status watcher: true while Claude is blocked on a question. */
+  onWaitingForInputChange: (waitingForInput: boolean) => void;
+  /** Withdraw anything published and stop accepting answers. */
+  dispose: () => void;
+}
+
+export function startLocalQuestionBridge(
+  session: Session,
+): LocalQuestionBridge {
+  // Id of the question currently published, so we withdraw exactly our own
+  // entry and never clobber a concurrent writer's.
+  let publishedId: string | null = null;
+  let disposed = false;
+  // Bumped on every state change. `findPendingQuestion` reads a file, so a
+  // quick true→false flip could otherwise publish after the withdraw and leave
+  // the phone offering to answer a question Claude has moved on from.
+  let generation = 0;
+
+  const withdraw = (reason: string) => {
+    const id = publishedId;
+    if (!id) {
+      return;
+    }
+    publishedId = null;
+    logger.debug(`[LocalQuestion] withdrawing ${id}: ${reason}`);
+    session.client.updateAgentState((state) => {
+      if (!state.requests?.[id]) {
+        return state;
+      }
+      const requests = { ...state.requests };
+      delete requests[id];
+      return { ...state, requests };
+    });
+  };
+
+  const publish = async () => {
+    const mine = ++generation;
+    const sessionId = session.sessionId;
+    if (!sessionId) {
+      return;
+    }
+    const pending = await findPendingQuestion(session.path, sessionId);
+    // Either we were disposed, or the status flipped again while reading the
+    // transcript. In both cases this result is already stale.
+    if (disposed || mine !== generation || !pending) {
+      return;
+    }
+    // Key by the provider tool-use id, and echo it in `toolUseId`: the app
+    // joins a request to its tool call by `toolUseId || requestId`, so both
+    // being the same id attaches the answer sheet to the question already
+    // visible in the transcript instead of adding a second card.
+    publishedId = pending.toolUseId;
+    logger.debug(`[LocalQuestion] publishing ${pending.toolUseId}`);
+    session.client.updateAgentState((state) => ({
+      ...state,
+      requests: {
+        ...state.requests,
+        [pending.toolUseId]: {
+          tool: "AskUserQuestion",
+          arguments: pending.input,
+          createdAt: Date.now(),
+          toolUseId: pending.toolUseId,
+        },
+      },
+    }));
+  };
+
+  session.client.rpcHandlerManager.registerHandler<
+    { id?: unknown; approved?: unknown; updatedInput?: unknown },
+    void
+  >("permission", async (message) => {
+    const id = typeof message?.id === "string" ? message.id : null;
+    if (!id || id !== publishedId) {
+      // Not the question we published — a stale response, or one belonging to a
+      // request from another mode. Dropping it is safer than enqueueing text
+      // Claude never asked for.
+      logger.debug(
+        `[LocalQuestion] ignoring permission response for ${id ?? "?"}`,
+      );
+      return;
+    }
+
+    if (message.approved !== true) {
+      // The app has no "deny" for a question today, so this is defensive. The
+      // terminal prompt is the user's to resolve either way.
+      logger.debug("[LocalQuestion] question was declined, nothing to enqueue");
+      withdraw("declined");
+      return;
+    }
+
+    const updatedInput =
+      message.updatedInput && typeof message.updatedInput === "object"
+        ? (message.updatedInput as { answers?: unknown })
+        : null;
+    const answers =
+      updatedInput?.answers && typeof updatedInput.answers === "object"
+        ? (updatedInput.answers as Record<string, unknown>)
+        : null;
+    // The mode has to be the live one: the queue keys its batches by a hash of
+    // it, so a hardcoded default would resume with a different model than the
+    // user picked.
+    const mode = session.getEnhancedMode?.();
+
+    // Validate before touching state. Withdrawing and then failing to enqueue
+    // would clear the question from the phone while the terminal stays blocked
+    // on it, and since the status file has not changed, nothing would republish
+    // it — the session would look idle with no way back.
+    if (!answers || !mode) {
+      logger.debug(
+        `[LocalQuestion] cannot forward the answer (answers=${!!answers} mode=${!!mode}); leaving the question published`,
+      );
+      return;
+    }
+
+    // Enqueueing triggers the queue's onMessage handler, which asks local mode
+    // to hand control to remote. That ends the terminal session the question
+    // belonged to, so withdrawing is not cosmetic: the prompt stops existing.
+    withdraw("answered");
+    session.queue.push(formatAnswer(answers), mode);
+    logger.debug("[LocalQuestion] answer enqueued, handing off to remote");
+  });
+
+  return {
+    onWaitingForInputChange: (waitingForInput) => {
+      if (disposed) {
+        return;
+      }
+      if (waitingForInput) {
+        void publish();
+      } else {
+        generation++;
+        withdraw("no longer waiting");
+      }
+    },
+    dispose: () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      generation++;
+      withdraw("local mode ended");
+      // Remote mode's PermissionHandler registers its own `permission` handler
+      // when it starts, but local mode can also exit for good. Leave a no-op
+      // rather than a handler closing over disposed state, matching how this
+      // launcher retires `abort` and `switch`.
+      session.client.rpcHandlerManager.registerHandler(
+        "permission",
+        async () => {},
+      );
+    },
+  };
+}

--- a/packages/happy-cli/src/claude/utils/pendingQuestion.test.ts
+++ b/packages/happy-cli/src/claude/utils/pendingQuestion.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
+import { findPendingQuestion } from "./pendingQuestion";
+import { getProjectPath } from "./path";
+
+const SESSION_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+/** One transcript line carrying an AskUserQuestion tool call. */
+const ask = (toolUseId: string, question: string) =>
+  JSON.stringify({
+    type: "assistant",
+    uuid: `u-${toolUseId}`,
+    message: {
+      content: [
+        {
+          type: "tool_use",
+          id: toolUseId,
+          name: "AskUserQuestion",
+          input: { questions: [{ question, header: "H", options: [] }] },
+        },
+      ],
+    },
+  });
+
+/** The tool_result that closes one out. `isError` covers the ESC-interrupt case. */
+const result = (toolUseId: string, isError = false) =>
+  JSON.stringify({
+    type: "user",
+    uuid: `r-${toolUseId}`,
+    message: {
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          is_error: isError,
+          content: isError ? "The user doesn't want to proceed" : "answered",
+        },
+      ],
+    },
+  });
+
+describe("findPendingQuestion", () => {
+  let workingDir: string;
+  let configDir: string;
+  let projectDir: string;
+  let prevConfigDir: string | undefined;
+
+  const writeTranscript = (lines: string[]) =>
+    writeFile(join(projectDir, `${SESSION_ID}.jsonl`), lines.join("\n") + "\n");
+
+  beforeEach(async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    workingDir = join(tmpdir(), `pq-work-${unique}`);
+    await mkdir(workingDir, { recursive: true });
+
+    // Isolate CLAUDE_CONFIG_DIR before deriving the project path, since
+    // getProjectPath() reads it — otherwise these tests write into the
+    // developer's real ~/.claude/projects.
+    configDir = join(tmpdir(), `pq-config-${unique}`);
+    prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+
+    projectDir = getProjectPath(workingDir);
+    await mkdir(projectDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (prevConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+    }
+    for (const dir of [workingDir, configDir]) {
+      if (existsSync(dir)) {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("finds an unresolved question and returns its raw input", async () => {
+    await writeTranscript([ask("toolu_1", "Which storage?")]);
+
+    const pending = await findPendingQuestion(workingDir, SESSION_ID);
+    expect(pending?.toolUseId).toBe("toolu_1");
+    expect((pending?.input as any).questions[0].question).toBe(
+      "Which storage?",
+    );
+  });
+
+  it("ignores a question that was answered", async () => {
+    await writeTranscript([
+      ask("toolu_1", "Which storage?"),
+      result("toolu_1"),
+    ]);
+
+    expect(await findPendingQuestion(workingDir, SESSION_ID)).toBeNull();
+  });
+
+  // An ESC interrupt still writes a tool_result, just with is_error set. Claude
+  // is no longer blocked, so this must not be reported as open — otherwise the
+  // phone would offer to answer something that was already abandoned.
+  it("ignores a question the user interrupted with ESC", async () => {
+    await writeTranscript([
+      ask("toolu_1", "Which storage?"),
+      result("toolu_1", true),
+    ]);
+
+    expect(await findPendingQuestion(workingDir, SESSION_ID)).toBeNull();
+  });
+
+  // This is the case that decides the whole design. A transcript can carry an
+  // orphan tool_use with no result that the session simply moved past — two of
+  // three real orphans measured were like this, with 86 and 4047 further
+  // entries written after them. That is why the status file, not this function,
+  // decides whether a question is still open: on its own, "last unresolved" is
+  // the best available guess, and it must not be treated as proof.
+  it("returns the most recent unresolved question, not an older orphan", async () => {
+    await writeTranscript([
+      ask("toolu_stale", "An abandoned question"),
+      ask("toolu_answered", "Answered later"),
+      result("toolu_answered"),
+      ask("toolu_current", "The one Claude is blocked on"),
+    ]);
+
+    const pending = await findPendingQuestion(workingDir, SESSION_ID);
+    expect(pending?.toolUseId).toBe("toolu_current");
+  });
+
+  it("returns null when the transcript does not exist yet", async () => {
+    expect(await findPendingQuestion(workingDir, SESSION_ID)).toBeNull();
+  });
+
+  it("survives a partially written final line", async () => {
+    await writeFile(
+      join(projectDir, `${SESSION_ID}.jsonl`),
+      ask("toolu_1", "Which storage?") + '\n{"message":{"content":[{"typ',
+    );
+
+    const pending = await findPendingQuestion(workingDir, SESSION_ID);
+    expect(pending?.toolUseId).toBe("toolu_1");
+  });
+
+  it("ignores tool calls that are not AskUserQuestion", async () => {
+    await writeTranscript([
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "tool_use", id: "toolu_bash", name: "Bash", input: {} },
+          ],
+        },
+      }),
+    ]);
+
+    expect(await findPendingQuestion(workingDir, SESSION_ID)).toBeNull();
+  });
+});

--- a/packages/happy-cli/src/claude/utils/pendingQuestion.ts
+++ b/packages/happy-cli/src/claude/utils/pendingQuestion.ts
@@ -1,0 +1,122 @@
+/**
+ * Finds the question a local Claude Code session is currently blocked on.
+ *
+ * In local mode Happy never sees tool calls as they happen — Claude runs as a
+ * separate binary in the terminal, so there is no `canUseTool` hook to
+ * intercept. The transcript is the only record of what was asked.
+ *
+ * The transcript alone cannot say whether a question is *still* open, though.
+ * An `AskUserQuestion` that was answered gets a `tool_result`, and one the user
+ * ESC-interrupted gets one too (`is_error: true`) — but a session that simply
+ * moved on can leave a `tool_use` with no result at all. Measured over a day of
+ * real transcripts, two of three such orphans were stale: the session had
+ * written 86 and 4047 further entries past them. Treating "no tool_result" as
+ * "waiting" would therefore misjudge most of them, and a question published on
+ * that basis would never be withdrawn.
+ *
+ * So liveness is decided elsewhere — by the session status file, which reports
+ * `waiting` + `waitingFor: "input needed"` and discards leftovers from dead
+ * processes (see claudeStatusWatcher). This module answers only the second
+ * question: *which* question is open. Callers must read it when that status
+ * flips, not on a timer, both because it is the wrong authority and because
+ * this reads the whole transcript, which can be very large.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { logger } from "@/ui/logger";
+import { getProjectPath } from "./path";
+
+/** One question as Claude Code writes it into the tool input. */
+export interface PendingQuestionAsked {
+  /** Provider tool-use id, which the app joins its answer card to. */
+  toolUseId: string;
+  /** Raw `AskUserQuestion` input, forwarded to the app unchanged. */
+  input: Record<string, unknown>;
+}
+
+interface ToolUseBlock {
+  type?: unknown;
+  id?: unknown;
+  name?: unknown;
+  input?: unknown;
+  tool_use_id?: unknown;
+}
+
+const ASK_USER_QUESTION = "AskUserQuestion";
+
+/**
+ * Read the transcript for `sessionId` and return the last `AskUserQuestion`
+ * that has no `tool_result`, or null when there is none.
+ *
+ * "Last" matters: a session can accumulate several answered questions, and only
+ * the most recent unresolved one can be the one Claude is blocked on now.
+ */
+export async function findPendingQuestion(
+  workingDirectory: string,
+  sessionId: string,
+): Promise<PendingQuestionAsked | null> {
+  const file = join(getProjectPath(workingDirectory), `${sessionId}.jsonl`);
+  let raw: string;
+  try {
+    raw = await readFile(file, "utf-8");
+  } catch {
+    // No transcript yet (Claude Code writes it lazily on the first prompt), or
+    // it is unreadable. Either way there is no question to forward.
+    return null;
+  }
+
+  const asked = new Map<string, Record<string, unknown>>();
+  const resolved = new Set<string>();
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    let parsed: { message?: { content?: unknown } };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // A partially flushed final line is normal while Claude is writing.
+      continue;
+    }
+    const content = parsed.message?.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const block of content as ToolUseBlock[]) {
+      if (
+        block?.type === "tool_use" &&
+        block.name === ASK_USER_QUESTION &&
+        typeof block.id === "string" &&
+        block.input !== null &&
+        typeof block.input === "object"
+      ) {
+        asked.set(block.id, block.input as Record<string, unknown>);
+      } else if (
+        block?.type === "tool_result" &&
+        typeof block.tool_use_id === "string"
+      ) {
+        // Counts whether the answer succeeded or the user interrupted with ESC
+        // (`is_error: true`): either way Claude is no longer blocked on it.
+        resolved.add(block.tool_use_id);
+      }
+    }
+  }
+
+  // Map iteration is insertion-ordered, so the last unresolved entry is the
+  // most recent one in the file.
+  let pending: PendingQuestionAsked | null = null;
+  for (const [toolUseId, input] of asked) {
+    if (!resolved.has(toolUseId)) {
+      pending = { toolUseId, input };
+    }
+  }
+
+  if (!pending) {
+    logger.debug(
+      `[PendingQuestion] status says a question is open but none is unresolved in ${sessionId}`,
+    );
+  }
+  return pending;
+}


### PR DESCRIPTION
> **Stacked on #1639.** The first commit here is that PR; this one is only `feat(cli): surface a local-mode question…`. It extends the `claudeStatusWatcher.ts` introduced there, so it cannot stand alone. Review or merge #1639 first and this rebases to a single commit.

## Summary

When Claude asks a question in local mode, the phone cannot answer it. Two halves, one cause:

1. **The session list shows it as merely online.** `sessionUtils.ts:24` derives "needs attention" from `agentState.requests` alone, and nothing populates that in local mode — so a session blocked on a question is indistinguishable from an idle one.
2. **Opening the session renders the answer sheet, but Submit sends nothing.** `AskUserQuestionView.tsx:243` only calls `sessionAllow` when `tool.permission?.id` exists, and `tool.permission` is derived from `agentState.requests`. The guard silently does not fire. Worse, `setIsSubmitted(true)` runs first, so the form disables itself and looks like it succeeded.

The cause is structural, not a regression. Permission interception runs through the SDK's `canUseTool`, so `permissionHandler` is wired only into `claudeRemoteLauncher`; local mode drives the real `claude` binary in a PTY, where no such hook exists. `git log -S permissionHandler -- claudeLocalLauncher.ts` is empty — this was never connected.

This publishes the open question into `agentState.requests` and registers the `permission` RPC in local mode. Both halves are fixed by the same change, and have to be: that map is the only input the status derives from, and populating it is also what makes Submit live. Doing one without the other would upgrade a dead button into a credible-looking one.

## Proof

Real local-mode session. Question opens, phone answers 30s later, control hands off, work resumes:

```
[01:45:28.304] [ClaudeStatusWatcher] status=waiting → thinking=false
[01:45:28.305] [ClaudeStatusWatcher] status=waiting waitingFor=input needed → waitingForInput=true
[01:45:28.306] [LocalQuestion] publishing toolu_bdrk_014A3G689JhDro7DQLmwYNUr
[01:45:58.030] [LocalQuestion] withdrawing toolu_bdrk_014A3G689JhDro7DQLmwYNUr: answered
[01:45:58.032] [LocalQuestion] answer enqueued, handing off to remote
[01:45:58.457] [loop] Iteration with mode: remote
[01:46:39.499] [ClaudeStatusWatcher] status=busy → thinking=true
```

The same log also covers answering in the terminal instead — the question is withdrawn rather than left published on the phone:

```
[02:41:32.222] [LocalQuestion] publishing toolu_bdrk_014MTEN3w71ssqDBosSU1ogM
[02:41:42.244] [LocalQuestion] withdrawing toolu_bdrk_014MTEN3w71ssqDBosSU1ogM: no longer waiting
```

Verified end to end on my own machine — orange dot on the list, answer sheet submits, session resumes with the answer. `823 tests passed (85 files)`, including 7 new cases for the transcript lookup; `tsc --noEmit` and `pnpm --filter happy build` clean.

## The semantic cost, stated plainly

**The answer is not returned as a `tool_result`.** That would require being inside the tool call, which is exactly what local mode is not. It is enqueued as a user message, which the queue's existing `onMessage` handler turns into the same handoff to remote mode a user performs by hand today when they type into the app to take over.

So the turn is interrupted rather than resumed, and Claude reads the answer as text rather than as the tool's result. That is a real difference from remote mode and the reason this is framed as *surfacing* the question rather than as full support for it. It is also strictly better than the status quo, where the answer is discarded.

## Why the status file decides liveness, not the transcript

The transcript says *which* question was asked; it cannot say whether one is still open. An answered `AskUserQuestion` gets a `tool_result`, an ESC interrupt gets one too (`is_error`), but a session that simply moved on leaves an orphan `tool_use` behind. Across a day of real transcripts, **two of three orphans were stale** — the session had written 86 and 4047 further entries past them. Publishing on that basis would misjudge most of them, and the question would never be withdrawn.

So `status: waiting` + `waitingFor: "input needed"` decides whether a question is open, and the transcript only supplies which one. That also inherits the liveness arbitration from #1639, so a question dies with the process that asked it.

## Why `requests` and not `agentState.communications`

The newer `communications` channel from 80cc6ac6 looks like the natural home, and I did not use it for two concrete reasons: nothing anywhere produces it (`grep -rn communications packages/happy-cli/src` → zero), and the session-list state does not read it (`sessionUtils.ts:24` looks at `requests` only), so routing through it would leave the list showing "online". Happy to move to it if you would rather add a producer and teach the list about it — that is a larger change than this PR.

## Notes

Enqueueing needs the live `EnhancedMode`, so it is threaded from `runClaude` through `loop` onto `Session`. The queue keys its batches by a hash of that mode; a hardcoded default would resume with a different model than the user selected.

Every path that clears `thinking` also withdraws the question — session change, missing status file, shutdown — because a published question that is no longer open leaves the phone offering to answer something Claude has stopped waiting for. Transcript reads are generation-guarded so a fast open/close flip cannot publish after the withdraw.

## Relationship to existing issues and PRs

- **#654** reported exactly this from the user side, quoting the *"Permissions shown in terminal only"* banner — which renders only when `agentState.controlledByUser` is set, i.e. only in local mode. It was closed as completed, but only the remote-mode path (#317, #995) was ever built; the local case the report describes is what this fixes.
- **#1388** covers the queued-message → handoff path this delivers the answer through.
- **#1406** would route remote sessions through the interactive runtime. If that direction is taken, the "local mode has no interception point" premise changes, and this should be revisited alongside it.
- **#1547 / #1502** forward `--permission-mode` to the local `claude` process — different goal (let local Claude decide) but they touch `claudeLocalLauncher.ts`, `loop.ts` and `session.ts`, so mechanical conflicts are likely whichever lands first.

## Scope

`happy-cli` only. Two new modules plus wiring, and a `getEnhancedMode` passthrough on `Session`/`loop`/`runClaude`. No app, server, protocol or wire-format changes — it writes a field the app already reads and answers an RPC the app already sends.
