### PR TITLE
fix(app): resolve stale Android agent selection

### DIFF
--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -42,6 +42,7 @@ import { useImagePicker } from '@/hooks/useImagePicker';
 import { Modal } from '@/modal';
 import { resolveMultiTextInputLayout } from './multiTextInputLayout';
 import { resolveCustomProjectPathSelection } from './homeDockInteraction';
+import { resolveMachineAgent } from '@/utils/newSessionAgentSelection';
 import {
     MOBILE_COMPOSER_LAYOUT,
     MOBILE_COMPOSER_METRICS,
@@ -573,9 +574,9 @@ export const HomeDock = React.memo(({
                 : { ...agent, disabled: true, description: 'Not installed on this machine' }
         ));
     }, [selectedMachine]);
-    const installedAgents = React.useMemo(
-        () => availableAgents.filter((agent) => !agent.disabled),
-        [availableAgents],
+    const resolvedAgentType = resolveMachineAgent(
+        agentType,
+        selectedMachine?.metadata?.cliAvailability,
     );
     const defaults = React.useMemo(
         () => resolveAgentDefaultConfig(defaultOverrides, agentType),
@@ -758,10 +759,10 @@ export const HomeDock = React.memo(({
     }, [defaultOverrides, setAgentType, setEffortLevel, setModelMode, setPermissionMode]);
 
     React.useEffect(() => {
-        if (installedAgents.length > 0 && !installedAgents.some((agent) => agent.key === agentType)) {
-            selectAgent(installedAgents[0].key as NewSessionAgentType);
+        if (resolvedAgentType !== agentType) {
+            selectAgent(resolvedAgentType);
         }
-    }, [agentType, installedAgents, selectAgent]);
+    }, [agentType, resolvedAgentType, selectAgent]);
 
     type SettingsRow = {
         page: string;

--- a/packages/happy-app/sources/hooks/useStartSessionFromDraft.test.ts
+++ b/packages/happy-app/sources/hooks/useStartSessionFromDraft.test.ts
@@ -1,7 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-    machines: [] as Array<{ id: string; online: boolean; metadata?: { homeDir?: string } }>,
+    machines: [] as Array<{
+        id: string;
+        online: boolean;
+        metadata?: {
+            homeDir?: string;
+            cliAvailability?: Partial<Record<'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy', boolean>>;
+        };
+    }>,
     defaultOverrides: {},
     draft: null as any,
     navigateToSession: vi.fn(),
@@ -26,7 +33,10 @@ vi.mock('@/sync/storage', () => ({
 }));
 
 vi.mock('@/sync/agentDefaults', () => ({
-    resolveAgentDefaultConfig: () => ({
+    resolveAgentDefaultConfig: (
+        overrides: Record<string, unknown>,
+        agentType: string,
+    ) => overrides[agentType] ?? ({
         permissionMode: 'default',
         modelMode: 'default',
         effortLevel: null,
@@ -70,6 +80,7 @@ vi.mock('@/utils/worktree', () => ({
 vi.mock('@/components/modelModeOptions', () => ({
     getHardcodedPermissionModes: () => [
         { key: 'default', name: 'Default' },
+        { key: 'safe-yolo', name: 'Safe YOLO' },
         { key: 'yolo', name: 'YOLO' },
     ],
     getHardcodedModelModes: () => [
@@ -115,6 +126,7 @@ function createDraft(overrides: Record<string, unknown> = {}) {
 describe('useStartSessionFromDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mocks.defaultOverrides = {};
         mocks.machines = [{ id: 'machine-1', online: true, metadata: { homeDir: '/Users/dev' } }];
         mocks.draft = createDraft();
         mocks.machineSpawnNewSession.mockResolvedValue({ type: 'success', sessionId: 'session-1' });
@@ -148,6 +160,45 @@ describe('useStartSessionFromDraft', () => {
         );
         expect(mocks.navigateToSession.mock.invocationCallOrder[0])
             .toBeLessThan(mocks.sendMessage.mock.invocationCallOrder[0]);
+    });
+
+    it('does not spawn a stale Claude draft when the machine only has Codex', async () => {
+        mocks.defaultOverrides = {
+            codex: {
+                permissionMode: 'safe-yolo',
+                modelMode: 'default',
+                effortLevel: 'medium',
+            },
+        };
+        mocks.machines = [{
+            id: 'machine-1',
+            online: true,
+            metadata: {
+                homeDir: '/Users/dev',
+                cliAvailability: {
+                    claude: false,
+                    codex: true,
+                    gemini: false,
+                    openclaw: false,
+                },
+            },
+        }];
+        mocks.draft = createDraft({
+            agentType: 'claude',
+            permissionMode: 'yolo',
+            modelMode: 'opus',
+        });
+
+        const { startSession } = useStartSessionFromDraft();
+
+        await expect(startSession()).resolves.toBe(true);
+
+        expect(mocks.machineSpawnNewSession).toHaveBeenCalledWith(expect.objectContaining({
+            agent: 'codex',
+            permissionMode: 'safe-yolo',
+            modelMode: undefined,
+            effortLevel: 'medium',
+        }));
     });
 
     it('retries creation after the user approves a new directory', async () => {

--- a/packages/happy-app/sources/hooks/useStartSessionFromDraft.ts
+++ b/packages/happy-app/sources/hooks/useStartSessionFromDraft.ts
@@ -15,6 +15,7 @@ import {
 } from '@/components/modelModeOptions';
 import { Modal } from '@/modal';
 import { t } from '@/text';
+import { resolveMachineAgent } from '@/utils/newSessionAgentSelection';
 
 function resolveOption<T extends { key: string }>(
     options: T[],
@@ -49,18 +50,32 @@ export function useStartSessionFromDraft() {
             return false;
         }
 
-        const defaults = resolveAgentDefaultConfig(defaultOverrides, draft.agentType);
+        // The draft survives machine changes and app upgrades. Resolve it again
+        // at launch time so a stale Claude selection cannot spawn Claude while
+        // the selected machine only reports Codex (the Android 1.7.0 regression).
+        const agentType = resolveMachineAgent(
+            draft.agentType,
+            machine.metadata?.cliAvailability,
+        );
+        const agentChanged = agentType !== draft.agentType;
+        const defaults = resolveAgentDefaultConfig(defaultOverrides, agentType);
         const permission = resolveOption(
-            getHardcodedPermissionModes(draft.agentType, t),
-            [draft.permissionMode, defaults.permissionMode],
+            getHardcodedPermissionModes(agentType, t),
+            agentChanged
+                ? [defaults.permissionMode]
+                : [draft.permissionMode, defaults.permissionMode],
         );
         const model = resolveOption(
-            getHardcodedModelModes(draft.agentType, t),
-            [draft.modelMode, defaults.modelMode],
+            getHardcodedModelModes(agentType, t),
+            agentChanged
+                ? [defaults.modelMode]
+                : [draft.modelMode, defaults.modelMode],
         );
         const effort = resolveOption(
-            getEffortLevelsForModel(draft.agentType, model?.key ?? 'default'),
-            [draft.effortLevel, defaults.effortLevel],
+            getEffortLevelsForModel(agentType, model?.key ?? 'default'),
+            agentChanged
+                ? [defaults.effortLevel]
+                : [draft.effortLevel, defaults.effortLevel],
         );
         if (!permission || !model) {
             Modal.alert(t('common.error'), 'The selected agent configuration is unavailable');
@@ -95,8 +110,8 @@ export function useStartSessionFromDraft() {
                     machineId: machine.id,
                     directory: spawnDirectory,
                     approvedNewDirectoryCreation,
-                    agent: draft.agentType,
-                    permissionMode: draft.agentType === 'codex' || permission.key !== 'default'
+                    agent: agentType,
+                    permissionMode: agentType === 'codex' || permission.key !== 'default'
                         ? permission.key
                         : undefined,
                     modelMode: model.key !== 'default' ? model.key : undefined,

--- a/packages/happy-app/sources/utils/newSessionAgentSelection.test.ts
+++ b/packages/happy-app/sources/utils/newSessionAgentSelection.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMachineAgent } from './newSessionAgentSelection';
+
+describe('resolveMachineAgent', () => {
+    it('replaces a stale Claude draft with the installed Codex CLI', () => {
+        expect(resolveMachineAgent('claude', {
+            claude: false,
+            codex: true,
+            openclaw: false,
+            gemini: false,
+        })).toBe('codex');
+    });
+
+    it('keeps an installed selection', () => {
+        expect(resolveMachineAgent('codex', {
+            claude: true,
+            codex: true,
+        })).toBe('codex');
+    });
+
+    it('keeps the persisted selection when capability metadata is missing', () => {
+        expect(resolveMachineAgent('claude', undefined)).toBe('claude');
+    });
+
+    it('keeps the persisted selection when no CLI is reported', () => {
+        expect(resolveMachineAgent('claude', {
+            claude: false,
+            codex: false,
+            openclaw: false,
+            gemini: false,
+        })).toBe('claude');
+    });
+});

--- a/packages/happy-app/sources/utils/newSessionAgentSelection.ts
+++ b/packages/happy-app/sources/utils/newSessionAgentSelection.ts
@@ -1,0 +1,27 @@
+import type { NewSessionAgentType } from '@/sync/persistence';
+
+export const NEW_SESSION_AGENT_ORDER: readonly NewSessionAgentType[] = [
+    'claude',
+    'codex',
+    'openclaw',
+    'gemini',
+    'agy',
+];
+
+type CliAvailability = Partial<Record<NewSessionAgentType, boolean>>;
+
+/**
+ * Keep the persisted selection when it is still installed. If it is stale,
+ * use the first CLI the selected machine actually reports as available.
+ * Older machines without capability metadata retain the persisted selection.
+ */
+export function resolveMachineAgent(
+    selectedAgent: NewSessionAgentType,
+    availability: CliAvailability | null | undefined,
+): NewSessionAgentType {
+    if (!availability || availability[selectedAgent]) {
+        return selectedAgent;
+    }
+
+    return NEW_SESSION_AGENT_ORDER.find((agent) => availability[agent]) ?? selectedAgent;
+}


### PR DESCRIPTION
## Summary

- normalize persisted agent selections against the selected machine's reported CLI availability
- revalidate the agent immediately before spawning a session so a stale Claude draft cannot launch Claude when only Codex is installed
- reset permission, model, and effort to the resolved agent's defaults when falling back
- add regression coverage for the Android 1.7.0 scenario

## Testing

- `pnpm --filter happy-app test --run` (860 tests)
- `pnpm --filter happy-app typecheck`

Fixes #1635
Related: #1618