### PR TITLE
feat: create and manage native Rig sessions in Happy

### DIFF
--- a/packages/happy-app/sources/app/(app)/machine/[id].tsx
+++ b/packages/happy-app/sources/app/(app)/machine/[id].tsx
@@ -562,6 +562,17 @@ export default function MachineDetailScreen() {
                                 </Text>
                             }
                         />
+                        {metadata.cliAvailability.rig !== undefined && (
+                            <Item
+                                title="Rig"
+                                showChevron={false}
+                                rightElement={
+                                    <Text style={{ color: metadata.cliAvailability.rig ? '#34C759' : theme.colors.textSecondary, fontSize: 14 }}>
+                                        {metadata.cliAvailability.rig ? t('machine.cliInstalled') : t('machine.cliNotFound')}
+                                    </Text>
+                                }
+                            />
+                        )}
                         <Item
                             title={t('machine.lastDetected')}
                             subtitle={new Date(metadata.cliAvailability.detectedAt).toLocaleString()}

--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -31,7 +31,6 @@ import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { KeyboardAvoidingView, KeyboardStickyView } from 'react-native-keyboard-controller';
 import Constants from 'expo-constants';
-import { randomUUID } from 'expo-crypto';
 import { useHeaderHeight } from '@/utils/responsive';
 import { t } from '@/text';
 import { useAllMachines, useLocalSetting, useSessions, useSetting, storage } from '@/sync/storage';
@@ -70,7 +69,14 @@ import { delay } from '@/utils/time';
 import {
     buildRigSpawnConfiguration,
     getRigMachineSessionCreation,
+    resolveRigPendingRetryDelayMs,
 } from '@/sync/rigSessionCreation';
+import {
+    buildSpawnRequestSignature,
+    completeSpawnRequest,
+    resolveSpawnRequestId,
+} from '@/sync/spawnRequestId';
+import { resolvePermissionStyle, resolveSelectedOption } from '@/utils/newSessionModeSelection';
 import { MobileGlassSurface } from '@/components/MobileGlass';
 import { getNativeGlassInteractivity } from '@/components/glassInteractionPolicy';
 import { BubblePressable } from '@/components/BubblePressable';
@@ -119,8 +125,6 @@ const NATIVE_PICKER_ESTIMATED_HEIGHT = 264;
 const MAX_RIG_PENDING_RESULTS = 3;
 const NATIVE_COMPOSER_RESERVED_HEIGHT = 98;
 
-type PermissionStyle = { color: string; icon: 'play-forward' | 'pause' };
-
 function findPreferredModeIndex<T extends { key: string }>(
     options: T[],
     preferredKeys: Array<string | null | undefined>,
@@ -159,26 +163,6 @@ function normalizePathForComparison(path: string | null | undefined, homeDir?: s
         return null;
     }
     return trimTrailingPathSeparator(resolveAbsolutePath(trimmed, homeDir));
-}
-
-function getPermissionStyle(key: string): PermissionStyle | null {
-    switch (key) {
-        case 'acceptEdits':
-        case 'auto_edit':
-            return { color: '#A78BFA', icon: 'play-forward' };
-        case 'plan':
-            return { color: '#5EABA4', icon: 'pause' };
-        case 'dontAsk':
-        case 'safe-yolo':
-            return { color: '#FBBF24', icon: 'play-forward' };
-        case 'bypassPermissions':
-        case 'yolo':
-            return { color: '#F87171', icon: 'play-forward' };
-        case 'read-only':
-            return { color: '#60A5FA', icon: 'pause' };
-        default:
-            return null;
-    }
 }
 
 // Bottom sheet modal — native formSheet on iOS, slide-up sheet on Android
@@ -950,7 +934,7 @@ function NewSessionScreen() {
         [selectedAgent, rigCreation],
     );
 
-    const currentModel = modelModes[modelIndex] ?? modelModes[0];
+    const currentModel = resolveSelectedOption(modelModes, modelIndex);
     const currentModelKey = currentModel?.key ?? 'default';
 
     const effortLevels = React.useMemo<EffortLevel[]>(
@@ -1073,9 +1057,11 @@ function NewSessionScreen() {
 
     const isOffline = selectedMachine ? !isMachineOnline(selectedMachine) : false;
     const agent = availableAgents.find(a => a.key === selectedAgent) ?? ALL_AGENTS[0];
-    const currentPermission = permissionModes[permissionIndex] ?? permissionModes[0];
-    const currentEffort = effortLevels[effortIndex] ?? effortLevels[0];
-    const permissionStyle = currentPermission?.key !== 'default' ? getPermissionStyle(currentPermission.key) : null;
+    // A Rig machine can publish an empty catalog, so every current pick is
+    // nullable — the composer hides the picker instead of rendering a pick.
+    const currentPermission = resolveSelectedOption(permissionModes, permissionIndex);
+    const currentEffort = resolveSelectedOption(effortLevels, effortIndex);
+    const permissionStyle = resolvePermissionStyle(currentPermission);
     const composerSettingsItems = React.useMemo(() => {
         const items: Array<{
             key: ComposerSettingPickerType;
@@ -1274,7 +1260,6 @@ function NewSessionScreen() {
     // Spawn session handler
     const handleSend = React.useCallback(async (
         approvedNewDirectoryCreation: boolean = false,
-        clientRequestId: string = randomUUID(),
     ) => {
         if (!selectedMachineId || !selectedMachine) {
             Modal.alert(t('common.error'), 'Please select a machine');
@@ -1289,6 +1274,21 @@ function NewSessionScreen() {
         try {
             const pathToUse = trimPathInput(selectedPath) || '~';
             const absolutePath = resolveAbsolutePath(pathToUse, selectedMachine.metadata?.homeDir);
+            const permissionKey = currentPermission?.key ?? null;
+            // Same key for every retry of this request (directory approval,
+            // pending polling, or the user pressing Start again) so Rig dedupes
+            // instead of spawning a second session. Built from what the user
+            // picked, not from the resolved worktree path, so retrying a "new
+            // worktree" spawn still lands on the session Rig already created.
+            const clientRequestId = resolveSpawnRequestId(buildSpawnRequestSignature({
+                machineId: selectedMachineId,
+                agent: selectedAgent,
+                directory: pathToUse,
+                worktree: supportsWorktree ? worktreeKey : '__none__',
+                modelKey: currentModelKey,
+                permissionMode: permissionKey,
+                effort: currentEffort?.key ?? null,
+            }));
 
             // Handle worktree selection
             let spawnDirectory = absolutePath;
@@ -1312,7 +1312,7 @@ function NewSessionScreen() {
                         clientRequestId,
                         approvedNewDirectoryCreation,
                         modelKey: currentModelKey,
-                        permissionMode: currentPermission.key,
+                        permissionMode: permissionKey,
                         effort: currentEffort?.key,
                     }),
                 }
@@ -1324,7 +1324,9 @@ function NewSessionScreen() {
                     // For codex, 'default' is a concrete ask-first mode (the codex
                     // launch default is yolo) — it must be forwarded. For other
                     // agents 'default' is the ambient no-override value.
-                    permissionMode: selectedAgent === 'codex' || currentPermission.key !== 'default' ? currentPermission.key : undefined,
+                    permissionMode: permissionKey && (selectedAgent === 'codex' || permissionKey !== 'default')
+                        ? permissionKey
+                        : undefined,
                     modelMode: currentModelKey !== 'default' ? currentModelKey : undefined,
                     effortLevel: currentEffort?.key,
                 };
@@ -1332,7 +1334,10 @@ function NewSessionScreen() {
             let pendingResults = 0;
             while (result.type === 'pending' && pendingResults < MAX_RIG_PENDING_RESULTS) {
                 pendingResults += 1;
-                await delay(Math.min(10_000, Math.max(250, result.retryAfterMs)));
+                await delay(resolveRigPendingRetryDelayMs(
+                    result.retryAfterMs,
+                    rigCreation?.pendingRetryAfterMs,
+                ));
                 if (!isMountedRef.current) return;
                 result = await machineSpawnNewSession(spawnOptions);
             }
@@ -1340,13 +1345,15 @@ function NewSessionScreen() {
 
             switch (result.type) {
                 case 'success':
+                    // The idempotency key did its job; the next Start is a new session.
+                    completeSpawnRequest();
                     await sync.refreshSessions();
 
                     // Store only per-session overrides. Matching the effective
                     // default stays null so future code default changes apply.
-                    const permissionOverride = currentPermission.key === effectiveAgentDefaults.permissionMode
+                    const permissionOverride = permissionKey === effectiveAgentDefaults.permissionMode
                         ? null
-                        : currentPermission.key;
+                        : permissionKey;
                     const modelOverride = currentModelKey === effectiveAgentDefaults.modelMode
                         ? null
                         : currentModelKey;
@@ -1391,7 +1398,9 @@ function NewSessionScreen() {
                         { cancelText: t('common.cancel'), confirmText: t('common.create') },
                     );
                     if (approved) {
-                        await handleSend(true, clientRequestId);
+                        // The request is unchanged, so the retry resolves to the
+                        // same clientRequestId.
+                        await handleSend(true);
                     }
                     break;
                 }
@@ -1413,7 +1422,7 @@ function NewSessionScreen() {
         } finally {
             if (isMountedRef.current) setIsSpawning(false);
         }
-    }, [selectedMachineId, selectedMachine, selectedPath, selectedAgent, router, navigateToSession, currentPermission.key, currentModelKey, currentEffort?.key, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.effortLevel, worktreeKey, rigCreation, supportsWorktree]);
+    }, [selectedMachineId, selectedMachine, selectedPath, selectedAgent, router, navigateToSession, currentPermission?.key, currentModelKey, currentEffort?.key, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.effortLevel, worktreeKey, rigCreation, supportsWorktree]);
 
     const canSend = selectedMachineId && selectedMachine && isMachineOnline(selectedMachine) && !isSpawning;
     React.useEffect(() => {
@@ -1708,7 +1717,7 @@ function NewSessionScreen() {
                                                 <Text style={[styles.configLabel, { color: theme.colors.textSecondary }]}>·</Text>
                                                 <BubblePressable scaleFeedback={false} onPress={() => togglePicker('model')} style={(p) => [styles.configInlineField, p.pressed && styles.configRowPressed]}>
                                                     <Text style={[styles.configLabel, styles.configInlineText, { color: theme.colors.textSecondary }]} numberOfLines={1}>
-                                                        {currentModel.name}
+                                                        {currentModel?.name}
                                                     </Text>
                                                     <Ionicons name="chevron-down" size={12} color={theme.colors.textSecondary} />
                                                 </BubblePressable>

--- a/packages/happy-app/sources/app/(app)/new/index.tsx
+++ b/packages/happy-app/sources/app/(app)/new/index.tsx
@@ -31,6 +31,7 @@ import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { KeyboardAvoidingView, KeyboardStickyView } from 'react-native-keyboard-controller';
 import Constants from 'expo-constants';
+import { randomUUID } from 'expo-crypto';
 import { useHeaderHeight } from '@/utils/responsive';
 import { t } from '@/text';
 import { useAllMachines, useLocalSetting, useSessions, useSetting, storage } from '@/sync/storage';
@@ -65,6 +66,11 @@ import {
     resolvePickerToggleAction,
 } from '@/utils/newSessionPickerInteraction';
 import { resolveAgentDefaultConfig } from '@/sync/agentDefaults';
+import { delay } from '@/utils/time';
+import {
+    buildRigSpawnConfiguration,
+    getRigMachineSessionCreation,
+} from '@/sync/rigSessionCreation';
 import { MobileGlassSurface } from '@/components/MobileGlass';
 import { getNativeGlassInteractivity } from '@/components/glassInteractionPolicy';
 import { BubblePressable } from '@/components/BubblePressable';
@@ -78,6 +84,7 @@ import {
 
 // Agent icon assets
 const agentIcons = {
+    rig: require('@/assets/images/icon-rig.png'),
     claude: require('@/assets/images/icon-claude.png'),
     codex: require('@/assets/images/icon-gpt.png'),
     openclaw: require('@/assets/images/icon-openclaw.png'),
@@ -87,6 +94,7 @@ const agentIcons = {
 
 type AgentKey = NewSessionAgentType;
 const ALL_AGENTS: { key: AgentKey; label: string }[] = [
+    { key: 'rig', label: 'rig' },
     { key: 'claude', label: 'claude code' },
     { key: 'codex', label: 'codex' },
     { key: 'openclaw', label: 'openclaw' },
@@ -108,6 +116,7 @@ const NATIVE_PICKER_TOP: Record<PickerType, number> = {
     worktree: 144,
 };
 const NATIVE_PICKER_ESTIMATED_HEIGHT = 264;
+const MAX_RIG_PENDING_RESULTS = 3;
 const NATIVE_COMPOSER_RESERVED_HEIGHT = 98;
 
 type PermissionStyle = { color: string; icon: 'play-forward' | 'pause' };
@@ -788,10 +797,14 @@ function NewSessionScreen() {
     const [mobileConfigHeight, setMobileConfigHeight] = React.useState(0);
     const [nativePickerMeasuredHeight, setNativePickerMeasuredHeight] = React.useState<number | null>(null);
     const autoSubmitStartedRef = React.useRef(false);
+    const isMountedRef = React.useRef(true);
     const composerInputRef = React.useRef<import('@/components/MultiTextInput').MultiTextInputHandle>(null);
     const pendingPickerRef = React.useRef<PickerType | null>(null);
     const pickerKeyboardSubscriptionRef = React.useRef<ReturnType<typeof Keyboard.addListener> | null>(null);
     const pickerOpenTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    React.useEffect(() => () => {
+        isMountedRef.current = false;
+    }, []);
 
     // Config collapse — auto-collapses when typing, expands when empty
     const [isConfigExpanded, setIsConfigExpanded] = React.useState(true);
@@ -808,6 +821,14 @@ function NewSessionScreen() {
         () => allMachines.find(m => m.id === selectedMachineId) ?? null,
         [allMachines, selectedMachineId],
     );
+    const selectedRigCreation = React.useMemo(
+        () => getRigMachineSessionCreation(selectedMachine?.metadata),
+        [selectedMachine?.metadata],
+    );
+    const rigCreation = selectedAgent === 'rig' ? selectedRigCreation : null;
+    const supportsWorktree = selectedMachine?.metadata?.rigOnly === true
+        ? selectedRigCreation?.supportsWorktrees ?? false
+        : rigCreation?.supportsWorktrees ?? getSupportsWorktree(selectedAgent);
     const selectedHomeDir = selectedMachine?.metadata?.homeDir;
 
     // Build machine picker items: online first, then offline
@@ -874,7 +895,7 @@ function NewSessionScreen() {
     // Fetch existing worktrees from the selected machine/path
     const [worktreeItems, setWorktreeItems] = React.useState<PickerItem[]>([]);
     React.useEffect(() => {
-        if (!selectedMachineId || !debouncedResolvedSelectedPath) {
+        if (!supportsWorktree || !selectedMachineId || !debouncedResolvedSelectedPath) {
             setWorktreeItems([]);
             return;
         }
@@ -892,7 +913,7 @@ function NewSessionScreen() {
             })));
         });
         return () => { cancelled = true; };
-    }, [debouncedResolvedSelectedPath, selectedMachineId, selectedMachine]);
+    }, [debouncedResolvedSelectedPath, selectedMachineId, selectedMachine, supportsWorktree]);
 
     React.useEffect(() => {
         if (worktreeKey === '__none__' || worktreeKey === '__new__') {
@@ -907,9 +928,10 @@ function NewSessionScreen() {
     // Filter available agents based on CLI availability from machine metadata
     const availableAgents = React.useMemo(() => {
         const availability = selectedMachine?.metadata?.cliAvailability;
-        if (!availability) return ALL_AGENTS;
-        return ALL_AGENTS.filter(a => availability[a.key]);
-    }, [selectedMachine]);
+        return ALL_AGENTS.filter((agent) => agent.key === 'rig'
+            ? selectedRigCreation !== null
+            : !availability || availability[agent.key]);
+    }, [selectedMachine, selectedRigCreation]);
 
     // If current agent not available on this machine, switch to first available
     React.useEffect(() => {
@@ -920,26 +942,32 @@ function NewSessionScreen() {
 
     // Derive options from agent type
     const permissionModes = React.useMemo<PermissionMode[]>(
-        () => getHardcodedPermissionModes(selectedAgent, t),
-        [selectedAgent],
+        () => rigCreation?.permissionModes ?? getHardcodedPermissionModes(selectedAgent, t),
+        [selectedAgent, rigCreation],
     );
     const modelModes = React.useMemo<ModelMode[]>(
-        () => getHardcodedModelModes(selectedAgent, t),
-        [selectedAgent],
+        () => rigCreation?.models ?? getHardcodedModelModes(selectedAgent, t),
+        [selectedAgent, rigCreation],
     );
 
     const currentModel = modelModes[modelIndex] ?? modelModes[0];
     const currentModelKey = currentModel?.key ?? 'default';
 
     const effortLevels = React.useMemo<EffortLevel[]>(
-        () => getEffortLevelsForModel(selectedAgent, currentModelKey),
-        [selectedAgent, currentModelKey],
+        () => rigCreation
+            ? rigCreation.effortsForModel(currentModelKey).map((key) => ({ key, name: key }))
+            : getEffortLevelsForModel(selectedAgent, currentModelKey),
+        [selectedAgent, currentModelKey, rigCreation],
     );
-    const effectiveAgentDefaults = React.useMemo(() => (
-        resolveAgentDefaultConfig(agentDefaultOverrides, selectedAgent)
-    ), [agentDefaultOverrides, selectedAgent]);
-
-    const supportsWorktree = getSupportsWorktree(selectedAgent);
+    const effectiveAgentDefaults = React.useMemo(() => rigCreation
+        ? {
+            permissionMode: rigCreation.defaultPermissionMode ?? '',
+            modelMode: rigCreation.defaultModelKey ?? '',
+            effortLevel: rigCreation.defaultEffortForModel(rigCreation.defaultModelKey),
+        }
+        : resolveAgentDefaultConfig(agentDefaultOverrides, selectedAgent), [agentDefaultOverrides, selectedAgent, rigCreation]);
+    const effectiveEffortDefault = rigCreation?.defaultEffortForModel(currentModelKey)
+        ?? effectiveAgentDefaults.effortLevel;
     const showModel = modelModes.length > 1;
     const showEffort = effortLevels.length > 0;
     const showPermission = permissionModes.length > 1;
@@ -975,9 +1003,9 @@ function NewSessionScreen() {
         }
         setEffortIndex(findPreferredModeIndex(effortLevels, [
             draft.effortLevel,
-            effectiveAgentDefaults.effortLevel,
+            effectiveEffortDefault,
         ]));
-    }, [draft.effortLevel, effectiveAgentDefaults.effortLevel, currentModelKey, effortLevels]);
+    }, [draft.effortLevel, effectiveEffortDefault, currentModelKey, effortLevels]);
 
     // The reference keeps the context controls visible while the keyboard is
     // open. Preserve that on mobile and let users collapse them explicitly.
@@ -1244,7 +1272,10 @@ function NewSessionScreen() {
     }, [composerSettingsPage, draft.setEffortLevel, draft.setModelMode, draft.setPermissionMode, effortLevels, modelModes, permissionModes]);
 
     // Spawn session handler
-    const handleSend = React.useCallback(async (approvedNewDirectoryCreation: boolean = false) => {
+    const handleSend = React.useCallback(async (
+        approvedNewDirectoryCreation: boolean = false,
+        clientRequestId: string = randomUUID(),
+    ) => {
         if (!selectedMachineId || !selectedMachine) {
             Modal.alert(t('common.error'), 'Please select a machine');
             return;
@@ -1261,30 +1292,51 @@ function NewSessionScreen() {
 
             // Handle worktree selection
             let spawnDirectory = absolutePath;
-            if (worktreeKey === '__new__') {
+            if (supportsWorktree && worktreeKey === '__new__') {
                 const worktreeResult = await createWorktree(selectedMachineId, absolutePath);
                 if (!worktreeResult.success) {
                     Modal.alert(t('common.error'), worktreeResult.error || 'Failed to create worktree');
                     return;
                 }
                 spawnDirectory = worktreeResult.worktreePath;
-            } else if (worktreeKey !== '__none__') {
+            } else if (supportsWorktree && worktreeKey !== '__none__') {
                 // Existing worktree — use its path directly
                 spawnDirectory = worktreeKey;
             }
 
-            const result = await machineSpawnNewSession({
-                machineId: selectedMachineId,
-                directory: spawnDirectory,
-                approvedNewDirectoryCreation,
-                agent: selectedAgent,
-                // For codex, 'default' is a concrete ask-first mode (the codex
-                // launch default is yolo) — it must be forwarded. For other
-                // agents 'default' is the ambient no-override value.
-                permissionMode: selectedAgent === 'codex' || currentPermission.key !== 'default' ? currentPermission.key : undefined,
-                modelMode: currentModelKey !== 'default' ? currentModelKey : undefined,
-                effortLevel: currentEffort?.key,
-            });
+            const spawnOptions = rigCreation
+                ? {
+                    machineId: selectedMachineId,
+                    ...buildRigSpawnConfiguration(selectedMachine.metadata, {
+                        directory: spawnDirectory,
+                        clientRequestId,
+                        approvedNewDirectoryCreation,
+                        modelKey: currentModelKey,
+                        permissionMode: currentPermission.key,
+                        effort: currentEffort?.key,
+                    }),
+                }
+                : {
+                    machineId: selectedMachineId,
+                    directory: spawnDirectory,
+                    approvedNewDirectoryCreation,
+                    agent: selectedAgent,
+                    // For codex, 'default' is a concrete ask-first mode (the codex
+                    // launch default is yolo) — it must be forwarded. For other
+                    // agents 'default' is the ambient no-override value.
+                    permissionMode: selectedAgent === 'codex' || currentPermission.key !== 'default' ? currentPermission.key : undefined,
+                    modelMode: currentModelKey !== 'default' ? currentModelKey : undefined,
+                    effortLevel: currentEffort?.key,
+                };
+            let result = await machineSpawnNewSession(spawnOptions);
+            let pendingResults = 0;
+            while (result.type === 'pending' && pendingResults < MAX_RIG_PENDING_RESULTS) {
+                pendingResults += 1;
+                await delay(Math.min(10_000, Math.max(250, result.retryAfterMs)));
+                if (!isMountedRef.current) return;
+                result = await machineSpawnNewSession(spawnOptions);
+            }
+            if (!isMountedRef.current) return;
 
             switch (result.type) {
                 case 'success':
@@ -1305,12 +1357,14 @@ function NewSessionScreen() {
                     // Mode picks sync via session metadata (#1492). Nothing to
                     // push when they match the defaults — a fresh session has
                     // no picks in its metadata yet.
-                    const modesPatch: SessionAgentModesPatch = {};
-                    if (permissionOverride !== null) modesPatch.permissionMode = permissionOverride;
-                    if (modelOverride !== null) modesPatch.modelMode = modelOverride;
-                    if (effortOverride !== null) modesPatch.effortLevel = effortOverride;
-                    if (Object.keys(modesPatch).length > 0) {
-                        sessionSetAgentModes(result.sessionId, modesPatch);
+                    if (!rigCreation) {
+                        const modesPatch: SessionAgentModesPatch = {};
+                        if (permissionOverride !== null) modesPatch.permissionMode = permissionOverride;
+                        if (modelOverride !== null) modesPatch.modelMode = modelOverride;
+                        if (effortOverride !== null) modesPatch.effortLevel = effortOverride;
+                        if (Object.keys(modesPatch).length > 0) {
+                            sessionSetAgentModes(result.sessionId, modesPatch);
+                        }
                     }
 
                     // Pull live prompt and clear it. We read via getState() so this
@@ -1337,12 +1391,18 @@ function NewSessionScreen() {
                         { cancelText: t('common.cancel'), confirmText: t('common.create') },
                     );
                     if (approved) {
-                        await handleSend(true);
+                        await handleSend(true, clientRequestId);
                     }
                     break;
                 }
                 case 'error':
                     Modal.alert(t('common.error'), result.errorMessage);
+                    break;
+                case 'pending':
+                    Modal.alert(
+                        t('common.error'),
+                        'Rig created the session, but it is still syncing with Happy. It should appear shortly.',
+                    );
                     break;
             }
         } catch (error) {
@@ -1351,9 +1411,9 @@ function NewSessionScreen() {
                 : 'Failed to start session';
             Modal.alert(t('common.error'), errorMessage);
         } finally {
-            setIsSpawning(false);
+            if (isMountedRef.current) setIsSpawning(false);
         }
-    }, [selectedMachineId, selectedMachine, selectedPath, selectedAgent, router, navigateToSession, currentPermission.key, currentModelKey, currentEffort?.key, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.effortLevel, worktreeKey]);
+    }, [selectedMachineId, selectedMachine, selectedPath, selectedAgent, router, navigateToSession, currentPermission.key, currentModelKey, currentEffort?.key, effectiveAgentDefaults.permissionMode, effectiveAgentDefaults.modelMode, effectiveAgentDefaults.effortLevel, worktreeKey, rigCreation, supportsWorktree]);
 
     const canSend = selectedMachineId && selectedMachine && isMachineOnline(selectedMachine) && !isSpawning;
     React.useEffect(() => {

--- a/packages/happy-app/sources/components/EmptyMainScreen.tsx
+++ b/packages/happy-app/sources/components/EmptyMainScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, Platform } from 'react-native';
+import { View, Text, Platform, Pressable } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Typography } from '@/constants/Typography';
 import { RoundButton } from '@/components/RoundButton';
 import { useConnectTerminal } from '@/hooks/useConnectTerminal';
@@ -82,8 +83,22 @@ const stylesheet = StyleSheet.create((theme) => ({
         width: 240,
         marginBottom: 12,
     },
-    buttonWrapperSecondary: {
-        width: 240,
+    manualUrlButton: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 7,
+        minHeight: 40,
+        paddingHorizontal: 14,
+        borderRadius: 20,
+    },
+    manualUrlButtonPressed: {
+        backgroundColor: theme.colors.surfacePressedOverlay,
+    },
+    manualUrlButtonText: {
+        fontSize: 15,
+        color: theme.colors.textSecondary,
+        ...Typography.default('semiBold'),
     },
 }));
 
@@ -91,6 +106,21 @@ export function EmptyMainScreen() {
     const { connectTerminal, connectWithUrl, isLoading } = useConnectTerminal();
     const { theme } = useUnistyles();
     const styles = stylesheet;
+    const enterUrlManually = React.useCallback(async () => {
+        const url = await Modal.prompt(
+            t('modals.authenticateTerminal'),
+            t('modals.pasteUrlFromTerminal'),
+            {
+                placeholder: 'happy://terminal?...',
+                cancelText: t('common.cancel'),
+                confirmText: t('common.authenticate'),
+            },
+        );
+
+        if (url?.trim()) {
+            connectWithUrl(url.trim());
+        }
+    }, [connectWithUrl]);
 
     return (
         <View style={styles.container}>
@@ -143,28 +173,20 @@ export function EmptyMainScreen() {
                                 onPress={connectTerminal}
                             />
                         </View>
-                        <View style={styles.buttonWrapperSecondary}>
-                            <RoundButton
-                                title={t('connect.enterUrlManually')}
-                                size="normal"
-                                display="inverted"
-                                onPress={async () => {
-                                    const url = await Modal.prompt(
-                                        t('modals.authenticateTerminal'),
-                                        t('modals.pasteUrlFromTerminal'),
-                                        {
-                                            placeholder: 'happy://terminal?...',
-                                            cancelText: t('common.cancel'),
-                                            confirmText: t('common.authenticate')
-                                        }
-                                    );
-
-                                    if (url?.trim()) {
-                                        connectWithUrl(url.trim());
-                                    }
-                                }}
-                            />
-                        </View>
+                        <Pressable
+                            onPress={enterUrlManually}
+                            accessibilityRole="button"
+                            accessibilityLabel={t('connect.enterUrlManually')}
+                            style={({ pressed }) => [
+                                styles.manualUrlButton,
+                                pressed && styles.manualUrlButtonPressed,
+                            ]}
+                        >
+                            <Ionicons name="link-outline" size={17} color={theme.colors.textSecondary} />
+                            <Text style={styles.manualUrlButtonText}>
+                                {t('connect.enterUrlManually')}
+                            </Text>
+                        </Pressable>
                     </View>
                 </>
             )}

--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -43,11 +43,17 @@ import { Modal } from '@/modal';
 import { resolveMultiTextInputLayout } from './multiTextInputLayout';
 import { resolveCustomProjectPathSelection } from './homeDockInteraction';
 import { resolveMachineAgent } from '@/utils/newSessionAgentSelection';
+import { findConnectedRigMachine, getRigMachineSessionCreation } from '@/sync/rigSessionCreation';
+import {
+    MobileHeaderScrim,
+    MOBILE_STRONG_HEADER_SCRIM_RESTING_OPACITY,
+} from './navigation/MobileHeaderScrim';
 import {
     MOBILE_COMPOSER_LAYOUT,
     MOBILE_COMPOSER_METRICS,
     resolveMobileComposerActionGeometry,
     resolveMobileComposerActionRowGeometry,
+    resolveMobileCollapsedComposerGeometry,
     resolveMobileComposerHeight,
     resolveMobileComposerMenuGeometry,
 } from './agentInputLayout';
@@ -60,6 +66,7 @@ type AgentSetting = 'agent' | 'model' | 'permission' | 'effort';
 const CUSTOM_PROJECT_PATH_KEY = '__custom_project_path__';
 
 const AGENTS: Array<{ key: NewSessionAgentType; name: string }> = [
+    { key: 'rig', name: 'Rig' },
     { key: 'claude', name: 'Claude Code' },
     { key: 'codex', name: 'Codex' },
     { key: 'openclaw', name: 'OpenClaw' },
@@ -73,10 +80,16 @@ const MOBILE_EFFORT_MENU_GEOMETRY = resolveMobileComposerMenuGeometry('effort');
 const MOBILE_ACTION_ROW_GEOMETRY = resolveMobileComposerActionRowGeometry();
 const MOBILE_ICON_ACTION_GEOMETRY = resolveMobileComposerActionGeometry('icon');
 const MOBILE_PRIMARY_ACTION_GEOMETRY = resolveMobileComposerActionGeometry('primary');
+const MOBILE_COLLAPSED_COMPOSER_GEOMETRY = resolveMobileCollapsedComposerGeometry();
 
 const styles = StyleSheet.create((theme) => ({
     keyboardFollower: {
         width: '100%',
+    },
+    bottomBackdrop: {
+        ...StyleSheet.absoluteFillObject,
+        top: -36,
+        opacity: MOBILE_STRONG_HEADER_SCRIM_RESTING_OPACITY,
     },
     safeArea: {
         paddingHorizontal: 16,
@@ -85,9 +98,9 @@ const styles = StyleSheet.create((theme) => ({
     composerSurface: {
         width: '100%',
         maxWidth: layout.maxWidth,
-        height: 56,
+        height: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.shellHeight,
         alignSelf: 'center',
-        borderRadius: 28,
+        borderRadius: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.shellRadius,
         overflow: 'hidden',
         borderWidth: StyleSheet.hairlineWidth,
         borderColor: theme.colors.glass.border,
@@ -103,7 +116,8 @@ const styles = StyleSheet.create((theme) => ({
         flex: 1,
         flexDirection: 'row',
         alignItems: 'center',
-        paddingHorizontal: 7,
+        paddingLeft: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.contentPaddingLeft,
+        paddingRight: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.contentPaddingRight,
         gap: 4,
     },
     sideButton: MOBILE_ICON_ACTION_GEOMETRY,
@@ -114,7 +128,8 @@ const styles = StyleSheet.create((theme) => ({
         flex: 1,
         minWidth: 0,
         height: '100%',
-        paddingHorizontal: 4,
+        paddingLeft: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.inputPaddingLeft,
+        paddingRight: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.inputPaddingRight,
         paddingVertical: 0,
         color: theme.colors.text,
         fontSize: 17,
@@ -125,7 +140,8 @@ const styles = StyleSheet.create((theme) => ({
         minWidth: 0,
         height: '100%',
         justifyContent: 'center',
-        paddingHorizontal: 4,
+        paddingLeft: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.inputPaddingLeft,
+        paddingRight: MOBILE_COLLAPSED_COMPOSER_GEOMETRY.inputPaddingRight,
     },
     inputEntryText: {
         color: theme.colors.text,
@@ -421,11 +437,13 @@ export const HomeDock = React.memo(({
     onPromptChange,
     onSubmit,
     isSubmitting,
+    showBottomBackdrop = true,
 }: {
     prompt: string;
     onPromptChange: (prompt: string) => void;
     onSubmit: () => Promise<boolean>;
     isSubmitting: boolean;
+    showBottomBackdrop?: boolean;
 }) => {
     const { theme } = useUnistyles();
     const safeArea = useSafeAreaInsets();
@@ -507,7 +525,25 @@ export const HomeDock = React.memo(({
         });
     }, [selectedMachine, selectedMachineId, selectedPath, sessions]);
     const currentProject = resolveOption(projectOptions, [selectedPath, '~']);
-    const supportsWorktree = getSupportsWorktree(agentType);
+    const selectedRigCreation = React.useMemo(
+        () => getRigMachineSessionCreation(selectedMachine?.metadata),
+        [selectedMachine?.metadata],
+    );
+    const connectedRigMachine = React.useMemo(
+        () => findConnectedRigMachine(machines),
+        [machines],
+    );
+    const selectedRigIsConnected = selectedRigCreation !== null
+        && selectedMachine !== null
+        && isMachineOnline(selectedMachine);
+    const rigSelectionMachine = selectedRigIsConnected ? selectedMachine : connectedRigMachine;
+    const rigSelectionCreation = selectedRigIsConnected
+        ? selectedRigCreation
+        : getRigMachineSessionCreation(connectedRigMachine?.metadata);
+    const rigCreation = agentType === 'rig' ? rigSelectionCreation : null;
+    const supportsWorktree = selectedMachine?.metadata?.rigOnly === true
+        ? selectedRigCreation?.supportsWorktrees ?? false
+        : rigCreation?.supportsWorktrees ?? getSupportsWorktree(agentType);
     const selectedWorktreeKey = sessionType === 'worktree'
         ? worktreeKey ?? '__new__'
         : '__none__';
@@ -568,35 +604,52 @@ export const HomeDock = React.memo(({
     // otherwise leaves a single checked row that looks like it does nothing.
     const availableAgents = React.useMemo<ModeOption[]>(() => {
         const availability = selectedMachine?.metadata?.cliAvailability;
-        return AGENTS.map((agent) => (
-            !availability || availability[agent.key]
+        return AGENTS.map((agent) => {
+            const available = agent.key === 'rig'
+                ? rigSelectionMachine !== null
+                : !availability || availability[agent.key];
+            return available
                 ? agent
-                : { ...agent, disabled: true, description: 'Not installed on this machine' }
-        ));
-    }, [selectedMachine]);
-    const resolvedAgentType = resolveMachineAgent(
-        agentType,
-        selectedMachine?.metadata?.cliAvailability,
-    );
-    const defaults = React.useMemo(
-        () => resolveAgentDefaultConfig(defaultOverrides, agentType),
-        [agentType, defaultOverrides],
-    );
+                : {
+                    ...agent,
+                    disabled: true,
+                    description: agent.key === 'rig'
+                        ? 'Select a connected Rig machine'
+                        : 'Not installed on this machine',
+                };
+        });
+    }, [rigSelectionMachine, selectedMachine]);
+    const resolvedAgentType = agentType === 'rig' && !rigSelectionMachine
+        ? (availableAgents.find((agent) => !agent.disabled && agent.key !== 'rig')?.key as NewSessionAgentType | undefined) ?? agentType
+        : agentType === 'rig'
+            ? agentType
+            : resolveMachineAgent(agentType, selectedMachine?.metadata?.cliAvailability);
+    const defaults = React.useMemo(() => rigCreation
+        ? {
+            permissionMode: rigCreation.defaultPermissionMode ?? '',
+            modelMode: rigCreation.defaultModelKey ?? '',
+            effortLevel: rigCreation.defaultEffortForModel(rigCreation.defaultModelKey),
+        }
+        : resolveAgentDefaultConfig(defaultOverrides, agentType), [agentType, defaultOverrides, rigCreation]);
     const permissionOptions = React.useMemo(
-        () => getHardcodedPermissionModes(agentType, t),
-        [agentType],
+        () => rigCreation?.permissionModes ?? getHardcodedPermissionModes(agentType, t),
+        [agentType, rigCreation],
     );
     const modelOptions = React.useMemo(
-        () => getHardcodedModelModes(agentType, t),
-        [agentType],
+        () => rigCreation?.models ?? getHardcodedModelModes(agentType, t),
+        [agentType, rigCreation],
     );
     const currentPermission = resolveOption(permissionOptions, [permissionMode, defaults.permissionMode]);
     const currentModel = resolveOption(modelOptions, [modelMode, defaults.modelMode]);
     const effortOptions = React.useMemo(
-        () => getEffortLevelsForModel(agentType, currentModel?.key ?? 'default'),
-        [agentType, currentModel?.key],
+        () => rigCreation
+            ? rigCreation.effortsForModel(currentModel?.key).map((key) => ({ key, name: key }))
+            : getEffortLevelsForModel(agentType, currentModel?.key ?? 'default'),
+        [agentType, currentModel?.key, rigCreation],
     );
-    const currentEffort = resolveOption(effortOptions, [effortLevel, defaults.effortLevel]);
+    const currentEffortDefault = rigCreation?.defaultEffortForModel(currentModel?.key)
+        ?? defaults.effortLevel;
+    const currentEffort = resolveOption(effortOptions, [effortLevel, currentEffortDefault]);
     const currentAgent = availableAgents.find((agent) => agent.key === agentType) ?? availableAgents[0] ?? AGENTS[0];
     const canSubmit = !isSubmitting && (
         prompt.trim().length > 0 || (expImageUpload && selectedImages.length > 0)
@@ -751,12 +804,28 @@ export const HomeDock = React.memo(({
     }, [finishCloseFocusMode, focusPresentation]);
 
     const selectAgent = React.useCallback((agent: NewSessionAgentType) => {
-        const nextDefaults = resolveAgentDefaultConfig(defaultOverrides, agent);
+        const nextRigCreation = agent === 'rig' ? rigSelectionCreation : null;
+        const nextDefaults = nextRigCreation
+            ? {
+                permissionMode: nextRigCreation.defaultPermissionMode ?? '',
+                modelMode: nextRigCreation.defaultModelKey ?? '',
+                effortLevel: nextRigCreation.defaultEffortForModel(nextRigCreation.defaultModelKey),
+            }
+            : resolveAgentDefaultConfig(defaultOverrides, agent);
+        if (agent === 'rig' && rigSelectionMachine && rigSelectionMachine.id !== selectedMachineId) {
+            setMachineId(rigSelectionMachine.id);
+        }
         setAgentType(agent);
         setPermissionMode(nextDefaults.permissionMode);
         setModelMode(nextDefaults.modelMode);
         if (nextDefaults.effortLevel) setEffortLevel(nextDefaults.effortLevel);
-    }, [defaultOverrides, setAgentType, setEffortLevel, setModelMode, setPermissionMode]);
+    }, [defaultOverrides, rigSelectionCreation, rigSelectionMachine, selectedMachineId, setAgentType, setEffortLevel, setMachineId, setModelMode, setPermissionMode]);
+
+    React.useEffect(() => {
+        if (agentType === 'rig' && rigSelectionMachine && rigSelectionMachine.id !== selectedMachineId) {
+            setMachineId(rigSelectionMachine.id);
+        }
+    }, [agentType, rigSelectionMachine, selectedMachineId, setMachineId]);
 
     React.useEffect(() => {
         if (resolvedAgentType !== agentType) {
@@ -1168,6 +1237,11 @@ export const HomeDock = React.memo(({
                 pointerEvents="box-none"
                 style={[styles.keyboardFollower, keyboardStyle]}
             >
+                {showBottomBackdrop && (
+                    <View pointerEvents="none" style={styles.bottomBackdrop}>
+                        <MobileHeaderScrim variant="strong" edge="bottom" />
+                    </View>
+                )}
                 <View
                     pointerEvents="box-none"
                     style={[

--- a/packages/happy-app/sources/components/MainView.tsx
+++ b/packages/happy-app/sources/components/MainView.tsx
@@ -283,14 +283,14 @@ const HeaderRight = React.memo(({
     searchActive,
     onSearchPress,
     hasArchivedSessions,
-    hideInactiveSessions,
+    hideArchivedSessions,
     onArchiveVisibilityPress,
 }: {
     activeTab: ActiveTabType;
     searchActive: boolean;
     onSearchPress: () => void;
     hasArchivedSessions: boolean;
-    hideInactiveSessions: boolean;
+    hideArchivedSessions: boolean;
     onArchiveVisibilityPress: () => void;
 }) => {
     const router = useRouter();
@@ -316,18 +316,18 @@ const HeaderRight = React.memo(({
                     {hasArchivedSessions && !searchActive && (
                         <Pressable
                             onPress={onArchiveVisibilityPress}
-                            accessibilityLabel={hideInactiveSessions
+                            accessibilityLabel={hideArchivedSessions
                                 ? t('sidebar.showArchived')
                                 : t('sidebar.hideArchived')}
                             accessibilityRole="button"
-                            accessibilityState={{ selected: !hideInactiveSessions }}
+                            accessibilityState={{ selected: !hideArchivedSessions }}
                             style={[
                                 styles.headerActionButton,
-                                !hideInactiveSessions && styles.headerActionButtonActive,
+                                !hideArchivedSessions && styles.headerActionButtonActive,
                             ]}
                         >
                             <Ionicons
-                                name={hideInactiveSessions ? 'archive-outline' : 'archive'}
+                                name={hideArchivedSessions ? 'archive-outline' : 'archive'}
                                 size={20}
                                 color={theme.colors.header.tint}
                             />
@@ -349,18 +349,18 @@ const HeaderRight = React.memo(({
                 {hasArchivedSessions && (
                     <Pressable
                         onPress={onArchiveVisibilityPress}
-                        accessibilityLabel={hideInactiveSessions
+                        accessibilityLabel={hideArchivedSessions
                             ? t('sidebar.showArchived')
                             : t('sidebar.hideArchived')}
                         accessibilityRole="button"
-                        accessibilityState={{ selected: !hideInactiveSessions }}
+                        accessibilityState={{ selected: !hideArchivedSessions }}
                         style={[
                             styles.headerButton,
-                            !hideInactiveSessions && styles.headerActionButtonActive,
+                            !hideArchivedSessions && styles.headerActionButtonActive,
                         ]}
                     >
                         <Ionicons
-                            name={hideInactiveSessions ? 'archive-outline' : 'archive'}
+                            name={hideArchivedSessions ? 'archive-outline' : 'archive'}
                             size={19}
                             color={theme.colors.header.tint}
                         />
@@ -414,7 +414,9 @@ export const MainView = React.memo(({ variant }: MainViewProps) => {
     const { theme } = useUnistyles();
     const sessionListViewData = useVisibleSessionListViewData();
     const hasArchivedSessions = useHasArchivedSessions();
-    const [hideInactiveSessions, setHideInactiveSessions] = useSettingMutable('hideInactiveSessions');
+    // Stored under its original `hideInactiveSessions` key — synced settings
+    // have no rename migration — but it hides archived sessions only.
+    const [hideArchivedSessions, setHideArchivedSessions] = useSettingMutable('hideInactiveSessions');
     const isTablet = useIsTablet();
     const router = useRouter();
     const friendRequests = useFriendRequests();
@@ -465,8 +467,8 @@ export const MainView = React.memo(({ variant }: MainViewProps) => {
     }, []);
 
     const handleArchiveVisibilityPress = React.useCallback(() => {
-        setHideInactiveSessions(!hideInactiveSessions);
-    }, [hideInactiveSessions, setHideInactiveSessions]);
+        setHideArchivedSessions(!hideArchivedSessions);
+    }, [hideArchivedSessions, setHideArchivedSessions]);
 
     const handleTabPress = React.useCallback((tab: ActiveTabType) => {
         // This callback is intentionally independent of activeTab. Gesture
@@ -551,7 +553,7 @@ export const MainView = React.memo(({ variant }: MainViewProps) => {
                         searchActive={searchActive}
                         onSearchPress={handleSearchPress}
                         hasArchivedSessions={hasArchivedSessions}
-                        hideInactiveSessions={hideInactiveSessions}
+                        hideArchivedSessions={hideArchivedSessions}
                         onArchiveVisibilityPress={handleArchiveVisibilityPress}
                     />
                 ) : undefined}

--- a/packages/happy-app/sources/components/MainView.tsx
+++ b/packages/happy-app/sources/components/MainView.tsx
@@ -12,8 +12,8 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
-import { useFriendRequests, useSocketStatus, useRealtimeStatus } from '@/sync/storage';
-import { useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
+import { useFriendRequests, useSocketStatus, useRealtimeStatus, useSettingMutable } from '@/sync/storage';
+import { useHasArchivedSessions, useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
 import { useIsTablet } from '@/utils/responsive';
 import { useRouter } from 'expo-router';
 import { EmptySessionsTablet } from './EmptySessionsTablet';
@@ -151,6 +151,13 @@ const styles = StyleSheet.create((theme) => ({
         alignItems: 'center',
         justifyContent: 'center',
     },
+    headerActionButtonActive: {
+        width: 36,
+        height: 36,
+        marginHorizontal: 4,
+        borderRadius: 12,
+        backgroundColor: theme.colors.surfaceSelected,
+    },
     headerSearch: {
         width: '100%',
         height: 40,
@@ -275,10 +282,16 @@ const HeaderRight = React.memo(({
     activeTab,
     searchActive,
     onSearchPress,
+    hasArchivedSessions,
+    hideInactiveSessions,
+    onArchiveVisibilityPress,
 }: {
     activeTab: ActiveTabType;
     searchActive: boolean;
     onSearchPress: () => void;
+    hasArchivedSessions: boolean;
+    hideInactiveSessions: boolean;
+    onArchiveVisibilityPress: () => void;
 }) => {
     const router = useRouter();
     const { theme } = useUnistyles();
@@ -290,6 +303,8 @@ const HeaderRight = React.memo(({
                 <View style={styles.headerActions}>
                     <Pressable
                         onPress={onSearchPress}
+                        accessibilityLabel={t('tools.names.search')}
+                        accessibilityRole="button"
                         style={styles.headerActionButton}
                     >
                         <Ionicons
@@ -298,8 +313,30 @@ const HeaderRight = React.memo(({
                             color={theme.colors.header.tint}
                         />
                     </Pressable>
+                    {hasArchivedSessions && !searchActive && (
+                        <Pressable
+                            onPress={onArchiveVisibilityPress}
+                            accessibilityLabel={hideInactiveSessions
+                                ? t('sidebar.showArchived')
+                                : t('sidebar.hideArchived')}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: !hideInactiveSessions }}
+                            style={[
+                                styles.headerActionButton,
+                                !hideInactiveSessions && styles.headerActionButtonActive,
+                            ]}
+                        >
+                            <Ionicons
+                                name={hideInactiveSessions ? 'archive-outline' : 'archive'}
+                                size={20}
+                                color={theme.colors.header.tint}
+                            />
+                        </Pressable>
+                    )}
                     <Pressable
                         onPress={() => router.push('/settings')}
+                        accessibilityLabel={t('settings.title')}
+                        accessibilityRole="button"
                         style={styles.headerActionButton}
                     >
                         <Ionicons name="settings-outline" size={21} color={theme.colors.header.tint} />
@@ -308,13 +345,35 @@ const HeaderRight = React.memo(({
             );
         }
         return (
-            <Pressable
-                onPress={() => router.navigate('/new')}
-                hitSlop={15}
-                style={styles.headerButton}
-            >
-                <Ionicons name="add-outline" size={28} color={theme.colors.header.tint} />
-            </Pressable>
+            <View style={styles.headerActions}>
+                {hasArchivedSessions && (
+                    <Pressable
+                        onPress={onArchiveVisibilityPress}
+                        accessibilityLabel={hideInactiveSessions
+                            ? t('sidebar.showArchived')
+                            : t('sidebar.hideArchived')}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: !hideInactiveSessions }}
+                        style={[
+                            styles.headerButton,
+                            !hideInactiveSessions && styles.headerActionButtonActive,
+                        ]}
+                    >
+                        <Ionicons
+                            name={hideInactiveSessions ? 'archive-outline' : 'archive'}
+                            size={19}
+                            color={theme.colors.header.tint}
+                        />
+                    </Pressable>
+                )}
+                <Pressable
+                    onPress={() => router.navigate('/new')}
+                    hitSlop={15}
+                    style={styles.headerButton}
+                >
+                    <Ionicons name="add-outline" size={28} color={theme.colors.header.tint} />
+                </Pressable>
+            </View>
         );
     }
 
@@ -354,6 +413,8 @@ const HeaderRight = React.memo(({
 export const MainView = React.memo(({ variant }: MainViewProps) => {
     const { theme } = useUnistyles();
     const sessionListViewData = useVisibleSessionListViewData();
+    const hasArchivedSessions = useHasArchivedSessions();
+    const [hideInactiveSessions, setHideInactiveSessions] = useSettingMutable('hideInactiveSessions');
     const isTablet = useIsTablet();
     const router = useRouter();
     const friendRequests = useFriendRequests();
@@ -402,6 +463,10 @@ export const MainView = React.memo(({ variant }: MainViewProps) => {
             return !currentValue;
         });
     }, []);
+
+    const handleArchiveVisibilityPress = React.useCallback(() => {
+        setHideInactiveSessions(!hideInactiveSessions);
+    }, [hideInactiveSessions, setHideInactiveSessions]);
 
     const handleTabPress = React.useCallback((tab: ActiveTabType) => {
         // This callback is intentionally independent of activeTab. Gesture
@@ -485,6 +550,9 @@ export const MainView = React.memo(({ variant }: MainViewProps) => {
                         activeTab={activeTab}
                         searchActive={searchActive}
                         onSearchPress={handleSearchPress}
+                        hasArchivedSessions={hasArchivedSessions}
+                        hideInactiveSessions={hideInactiveSessions}
+                        onArchiveVisibilityPress={handleArchiveVisibilityPress}
                     />
                 ) : undefined}
                 headerLeft={() => <HeaderLogo />}
@@ -532,6 +600,7 @@ export const MainView = React.memo(({ variant }: MainViewProps) => {
                             onPromptChange={setHomePrompt}
                             onSubmit={handleHomePromptSubmit}
                             isSubmitting={isStartingHomeSession}
+                            showBottomBackdrop={sessionListViewData !== null && sessionListViewData.length > 0}
                         />
                     )}
                 </View>

--- a/packages/happy-app/sources/components/ProjectGroup.tsx
+++ b/packages/happy-app/sources/components/ProjectGroup.tsx
@@ -13,9 +13,8 @@ interface ProjectGroupProps {
 }
 
 /**
- * A Rig project and every git worktree inside it, shown together the way Rig
- * itself groups them. Sessions from the Happy CLI never reach this component —
- * they keep the flat, date-grouped list.
+ * One project and its sessions. Rig projects may contain named worktrees;
+ * Happy CLI projects use a single workspace derived from their working path.
  */
 export const ProjectGroup = React.memo(({ project, selectedSessionId }: ProjectGroupProps) => {
     const styles = stylesheet;

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -21,7 +21,6 @@ import { layout } from './layout';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
 import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
-import { useSettingMutable } from '@/sync/storage';
 import { t } from '@/text';
 import { SessionShortcutHintBadge } from './ShortcutHints';
 import { ProviderIcon } from './ProviderIcon';
@@ -187,24 +186,6 @@ const stylesheet = StyleSheet.create((theme) => ({
         paddingBottom: 12,
         backgroundColor: Platform.select({ web: theme.colors.groupped.background, default: 'transparent' }),
     },
-    archiveToggle: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        paddingHorizontal: 24,
-        paddingVertical: 16,
-    },
-    archiveToggleLine: {
-        flex: 1,
-        height: StyleSheet.hairlineWidth,
-        backgroundColor: theme.colors.groupped.sectionTitle,
-        opacity: 0.3,
-    },
-    archiveToggleText: {
-        fontSize: 12,
-        color: theme.colors.textSecondary,
-        paddingHorizontal: 12,
-        ...Typography.default('semiBold'),
-    },
 }));
 
 export function SessionsList({
@@ -223,10 +204,6 @@ export function SessionsList({
     const sourceData = useVisibleSessionListViewData();
     const pathname = usePathname();
     const isTablet = useIsTablet();
-    const [hideInactiveSessions, setHideInactiveSessions] = useSettingMutable('hideInactiveSessions');
-    const toggleArchived = React.useCallback(() => {
-        setHideInactiveSessions(!hideInactiveSessions);
-    }, [hideInactiveSessions, setHideInactiveSessions]);
     // Selection is derived once from pathname so the data array stays stable
     // across navigations. This keeps FlatList virtualization intact: only
     // the previously- and newly-selected rows re-render, instead of the
@@ -255,10 +232,14 @@ export function SessionsList({
         // Projects nest their sessions inside worktrees, so they need a pass of
         // their own: the index walk below only ever sees flat `session` items.
         const keptProjects = new Map<number, SessionListViewItem>();
+        const keptProjectSources = new Set<'rig' | 'happy'>();
         sourceData.forEach((item, index) => {
             if (item.type !== 'project') return;
             const project = filterProjectGroup(item.project, normalizedQuery);
-            if (project) keptProjects.set(index, { ...item, project });
+            if (project) {
+                keptProjects.set(index, { ...item, project });
+                keptProjectSources.add(item.source);
+            }
         });
 
         const keepIndices = new Set<number>();
@@ -290,7 +271,7 @@ export function SessionsList({
                 return;
             }
             if (item.type === 'projects-header') {
-                if (keptProjects.size > 0) result.push(item);
+                if (keptProjectSources.has(item.source)) result.push(item);
                 return;
             }
             if (item.type === 'project') {
@@ -314,9 +295,8 @@ export function SessionsList({
         switch (item.type) {
             case 'header': return `header-${item.title}-${index}`;
             case 'active-sessions': return 'active-sessions';
-            case 'archive-toggle': return 'archive-toggle';
             case 'project-group': return `project-group-${item.machine.id}-${item.displayPath}-${index}`;
-            case 'projects-header': return 'projects-header';
+            case 'projects-header': return `projects-header-${item.source}`;
             case 'project': return `project-${item.project.id}`;
             case 'session': return `session-${item.session.id}`;
         }
@@ -333,17 +313,6 @@ export function SessionsList({
                     </View>
                 );
 
-            case 'archive-toggle':
-                return (
-                    <Pressable style={styles.archiveToggle} onPress={toggleArchived}>
-                        <View style={styles.archiveToggleLine} />
-                        <Text style={styles.archiveToggleText}>
-                            {item.hidden ? t('sidebar.showArchived') : t('sidebar.hideArchived')}
-                        </Text>
-                        <View style={styles.archiveToggleLine} />
-                    </Pressable>
-                );
-
             case 'active-sessions':
                 return (
                     <ActiveSessionsGroupCompact
@@ -356,7 +325,7 @@ export function SessionsList({
                 return (
                     <View style={styles.headerSection}>
                         <Text style={styles.headerText}>
-                            {t('sidebar.projects')}
+                            {item.source === 'rig' ? 'Rig' : t('sidebar.sessionsTitle')}
                         </Text>
                     </View>
                 );
@@ -401,7 +370,7 @@ export function SessionsList({
                     />
                 );
         }
-    }, [selectedSessionId, data, toggleArchived]);
+    }, [selectedSessionId, data]);
 
 
     // Remove this section as we'll use FlatList for all items now

--- a/packages/happy-app/sources/components/SidebarView.tsx
+++ b/packages/happy-app/sources/components/SidebarView.tsx
@@ -93,15 +93,17 @@ export const SidebarView = React.memo(() => {
     const headerHeight = useHeaderHeight();
     const realtimeStatus = useRealtimeStatus();
     const hasArchivedSessions = useHasArchivedSessions();
-    const [hideInactiveSessions, setHideInactiveSessions] = useSettingMutable('hideInactiveSessions');
+    // Stored under its original `hideInactiveSessions` key — synced settings
+    // have no rename migration — but it hides archived sessions only.
+    const [hideArchivedSessions, setHideArchivedSessions] = useSettingMutable('hideInactiveSessions');
     const { visible: shortcutHintsVisible } = useShortcutHints();
 
     const handleNewSession = React.useCallback(() => {
         router.navigate('/new');
     }, [router]);
     const handleArchiveVisibility = React.useCallback(() => {
-        setHideInactiveSessions(!hideInactiveSessions);
-    }, [hideInactiveSessions, setHideInactiveSessions]);
+        setHideArchivedSessions(!hideArchivedSessions);
+    }, [hideArchivedSessions, setHideArchivedSessions]);
 
     return (
         <View style={[styles.container, { paddingTop: safeArea.top + headerHeight }]}>
@@ -121,19 +123,19 @@ export const SidebarView = React.memo(() => {
                 {hasArchivedSessions && (
                     <Pressable
                         onPress={handleArchiveVisibility}
-                        accessibilityLabel={hideInactiveSessions
+                        accessibilityLabel={hideArchivedSessions
                             ? t('sidebar.showArchived')
                             : t('sidebar.hideArchived')}
                         accessibilityRole="button"
-                        accessibilityState={{ selected: !hideInactiveSessions }}
+                        accessibilityState={{ selected: !hideArchivedSessions }}
                         style={({ pressed }) => [
                             styles.archiveButton,
-                            !hideInactiveSessions && styles.archiveButtonActive,
+                            !hideArchivedSessions && styles.archiveButtonActive,
                             pressed && styles.newSessionButtonPressed,
                         ]}
                     >
                         <Ionicons
-                            name={hideInactiveSessions ? 'archive-outline' : 'archive'}
+                            name={hideArchivedSessions ? 'archive-outline' : 'archive'}
                             size={18}
                             color={stylesheet.newSessionText.color}
                         />

--- a/packages/happy-app/sources/components/SidebarView.tsx
+++ b/packages/happy-app/sources/components/SidebarView.tsx
@@ -4,13 +4,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useHeaderHeight } from '@/utils/responsive';
 import { VoiceAssistantStatusBar } from './VoiceAssistantStatusBar';
-import { useRealtimeStatus } from '@/sync/storage';
+import { useRealtimeStatus, useSettingMutable } from '@/sync/storage';
 import { MainView } from './MainView';
 import { StyleSheet } from 'react-native-unistyles';
 import { t } from '@/text';
 import { Ionicons } from '@expo/vector-icons';
 import { Typography } from '@/constants/Typography';
 import { ShortcutHintBadge, useShortcutHints } from './ShortcutHints';
+import { useHasArchivedSessions } from '@/hooks/useVisibleSessionListViewData';
 
 const stylesheet = StyleSheet.create((theme) => ({
     container: {
@@ -20,12 +21,18 @@ const stylesheet = StyleSheet.create((theme) => ({
         borderWidth: StyleSheet.hairlineWidth,
         borderColor: theme.colors.divider,
     },
-    newSessionButton: {
+    topControls: {
         flexDirection: 'row',
         alignItems: 'center',
         marginHorizontal: 16,
         marginTop: 8,
         marginBottom: 4,
+        gap: 8,
+    },
+    newSessionButton: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
         paddingVertical: 10,
         paddingHorizontal: 14,
         borderRadius: 10,
@@ -36,6 +43,19 @@ const stylesheet = StyleSheet.create((theme) => ({
     },
     newSessionButtonPressed: {
         backgroundColor: theme.colors.surfacePressed,
+    },
+    archiveButton: {
+        width: 40,
+        height: 40,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 10,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: theme.colors.divider,
+        backgroundColor: theme.colors.surface,
+    },
+    archiveButtonActive: {
+        backgroundColor: theme.colors.surfaceSelected,
     },
     shortcutTargetActive: {
         backgroundColor: theme.colors.surfacePressed,
@@ -72,27 +92,54 @@ export const SidebarView = React.memo(() => {
     const router = useRouter();
     const headerHeight = useHeaderHeight();
     const realtimeStatus = useRealtimeStatus();
+    const hasArchivedSessions = useHasArchivedSessions();
+    const [hideInactiveSessions, setHideInactiveSessions] = useSettingMutable('hideInactiveSessions');
     const { visible: shortcutHintsVisible } = useShortcutHints();
 
     const handleNewSession = React.useCallback(() => {
         router.navigate('/new');
     }, [router]);
+    const handleArchiveVisibility = React.useCallback(() => {
+        setHideInactiveSessions(!hideInactiveSessions);
+    }, [hideInactiveSessions, setHideInactiveSessions]);
 
     return (
         <View style={[styles.container, { paddingTop: safeArea.top + headerHeight }]}>
-            {/* New Session button */}
-            <Pressable
-                onPress={handleNewSession}
-                style={({ pressed }) => [
-                    styles.newSessionButton,
-                    shortcutHintsVisible && styles.shortcutTargetActive,
-                    pressed && styles.newSessionButtonPressed,
-                ]}
-            >
-                <Ionicons name="create-outline" size={16} color={stylesheet.newSessionText.color} />
-                <Text style={styles.newSessionText}>{t('sidebar.newSession')}</Text>
-                <ShortcutHintBadge shortcutKey="N" style={styles.shortcutBadgeInline} />
-            </Pressable>
+            <View style={styles.topControls}>
+                <Pressable
+                    onPress={handleNewSession}
+                    style={({ pressed }) => [
+                        styles.newSessionButton,
+                        shortcutHintsVisible && styles.shortcutTargetActive,
+                        pressed && styles.newSessionButtonPressed,
+                    ]}
+                >
+                    <Ionicons name="create-outline" size={16} color={stylesheet.newSessionText.color} />
+                    <Text style={styles.newSessionText}>{t('sidebar.newSession')}</Text>
+                    <ShortcutHintBadge shortcutKey="N" style={styles.shortcutBadgeInline} />
+                </Pressable>
+                {hasArchivedSessions && (
+                    <Pressable
+                        onPress={handleArchiveVisibility}
+                        accessibilityLabel={hideInactiveSessions
+                            ? t('sidebar.showArchived')
+                            : t('sidebar.hideArchived')}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: !hideInactiveSessions }}
+                        style={({ pressed }) => [
+                            styles.archiveButton,
+                            !hideInactiveSessions && styles.archiveButtonActive,
+                            pressed && styles.newSessionButtonPressed,
+                        ]}
+                    >
+                        <Ionicons
+                            name={hideInactiveSessions ? 'archive-outline' : 'archive'}
+                            size={18}
+                            color={stylesheet.newSessionText.color}
+                        />
+                    </Pressable>
+                )}
+            </View>
 
             {realtimeStatus !== 'disconnected' && (
                 <VoiceAssistantStatusBar variant="sidebar" />

--- a/packages/happy-app/sources/components/agentInputLayout.test.ts
+++ b/packages/happy-app/sources/components/agentInputLayout.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import * as agentInputLayout from './agentInputLayout';
 
-const { resolveAgentInputLayout } = agentInputLayout;
+const { resolveAgentInputLayout, resolveMobileCollapsedComposerGeometry } = agentInputLayout;
 
 describe('agent input compact mobile layout', () => {
     it('aligns composer text start with the left edge of the add glyph', () => {
@@ -40,6 +40,21 @@ describe('agent input compact mobile layout', () => {
         });
         expect((agentInputLayout as Record<string, unknown>).MOBILE_COMPOSER_BASE_HEIGHT).toBe(102);
         expect((agentInputLayout as Record<string, unknown>).MOBILE_COMPOSER_CHROME_HEIGHT).toBe(58);
+    });
+
+    it('starts collapsed composer text where the capsule becomes straight', () => {
+        const geometry = resolveMobileCollapsedComposerGeometry();
+
+        expect(geometry).toEqual({
+            shellHeight: 56,
+            shellRadius: 28,
+            contentPaddingLeft: 7,
+            contentPaddingRight: 7,
+            inputPaddingLeft: 21,
+            inputPaddingRight: 4,
+            textInset: 28,
+        });
+        expect(geometry.textInset).toBe(geometry.shellRadius);
     });
 
     it('matches the chat shell height while the input grows and attachments appear', () => {

--- a/packages/happy-app/sources/components/agentInputLayout.ts
+++ b/packages/happy-app/sources/components/agentInputLayout.ts
@@ -83,6 +83,39 @@ export interface MobileComposerMenuGeometry {
     content: MobileComposerGeometryStyle;
 }
 
+export interface MobileCollapsedComposerGeometry {
+    shellHeight: number;
+    shellRadius: number;
+    contentPaddingLeft: number;
+    contentPaddingRight: number;
+    inputPaddingLeft: number;
+    inputPaddingRight: number;
+    textInset: number;
+}
+
+/**
+ * Places collapsed-composer text at the tangent where the capsule's rounded
+ * end meets its straight edge, rather than halfway through the rounded end.
+ */
+export function resolveMobileCollapsedComposerGeometry(
+    shellHeight = 56,
+    contentPaddingHorizontal = 7,
+    inputPaddingRight = 4,
+): MobileCollapsedComposerGeometry {
+    const shellRadius = shellHeight / 2;
+    const inputPaddingLeft = shellRadius - contentPaddingHorizontal;
+
+    return {
+        shellHeight,
+        shellRadius,
+        contentPaddingLeft: contentPaddingHorizontal,
+        contentPaddingRight: contentPaddingHorizontal,
+        inputPaddingLeft,
+        inputPaddingRight,
+        textInset: contentPaddingHorizontal + inputPaddingLeft,
+    };
+}
+
 /**
  * Keeps the Expo native-menu host frame free of visual padding. Padding and
  * alignment belong exclusively to the visible React Native label inside it.

--- a/packages/happy-app/sources/components/navigation/MobileHeaderScrim.tsx
+++ b/packages/happy-app/sources/components/navigation/MobileHeaderScrim.tsx
@@ -6,6 +6,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useUnistyles } from 'react-native-unistyles';
 
 export type MobileHeaderScrimVariant = 'subtle' | 'strong';
+export type MobileHeaderScrimEdge = 'top' | 'bottom';
 
 // Shared by headers that keep a strong material visible at rest and deepen it
 // slightly as scrolling content moves underneath.
@@ -18,9 +19,17 @@ export const MOBILE_STRONG_HEADER_SCRIM_UNDERLAP_OPACITY = 0.96;
  * into a glass surface. The strong variant is used for the chat title, where
  * the text must stay readable without its own capsule.
  */
-export function MobileHeaderScrim({ variant = 'subtle' }: { variant?: MobileHeaderScrimVariant }) {
+export function MobileHeaderScrim({
+    variant = 'subtle',
+    edge = 'top',
+}: {
+    variant?: MobileHeaderScrimVariant;
+    edge?: MobileHeaderScrimEdge;
+}) {
     const { theme } = useUnistyles();
     const isStrong = variant === 'strong';
+    const gradientStart = edge === 'bottom' ? { x: 0.5, y: 1 } : { x: 0.5, y: 0 };
+    const gradientEnd = edge === 'bottom' ? { x: 0.5, y: 0 } : { x: 0.5, y: 1 };
     const strongBlurMaskColors = [
         'rgba(255, 255, 255, 1)',
         'rgba(255, 255, 255, 0.94)',
@@ -45,8 +54,8 @@ export function MobileHeaderScrim({ variant = 'subtle' }: { variant?: MobileHead
                     <LinearGradient
                         colors={blurMaskColors}
                         locations={isStrong ? [0, 0.20, 0.68, 1] : [0, 0.34, 0.7, 1]}
-                        start={{ x: 0.5, y: 0 }}
-                        end={{ x: 0.5, y: 1 }}
+                        start={gradientStart}
+                        end={gradientEnd}
                         style={styles.fill}
                     />
                 )}
@@ -69,8 +78,8 @@ export function MobileHeaderScrim({ variant = 'subtle' }: { variant?: MobileHead
                         ? ['rgba(255, 255, 255, 0.34)', 'rgba(255, 255, 255, 0.22)', 'rgba(255, 255, 255, 0.07)', 'rgba(255, 255, 255, 0)']
                         : ['rgba(255, 255, 255, 0.68)', 'rgba(255, 255, 255, 0.50)', 'rgba(255, 255, 255, 0.18)', 'rgba(255, 255, 255, 0)']}
                 locations={isStrong ? [0, 0.34, 0.80, 1] : [0, 0.34, 0.7, 1]}
-                start={{ x: 0.5, y: 0 }}
-                end={{ x: 0.5, y: 1 }}
+                start={gradientStart}
+                end={gradientEnd}
                 style={styles.fill}
             />
         </View>

--- a/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
+++ b/packages/happy-app/sources/hooks/useNewSessionDraft.test.ts
@@ -4,7 +4,7 @@ type Draft = {
     input: string;
     selectedMachineId: string | null;
     selectedPath: string | null;
-    agentType: 'claude' | 'codex' | 'gemini' | 'openclaw';
+    agentType: 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy' | 'rig';
     permissionMode: string | null;
     modelMode: string | null;
     effortLevel: string | null;

--- a/packages/happy-app/sources/hooks/useStartSessionFromDraft.test.ts
+++ b/packages/happy-app/sources/hooks/useStartSessionFromDraft.test.ts
@@ -4,10 +4,7 @@ const mocks = vi.hoisted(() => ({
     machines: [] as Array<{
         id: string;
         online: boolean;
-        metadata?: {
-            homeDir?: string;
-            cliAvailability?: Partial<Record<'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy', boolean>>;
-        };
+        metadata?: any;
     }>,
     defaultOverrides: {},
     draft: null as any,
@@ -19,12 +16,16 @@ const mocks = vi.hoisted(() => ({
     createWorktree: vi.fn(),
     alert: vi.fn(),
     confirm: vi.fn(),
+    delay: vi.fn(),
 }));
+
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'rig-request-1' }));
 
 vi.mock('react', () => ({
     useState: <T,>(value: T) => [value, vi.fn()] as const,
     useRef: <T,>(value: T) => ({ current: value }),
     useCallback: <T,>(callback: T) => callback,
+    useEffect: (effect: () => void | (() => void)) => { effect(); },
 }));
 
 vi.mock('@/sync/storage', () => ({
@@ -76,6 +77,8 @@ vi.mock('@/utils/pathUtils', () => ({
 vi.mock('@/utils/worktree', () => ({
     createWorktree: mocks.createWorktree,
 }));
+
+vi.mock('@/utils/time', () => ({ delay: mocks.delay }));
 
 vi.mock('@/components/modelModeOptions', () => ({
     getHardcodedPermissionModes: () => [
@@ -218,6 +221,122 @@ describe('useStartSessionFromDraft', () => {
             approvedNewDirectoryCreation: true,
         }));
         expect(mocks.navigateToSession).toHaveBeenCalledWith('session-2');
+    });
+
+    it('creates a Rig session from its machine catalog and retries pending idempotently', async () => {
+        mocks.machines = [{
+            id: 'machine-1',
+            online: true,
+            metadata: {
+                homeDir: '/Users/dev',
+                machineKind: 'rig',
+                rigOnly: true,
+                cliAvailability: {
+                    rig: true,
+                    claude: false,
+                    codex: false,
+                    gemini: false,
+                    openclaw: false,
+                    detectedAt: 1,
+                },
+                capabilities: { newSession: true, resume: false, worktrees: false },
+                defaults: {
+                    providerId: 'codex',
+                    modelId: 'gpt-5.6-sol',
+                    permissionMode: 'auto',
+                    effort: 'high',
+                },
+                models: [{
+                    providerId: 'codex',
+                    id: 'gpt-5.6-sol',
+                    name: 'GPT-5.6 Sol',
+                    providerName: 'OpenAI Codex',
+                    thinkingLevels: ['low', 'high'],
+                    defaultThinkingLevel: 'high',
+                }],
+                operatingModes: [{
+                    code: 'auto',
+                    value: 'Auto',
+                    description: 'Reviews elevated actions.',
+                    kind: 'safe-yolo',
+                }],
+            },
+        }];
+        mocks.draft = createDraft({
+            agentType: 'claude',
+            sessionType: 'worktree',
+            worktreeKey: null,
+        });
+        mocks.machineSpawnNewSession
+            .mockResolvedValueOnce({ type: 'pending', clientRequestId: 'rig-request-1', retryAfterMs: 0 })
+            .mockResolvedValueOnce({ type: 'success', sessionId: 'rig-session-1' });
+
+        const { startSession } = useStartSessionFromDraft();
+
+        await expect(startSession()).resolves.toBe(true);
+
+        const expected = expect.objectContaining({
+            machineId: 'machine-1',
+            agent: 'rig',
+            clientRequestId: 'rig-request-1',
+            directory: '/absolute/project',
+            providerId: 'codex',
+            modelId: 'gpt-5.6-sol',
+            permissionMode: 'auto',
+            effort: 'high',
+        });
+        expect(mocks.machineSpawnNewSession).toHaveBeenNthCalledWith(1, expected);
+        expect(mocks.machineSpawnNewSession).toHaveBeenNthCalledWith(2, expected);
+        expect(mocks.delay).toHaveBeenCalledWith(250);
+        expect(mocks.createWorktree).not.toHaveBeenCalled();
+        expect(mocks.sessionSetAgentModes).not.toHaveBeenCalled();
+        expect(mocks.navigateToSession).toHaveBeenCalledWith('rig-session-1');
+    });
+
+    it('stops polling when a created Rig session remains pending', async () => {
+        mocks.machines = [{
+            id: 'machine-1',
+            online: true,
+            metadata: {
+                homeDir: '/Users/dev',
+                machineKind: 'rig',
+                rigOnly: true,
+                cliAvailability: {
+                    rig: true,
+                    claude: false,
+                    codex: false,
+                    gemini: false,
+                    openclaw: false,
+                    detectedAt: 1,
+                },
+                capabilities: { newSession: true, resume: false, worktrees: false },
+                defaults: {
+                    providerId: 'codex', modelId: 'model', permissionMode: 'auto', effort: 'high',
+                },
+                models: [{
+                    providerId: 'codex', id: 'model', name: 'Model', providerName: 'Codex',
+                    thinkingLevels: ['high'], defaultThinkingLevel: 'high',
+                }],
+                operatingModes: [{
+                    code: 'auto', value: 'Auto', description: 'Automatic review', kind: 'safe-yolo',
+                }],
+            },
+        }];
+        mocks.draft = createDraft({ agentType: 'rig' });
+        mocks.machineSpawnNewSession.mockResolvedValue({
+            type: 'pending', clientRequestId: 'rig-request-1', retryAfterMs: 2_000,
+        });
+
+        const { startSession } = useStartSessionFromDraft();
+
+        await expect(startSession()).resolves.toBe(false);
+        expect(mocks.machineSpawnNewSession).toHaveBeenCalledTimes(4);
+        expect(mocks.delay).toHaveBeenCalledTimes(3);
+        expect(mocks.alert).toHaveBeenCalledWith(
+            'common.error',
+            'Rig created the session, but it is still syncing with Happy. It should appear shortly.',
+        );
+        expect(mocks.navigateToSession).not.toHaveBeenCalled();
     });
 
     it('keeps the draft in place when creation fails', async () => {

--- a/packages/happy-app/sources/hooks/useStartSessionFromDraft.test.ts
+++ b/packages/happy-app/sources/hooks/useStartSessionFromDraft.test.ts
@@ -17,9 +17,11 @@ const mocks = vi.hoisted(() => ({
     alert: vi.fn(),
     confirm: vi.fn(),
     delay: vi.fn(),
+    uuidCount: 0,
 }));
 
-vi.mock('expo-crypto', () => ({ randomUUID: () => 'rig-request-1' }));
+// Counts up so a test can tell a reused idempotency key from a fresh one.
+vi.mock('expo-crypto', () => ({ randomUUID: () => `rig-request-${++mocks.uuidCount}` }));
 
 vi.mock('react', () => ({
     useState: <T,>(value: T) => [value, vi.fn()] as const,
@@ -106,7 +108,40 @@ vi.mock('@/text', () => ({
     t: (key: string) => key,
 }));
 
+import { completeSpawnRequest } from '@/sync/spawnRequestId';
 import { useStartSessionFromDraft } from './useStartSessionFromDraft';
+
+function createRigMachine(metadata: Record<string, unknown> = {}) {
+    return {
+        id: 'machine-1',
+        online: true,
+        metadata: {
+            homeDir: '/Users/dev',
+            machineKind: 'rig',
+            rigOnly: true,
+            cliAvailability: {
+                rig: true,
+                claude: false,
+                codex: false,
+                gemini: false,
+                openclaw: false,
+                detectedAt: 1,
+            },
+            capabilities: { newSession: true, resume: false, worktrees: false },
+            defaults: {
+                providerId: 'codex', modelId: 'model', permissionMode: 'auto', effort: 'high',
+            },
+            models: [{
+                providerId: 'codex', id: 'model', name: 'Model', providerName: 'Codex',
+                thinkingLevels: ['high'], defaultThinkingLevel: 'high',
+            }],
+            operatingModes: [{
+                code: 'auto', value: 'Auto', description: 'Automatic review', kind: 'safe-yolo',
+            }],
+            ...metadata,
+        },
+    };
+}
 
 function createDraft(overrides: Record<string, unknown> = {}) {
     return {
@@ -129,6 +164,8 @@ function createDraft(overrides: Record<string, unknown> = {}) {
 describe('useStartSessionFromDraft', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mocks.uuidCount = 0;
+        completeSpawnRequest();
         mocks.defaultOverrides = {};
         mocks.machines = [{ id: 'machine-1', online: true, metadata: { homeDir: '/Users/dev' } }];
         mocks.draft = createDraft();
@@ -337,6 +374,64 @@ describe('useStartSessionFromDraft', () => {
             'Rig created the session, but it is still syncing with Happy. It should appear shortly.',
         );
         expect(mocks.navigateToSession).not.toHaveBeenCalled();
+    });
+
+    it('degrades instead of crashing when a Rig machine publishes no operating modes', async () => {
+        mocks.machines = [createRigMachine({ operatingModes: [] })];
+        mocks.draft = createDraft({ agentType: 'rig' });
+
+        const { startSession } = useStartSessionFromDraft();
+
+        await expect(startSession()).resolves.toBe(false);
+        expect(mocks.alert).toHaveBeenCalledWith(
+            'common.error',
+            'The selected agent configuration is unavailable',
+        );
+        expect(mocks.machineSpawnNewSession).not.toHaveBeenCalled();
+    });
+
+    it('reuses the idempotency key when the user retries the same spawn', async () => {
+        mocks.machines = [createRigMachine()];
+        mocks.draft = createDraft({ agentType: 'rig' });
+        mocks.machineSpawnNewSession.mockResolvedValue({
+            type: 'pending', clientRequestId: 'rig-request-1', retryAfterMs: 250,
+        });
+
+        const { startSession } = useStartSessionFromDraft();
+
+        // Rig stayed pending past the retry budget, so the user presses Start again.
+        await expect(startSession()).resolves.toBe(false);
+        mocks.machineSpawnNewSession.mockResolvedValue({ type: 'success', sessionId: 'rig-session-1' });
+        await expect(startSession()).resolves.toBe(true);
+
+        const requestIds = mocks.machineSpawnNewSession.mock.calls
+            .map(([options]) => options.clientRequestId);
+        expect(new Set(requestIds)).toEqual(new Set(['rig-request-1']));
+
+        // The spawn succeeded, so the next one is a genuinely new session.
+        await expect(startSession()).resolves.toBe(true);
+        expect(mocks.machineSpawnNewSession).toHaveBeenLastCalledWith(expect.objectContaining({
+            clientRequestId: 'rig-request-2',
+        }));
+    });
+
+    it('backs off with the published delay when a pending result omits one', async () => {
+        mocks.machines = [createRigMachine({
+            sessionCreation: {
+                idempotencyKey: 'clientRequestId',
+                pendingRetryAfterMs: 4_000,
+                resultKinds: ['success', 'pending'],
+            },
+        })];
+        mocks.draft = createDraft({ agentType: 'rig' });
+        mocks.machineSpawnNewSession
+            .mockResolvedValueOnce({ type: 'pending', clientRequestId: 'rig-request-1' })
+            .mockResolvedValueOnce({ type: 'success', sessionId: 'rig-session-1' });
+
+        const { startSession } = useStartSessionFromDraft();
+
+        await expect(startSession()).resolves.toBe(true);
+        expect(mocks.delay).toHaveBeenCalledWith(4_000);
     });
 
     it('keeps the draft in place when creation fails', async () => {

--- a/packages/happy-app/sources/hooks/useStartSessionFromDraft.ts
+++ b/packages/happy-app/sources/hooks/useStartSessionFromDraft.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { randomUUID } from 'expo-crypto';
 import { useAllMachines, useSetting } from '@/sync/storage';
 import { resolveAgentDefaultConfig } from '@/sync/agentDefaults';
 import { machineSpawnNewSession, sessionSetAgentModes, type SessionAgentModesPatch } from '@/sync/ops';
@@ -16,6 +17,13 @@ import {
 import { Modal } from '@/modal';
 import { t } from '@/text';
 import { resolveMachineAgent } from '@/utils/newSessionAgentSelection';
+import { delay } from '@/utils/time';
+import {
+    buildRigSpawnConfiguration,
+    getRigMachineSessionCreation,
+} from '@/sync/rigSessionCreation';
+
+const MAX_RIG_PENDING_RESULTS = 3;
 
 function resolveOption<T extends { key: string }>(
     options: T[],
@@ -35,6 +43,10 @@ export function useStartSessionFromDraft() {
     const navigateToSession = useNavigateToSession();
     const [isStarting, setIsStarting] = React.useState(false);
     const isStartingRef = React.useRef(false);
+    const isMountedRef = React.useRef(true);
+    React.useEffect(() => () => {
+        isMountedRef.current = false;
+    }, []);
 
     const startSession = React.useCallback(async (): Promise<boolean> => {
         if (isStartingRef.current) return false;
@@ -58,24 +70,41 @@ export function useStartSessionFromDraft() {
             machine.metadata?.cliAvailability,
         );
         const agentChanged = agentType !== draft.agentType;
-        const defaults = resolveAgentDefaultConfig(defaultOverrides, agentType);
-        const permission = resolveOption(
-            getHardcodedPermissionModes(agentType, t),
+        const rigCreation = agentType === 'rig'
+            ? getRigMachineSessionCreation(machine.metadata)
+            : null;
+        if (agentType === 'rig' && !rigCreation) {
+            Modal.alert(t('common.error'), 'This Rig machine is not available for session creation');
+            return false;
+        }
+        const defaults = rigCreation
+            ? {
+                permissionMode: rigCreation.defaultPermissionMode ?? '',
+                modelMode: rigCreation.defaultModelKey ?? '',
+                effortLevel: rigCreation.defaultEffortForModel(rigCreation.defaultModelKey),
+            }
+            : resolveAgentDefaultConfig(defaultOverrides, agentType);
+        const permission = resolveOption<{ key: string }>(
+            rigCreation?.permissionModes ?? getHardcodedPermissionModes(agentType, t),
             agentChanged
                 ? [defaults.permissionMode]
                 : [draft.permissionMode, defaults.permissionMode],
         );
-        const model = resolveOption(
-            getHardcodedModelModes(agentType, t),
+        const model = resolveOption<{ key: string }>(
+            rigCreation?.models ?? getHardcodedModelModes(agentType, t),
             agentChanged
                 ? [defaults.modelMode]
                 : [draft.modelMode, defaults.modelMode],
         );
-        const effort = resolveOption(
-            getEffortLevelsForModel(agentType, model?.key ?? 'default'),
+        const effortDefault = rigCreation?.defaultEffortForModel(model?.key)
+            ?? defaults.effortLevel;
+        const effort = resolveOption<{ key: string }>(
+            rigCreation
+                ? rigCreation.effortsForModel(model?.key).map((key) => ({ key, name: key }))
+                : getEffortLevelsForModel(agentType, model?.key ?? 'default'),
             agentChanged
-                ? [defaults.effortLevel]
-                : [draft.effortLevel, defaults.effortLevel],
+                ? [effortDefault]
+                : [draft.effortLevel, effortDefault],
         );
         if (!permission || !model) {
             Modal.alert(t('common.error'), 'The selected agent configuration is unavailable');
@@ -86,9 +115,12 @@ export function useStartSessionFromDraft() {
         const attachments = draft.attachments;
         const selectedPath = draft.selectedPath?.trim() || '~';
         const absolutePath = resolveAbsolutePath(selectedPath, machine.metadata?.homeDir);
-        const worktreeSelection = draft.sessionType === 'worktree'
-            ? draft.worktreeKey ?? '__new__'
-            : '__none__';
+        const worktreeSelection = rigCreation?.supportsWorktrees === false
+            ? '__none__'
+            : draft.sessionType === 'worktree'
+                ? draft.worktreeKey ?? '__new__'
+                : '__none__';
+        const clientRequestId = randomUUID();
 
         isStartingRef.current = true;
         setIsStarting(true);
@@ -106,21 +138,49 @@ export function useStartSessionFromDraft() {
             }
 
             const spawn = async (approvedNewDirectoryCreation = false): Promise<string | null> => {
-                const result = await machineSpawnNewSession({
-                    machineId: machine.id,
-                    directory: spawnDirectory,
-                    approvedNewDirectoryCreation,
-                    agent: agentType,
-                    permissionMode: agentType === 'codex' || permission.key !== 'default'
-                        ? permission.key
-                        : undefined,
-                    modelMode: model.key !== 'default' ? model.key : undefined,
-                    effortLevel: effort?.key,
-                });
+                const spawnOptions = rigCreation
+                    ? {
+                        machineId: machine.id,
+                        ...buildRigSpawnConfiguration(machine.metadata, {
+                            directory: spawnDirectory,
+                            clientRequestId,
+                            approvedNewDirectoryCreation,
+                            modelKey: model.key,
+                            permissionMode: permission.key,
+                            effort: effort?.key,
+                        }),
+                    }
+                    : {
+                        machineId: machine.id,
+                        directory: spawnDirectory,
+                        approvedNewDirectoryCreation,
+                        agent: agentType,
+                        permissionMode: agentType === 'codex' || permission.key !== 'default'
+                            ? permission.key
+                            : undefined,
+                        modelMode: model.key !== 'default' ? model.key : undefined,
+                        effortLevel: effort?.key,
+                    };
+                let result = await machineSpawnNewSession(spawnOptions);
+                let pendingResults = 0;
+                while (result.type === 'pending' && pendingResults < MAX_RIG_PENDING_RESULTS) {
+                    pendingResults += 1;
+                    await delay(Math.min(10_000, Math.max(250, result.retryAfterMs)));
+                    if (!isMountedRef.current) return null;
+                    result = await machineSpawnNewSession(spawnOptions);
+                }
+                if (!isMountedRef.current) return null;
 
                 if (result.type === 'success') return result.sessionId;
                 if (result.type === 'error') {
                     Modal.alert(t('common.error'), result.errorMessage);
+                    return null;
+                }
+                if (result.type === 'pending') {
+                    Modal.alert(
+                        t('common.error'),
+                        'Rig created the session, but it is still syncing with Happy. It should appear shortly.',
+                    );
                     return null;
                 }
 
@@ -137,12 +197,14 @@ export function useStartSessionFromDraft() {
 
             await sync.refreshSessions();
 
-            const modesPatch: SessionAgentModesPatch = {};
-            if (permission.key !== defaults.permissionMode) modesPatch.permissionMode = permission.key;
-            if (model.key !== defaults.modelMode) modesPatch.modelMode = model.key;
-            if ((effort?.key ?? null) !== defaults.effortLevel) modesPatch.effortLevel = effort?.key ?? null;
-            if (Object.keys(modesPatch).length > 0) {
-                sessionSetAgentModes(sessionId, modesPatch);
+            if (!rigCreation) {
+                const modesPatch: SessionAgentModesPatch = {};
+                if (permission.key !== defaults.permissionMode) modesPatch.permissionMode = permission.key;
+                if (model.key !== defaults.modelMode) modesPatch.modelMode = model.key;
+                if ((effort?.key ?? null) !== defaults.effortLevel) modesPatch.effortLevel = effort?.key ?? null;
+                if (Object.keys(modesPatch).length > 0) {
+                    sessionSetAgentModes(sessionId, modesPatch);
+                }
             }
 
             draft.setInput('');
@@ -168,7 +230,7 @@ export function useStartSessionFromDraft() {
             return false;
         } finally {
             isStartingRef.current = false;
-            setIsStarting(false);
+            if (isMountedRef.current) setIsStarting(false);
         }
     }, [defaultOverrides, machines, navigateToSession]);
 

--- a/packages/happy-app/sources/hooks/useStartSessionFromDraft.ts
+++ b/packages/happy-app/sources/hooks/useStartSessionFromDraft.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { randomUUID } from 'expo-crypto';
 import { useAllMachines, useSetting } from '@/sync/storage';
 import { resolveAgentDefaultConfig } from '@/sync/agentDefaults';
 import { machineSpawnNewSession, sessionSetAgentModes, type SessionAgentModesPatch } from '@/sync/ops';
@@ -21,7 +20,13 @@ import { delay } from '@/utils/time';
 import {
     buildRigSpawnConfiguration,
     getRigMachineSessionCreation,
+    resolveRigPendingRetryDelayMs,
 } from '@/sync/rigSessionCreation';
+import {
+    buildSpawnRequestSignature,
+    completeSpawnRequest,
+    resolveSpawnRequestId,
+} from '@/sync/spawnRequestId';
 
 const MAX_RIG_PENDING_RESULTS = 3;
 
@@ -120,7 +125,17 @@ export function useStartSessionFromDraft() {
             : draft.sessionType === 'worktree'
                 ? draft.worktreeKey ?? '__new__'
                 : '__none__';
-        const clientRequestId = randomUUID();
+        // Reused across every retry of this exact request so a second press of
+        // Start is deduped by Rig instead of spawning a second session.
+        const clientRequestId = resolveSpawnRequestId(buildSpawnRequestSignature({
+            machineId: machine.id,
+            agent: agentType,
+            directory: selectedPath,
+            worktree: worktreeSelection,
+            modelKey: model.key,
+            permissionMode: permission.key,
+            effort: effort?.key ?? null,
+        }));
 
         isStartingRef.current = true;
         setIsStarting(true);
@@ -165,7 +180,10 @@ export function useStartSessionFromDraft() {
                 let pendingResults = 0;
                 while (result.type === 'pending' && pendingResults < MAX_RIG_PENDING_RESULTS) {
                     pendingResults += 1;
-                    await delay(Math.min(10_000, Math.max(250, result.retryAfterMs)));
+                    await delay(resolveRigPendingRetryDelayMs(
+                        result.retryAfterMs,
+                        rigCreation?.pendingRetryAfterMs,
+                    ));
                     if (!isMountedRef.current) return null;
                     result = await machineSpawnNewSession(spawnOptions);
                 }
@@ -194,6 +212,8 @@ export function useStartSessionFromDraft() {
 
             const sessionId = await spawn();
             if (!sessionId) return false;
+            // The idempotency key did its job; the next Start is a new session.
+            completeSpawnRequest();
 
             await sync.refreshSessions();
 

--- a/packages/happy-app/sources/hooks/useVisibleSessionListViewData.test.ts
+++ b/packages/happy-app/sources/hooks/useVisibleSessionListViewData.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionListViewItem, SessionRowData } from '@/sync/storage';
+
+const mocks = vi.hoisted(() => ({
+    data: null as SessionListViewItem[] | null,
+    hideArchivedSessions: false,
+}));
+
+// The hook only ever reads `React.useMemo`, and storage.ts pulls in React
+// Native, so both are stubbed down to the surface the hook actually touches.
+vi.mock('react', () => ({
+    useMemo: <T,>(factory: () => T) => factory(),
+}));
+
+vi.mock('@/sync/storage', () => ({
+    useSessionListViewData: () => mocks.data,
+    useSetting: (key: string) => {
+        if (key !== 'hideInactiveSessions') {
+            throw new Error(`Unexpected setting read: ${key}`);
+        }
+        return mocks.hideArchivedSessions;
+    },
+}));
+
+import { useHasArchivedSessions, useVisibleSessionListViewData } from './useVisibleSessionListViewData';
+
+// Only the fields the visibility filter reads; the real rows are built in
+// storage.ts.
+function row(id: string, options: { active?: boolean; archived?: boolean } = {}): SessionRowData {
+    return {
+        id,
+        name: id,
+        active: options.active ?? false,
+        archived: options.archived ?? false,
+    } as SessionRowData;
+}
+
+function project(id: string, sessions: SessionRowData[]): SessionListViewItem {
+    return {
+        type: 'project',
+        source: 'rig',
+        project: {
+            id,
+            name: id,
+            machineId: 'machine-1',
+            sessionCount: sessions.length,
+            activeCount: sessions.filter((session) => session.active).length,
+            workspaces: [{ id: '', name: null, sessions }],
+        },
+    };
+}
+
+function projectSessionIds(items: SessionListViewItem[]): string[] {
+    return items.flatMap((item) => (item.type === 'project'
+        ? item.project.workspaces.flatMap((workspace) => workspace.sessions.map((s) => s.id))
+        : []));
+}
+
+function flatSessionIds(items: SessionListViewItem[]): string[] {
+    return items.flatMap((item) => (item.type === 'session' ? [item.session.id] : []));
+}
+
+beforeEach(() => {
+    mocks.data = null;
+    mocks.hideArchivedSessions = false;
+});
+
+describe('useVisibleSessionListViewData', () => {
+    // A project card and a flat row, each holding one merely-disconnected
+    // session and one archived one.
+    function mixedList(): SessionListViewItem[] {
+        return [
+            { type: 'projects-header', source: 'rig' },
+            project('p1', [row('project-disconnected'), row('project-archived', { archived: true })]),
+            { type: 'header', title: 'Today' },
+            { type: 'session', session: row('flat-disconnected') },
+            { type: 'session', session: row('flat-archived', { archived: true }) },
+        ];
+    }
+
+    it('passes through a list that has not loaded yet', () => {
+        mocks.data = null;
+
+        expect(useVisibleSessionListViewData()).toBeNull();
+    });
+
+    it('keeps a disconnected-but-unarchived session in both list shapes while hiding the archive', () => {
+        mocks.data = mixedList();
+        mocks.hideArchivedSessions = true;
+
+        const result = useVisibleSessionListViewData()!;
+
+        expect(projectSessionIds(result)).toEqual(['project-disconnected']);
+        expect(flatSessionIds(result)).toEqual(['flat-disconnected']);
+    });
+
+    it('hides an archived session in both list shapes', () => {
+        mocks.data = mixedList();
+        mocks.hideArchivedSessions = true;
+
+        const result = useVisibleSessionListViewData()!;
+
+        expect(projectSessionIds(result)).not.toContain('project-archived');
+        expect(flatSessionIds(result)).not.toContain('flat-archived');
+    });
+
+    it('refreshes the project badge to match the rows left', () => {
+        mocks.data = [project('p1', [
+            row('live', { active: true }),
+            row('disconnected'),
+            row('archived', { archived: true }),
+        ])];
+        mocks.hideArchivedSessions = true;
+
+        const [item] = useVisibleSessionListViewData()!;
+
+        expect(item.type === 'project' && item.project).toMatchObject({
+            sessionCount: 2,
+            activeCount: 1,
+        });
+    });
+
+    it('shows every session in both list shapes when the archive is revealed', () => {
+        mocks.data = mixedList();
+        mocks.hideArchivedSessions = false;
+
+        const result = useVisibleSessionListViewData()!;
+
+        expect(projectSessionIds(result)).toEqual(['project-disconnected', 'project-archived']);
+        expect(flatSessionIds(result)).toEqual(['flat-disconnected', 'flat-archived']);
+    });
+
+    it('drops a date header once everything under it is archived', () => {
+        mocks.data = [
+            { type: 'header', title: 'Today' },
+            { type: 'session', session: row('archived', { archived: true }) },
+            { type: 'header', title: 'Yesterday' },
+            { type: 'session', session: row('disconnected') },
+        ];
+        mocks.hideArchivedSessions = true;
+
+        const result = useVisibleSessionListViewData()!;
+
+        expect(result.map((item) => (item.type === 'header' ? item.title : item.type)))
+            .toEqual(['Yesterday', 'session']);
+    });
+
+    it('drops a projects header once every project under it is archived', () => {
+        mocks.data = [
+            { type: 'projects-header', source: 'rig' },
+            project('p1', [row('archived', { archived: true })]),
+        ];
+        mocks.hideArchivedSessions = true;
+
+        expect(useVisibleSessionListViewData()).toEqual([]);
+    });
+
+    it('keeps the active-sessions group regardless of the toggle', () => {
+        mocks.data = [{ type: 'active-sessions', sessions: [row('live', { active: true })] }];
+        mocks.hideArchivedSessions = true;
+
+        expect(useVisibleSessionListViewData()).toEqual(mocks.data);
+    });
+});
+
+describe('useHasArchivedSessions', () => {
+    it('is false when nothing is archived, even with disconnected sessions around', () => {
+        mocks.data = [
+            project('p1', [row('project-disconnected')]),
+            { type: 'session', session: row('flat-disconnected') },
+        ];
+
+        expect(useHasArchivedSessions()).toBe(false);
+    });
+
+    it('spots an archived session nested inside a project', () => {
+        mocks.data = [project('p1', [row('archived', { archived: true })])];
+
+        expect(useHasArchivedSessions()).toBe(true);
+    });
+
+    it('spots an archived session in the flat list', () => {
+        mocks.data = [{ type: 'session', session: row('archived', { archived: true }) }];
+
+        expect(useHasArchivedSessions()).toBe(true);
+    });
+});

--- a/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
+++ b/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
@@ -2,9 +2,24 @@ import * as React from 'react';
 import { SessionListViewItem, useSessionListViewData, useSetting } from '@/sync/storage';
 import { filterProjectGroupSessions } from '@/sync/projectGroups';
 
+/**
+ * Applies the archive-visibility control to the session list.
+ *
+ * The rule is `session.archived`, never `!session.active`: a Rig session that
+ * merely lost its connection is still live work and stays on screen, while a
+ * session the agent actually retired hides. Both list shapes — the project
+ * cards and the flat, date-grouped rows — run that one rule, so the single
+ * toggle in the header and sidebar means the same thing wherever the list
+ * happens to be rendered.
+ *
+ * The setting behind it is still stored as `hideInactiveSessions`: it is a
+ * server-synced settings field (see sync/settings.ts) with no per-field rename
+ * migration, so the key stays put and only the local naming reflects what it
+ * actually does.
+ */
 export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
     const data = useSessionListViewData();
-    const hideInactiveSessions = useSetting('hideInactiveSessions');
+    const hideArchivedSessions = useSetting('hideInactiveSessions');
 
     return React.useMemo(() => {
         if (!data) {
@@ -15,7 +30,7 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
         const visibleProjectSources = new Set<'rig' | 'happy'>();
         data.forEach((item, index) => {
             if (item.type !== 'project') return;
-            const project = hideInactiveSessions
+            const project = hideArchivedSessions
                 ? filterProjectGroupSessions(item.project, (session) => !session.archived)
                 : item.project;
             if (project) {
@@ -38,18 +53,33 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
             if (item.type === 'active-sessions') result.push(item);
         });
 
-        if (hideInactiveSessions) return result;
-
+        // Flat, date-grouped rows trail the project cards. A date header is
+        // held back until a row underneath it survives the filter, so hiding
+        // the archive never leaves a heading with nothing under it.
+        let pendingHeader: SessionListViewItem | null = null;
         for (const item of data) {
-            if (item.type === 'header' || (item.type === 'session' && !item.session.active)) {
-                result.push(item);
+            if (item.type === 'header') {
+                pendingHeader = item;
+                continue;
             }
+            if (item.type !== 'session') continue;
+            if (hideArchivedSessions && item.session.archived) continue;
+            if (pendingHeader) {
+                result.push(pendingHeader);
+                pendingHeader = null;
+            }
+            result.push(item);
         }
 
         return result;
-    }, [data, hideInactiveSessions]);
+    }, [data, hideArchivedSessions]);
 }
 
+/**
+ * Whether anything is currently hidden-able, i.e. whether the archive toggle
+ * has any work to do. Keyed off the same `archived` flag the filter above uses
+ * so the control never appears without changing what is on screen.
+ */
 export function useHasArchivedSessions(): boolean {
     const data = useSessionListViewData();
     return React.useMemo(() => {

--- a/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
+++ b/packages/happy-app/sources/hooks/useVisibleSessionListViewData.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { SessionListViewItem, useSessionListViewData, useSetting } from '@/sync/storage';
+import { filterProjectGroupSessions } from '@/sync/projectGroups';
 
 export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
     const data = useSessionListViewData();
@@ -10,63 +11,56 @@ export function useVisibleSessionListViewData(): SessionListViewItem[] | null {
             return data;
         }
 
+        const visibleProjects = new Map<number, SessionListViewItem>();
+        const visibleProjectSources = new Set<'rig' | 'happy'>();
+        data.forEach((item, index) => {
+            if (item.type !== 'project') return;
+            const project = hideInactiveSessions
+                ? filterProjectGroupSessions(item.project, (session) => !session.archived)
+                : item.project;
+            if (project) {
+                visibleProjects.set(index, { ...item, project });
+                visibleProjectSources.add(item.source);
+            }
+        });
+
         const result: SessionListViewItem[] = [];
-        let hasInactive = false;
-
-        // First pass: projects lead, then the active sessions group. Projects
-        // carry their own archived sessions, so the toggle below never hides
-        // them and they are not counted as inactive here.
-        for (const item of data) {
-            if (item.type === 'projects-header' || item.type === 'project') {
-                result.push(item);
+        data.forEach((item, index) => {
+            if (item.type === 'projects-header') {
+                if (visibleProjectSources.has(item.source)) result.push(item);
+                return;
             }
-        }
-        for (const item of data) {
-            if (item.type === 'active-sessions') {
-                result.push(item);
-            } else if (item.type === 'session' && !item.session.active) {
-                hasInactive = true;
+            if (item.type === 'project') {
+                const project = visibleProjects.get(index);
+                if (project) result.push(project);
+                return;
             }
-        }
+            if (item.type === 'active-sessions') result.push(item);
+        });
 
-        // Insert archive toggle if there are inactive sessions
-        if (hasInactive) {
-            result.push({ type: 'archive-toggle', hidden: hideInactiveSessions });
-        }
+        if (hideInactiveSessions) return result;
 
-        // If not hiding, add all remaining items (headers, project groups, inactive sessions)
-        if (!hideInactiveSessions) {
-            let pendingProjectGroup: SessionListViewItem | null = null;
-
-            for (const item of data) {
-                if (item.type === 'active-sessions' || item.type === 'projects-header' || item.type === 'project') {
-                    continue; // already added
-                }
-
-                if (item.type === 'project-group') {
-                    pendingProjectGroup = item;
-                    continue;
-                }
-
-                if (item.type === 'session') {
-                    if (!item.session.active) {
-                        if (pendingProjectGroup) {
-                            result.push(pendingProjectGroup);
-                            pendingProjectGroup = null;
-                        }
-                        result.push(item);
-                    }
-                    continue;
-                }
-
-                pendingProjectGroup = null;
-
-                if (item.type === 'header') {
-                    result.push(item);
-                }
+        for (const item of data) {
+            if (item.type === 'header' || (item.type === 'session' && !item.session.active)) {
+                result.push(item);
             }
         }
 
         return result;
     }, [data, hideInactiveSessions]);
+}
+
+export function useHasArchivedSessions(): boolean {
+    const data = useSessionListViewData();
+    return React.useMemo(() => {
+        if (!data) return false;
+        return data.some((item) => {
+            if (item.type === 'project') {
+                return item.project.workspaces.some((workspace) =>
+                    workspace.sessions.some((session) => session.archived),
+                );
+            }
+            return item.type === 'session' && item.session.archived;
+        });
+    }, [data]);
 }

--- a/packages/happy-app/sources/sync/localSettings.ts
+++ b/packages/happy-app/sources/sync/localSettings.ts
@@ -22,7 +22,7 @@ export const LocalSettingsSchema = z.object({
     // CLI version acknowledgments - keyed by machineId
     acknowledgedCliVersions: z.record(z.string(), z.string()).describe('Acknowledged CLI versions per machine'),
     // Collapsed Rig projects in the session list - keyed by project id
-    collapsedProjects: z.record(z.string(), z.boolean()).describe('Collapsed state per Rig project'),
+    collapsedProjects: z.record(z.string(), z.boolean()).describe('Collapsed state per sidebar project'),
 });
 
 //

--- a/packages/happy-app/sources/sync/ops.rigSpawn.test.ts
+++ b/packages/happy-app/sources/sync/ops.rigSpawn.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { machineRPC } = vi.hoisted(() => ({ machineRPC: vi.fn() }));
+
+vi.mock('./apiSocket', () => ({ apiSocket: { machineRPC } }));
+vi.mock('./sync', () => ({ sync: {} }));
+vi.mock('./storage', () => ({ storage: { getState: vi.fn() } }));
+
+describe('Rig machine spawn RPC', () => {
+    beforeEach(() => {
+        machineRPC.mockReset();
+    });
+
+    it('sends only the Rig-native idempotent creation payload', async () => {
+        machineRPC.mockResolvedValue({
+            type: 'pending',
+            clientRequestId: 'request-1',
+            retryAfterMs: 2_000,
+        });
+        const { machineSpawnNewSession } = await import('./ops');
+
+        await expect(machineSpawnNewSession({
+            machineId: 'rig-machine',
+            directory: '/work/project',
+            approvedNewDirectoryCreation: false,
+            agent: 'rig',
+            clientRequestId: 'request-1',
+            providerId: 'codex',
+            modelId: 'gpt-5.6-sol',
+            permissionMode: 'auto',
+            effort: 'high',
+            // These happy-cli fields must not leak into Rig's RPC contract.
+            token: 'unused',
+            modelMode: 'unused',
+            effortLevel: 'unused',
+            resumeClaudeSessionId: 'unused',
+        })).resolves.toEqual({
+            type: 'pending',
+            clientRequestId: 'request-1',
+            retryAfterMs: 2_000,
+        });
+
+        expect(machineRPC).toHaveBeenCalledWith(
+            'rig-machine',
+            'spawn-happy-session',
+            {
+                type: 'spawn-in-directory',
+                agent: 'rig',
+                clientRequestId: 'request-1',
+                directory: '/work/project',
+                approvedNewDirectoryCreation: false,
+                providerId: 'codex',
+                modelId: 'gpt-5.6-sol',
+                permissionMode: 'auto',
+                effort: 'high',
+            },
+        );
+    });
+
+    it('rejects a non-idempotent Rig spawn before calling the machine', async () => {
+        const { machineSpawnNewSession } = await import('./ops');
+
+        await expect(machineSpawnNewSession({
+            machineId: 'rig-machine',
+            directory: '/work/project',
+            agent: 'rig',
+        })).resolves.toEqual({
+            type: 'error',
+            errorMessage: 'Rig session creation requires a client request ID',
+        });
+        expect(machineRPC).not.toHaveBeenCalled();
+    });
+});

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -161,6 +161,7 @@ interface SessionKillResponse {
 // Response types for spawn session
 export type SpawnSessionResult =
     | { type: 'success'; sessionId: string }
+    | { type: 'pending'; clientRequestId: string; retryAfterMs: number }
     | { type: 'requestToApproveDirectoryCreation'; directory: string }
     | { type: 'error'; errorMessage: string };
 
@@ -170,10 +171,16 @@ export interface SpawnSessionOptions {
     directory: string;
     approvedNewDirectoryCreation?: boolean;
     token?: string;
-    agent?: 'codex' | 'claude' | 'gemini' | 'openclaw' | 'agy';
+    agent?: 'codex' | 'claude' | 'gemini' | 'openclaw' | 'agy' | 'rig';
     permissionMode?: string;
     modelMode?: string;
     effortLevel?: string;
+    /** Stable idempotency key required by Rig's machine RPC. */
+    clientRequestId?: string;
+    /** Rig-native provider/model selection. */
+    providerId?: string;
+    modelId?: string;
+    effort?: string;
     /**
      * If set, the daemon spawns the agent with `--resume <id>` so the new
      * Happy session attaches to a pre-existing on-disk Claude conversation
@@ -250,27 +257,48 @@ export interface ResumeSessionOptions {
  */
 export async function machineSpawnNewSession(options: SpawnSessionOptions): Promise<SpawnSessionResult> {
 
-    const { machineId, directory, approvedNewDirectoryCreation = false, token, agent, permissionMode, modelMode, effortLevel, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, isSideChat } = options;
+    const { machineId, directory, approvedNewDirectoryCreation = false, token, agent, permissionMode, modelMode, effortLevel, clientRequestId, providerId, modelId, effort, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, isSideChat } = options;
 
     try {
-        const result = await apiSocket.machineRPC<SpawnSessionResult, {
+        if (agent === 'rig' && !clientRequestId) {
+            throw new Error('Rig session creation requires a client request ID');
+        }
+        type SpawnRequest = {
             type: 'spawn-in-directory'
             directory: string
             approvedNewDirectoryCreation?: boolean,
             token?: string,
-            agent?: 'codex' | 'claude' | 'gemini' | 'openclaw' | 'agy',
+            agent?: 'codex' | 'claude' | 'gemini' | 'openclaw' | 'agy' | 'rig',
             permissionMode?: string,
             modelMode?: string,
             effortLevel?: string,
+            clientRequestId?: string,
+            providerId?: string,
+            modelId?: string,
+            effort?: string,
             resumeClaudeSessionId?: string,
             resumeCodexThreadId?: string,
             parentSessionId?: string,
             forkedFromMessageId?: string,
             isSideChat?: boolean,
-        }>(
+        };
+        const request: SpawnRequest = agent === 'rig'
+            ? {
+                type: 'spawn-in-directory',
+                agent: 'rig',
+                directory,
+                approvedNewDirectoryCreation,
+                ...(clientRequestId ? { clientRequestId } : {}),
+                ...(permissionMode ? { permissionMode } : {}),
+                ...(providerId ? { providerId } : {}),
+                ...(modelId ? { modelId } : {}),
+                ...((effort ?? effortLevel) ? { effort: effort ?? effortLevel } : {}),
+            }
+            : { type: 'spawn-in-directory', directory, approvedNewDirectoryCreation, token, agent, permissionMode, modelMode, effortLevel, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, isSideChat };
+        const result = await apiSocket.machineRPC<SpawnSessionResult, SpawnRequest>(
             machineId,
             'spawn-happy-session',
-            { type: 'spawn-in-directory', directory, approvedNewDirectoryCreation, token, agent, permissionMode, modelMode, effortLevel, resumeClaudeSessionId, resumeCodexThreadId, parentSessionId, forkedFromMessageId, isSideChat }
+            request,
         );
         return result;
     } catch (error) {

--- a/packages/happy-app/sources/sync/persistence.ts
+++ b/packages/happy-app/sources/sync/persistence.ts
@@ -12,7 +12,7 @@ const VOICE_SOFT_PAYWALL_SHOWN_KEY = 'voice-soft-paywall-shown';
 const VOICE_ONBOARDING_PROMPT_LOAD_COUNT_KEY = 'voice-onboarding-prompt-load-count';
 const VOICE_MESSAGE_COUNT_KEY = 'voice-message-count';
 
-export type NewSessionAgentType = 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy';
+export type NewSessionAgentType = 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy' | 'rig';
 export type NewSessionSessionType = 'simple' | 'worktree';
 
 export interface NewSessionDraft {
@@ -146,7 +146,7 @@ export function loadNewSessionDraft(): NewSessionDraft | null {
         const input = typeof parsed.input === 'string' ? parsed.input : '';
         const selectedMachineId = typeof parsed.selectedMachineId === 'string' ? parsed.selectedMachineId : null;
         const selectedPath = typeof parsed.selectedPath === 'string' ? parsed.selectedPath : null;
-        const agentType: NewSessionAgentType = parsed.agentType === 'codex' || parsed.agentType === 'gemini' || parsed.agentType === 'openclaw' || parsed.agentType === 'agy'
+        const agentType: NewSessionAgentType = parsed.agentType === 'codex' || parsed.agentType === 'gemini' || parsed.agentType === 'openclaw' || parsed.agentType === 'agy' || parsed.agentType === 'rig'
             ? parsed.agentType
             : 'claude';
         const permissionMode: PermissionModeKey | null = typeof parsed.permissionMode === 'string'

--- a/packages/happy-app/sources/sync/projectGroups.spec.ts
+++ b/packages/happy-app/sources/sync/projectGroups.spec.ts
@@ -195,6 +195,32 @@ describe('filterProjectGroupSessions', () => {
             workspaces: [{ sessions: [{ id: 'active' }] }],
         });
     });
+
+    // A Rig session that dropped its connection is inactive but not archived —
+    // hiding the archive must leave it on screen.
+    it('keeps a disconnected session that was never archived', () => {
+        const project: ProjectGroupData = {
+            id: 'rig-project',
+            name: 'rig',
+            machineId: 'machine-1',
+            sessionCount: 2,
+            activeCount: 0,
+            workspaces: [{
+                id: '',
+                name: null,
+                sessions: [
+                    { id: 'disconnected', active: false, archived: false } as SessionRowData,
+                    { id: 'archived', active: false, archived: true } as SessionRowData,
+                ],
+            }],
+        };
+
+        expect(filterProjectGroupSessions(project, session => !session.archived)).toMatchObject({
+            sessionCount: 1,
+            activeCount: 0,
+            workspaces: [{ sessions: [{ id: 'disconnected' }] }],
+        });
+    });
 });
 
 describe('filterProjectGroup', () => {

--- a/packages/happy-app/sources/sync/projectGroups.spec.ts
+++ b/packages/happy-app/sources/sync/projectGroups.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildProjectGroups, filterProjectGroup } from './projectGroups';
+import {
+    buildPathProjectGroups,
+    buildProjectGroups,
+    filterProjectGroup,
+    filterProjectGroupSessions,
+} from './projectGroups';
 import type { ProjectGroupData } from './projectGroups';
 import type { Session } from './storageTypes';
 import type { SessionRowData } from './storage';
@@ -13,6 +18,8 @@ function session(options: {
     workspaceName?: string;
     active?: boolean;
     machineId?: string;
+    path?: string;
+    homeDir?: string;
 }): Session {
     const active = options.active ?? true;
     return {
@@ -23,7 +30,8 @@ function session(options: {
         active,
         activeAt: active ? Date.now() : 0,
         metadata: {
-            path: '/repo',
+            path: options.path ?? '/repo',
+            ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
             host: 'localhost',
             machineId: options.machineId ?? 'machine-1',
             client: { id: 'rig', name: 'Rig', version: 'test' },
@@ -60,7 +68,7 @@ const isActive = (session: Session) => session.active;
 
 // A row carrying only the fields the search filter reads.
 function row(id: string, name: string, active = true): SessionRowData {
-    return { id, name, active } as SessionRowData;
+    return { id, name, active, archived: !active } as SessionRowData;
 }
 
 describe('buildProjectGroups', () => {
@@ -126,6 +134,65 @@ describe('buildProjectGroups', () => {
             projectName: 'happy',
             workspaceId: 'w1',
             workspaceName: 'feature',
+        });
+    });
+});
+
+describe('buildPathProjectGroups', () => {
+    it('groups Happy sessions by machine and working directory', () => {
+        const groups = buildPathProjectGroups([
+            session({ id: 'a', machineId: 'machine-1', path: '/projects/happy' }),
+            session({ id: 'b', machineId: 'machine-1', path: '/projects/happy', active: false }),
+        ], toRow, isActive, 'happy');
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0]).toMatchObject({
+            name: 'happy',
+            machineId: 'machine-1',
+            sessionCount: 2,
+            activeCount: 1,
+        });
+        expect(groups[0].workspaces[0].sessions.map(s => s.id)).toEqual(['a', 'b']);
+    });
+
+    it('does not merge the same path from different machines', () => {
+        const groups = buildPathProjectGroups([
+            session({ id: 'a', machineId: 'machine-1', path: '/projects/happy' }),
+            session({ id: 'b', machineId: 'machine-2', path: '/projects/happy' }),
+        ], toRow, isActive, 'happy');
+
+        expect(groups.map(group => group.machineId)).toEqual(['machine-1', 'machine-2']);
+        expect(new Set(groups.map(group => group.id)).size).toBe(2);
+    });
+
+    it('names the machine home directory Home', () => {
+        const groups = buildPathProjectGroups([
+            session({ id: 'a', path: '/Users/dev', homeDir: '/Users/dev/' }),
+        ], toRow, isActive, 'happy');
+
+        expect(groups[0].name).toBe('Home');
+    });
+});
+
+describe('filterProjectGroupSessions', () => {
+    it('hides archived rows inside a Happy project and refreshes its count', () => {
+        const project: ProjectGroupData = {
+            id: 'happy-project',
+            name: 'happy',
+            machineId: 'machine-1',
+            sessionCount: 2,
+            activeCount: 1,
+            workspaces: [{
+                id: '',
+                name: null,
+                sessions: [row('active', 'active'), row('archived', 'archived', false)],
+            }],
+        };
+
+        expect(filterProjectGroupSessions(project, session => !session.archived)).toMatchObject({
+            sessionCount: 1,
+            activeCount: 1,
+            workspaces: [{ sessions: [{ id: 'active' }] }],
         });
     });
 });

--- a/packages/happy-app/sources/sync/projectGroups.ts
+++ b/packages/happy-app/sources/sync/projectGroups.ts
@@ -1,7 +1,7 @@
 import type { Session } from './storageTypes';
 import type { SessionRowData } from './storage';
 
-// One git worktree inside a Rig project. `id` is empty and `name` is null for
+// One git worktree inside a project. `id` is empty and `name` is null for
 // the project's primary tree, which always sorts first.
 export interface ProjectWorkspaceGroup {
     id: string;
@@ -9,7 +9,8 @@ export interface ProjectWorkspaceGroup {
     sessions: SessionRowData[];
 }
 
-// A Rig project: every worktree of the same repo, shown together.
+// A project shown in the sessions sidebar. Rig supplies a durable project
+// identity; Happy CLI sessions use their machine and working directory.
 export interface ProjectGroupData {
     id: string;
     name: string;
@@ -20,12 +21,81 @@ export interface ProjectGroupData {
 }
 
 /**
- * Rig reports a project (and optionally a worktree) for every session it runs;
- * the Happy CLI does not. Only Rig sessions get the project presentation, so
- * that CLI sessions keep the flat, date-grouped list they have always had.
+ * Rig reports a project (and optionally a worktree) for its current sessions.
  */
 export function isProjectSession(session: Session): boolean {
     return !!session.metadata?.project?.id;
+}
+
+/**
+ * Groups sessions without a native project identity by machine and working
+ * directory. This gives Happy CLI sessions the same project-card presentation
+ * as Rig without merging identical paths from different computers.
+ */
+export function buildPathProjectGroups(
+    sessions: Session[],
+    toRow: (session: Session) => SessionRowData,
+    isActive: (session: Session) => boolean,
+    idPrefix: string,
+): ProjectGroupData[] {
+    const projects = new Map<string, ProjectGroupData>();
+
+    for (const session of sessions) {
+        const machineId = session.metadata?.machineId ?? null;
+        const path = session.metadata?.path?.trim() || '';
+        const key = JSON.stringify([machineId, path]);
+        let group = projects.get(key);
+        if (!group) {
+            group = {
+                id: `${idPrefix}:${key}`,
+                name: pathProjectName(path, session.metadata?.homeDir),
+                machineId,
+                workspaces: [{ id: '', name: null, sessions: [] }],
+                sessionCount: 0,
+                activeCount: 0,
+            };
+            projects.set(key, group);
+        }
+
+        group.workspaces[0].sessions.push(toRow(session));
+        group.sessionCount += 1;
+        if (isActive(session)) {
+            group.activeCount += 1;
+        }
+    }
+
+    return [...projects.values()];
+}
+
+function pathProjectName(path: string, homeDir: string | undefined): string {
+    const normalizedPath = path.replace(/[\\/]+$/, '');
+    const normalizedHome = homeDir?.replace(/[\\/]+$/, '');
+    if (!normalizedPath || normalizedPath === '~' || normalizedPath === normalizedHome) {
+        return 'Home';
+    }
+    return normalizedPath.split(/[\\/]/).filter(Boolean).at(-1) ?? normalizedPath;
+}
+
+/** Keeps only the rows accepted by a visibility rule and refreshes its badge. */
+export function filterProjectGroupSessions(
+    project: ProjectGroupData,
+    keep: (session: SessionRowData) => boolean,
+): ProjectGroupData | null {
+    const workspaces = project.workspaces
+        .map((workspace) => ({
+            ...workspace,
+            sessions: workspace.sessions.filter(keep),
+        }))
+        .filter((workspace) => workspace.sessions.length > 0);
+    if (workspaces.length === 0) return null;
+
+    const sessions = workspaces.flatMap((workspace) => workspace.sessions);
+    return {
+        ...project,
+        workspaces,
+        sessionCount: sessions.length,
+        activeCount: sessions.filter((session) => session.active).length,
+    };
 }
 
 /**

--- a/packages/happy-app/sources/sync/rigSessionCreation.test.ts
+++ b/packages/happy-app/sources/sync/rigSessionCreation.test.ts
@@ -6,6 +6,7 @@ import {
     findConnectedRigMachine,
     getRigMachineSessionCreation,
     isRigMachine,
+    resolveRigPendingRetryDelayMs,
 } from './rigSessionCreation';
 
 const rigMachine = {
@@ -149,5 +150,46 @@ describe('Rig machine session creation', () => {
             modelKey: 'claude:shared-model',
             effort: 'high',
         })).toThrow('reasoning level is unavailable');
+    });
+
+    it('has an empty catalog when the machine publishes no operating modes', () => {
+        const creation = getRigMachineSessionCreation({
+            ...rigMachine,
+            operatingModes: undefined,
+        } as unknown as MachineMetadata);
+
+        expect(creation?.permissionModes).toEqual([]);
+        expect(creation?.defaultPermissionMode).toBeNull();
+        expect(creation?.pendingRetryAfterMs).toBeNull();
+    });
+
+    it('reads the retry backoff the machine publishes', () => {
+        const creation = getRigMachineSessionCreation({
+            ...rigMachine,
+            sessionCreation: {
+                idempotencyKey: 'clientRequestId',
+                pendingRetryAfterMs: 2_000,
+                resultKinds: ['success', 'pending'],
+            },
+        } as unknown as MachineMetadata);
+
+        expect(creation?.pendingRetryAfterMs).toBe(2_000);
+    });
+
+    it('never turns a missing pending retry delay into an instant retry', () => {
+        // `retryAfterMs` comes from an unvalidated RPC payload: a Rig that omits
+        // it used to produce Math.max(250, undefined) === NaN, and delay(NaN)
+        // resolves immediately.
+        expect(resolveRigPendingRetryDelayMs(undefined, null)).toBe(1_000);
+        expect(resolveRigPendingRetryDelayMs(Number.NaN, null)).toBe(1_000);
+        expect(resolveRigPendingRetryDelayMs('soon', null)).toBe(1_000);
+        expect(resolveRigPendingRetryDelayMs(undefined, 2_000)).toBe(2_000);
+    });
+
+    it('clamps the pending retry delay to a sane window', () => {
+        expect(resolveRigPendingRetryDelayMs(0, null)).toBe(250);
+        expect(resolveRigPendingRetryDelayMs(-5_000, null)).toBe(250);
+        expect(resolveRigPendingRetryDelayMs(60_000, null)).toBe(10_000);
+        expect(resolveRigPendingRetryDelayMs(3_000, 250)).toBe(3_000);
     });
 });

--- a/packages/happy-app/sources/sync/rigSessionCreation.test.ts
+++ b/packages/happy-app/sources/sync/rigSessionCreation.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Machine, MachineMetadata } from './storageTypes';
+import {
+    buildRigSpawnConfiguration,
+    findConnectedRigMachine,
+    getRigMachineSessionCreation,
+    isRigMachine,
+} from './rigSessionCreation';
+
+const rigMachine = {
+    host: 'rig-host',
+    platform: 'darwin',
+    happyCliVersion: '0.0.30',
+    happyHomeDir: '/Users/rig/.happy/rig',
+    homeDir: '/Users/rig',
+    machineKind: 'rig',
+    rigOnly: true,
+    cliAvailability: {
+        claude: false,
+        codex: false,
+        gemini: false,
+        openclaw: false,
+        agy: false,
+        rig: true,
+        detectedAt: 1,
+    },
+    capabilities: { newSession: true, resume: false, worktrees: false },
+    defaults: {
+        providerId: 'codex',
+        modelId: 'shared-model',
+        permissionMode: 'auto',
+        effort: 'high',
+    },
+    models: [
+        {
+            providerId: 'codex',
+            id: 'shared-model',
+            name: 'GPT Shared',
+            providerName: 'OpenAI Codex',
+            thinkingLevels: ['low', 'medium', 'high'],
+            defaultThinkingLevel: 'high',
+        },
+        {
+            providerId: 'claude',
+            id: 'shared-model',
+            name: 'Claude Shared',
+            providerName: 'Anthropic Claude',
+            thinkingLevels: ['low', 'max'],
+            defaultThinkingLevel: 'max',
+        },
+    ],
+    operatingModes: [
+        { code: 'auto', value: 'Auto', description: 'Safe default', kind: 'safe-yolo' },
+        { code: 'read_only', value: 'Read only', description: 'No writes', kind: 'read-only' },
+    ],
+} as unknown as MachineMetadata;
+
+describe('Rig machine session creation', () => {
+    it('recognizes only Rig-published machines', () => {
+        expect(isRigMachine(rigMachine)).toBe(true);
+        expect(isRigMachine({
+            host: 'future-rig-host',
+            platform: 'darwin',
+            happyCliVersion: '1.0.0',
+            happyHomeDir: '/Users/me/.happy',
+            homeDir: '/Users/me',
+            client: { id: 'rig', name: 'Rig', version: '1.0.0' },
+        })).toBe(true);
+        expect(isRigMachine({
+            host: 'cli-host',
+            platform: 'darwin',
+            happyCliVersion: '1.0.0',
+            happyHomeDir: '/Users/me/.happy',
+            homeDir: '/Users/me',
+        })).toBe(false);
+    });
+
+    it('returns provider-qualified dynamic options and model-specific defaults', () => {
+        const creation = getRigMachineSessionCreation(rigMachine);
+
+        expect(creation).toMatchObject({
+            defaultModelKey: 'codex:shared-model',
+            defaultPermissionMode: 'auto',
+            supportsWorktrees: false,
+            models: [
+                { key: 'codex:shared-model', description: 'OpenAI Codex' },
+                { key: 'claude:shared-model', description: 'Anthropic Claude' },
+            ],
+            permissionModes: [
+                { key: 'auto', semanticKind: 'safe-yolo' },
+                { key: 'read_only', semanticKind: 'read-only' },
+            ],
+        });
+        expect(creation?.effortsForModel('claude:shared-model')).toEqual(['low', 'max']);
+        expect(creation?.defaultEffortForModel('claude:shared-model')).toBe('max');
+    });
+
+    it('finds an online Rig machine for automatic composer selection', () => {
+        const machine = (id: string, active: boolean, metadata: MachineMetadata): Machine => ({
+            id,
+            active,
+            metadata,
+        } as Machine);
+        const regularMetadata = {
+            host: 'happy-host',
+            platform: 'darwin',
+            happyCliVersion: '1.0.0',
+            happyHomeDir: '/Users/happy/.happy',
+            homeDir: '/Users/happy',
+        } satisfies MachineMetadata;
+
+        expect(findConnectedRigMachine([
+            machine('regular', true, regularMetadata),
+            machine('offline-rig', false, rigMachine),
+            machine('online-rig', true, rigMachine),
+        ])?.id).toBe('online-rig');
+        expect(findConnectedRigMachine([
+            machine('regular', true, regularMetadata),
+            machine('offline-rig', false, rigMachine),
+        ])).toBeNull();
+    });
+
+    it("builds Rig's exact provider-qualified spawn payload", () => {
+        expect(buildRigSpawnConfiguration(rigMachine, {
+            directory: '/Users/rig/project',
+            clientRequestId: 'mobile-request-1',
+            approvedNewDirectoryCreation: true,
+            modelKey: 'claude:shared-model',
+            permissionMode: 'read_only',
+            effort: 'max',
+        })).toEqual({
+            type: 'spawn-in-directory',
+            agent: 'rig',
+            directory: '/Users/rig/project',
+            clientRequestId: 'mobile-request-1',
+            approvedNewDirectoryCreation: true,
+            providerId: 'claude',
+            modelId: 'shared-model',
+            permissionMode: 'read_only',
+            effort: 'max',
+        });
+    });
+
+    it('rejects a model/effort combination absent from the published catalog', () => {
+        expect(() => buildRigSpawnConfiguration(rigMachine, {
+            directory: '/Users/rig/project',
+            clientRequestId: 'mobile-request-2',
+            modelKey: 'claude:shared-model',
+            effort: 'high',
+        })).toThrow('reasoning level is unavailable');
+    });
+});

--- a/packages/happy-app/sources/sync/rigSessionCreation.ts
+++ b/packages/happy-app/sources/sync/rigSessionCreation.ts
@@ -26,6 +26,8 @@ export type RigMachineSessionCreation = {
     defaultModelKey: string | null;
     defaultPermissionMode: string | null;
     supportsWorktrees: boolean;
+    /** Backoff the machine publishes for polling a `pending` spawn result. */
+    pendingRetryAfterMs: number | null;
     effortsForModel: (modelKey: string | null | undefined) => string[];
     defaultEffortForModel: (modelKey: string | null | undefined) => string | null;
 };
@@ -70,7 +72,14 @@ type RigMachineMetadata = {
     } | null;
     models?: unknown;
     operatingModes?: unknown;
+    sessionCreation?: { pendingRetryAfterMs?: unknown } | null;
 };
+
+/** Bounds applied to any retry delay before it reaches `delay()`. */
+const PENDING_RETRY_MIN_MS = 250;
+const PENDING_RETRY_MAX_MS = 10_000;
+/** Used when neither the RPC result nor the machine publishes a delay. */
+const PENDING_RETRY_DEFAULT_MS = 1_000;
 
 function asRigMachineMetadata(metadata: MachineMetadata | null | undefined): RigMachineMetadata | null {
     return metadata as unknown as RigMachineMetadata | null;
@@ -78,6 +87,29 @@ function asRigMachineMetadata(metadata: MachineMetadata | null | undefined): Rig
 
 function nonEmptyString(value: unknown): string | null {
     return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Backoff before polling a `pending` spawn result again.
+ *
+ * `retryAfterMs` arrives from an unvalidated machine RPC payload, so it is only
+ * typed as a number: a Rig that omits it produced `Math.max(250, undefined)` —
+ * `NaN` — and `delay(NaN)` resolves immediately, turning the backoff into
+ * back-to-back retries. Falls back to the delay the machine publishes in
+ * `sessionCreation.pendingRetryAfterMs`, then to a fixed default.
+ */
+export function resolveRigPendingRetryDelayMs(
+    retryAfterMs: unknown,
+    publishedRetryAfterMs?: number | null,
+): number {
+    const requested = finiteNumber(retryAfterMs)
+        ?? finiteNumber(publishedRetryAfterMs)
+        ?? PENDING_RETRY_DEFAULT_MS;
+    return Math.min(PENDING_RETRY_MAX_MS, Math.max(PENDING_RETRY_MIN_MS, requested));
 }
 
 function records(value: unknown): Record<string, unknown>[] {
@@ -178,6 +210,7 @@ export function getRigMachineSessionCreation(
         defaultModelKey,
         defaultPermissionMode,
         supportsWorktrees: rig.capabilities?.worktrees === true,
+        pendingRetryAfterMs: finiteNumber(rig.sessionCreation?.pendingRetryAfterMs),
         effortsForModel: (modelKey) => modelFor(modelKey)?.thinkingLevels ?? [],
         defaultEffortForModel: (modelKey) => modelFor(modelKey)?.defaultThinkingLevel ?? null,
     };

--- a/packages/happy-app/sources/sync/rigSessionCreation.ts
+++ b/packages/happy-app/sources/sync/rigSessionCreation.ts
@@ -1,0 +1,228 @@
+import type { Machine, MachineMetadata } from './storageTypes';
+import { qualifyRigModelKey } from './rig';
+
+/** A model option as published by a Rig machine, qualified by provider. */
+export type RigMachineModelOption = {
+    key: string;
+    id: string;
+    providerId: string;
+    name: string;
+    providerName: string;
+    description: string | null;
+    thinkingLevels: string[];
+    defaultThinkingLevel: string | null;
+};
+
+export type RigMachineModeOption = {
+    key: string;
+    name: string;
+    description: string | null;
+    semanticKind: string | null;
+};
+
+export type RigMachineSessionCreation = {
+    models: RigMachineModelOption[];
+    permissionModes: RigMachineModeOption[];
+    defaultModelKey: string | null;
+    defaultPermissionMode: string | null;
+    supportsWorktrees: boolean;
+    effortsForModel: (modelKey: string | null | undefined) => string[];
+    defaultEffortForModel: (modelKey: string | null | undefined) => string | null;
+};
+
+export type BuildRigSpawnConfigurationInput = {
+    directory: string;
+    clientRequestId: string;
+    approvedNewDirectoryCreation?: boolean;
+    modelKey?: string | null;
+    permissionMode?: string | null;
+    effort?: string | null;
+};
+
+/**
+ * The precise machine RPC payload accepted by Rig's `spawn-happy-session`
+ * handler. It deliberately has no Happy CLI-only fields such as `modelMode`
+ * or resume ids.
+ */
+export type RigSpawnConfiguration = {
+    type: 'spawn-in-directory';
+    agent: 'rig';
+    directory: string;
+    clientRequestId: string;
+    approvedNewDirectoryCreation?: boolean;
+    providerId: string;
+    modelId: string;
+    permissionMode: string;
+    effort: string;
+};
+
+type RigMachineMetadata = {
+    machineKind?: unknown;
+    rigOnly?: unknown;
+    client?: { id?: unknown } | null;
+    cliAvailability?: { rig?: unknown } | null;
+    capabilities?: { newSession?: unknown; worktrees?: unknown } | null;
+    defaults?: {
+        providerId?: unknown;
+        modelId?: unknown;
+        permissionMode?: unknown;
+        effort?: unknown;
+    } | null;
+    models?: unknown;
+    operatingModes?: unknown;
+};
+
+function asRigMachineMetadata(metadata: MachineMetadata | null | undefined): RigMachineMetadata | null {
+    return metadata as unknown as RigMachineMetadata | null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+    return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+    if (!Array.isArray(value)) return [];
+    return value.filter((item): item is Record<string, unknown> => (
+        typeof item === 'object' && item !== null && !Array.isArray(item)
+    ));
+}
+
+function strings(value: unknown): string[] {
+    return Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === 'string' && item.length > 0)
+        : [];
+}
+
+/** True only for a machine published by Rig, never for a Rig session. */
+export function isRigMachine(metadata: MachineMetadata | null | undefined): boolean {
+    const rig = asRigMachineMetadata(metadata);
+    return rig?.machineKind === 'rig'
+        || rig?.rigOnly === true
+        || rig?.client?.id === 'rig'
+        || rig?.cliAvailability?.rig === true;
+}
+
+/**
+ * Turns a Rig machine's dynamic catalog into picker-ready options. Returns
+ * null for regular Happy CLI machines or a Rig machine that cannot create
+ * sessions.
+ */
+export function getRigMachineSessionCreation(
+    metadata: MachineMetadata | null | undefined,
+): RigMachineSessionCreation | null {
+    const rig = asRigMachineMetadata(metadata);
+    if (!isRigMachine(metadata) || rig?.capabilities?.newSession !== true) return null;
+
+    const models = records(rig.models).flatMap((model): RigMachineModelOption[] => {
+        const providerId = nonEmptyString(model.providerId)
+            ?? nonEmptyString((model.provider as Record<string, unknown> | undefined)?.id);
+        const id = nonEmptyString(model.id) ?? nonEmptyString(model.code);
+        if (!providerId || !id) return [];
+
+        const provider = model.provider as Record<string, unknown> | undefined;
+        const name = nonEmptyString(model.name) ?? nonEmptyString(model.value) ?? id;
+        const providerName = nonEmptyString(model.providerName)
+            ?? nonEmptyString(provider?.name)
+            ?? providerId;
+        const thinkingLevels = strings(model.thinkingLevels);
+        const declaredDefault = nonEmptyString(model.defaultThinkingLevel);
+        return [{
+            key: qualifyRigModelKey(providerId, id),
+            id,
+            providerId,
+            name,
+            providerName,
+            description: providerName,
+            thinkingLevels,
+            defaultThinkingLevel: declaredDefault && thinkingLevels.includes(declaredDefault)
+                ? declaredDefault
+                : thinkingLevels[0] ?? null,
+        }];
+    });
+
+    const permissionModes = records(rig.operatingModes).flatMap((mode): RigMachineModeOption[] => {
+        const key = nonEmptyString(mode.code);
+        if (!key) return [];
+        return [{
+            key,
+            name: nonEmptyString(mode.value) ?? key,
+            description: nonEmptyString(mode.description),
+            semanticKind: nonEmptyString(mode.kind),
+        }];
+    });
+
+    const defaultModelKey = (() => {
+        const providerId = nonEmptyString(rig.defaults?.providerId);
+        const modelId = nonEmptyString(rig.defaults?.modelId);
+        const publishedDefault = providerId && modelId
+            ? qualifyRigModelKey(providerId, modelId)
+            : null;
+        return models.some((model) => model.key === publishedDefault)
+            ? publishedDefault
+            : models[0]?.key ?? null;
+    })();
+    const publishedPermission = nonEmptyString(rig.defaults?.permissionMode);
+    const defaultPermissionMode = permissionModes.some((mode) => mode.key === publishedPermission)
+        ? publishedPermission
+        : permissionModes[0]?.key ?? null;
+
+    const modelFor = (modelKey: string | null | undefined) => (
+        models.find((model) => model.key === modelKey)
+        ?? models.find((model) => model.key === defaultModelKey)
+        ?? null
+    );
+
+    return {
+        models,
+        permissionModes,
+        defaultModelKey,
+        defaultPermissionMode,
+        supportsWorktrees: rig.capabilities?.worktrees === true,
+        effortsForModel: (modelKey) => modelFor(modelKey)?.thinkingLevels ?? [],
+        defaultEffortForModel: (modelKey) => modelFor(modelKey)?.defaultThinkingLevel ?? null,
+    };
+}
+
+/** Finds an online Rig machine whose machine RPC can create new sessions. */
+export function findConnectedRigMachine(machines: readonly Machine[]): Machine | null {
+    return machines.find((machine) => (
+        machine.active && getRigMachineSessionCreation(machine.metadata) !== null
+    )) ?? null;
+}
+
+/** Builds a validated, provider-qualified request for Rig's machine RPC. */
+export function buildRigSpawnConfiguration(
+    metadata: MachineMetadata | null | undefined,
+    input: BuildRigSpawnConfigurationInput,
+): RigSpawnConfiguration {
+    const creation = getRigMachineSessionCreation(metadata);
+    if (!creation) throw new Error('This machine is not available for Rig session creation.');
+    if (!nonEmptyString(input.directory)) throw new Error('A Rig session directory is required.');
+    if (!nonEmptyString(input.clientRequestId)) throw new Error('A Rig client request ID is required.');
+
+    const modelKey = input.modelKey ?? creation.defaultModelKey;
+    const model = creation.models.find((candidate) => candidate.key === modelKey);
+    if (!model) throw new Error('The selected Rig model is unavailable.');
+
+    const permissionMode = input.permissionMode ?? creation.defaultPermissionMode;
+    if (!permissionMode || !creation.permissionModes.some((mode) => mode.key === permissionMode)) {
+        throw new Error('The selected Rig permission mode is unavailable.');
+    }
+
+    const effort = input.effort ?? creation.defaultEffortForModel(model.key);
+    if (!effort || !model.thinkingLevels.includes(effort)) {
+        throw new Error('The selected Rig reasoning level is unavailable for this model.');
+    }
+
+    return {
+        type: 'spawn-in-directory',
+        agent: 'rig',
+        directory: input.directory,
+        clientRequestId: input.clientRequestId,
+        ...(input.approvedNewDirectoryCreation === true && { approvedNewDirectoryCreation: true }),
+        providerId: model.providerId,
+        modelId: model.id,
+        permissionMode,
+        effort,
+    };
+}

--- a/packages/happy-app/sources/sync/settings.ts
+++ b/packages/happy-app/sources/sync/settings.ts
@@ -35,7 +35,11 @@ export const SettingsSchema = z.object({
     sessionStatusBarDisplay: z.enum(SESSION_STATUS_BAR_DISPLAY_MODES).describe('Whether/where to show the branch, model, effort, and context status bar'),
     usageLimitShowRemaining: z.boolean().describe('Show plan rate limits as quota remaining instead of quota used'),
 
-    hideInactiveSessions: z.boolean().describe('Hide inactive sessions in the main list'),
+    // Drives the archive-visibility toggle: it hides archived sessions, not
+    // merely disconnected ones. The key keeps its original name because these
+    // settings sync between devices and app versions field by field, with no
+    // rename migration to carry an old key across.
+    hideInactiveSessions: z.boolean().describe('Hide archived sessions in the main list'),
     sortSessionsByActivity: z.boolean().describe('Sort the session list by last activity instead of creation date'),
     expResumeSession: z.boolean().describe('Enable experimental session resume feature'),
     fileDiffsSidebar: z.boolean().describe('Show the file diffs sidebar next to the chat on desktop'),

--- a/packages/happy-app/sources/sync/spawnRequestId.test.ts
+++ b/packages/happy-app/sources/sync/spawnRequestId.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ uuidCount: 0 }));
+
+vi.mock('expo-crypto', () => ({
+    randomUUID: () => `request-${++mocks.uuidCount}`,
+}));
+
+import {
+    buildSpawnRequestSignature,
+    completeSpawnRequest,
+    resolveSpawnRequestId,
+} from './spawnRequestId';
+
+const baseInput = {
+    machineId: 'machine-1',
+    agent: 'rig',
+    directory: '~/project',
+    worktree: '__none__',
+    modelKey: 'codex/gpt-5.6-sol',
+    permissionMode: 'auto',
+    effort: 'high',
+};
+
+describe('spawn request id', () => {
+    beforeEach(() => {
+        mocks.uuidCount = 0;
+        completeSpawnRequest();
+    });
+
+    it('reuses the key while the user retries the same request', () => {
+        const signature = buildSpawnRequestSignature(baseInput);
+
+        expect(resolveSpawnRequestId(signature)).toBe('request-1');
+        expect(resolveSpawnRequestId(signature)).toBe('request-1');
+        expect(resolveSpawnRequestId(buildSpawnRequestSignature(baseInput))).toBe('request-1');
+    });
+
+    it('mints a new key once a spawn succeeded', () => {
+        const signature = buildSpawnRequestSignature(baseInput);
+
+        expect(resolveSpawnRequestId(signature)).toBe('request-1');
+        completeSpawnRequest();
+        expect(resolveSpawnRequestId(signature)).toBe('request-2');
+    });
+
+    it('mints a new key when the user changes what they asked for', () => {
+        expect(resolveSpawnRequestId(buildSpawnRequestSignature(baseInput))).toBe('request-1');
+        expect(resolveSpawnRequestId(buildSpawnRequestSignature({
+            ...baseInput,
+            permissionMode: 'read_only',
+        }))).toBe('request-2');
+        expect(resolveSpawnRequestId(buildSpawnRequestSignature({
+            ...baseInput,
+            directory: '~/other',
+        }))).toBe('request-3');
+    });
+});

--- a/packages/happy-app/sources/sync/spawnRequestId.ts
+++ b/packages/happy-app/sources/sync/spawnRequestId.ts
@@ -1,0 +1,68 @@
+/**
+ * Idempotency key lifecycle for session spawning.
+ *
+ * Rig's `spawn-happy-session` RPC dedupes on `clientRequestId`: that key is the
+ * only thing that makes a retry safe, because the second call returns the
+ * session the first call created instead of creating another one. Minting a
+ * fresh UUID on every send threw that guarantee away — once the `pending` retry
+ * budget ran out (or an RPC timed out after Rig had already spawned), the user
+ * doing the obvious thing and pressing Start again shipped a brand new key, so
+ * Rig spawned a SECOND session in the same directory and the prompt only ever
+ * reached the newest one.
+ *
+ * The key therefore lives here, keyed by a signature of what the user asked
+ * for. It is reused for every retry of that same request and replaced only once
+ * a spawn actually produced a session, or once the user changed the request.
+ *
+ * It is deliberately in-memory only. The new session draft persists to MMKV,
+ * but this key is like the draft's attachments: it is only meaningful while the
+ * machine still remembers the in-flight request, and a key restored days later
+ * would at best be ignored and at worst attach to something unrelated.
+ */
+import { randomUUID } from 'expo-crypto';
+
+export type SpawnRequestSignatureInput = {
+    machineId: string | null;
+    agent: string;
+    /** Directory as the user picked it, before any worktree resolution. */
+    directory: string;
+    worktree: string | null;
+    modelKey: string | null;
+    permissionMode: string | null;
+    effort: string | null;
+};
+
+let pendingRequest: { signature: string; clientRequestId: string } | null = null;
+
+/** Stable description of "the same spawn the user is asking for". */
+export function buildSpawnRequestSignature(input: SpawnRequestSignatureInput): string {
+    return JSON.stringify([
+        input.machineId ?? '',
+        input.agent,
+        input.directory,
+        input.worktree ?? '',
+        input.modelKey ?? '',
+        input.permissionMode ?? '',
+        input.effort ?? '',
+    ]);
+}
+
+/**
+ * The idempotency key for this request. Retrying an unchanged request reuses
+ * the previous key; any change to the request mints a new one.
+ */
+export function resolveSpawnRequestId(signature: string): string {
+    if (pendingRequest?.signature === signature) {
+        return pendingRequest.clientRequestId;
+    }
+    pendingRequest = { signature, clientRequestId: randomUUID() };
+    return pendingRequest.clientRequestId;
+}
+
+/**
+ * Called once a spawn produced a session, so the next spawn of an identical
+ * request is treated as a new one rather than deduped into the finished session.
+ */
+export function completeSpawnRequest(): void {
+    pendingRequest = null;
+}

--- a/packages/happy-app/sources/sync/storage.ts
+++ b/packages/happy-app/sources/sync/storage.ts
@@ -12,7 +12,7 @@ function useDeepEqual<T>(selector: (state: StorageState) => T): (state: StorageS
 import { Session, Machine, GitStatus, SessionAgentModesPatch } from "./storageTypes";
 import type { GitStatusFiles } from "./gitStatusFiles";
 import type { ProjectFilesList } from "./projectFiles";
-import { buildProjectGroups, isProjectSession, type ProjectGroupData } from "./projectGroups";
+import { buildPathProjectGroups, buildProjectGroups, isProjectSession, type ProjectGroupData } from "./projectGroups";
 import { selectPendingCommunications, type PendingAgentCommunication } from "./agentCommunications";
 import { createReducer, reducer, ReducerState } from "./reducer/reducer";
 import { Message } from "./typesMessage";
@@ -34,7 +34,7 @@ import { getCurrentRealtimeSessionId, getVoiceSession } from '@/realtime/Realtim
 import { isMutableTool } from "@/components/tools/knownTools";
 import { DecryptedArtifact } from "./artifactTypes";
 import { FeedItem } from "./feedTypes";
-import { getRigActivityIndicators, getRigIdentity } from './rig';
+import { getRigActivityIndicators, getRigIdentity, isRigMetadata } from './rig';
 import { indexSessionsById } from './sessionIdentity';
 
 // Debounce timer for realtimeMode changes
@@ -98,14 +98,15 @@ export interface SessionRowData {
     createdAt?: number;
     hasDraft: boolean;
     active: boolean;
+    archived: boolean;
     machineId: string | null;
     path: string | null;
     homeDir: string | null;
     completedTodosCount: number;
     totalTodosCount: number;
     hasUnread: boolean;
-    // Rig-only project identity. Sessions from the Happy CLI leave these null
-    // and keep the flat, date-grouped presentation.
+    // Native project identity supplied by Rig. Happy CLI project cards derive
+    // their identity from machineId + path instead.
     projectId: string | null;
     projectName: string | null;
     // Names the git worktree this session runs in; null in the primary tree.
@@ -147,6 +148,8 @@ function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): 
         ...(!session.active && { activeAt: session.activeAt, createdAt: session.createdAt }),
         hasDraft: !!session.draft,
         active: session.active,
+        archived: session.metadata?.lifecycleState === 'archived'
+            || (!isRigMetadata(session.metadata) && !session.active),
         machineId: session.metadata?.machineId ?? null,
         path: session.metadata?.path ?? null,
         homeDir: session.metadata?.homeDir ?? null,
@@ -165,10 +168,9 @@ function buildSessionRowData(session: Session, unreadSessionIds?: Set<string>): 
 export type SessionListViewItem =
     | { type: 'header'; title: string }
     | { type: 'active-sessions'; sessions: SessionRowData[] }
-    | { type: 'archive-toggle'; hidden: boolean }
     | { type: 'project-group'; displayPath: string; machine: Machine }
-    | { type: 'projects-header' }
-    | { type: 'project'; project: ProjectGroupData }
+    | { type: 'projects-header'; source: 'rig' | 'happy' }
+    | { type: 'project'; source: 'rig' | 'happy'; project: ProjectGroupData }
     | { type: 'session'; session: SessionRowData };
 
 export type { ProjectGroupData, ProjectWorkspaceGroup } from './projectGroups';
@@ -272,11 +274,9 @@ function buildSessionListViewData(
     // hasUnread=false everywhere — exactly the bug this parameter caused twice.
     unreadSessionIds: Set<string>,
 ): SessionListViewItem[] {
-    // Separate active and inactive sessions. Rig sessions are pulled out
-    // entirely — they live in the projects section instead of the flat list.
-    const projectSessions: Session[] = [];
-    const activeSessions: Session[] = [];
-    const inactiveSessions: Session[] = [];
+    const rigProjectSessions: Session[] = [];
+    const rigPathSessions: Session[] = [];
+    const happySessions: Session[] = [];
 
     Object.values(sessions).forEach(session => {
         // Side chats are hidden children of another session — they render only
@@ -284,12 +284,14 @@ function buildSessionListViewData(
         if (session.metadata?.isSideChat) {
             return;
         }
-        if (isProjectSession(session)) {
-            projectSessions.push(session);
-        } else if (isSessionActive(session)) {
-            activeSessions.push(session);
+        if (isRigMetadata(session.metadata)) {
+            if (isProjectSession(session)) {
+                rigProjectSessions.push(session);
+            } else {
+                rigPathSessions.push(session);
+            }
         } else {
-            inactiveSessions.push(session);
+            happySessions.push(session);
         }
     });
 
@@ -300,98 +302,39 @@ function buildSessionListViewData(
     const sortKey = storage.getState().settings.sortSessionsByActivity
         ? (s: Session) => s.lastMessageSentAt ?? s.createdAt
         : (s: Session) => s.createdAt;
-    activeSessions.sort((a, b) => sortKey(b) - sortKey(a));
-    inactiveSessions.sort((a, b) => sortKey(b) - sortKey(a));
-    // Active first so a project surfaces its live work, newest-first within each.
-    projectSessions.sort((a, b) => {
+    const sortProjectSessions = (items: Session[]) => items.sort((a, b) => {
         const activeDelta = Number(isSessionActive(b)) - Number(isSessionActive(a));
         return activeDelta !== 0 ? activeDelta : sortKey(b) - sortKey(a);
     });
+    sortProjectSessions(rigProjectSessions);
+    sortProjectSessions(rigPathSessions);
+    sortProjectSessions(happySessions);
 
-    // Build unified list view data
     const listData: SessionListViewItem[] = [];
+    const toRow = (session: Session) => buildSessionRowData(session, unreadSessionIds);
 
-    // Projects sit above everything else and never mix with plain sessions
-    const projects = buildProjectGroups(
-        projectSessions,
-        s => buildSessionRowData(s, unreadSessionIds),
+    const rigProjects = [
+        ...buildProjectGroups(rigProjectSessions, toRow, isSessionActive),
+        ...buildPathProjectGroups(rigPathSessions, toRow, isSessionActive, 'rig'),
+    ];
+    if (rigProjects.length > 0) {
+        listData.push({ type: 'projects-header', source: 'rig' });
+        for (const project of rigProjects) {
+            listData.push({ type: 'project', source: 'rig', project });
+        }
+    }
+
+    const happyProjects = buildPathProjectGroups(
+        happySessions,
+        toRow,
         isSessionActive,
+        'happy',
     );
-    if (projects.length > 0) {
-        listData.push({ type: 'projects-header' });
-        for (const project of projects) {
-            listData.push({ type: 'project', project });
+    if (happyProjects.length > 0) {
+        listData.push({ type: 'projects-header', source: 'happy' });
+        for (const project of happyProjects) {
+            listData.push({ type: 'project', source: 'happy', project });
         }
-    }
-
-    // Add active sessions as a single item at the top (if any)
-    if (activeSessions.length > 0) {
-        listData.push({ type: 'active-sessions', sessions: activeSessions.map(s => buildSessionRowData(s, unreadSessionIds)) });
-    }
-
-    // Group inactive sessions by date
-    const now = new Date();
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-
-    let currentDateGroup: Session[] = [];
-    let currentDateString: string | null = null;
-
-    for (const session of inactiveSessions) {
-        const sessionDate = new Date(sortKey(session));
-        const dateString = sessionDate.toDateString();
-
-        if (currentDateString !== dateString) {
-            // Process previous group
-            if (currentDateGroup.length > 0 && currentDateString) {
-                const groupDate = new Date(currentDateString);
-                const sessionDateOnly = new Date(groupDate.getFullYear(), groupDate.getMonth(), groupDate.getDate());
-
-                let headerTitle: string;
-                if (sessionDateOnly.getTime() === today.getTime()) {
-                    headerTitle = 'Today';
-                } else if (sessionDateOnly.getTime() === yesterday.getTime()) {
-                    headerTitle = 'Yesterday';
-                } else {
-                    const diffTime = today.getTime() - sessionDateOnly.getTime();
-                    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-                    headerTitle = `${diffDays} days ago`;
-                }
-
-                listData.push({ type: 'header', title: headerTitle });
-                currentDateGroup.forEach(sess => {
-                    listData.push({ type: 'session', session: buildSessionRowData(sess, unreadSessionIds) });
-                });
-            }
-
-            // Start new group
-            currentDateString = dateString;
-            currentDateGroup = [session];
-        } else {
-            currentDateGroup.push(session);
-        }
-    }
-
-    // Process final group
-    if (currentDateGroup.length > 0 && currentDateString) {
-        const groupDate = new Date(currentDateString);
-        const sessionDateOnly = new Date(groupDate.getFullYear(), groupDate.getMonth(), groupDate.getDate());
-
-        let headerTitle: string;
-        if (sessionDateOnly.getTime() === today.getTime()) {
-            headerTitle = 'Today';
-        } else if (sessionDateOnly.getTime() === yesterday.getTime()) {
-            headerTitle = 'Yesterday';
-        } else {
-            const diffTime = today.getTime() - sessionDateOnly.getTime();
-            const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-            headerTitle = `${diffDays} days ago`;
-        }
-
-        listData.push({ type: 'header', title: headerTitle });
-        currentDateGroup.forEach(sess => {
-            listData.push({ type: 'session', session: buildSessionRowData(sess, unreadSessionIds) });
-        });
     }
 
     return listData;

--- a/packages/happy-app/sources/sync/storageTypes.spec.ts
+++ b/packages/happy-app/sources/sync/storageTypes.spec.ts
@@ -97,6 +97,42 @@ describe('MachineMetadataSchema', () => {
         expect(metadata.models?.[0]?.thinkingLevels).toEqual(['low', 'high']);
         expect((metadata as any).futureRigMachineField).toEqual({ enabled: true });
     });
+
+    // A failed parse returns null for the whole metadata object, so anything Rig
+    // may legitimately omit has to survive. These are the shapes its own session
+    // schema already permits.
+    const machineBase = {
+        host: 'workstation',
+        platform: 'darwin',
+        happyCliVersion: '0.0.136',
+        happyHomeDir: '/Users/dev/.happy',
+        homeDir: '/Users/dev',
+        machineKind: 'rig',
+        cliAvailability: {
+            claude: false,
+            codex: false,
+            gemini: false,
+            openclaw: false,
+            agy: false,
+            rig: true,
+            detectedAt: 123,
+        },
+    };
+
+    it.each([
+        ['a model without a reasoning level', { models: [{ code: 'c', value: 'v', id: 'm', providerId: 'p' }] }],
+        ['a model with a null reasoning level', { models: [{ code: 'c', value: 'v', id: 'm', providerId: 'p', defaultThinkingLevel: null }] }],
+        ['an operating mode with a null description', { operatingModes: [{ code: 'auto', value: 'Auto', description: null }] }],
+        ['an operating mode without a kind', { operatingModes: [{ code: 'auto', value: 'Auto', description: 'd' }] }],
+        ['partial defaults', { defaults: { providerId: 'codex' } }],
+        ['an unreadable catalog block', { models: 'not-an-array' }],
+    ])('keeps the rest of the machine when Rig publishes %s', (_label, rigFields) => {
+        const metadata = MachineMetadataSchema.parse({ ...machineBase, ...rigFields });
+
+        expect(metadata.host).toBe('workstation');
+        expect(metadata.platform).toBe('darwin');
+        expect(metadata.cliAvailability?.rig).toBe(true);
+    });
 });
 
 describe('AgentGoalStatusSchema', () => {

--- a/packages/happy-app/sources/sync/storageTypes.spec.ts
+++ b/packages/happy-app/sources/sync/storageTypes.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AgentGoalStatusSchema, AgentStateSchema, MetadataSchema } from './storageTypes';
+import { AgentGoalStatusSchema, AgentStateSchema, MachineMetadataSchema, MetadataSchema } from './storageTypes';
 import { rigMetadataFixture } from './__testdata__/rigMetadata';
 
 describe('MetadataSchema', () => {
@@ -33,6 +33,69 @@ describe('MetadataSchema', () => {
         expect(metadata.models).toHaveLength(2);
         expect(metadata.activity?.subagents.queued).toBe(2);
         expect((metadata as any).futureCapability).toEqual({ supported: true });
+    });
+});
+
+describe('MachineMetadataSchema', () => {
+    it('preserves the Rig creation catalog and future machine fields', () => {
+        const metadata = MachineMetadataSchema.parse({
+            host: 'workstation',
+            platform: 'darwin',
+            happyCliVersion: '0.0.136',
+            happyHomeDir: '/Users/dev/.happy',
+            homeDir: '/Users/dev',
+            machineKind: 'rig',
+            rigOnly: true,
+            rigMetadataVersion: 1,
+            client: { id: 'rig', name: 'Rig', version: '0.0.136' },
+            cliAvailability: {
+                claude: false,
+                codex: false,
+                gemini: false,
+                openclaw: false,
+                agy: false,
+                rig: true,
+                detectedAt: 123,
+            },
+            capabilities: { newSession: true, resume: false, worktrees: false },
+            defaults: {
+                effort: 'high',
+                modelId: 'gpt-5.6-sol',
+                permissionMode: 'auto',
+                providerId: 'codex',
+            },
+            providers: [{ id: 'codex', kind: 'codex', name: 'OpenAI Codex' }],
+            models: [{
+                id: 'gpt-5.6-sol',
+                code: 'gpt-5.6-sol',
+                name: 'GPT-5.6 Sol',
+                value: 'GPT-5.6 Sol',
+                providerId: 'codex',
+                providerKind: 'codex',
+                providerName: 'OpenAI Codex',
+                provider: { id: 'codex', kind: 'codex', name: 'OpenAI Codex' },
+                serviceTiers: [],
+                thinkingLevels: ['low', 'high'],
+                defaultThinkingLevel: 'high',
+            }],
+            operatingModes: [{
+                code: 'auto',
+                value: 'Auto',
+                description: 'Reviews elevated actions automatically.',
+                kind: 'safe-yolo',
+            }],
+            sessionCreation: {
+                idempotencyKey: 'clientRequestId',
+                pendingRetryAfterMs: 2_000,
+                resultKinds: ['success', 'pending', 'requestToApproveDirectoryCreation', 'error'],
+            },
+            futureRigMachineField: { enabled: true },
+        });
+
+        expect(metadata.cliAvailability?.rig).toBe(true);
+        expect(metadata.defaults?.providerId).toBe('codex');
+        expect(metadata.models?.[0]?.thinkingLevels).toEqual(['low', 'high']);
+        expect((metadata as any).futureRigMachineField).toEqual({ enabled: true });
     });
 });
 

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -428,8 +428,65 @@ export const MachineMetadataSchema = z.object({
         gemini: z.boolean(),
         openclaw: z.boolean(),
         agy: z.boolean().optional(), // optional: older CLIs don't report agy
+        rig: z.boolean().optional(), // Rig runs its own Happy-connected daemon
         detectedAt: z.number(),
     }).optional(),
+    // Rig registers as its own machine instead of being launched by happy-cli.
+    // Keep its creation catalog so the new-session UI can send Rig-native
+    // provider/model identifiers to the machine RPC.
+    machineKind: z.string().optional(),
+    rigOnly: z.boolean().optional(),
+    rigMetadataVersion: z.number().int().positive().optional(),
+    client: z.object({
+        id: z.string(),
+        name: z.string(),
+        version: z.string(),
+    }).passthrough().optional(),
+    capabilities: z.object({
+        newSession: z.boolean().optional(),
+        resume: z.boolean().optional(),
+        worktrees: z.boolean().optional(),
+    }).passthrough().optional(),
+    defaults: z.object({
+        effort: z.string(),
+        modelId: z.string(),
+        permissionMode: z.string(),
+        providerId: z.string(),
+    }).passthrough().optional(),
+    providers: z.array(z.object({
+        id: z.string(),
+        kind: z.string(),
+        name: z.string(),
+    }).passthrough()).optional(),
+    models: z.array(z.object({
+        id: z.string(),
+        code: z.string(),
+        name: z.string(),
+        value: z.string(),
+        providerId: z.string(),
+        providerKind: z.string(),
+        providerName: z.string(),
+        provider: z.object({
+            id: z.string(),
+            kind: z.string(),
+            name: z.string(),
+        }).passthrough(),
+        contextWindow: z.number().optional(),
+        serviceTiers: z.array(z.string()),
+        thinkingLevels: z.array(z.string()),
+        defaultThinkingLevel: z.string(),
+    }).passthrough()).optional(),
+    operatingModes: z.array(z.object({
+        code: z.string(),
+        value: z.string(),
+        description: z.string(),
+        kind: z.string(),
+    }).passthrough()).optional(),
+    sessionCreation: z.object({
+        idempotencyKey: z.string(),
+        pendingRetryAfterMs: z.number(),
+        resultKinds: z.array(z.string()),
+    }).passthrough().optional(),
     resumeSupport: z.object({
         rpcAvailable: z.boolean(),
         requiresSameMachine: z.boolean(),
@@ -437,7 +494,7 @@ export const MachineMetadataSchema = z.object({
         happyAgentAuthenticated: z.boolean(),
         detectedAt: z.number(),
     }).optional(),
-});
+}).passthrough();
 
 export type MachineMetadata = z.infer<typeof MachineMetadataSchema>;
 

--- a/packages/happy-app/sources/sync/storageTypes.ts
+++ b/packages/happy-app/sources/sync/storageTypes.ts
@@ -447,53 +447,62 @@ export const MachineMetadataSchema = z.object({
         resume: z.boolean().optional(),
         worktrees: z.boolean().optional(),
     }).passthrough().optional(),
+    // The Rig catalog below mirrors the optionality of MetadataSchema at the top
+    // of this file, which models the same payload for a session. Rig is a
+    // separate codebase shipping on its own schedule, so a field it omits or
+    // sends as null must not fail the parse: a rejected parse returns null for
+    // the ENTIRE machine metadata (see machineEncryption.ts), which would strip
+    // host, platform and CLI availability over an unread reasoning level.
+    // Each block also catches independently, so an unforeseen shape degrades to
+    // "no Rig session creation" rather than "no machine".
     defaults: z.object({
-        effort: z.string(),
-        modelId: z.string(),
-        permissionMode: z.string(),
-        providerId: z.string(),
-    }).passthrough().optional(),
+        effort: z.string().optional(),
+        modelId: z.string().optional(),
+        permissionMode: z.string().optional(),
+        providerId: z.string().optional(),
+    }).passthrough().optional().catch(undefined),
     providers: z.array(z.object({
         id: z.string(),
-        kind: z.string(),
-        name: z.string(),
-    }).passthrough()).optional(),
+        kind: z.string().optional(),
+        name: z.string().optional(),
+    }).passthrough()).optional().catch(undefined),
     models: z.array(z.object({
-        id: z.string(),
         code: z.string(),
-        name: z.string(),
         value: z.string(),
-        providerId: z.string(),
-        providerKind: z.string(),
-        providerName: z.string(),
+        description: z.string().nullish(),
+        id: z.string().optional(),
+        name: z.string().optional(),
+        providerId: z.string().optional(),
+        providerKind: z.string().optional(),
+        providerName: z.string().optional(),
         provider: z.object({
             id: z.string(),
             kind: z.string(),
             name: z.string(),
-        }).passthrough(),
+        }).passthrough().optional(),
         contextWindow: z.number().optional(),
-        serviceTiers: z.array(z.string()),
-        thinkingLevels: z.array(z.string()),
-        defaultThinkingLevel: z.string(),
-    }).passthrough()).optional(),
+        serviceTiers: z.array(z.string()).optional(),
+        thinkingLevels: z.array(z.string()).optional(),
+        defaultThinkingLevel: z.string().nullish(),
+    }).passthrough()).optional().catch(undefined),
     operatingModes: z.array(z.object({
         code: z.string(),
         value: z.string(),
-        description: z.string(),
-        kind: z.string(),
-    }).passthrough()).optional(),
+        description: z.string().nullish(),
+        kind: z.string().optional(),
+    }).passthrough()).optional().catch(undefined),
     sessionCreation: z.object({
-        idempotencyKey: z.string(),
-        pendingRetryAfterMs: z.number(),
-        resultKinds: z.array(z.string()),
-    }).passthrough().optional(),
+        idempotencyKey: z.string().optional(),
+        pendingRetryAfterMs: z.number().optional(),
+        resultKinds: z.array(z.string()).optional(),
+    }).passthrough().optional().catch(undefined),
     resumeSupport: z.object({
-        rpcAvailable: z.boolean(),
-        requiresSameMachine: z.boolean(),
-        requiresHappyAgentAuth: z.boolean(),
-        happyAgentAuthenticated: z.boolean(),
-        detectedAt: z.number(),
-    }).optional(),
+        rpcAvailable: z.boolean().optional(),
+        requiresSameMachine: z.boolean().optional(),
+        requiresHappyAgentAuth: z.boolean().optional(),
+        happyAgentAuthenticated: z.boolean().optional(),
+        detectedAt: z.number().optional(),
+    }).passthrough().optional().catch(undefined),
 }).passthrough();
 
 export type MachineMetadata = z.infer<typeof MachineMetadataSchema>;

--- a/packages/happy-app/sources/utils/newSessionAgentSelection.test.ts
+++ b/packages/happy-app/sources/utils/newSessionAgentSelection.test.ts
@@ -19,6 +19,14 @@ describe('resolveMachineAgent', () => {
         })).toBe('codex');
     });
 
+    it('selects Rig on a Rig-only machine', () => {
+        expect(resolveMachineAgent('claude', {
+            rig: true,
+            claude: false,
+            codex: false,
+        })).toBe('rig');
+    });
+
     it('keeps the persisted selection when capability metadata is missing', () => {
         expect(resolveMachineAgent('claude', undefined)).toBe('claude');
     });

--- a/packages/happy-app/sources/utils/newSessionAgentSelection.ts
+++ b/packages/happy-app/sources/utils/newSessionAgentSelection.ts
@@ -1,6 +1,7 @@
 import type { NewSessionAgentType } from '@/sync/persistence';
 
 export const NEW_SESSION_AGENT_ORDER: readonly NewSessionAgentType[] = [
+    'rig',
     'claude',
     'codex',
     'openclaw',

--- a/packages/happy-app/sources/utils/newSessionModeSelection.test.ts
+++ b/packages/happy-app/sources/utils/newSessionModeSelection.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePermissionStyle, resolveSelectedOption } from './newSessionModeSelection';
+
+const modes = [
+    { key: 'default', name: 'Default' },
+    { key: 'yolo', name: 'YOLO' },
+];
+
+describe('new session mode selection', () => {
+    it('resolves the indexed option and falls back to the first one', () => {
+        expect(resolveSelectedOption(modes, 1)).toEqual({ key: 'yolo', name: 'YOLO' });
+        expect(resolveSelectedOption(modes, 7)).toEqual({ key: 'default', name: 'Default' });
+    });
+
+    it('returns null when a Rig machine publishes no options at all', () => {
+        // Rig machines with no `operatingModes` reach the composer with an
+        // empty permission catalog; the screen must render without a pick.
+        expect(resolveSelectedOption([], 0)).toBeNull();
+        expect(resolveSelectedOption([], 3)).toBeNull();
+    });
+
+    it('has no permission accent without a selection or for the default mode', () => {
+        expect(resolvePermissionStyle(null)).toBeNull();
+        expect(resolvePermissionStyle(undefined)).toBeNull();
+        expect(resolvePermissionStyle(resolveSelectedOption(modes, 0))).toBeNull();
+        expect(resolvePermissionStyle(resolveSelectedOption([], 0))).toBeNull();
+    });
+
+    it('accents the permission modes that change agent behaviour', () => {
+        expect(resolvePermissionStyle({ key: 'yolo' })?.color).toBe('#F87171');
+        expect(resolvePermissionStyle({ key: 'plan' })?.icon).toBe('pause');
+        expect(resolvePermissionStyle({ key: 'read-only' })?.icon).toBe('pause');
+    });
+});

--- a/packages/happy-app/sources/utils/newSessionModeSelection.ts
+++ b/packages/happy-app/sources/utils/newSessionModeSelection.ts
@@ -1,0 +1,44 @@
+/**
+ * Null-safe option selection for the new session composer.
+ *
+ * A Rig machine publishes its own catalog and the machine metadata schema
+ * makes `operatingModes` / `models` optional, so `getRigMachineSessionCreation`
+ * legitimately returns empty option arrays. `options[index] ?? options[0]` is
+ * then `undefined`, and every consumer that dereferenced it crashed the whole
+ * screen. Selections are nullable here so the composer degrades to "no picker,
+ * no styling" instead — the same shape HomeDock already resolves its options in.
+ */
+import type { PermissionMode } from '@/components/modelModeOptions';
+
+export type PermissionStyle = { color: string; icon: 'play-forward' | 'pause' };
+
+/** The current option of an index-driven picker, or null when none is offered. */
+export function resolveSelectedOption<T>(options: readonly T[], index: number): T | null {
+    return options[index] ?? options[0] ?? null;
+}
+
+/**
+ * Accent for permission modes that deviate from plain ask-first behaviour.
+ * Returns null for the ambient `default` mode and for no selection at all.
+ */
+export function resolvePermissionStyle(
+    permission: Pick<PermissionMode, 'key'> | null | undefined,
+): PermissionStyle | null {
+    switch (permission?.key) {
+        case 'acceptEdits':
+        case 'auto_edit':
+            return { color: '#A78BFA', icon: 'play-forward' };
+        case 'plan':
+            return { color: '#5EABA4', icon: 'pause' };
+        case 'dontAsk':
+        case 'safe-yolo':
+            return { color: '#FBBF24', icon: 'play-forward' };
+        case 'bypassPermissions':
+        case 'yolo':
+            return { color: '#F87171', icon: 'play-forward' };
+        case 'read-only':
+            return { color: '#60A5FA', icon: 'pause' };
+        default:
+            return null;
+    }
+}

--- a/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
+++ b/packages/happy-app/sources/utils/sessionDisplayOrder.test.ts
@@ -26,6 +26,7 @@ function session(
         createdAt,
         hasDraft: false,
         active: true,
+        archived: false,
         machineId,
         path,
         homeDir: null,
@@ -71,7 +72,6 @@ describe('session display order', () => {
         }));
         const data: SessionListViewItem[] = [
             { type: 'active-sessions', sessions: activeSessions },
-            { type: 'archive-toggle', hidden: false },
             ...inactiveSessions,
         ];
 
@@ -85,6 +85,50 @@ describe('session display order', () => {
             'inactive-4',
             'inactive-5',
             'inactive-6',
+        ]);
+    });
+
+    it('numbers sessions nested in the shared project-card layout', () => {
+        const data: SessionListViewItem[] = [
+            { type: 'projects-header', source: 'rig' },
+            {
+                type: 'project',
+                source: 'rig',
+                project: {
+                    id: 'rig-project',
+                    name: 'rig',
+                    machineId: 'machine-a',
+                    activeCount: 1,
+                    sessionCount: 1,
+                    workspaces: [{
+                        id: '',
+                        name: null,
+                        sessions: [session('rig-session', 'machine-a', '/rig')],
+                    }],
+                },
+            },
+            { type: 'projects-header', source: 'happy' },
+            {
+                type: 'project',
+                source: 'happy',
+                project: {
+                    id: 'happy-project',
+                    name: 'happy',
+                    machineId: 'machine-a',
+                    activeCount: 1,
+                    sessionCount: 1,
+                    workspaces: [{
+                        id: '',
+                        name: null,
+                        sessions: [session('happy-session', 'machine-a', '/happy')],
+                    }],
+                },
+            },
+        ];
+
+        expect(getSessionShortcutIdsInDisplayOrder(data, machines, 'Unknown')).toEqual([
+            'rig-session',
+            'happy-session',
         ]);
     });
 });

--- a/packages/happy-app/sources/utils/sessionDisplayOrder.ts
+++ b/packages/happy-app/sources/utils/sessionDisplayOrder.ts
@@ -98,6 +98,10 @@ export function getSessionShortcutIdsInDisplayOrder(
                         projectGroup.sessions.forEach((session) => sessionIds.push(session.id));
                     });
             });
+        } else if (item.type === 'project') {
+            item.project.workspaces.forEach((workspace) => {
+                workspace.sessions.forEach((session) => sessionIds.push(session.id));
+            });
         } else if (item.type === 'session') {
             sessionIds.push(item.session.id);
         }

--- a/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
@@ -7,6 +7,7 @@ import { log } from "@/utils/log";
 import { randomKeyNaked } from "@/utils/randomKeyNaked";
 import { allocateUserSeq } from "@/storage/seq";
 import { sessionDelete } from "@/app/session/sessionDelete";
+import { activityCache } from "@/app/presence/sessionCache";
 
 export function sessionRoutes(app: Fastify) {
 
@@ -366,6 +367,8 @@ export function sessionRoutes(app: Fastify) {
         const userId = request.userId;
         const { sessionId } = request.params;
 
+        activityCache.clearSessionUpdates(sessionId);
+
         const result = await db.session.updateMany({
             where: { id: sessionId, accountId: userId },
             data: { active: false, lastActiveAt: new Date() }
@@ -397,6 +400,8 @@ export function sessionRoutes(app: Fastify) {
     }, async (request, reply) => {
         const userId = request.userId;
         const { sessionId } = request.params;
+
+        activityCache.clearSessionUpdates(sessionId);
 
         const deleted = await sessionDelete({ uid: userId }, sessionId);
 

--- a/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
@@ -239,6 +239,10 @@ export function sessionRoutes(app: Fastify) {
         });
         if (session) {
             log({ module: 'session-create', sessionId: session.id, userId, tag }, `Found existing session: ${session.id} for tag ${tag}`);
+
+            // Session is starting back up - stop ignoring its heartbeats if it was stopped
+            activityCache.resumeSessionUpdates(session.id);
+
             return reply.send({
                 session: {
                     id: session.id,

--- a/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
+++ b/packages/happy-server/sources/app/api/socket/sessionUpdateHandler.ts
@@ -270,6 +270,8 @@ export function sessionUpdateHandler(userId: string, socket: Socket, connection:
                 return;
             }
 
+            activityCache.clearSessionUpdates(sid);
+
             // Update last active at
             await db.session.update({
                 where: { id: sid },

--- a/packages/happy-server/sources/app/presence/sessionCache.spec.ts
+++ b/packages/happy-server/sources/app/presence/sessionCache.spec.ts
@@ -77,4 +77,25 @@ describe("ActivityCache machine heartbeats", () => {
 
         activityCache.shutdown();
     });
+
+    it("discards a queued session heartbeat when the session is stopped", async () => {
+        const now = Date.parse("2026-01-01T00:00:00.000Z");
+        vi.setSystemTime(now);
+        dbMock.session.findUnique.mockResolvedValue({
+            id: "session-1",
+            accountId: "user-1",
+            lastActiveAt: new Date(now - 60_000),
+        });
+
+        const { activityCache } = await import("./sessionCache");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+        expect(activityCache.queueSessionUpdate("session-1", now)).toBe(true);
+        activityCache.clearSessionUpdates("session-1");
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(dbMock.session.update).not.toHaveBeenCalled();
+        activityCache.shutdown();
+    });
 });

--- a/packages/happy-server/sources/app/presence/sessionCache.spec.ts
+++ b/packages/happy-server/sources/app/presence/sessionCache.spec.ts
@@ -98,4 +98,117 @@ describe("ActivityCache machine heartbeats", () => {
         expect(dbMock.session.update).not.toHaveBeenCalled();
         activityCache.shutdown();
     });
+
+    it("ignores a heartbeat that arrives while the stopping write is still in flight", async () => {
+        const now = Date.parse("2026-01-01T00:00:00.000Z");
+        vi.setSystemTime(now);
+        // Session row is still active - the stop has not been committed yet
+        dbMock.session.findUnique.mockResolvedValue({
+            id: "session-1",
+            accountId: "user-1",
+            lastActiveAt: new Date(now - 60_000),
+        });
+
+        const { activityCache } = await import("./sessionCache");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+
+        // Stop route clears the cache, then awaits its database write
+        activityCache.clearSessionUpdates("session-1");
+
+        // Heartbeat lands in that window and would otherwise repopulate the cache
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(false);
+        expect(activityCache.queueSessionUpdate("session-1", now)).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(dbMock.session.update).not.toHaveBeenCalled();
+        activityCache.shutdown();
+    });
+
+    it("does not revive a session that was deleted while a heartbeat was reading the database", async () => {
+        const now = Date.parse("2026-01-01T00:00:00.000Z");
+        vi.setSystemTime(now);
+        let resolveFindUnique: (session: unknown) => void = () => { };
+        dbMock.session.findUnique.mockReturnValue(new Promise((resolve) => {
+            resolveFindUnique = resolve;
+        }));
+
+        const { activityCache } = await import("./sessionCache");
+
+        const heartbeat = activityCache.isSessionValid("session-1", "user-1");
+
+        // Session is deleted while the validation query is still in flight
+        activityCache.clearSessionUpdates("session-1");
+        resolveFindUnique({
+            id: "session-1",
+            accountId: "user-1",
+            lastActiveAt: new Date(now - 60_000),
+        });
+
+        await expect(heartbeat).resolves.toBe(false);
+        expect(activityCache.queueSessionUpdate("session-1", now)).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        // Updating a deleted row would throw P2025 and fail the whole batch
+        expect(dbMock.session.update).not.toHaveBeenCalled();
+        activityCache.shutdown();
+    });
+
+    it("marks a restarted session active again", async () => {
+        const now = Date.parse("2026-01-01T00:00:00.000Z");
+        vi.setSystemTime(now);
+        dbMock.session.findUnique.mockResolvedValue({
+            id: "session-1",
+            accountId: "user-1",
+            lastActiveAt: new Date(now - 60_000),
+        });
+        dbMock.session.update.mockResolvedValue({});
+
+        const { activityCache } = await import("./sessionCache");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+        activityCache.clearSessionUpdates("session-1");
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(false);
+
+        // Session comes back through POST /v1/sessions
+        activityCache.resumeSessionUpdates("session-1");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+        expect(activityCache.queueSessionUpdate("session-1", now)).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(dbMock.session.update).toHaveBeenCalledWith({
+            where: { id: "session-1" },
+            data: {
+                lastActiveAt: new Date(now),
+                active: true,
+            },
+        });
+
+        activityCache.shutdown();
+    });
+
+    it("stops ignoring heartbeats once the stop window expires", async () => {
+        const now = Date.parse("2026-01-01T00:00:00.000Z");
+        vi.setSystemTime(now);
+        dbMock.session.findUnique.mockResolvedValue({
+            id: "session-1",
+            accountId: "user-1",
+            lastActiveAt: new Date(now - 60_000),
+        });
+
+        const { activityCache } = await import("./sessionCache");
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+        activityCache.clearSessionUpdates("session-1");
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(false);
+
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        await expect(activityCache.isSessionValid("session-1", "user-1")).resolves.toBe(true);
+        activityCache.shutdown();
+    });
 });

--- a/packages/happy-server/sources/app/presence/sessionCache.ts
+++ b/packages/happy-server/sources/app/presence/sessionCache.ts
@@ -142,6 +142,14 @@ class ActivityCache {
         return false; // No update needed
     }
 
+    /**
+     * Forget queued heartbeats before a session is stopped, archived, or deleted.
+     * Otherwise the next batch flush can overwrite active=false with stale activity.
+     */
+    clearSessionUpdates(sessionId: string): void {
+        this.sessionCache.delete(sessionId);
+    }
+
     queueMachineUpdate(machineId: string, timestamp: number): boolean {
         const cached = this.machineCache.get(machineId);
         if (!cached) {

--- a/packages/happy-server/sources/app/presence/sessionCache.ts
+++ b/packages/happy-server/sources/app/presence/sessionCache.ts
@@ -20,6 +20,9 @@ interface MachineCacheEntry {
 class ActivityCache {
     private sessionCache = new Map<string, SessionCacheEntry>();
     private machineCache = new Map<string, MachineCacheEntry>();
+    // Sessions that were just stopped, archived or deleted, mapped to the time their
+    // heartbeat suppression expires
+    private stoppedSessions = new Map<string, number>();
     private batchTimer: ReturnType<typeof setInterval> | null = null;
     
     // Cache TTL (30 seconds)
@@ -30,6 +33,11 @@ class ActivityCache {
     
     // Batch update interval (5 seconds)
     private readonly BATCH_INTERVAL = 5 * 1000;
+
+    // How long heartbeats are ignored after a session is stopped (60 seconds).
+    // Longer than CACHE_TTL + BATCH_INTERVAL so that every in-flight heartbeat and
+    // every pending flush from before the stop is gone by the time it expires.
+    private readonly STOPPED_TTL = 60 * 1000;
 
     constructor() {
         this.startBatchTimer();
@@ -49,6 +57,14 @@ class ActivityCache {
 
     async isSessionValid(sessionId: string, userId: string): Promise<boolean> {
         const now = Date.now();
+
+        // Session was just stopped, archived or deleted - ignore heartbeats for a while
+        // instead of caching it again and letting a batch flush revive it
+        if (this.isSessionStopped(sessionId, now)) {
+            sessionCacheCounter.inc({ operation: 'session_validation', result: 'stopped' });
+            return false;
+        }
+
         const cached = this.sessionCache.get(sessionId);
         
         // Check cache first
@@ -66,6 +82,12 @@ class ActivityCache {
             });
             
             if (session) {
+                // Session could have been stopped while we were reading the database
+                if (this.isSessionStopped(sessionId, Date.now())) {
+                    sessionCacheCounter.inc({ operation: 'session_validation', result: 'stopped' });
+                    return false;
+                }
+
                 // Cache the result
                 this.sessionCache.set(sessionId, {
                     validUntil: now + this.CACHE_TTL,
@@ -126,6 +148,12 @@ class ActivityCache {
     }
 
     queueSessionUpdate(sessionId: string, timestamp: number): boolean {
+        // Heartbeat that was already in flight when the session was stopped
+        if (this.isSessionStopped(sessionId, Date.now())) {
+            databaseUpdatesSkippedCounter.inc({ type: 'session' });
+            return false;
+        }
+
         const cached = this.sessionCache.get(sessionId);
         if (!cached) {
             return false; // Should validate first
@@ -143,11 +171,36 @@ class ActivityCache {
     }
 
     /**
-     * Forget queued heartbeats before a session is stopped, archived, or deleted.
-     * Otherwise the next batch flush can overwrite active=false with stale activity.
+     * Forget queued heartbeats and ignore new ones before a session is stopped,
+     * archived, or deleted. Call this before the deactivating write: dropping the cache
+     * entry alone leaves a window where a heartbeat re-validates the session, caches it
+     * again and queues an update, and the next batch flush overwrites active=false with
+     * stale activity (or updates an already deleted row). Suppression expires by itself
+     * after STOPPED_TTL and is lifted early by resumeSessionUpdates.
      */
     clearSessionUpdates(sessionId: string): void {
         this.sessionCache.delete(sessionId);
+        this.stoppedSessions.set(sessionId, Date.now() + this.STOPPED_TTL);
+    }
+
+    /**
+     * Accept heartbeats again for a session that is legitimately starting back up,
+     * so a restarted session goes active without waiting out the suppression window.
+     */
+    resumeSessionUpdates(sessionId: string): void {
+        this.stoppedSessions.delete(sessionId);
+    }
+
+    private isSessionStopped(sessionId: string, now: number): boolean {
+        const stoppedUntil = this.stoppedSessions.get(sessionId);
+        if (stoppedUntil === undefined) {
+            return false;
+        }
+        if (stoppedUntil <= now) {
+            this.stoppedSessions.delete(sessionId);
+            return false;
+        }
+        return true;
     }
 
     queueMachineUpdate(machineId: string, timestamp: number): boolean {
@@ -247,6 +300,12 @@ class ActivityCache {
         for (const [machineId, entry] of this.machineCache.entries()) {
             if (entry.validUntil < now) {
                 this.machineCache.delete(machineId);
+            }
+        }
+
+        for (const [sessionId, stoppedUntil] of this.stoppedSessions.entries()) {
+            if (stoppedUntil <= now) {
+                this.stoppedSessions.delete(sessionId);
             }
         }
     }


### PR DESCRIPTION
## Summary

- add Rig as a first-class agent in the Happy composer, using the connected Rig machine and its published models, permission modes, effort levels, and worktree support
- spawn Rig sessions through an idempotent machine RPC and wait for the synchronized Happy session before navigating
- present Rig and Happy sessions with the same project-card hierarchy while preserving Rig project/worktree metadata
- make archive and delete lifecycle handling reliable by clearing stale heartbeats and distinguishing a true Rig archive from a temporary disconnect
- place archive visibility in the shared header and polish the mobile empty state, manual URL action, and bottom composer backdrop

## Behavior

Selecting Rig automatically targets an online Rig machine for the new session without rebinding the application. Temporarily disconnected Rig sessions remain visible, while genuinely archived sessions are hidden by the global archive control.

## Testing

- `pnpm --filter happy-app exec vitest run` (79 files, 877 tests)
- `pnpm --filter happy-app typecheck`
- `pnpm --filter happy-server exec vitest run sources/app/presence/sessionCache.spec.ts` (2 tests)
- `pnpm --filter happy-server typecheck`
- `git diff --check`