### PR TITLE
fix(app): size chat markdown images by their own aspect ratio

### DIFF
--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -17,6 +17,7 @@ import { MermaidRenderer } from './MermaidRenderer';
 import { t } from '@/text';
 import { isHttpMarkdownLink } from './linkUtils';
 import { openExternalUrl } from '@/utils/openExternalUrl';
+import { useImageIntrinsicSize } from '@/hooks/useImageIntrinsicSize';
 
 // Option type for callback
 export type Option = {
@@ -207,14 +208,28 @@ function RenderCodeBlock(props: { content: string, language: string | null, firs
     );
 }
 
+// Ratio used to reserve space before an image's real dimensions are known, so
+// the block does not start at zero height and then snap open.
+const DEFAULT_IMAGE_ASPECT_RATIO = 4 / 3;
+
 function RenderImageBlock(props: { url: string, alt: string, first: boolean, last: boolean }) {
     const accessibleLabel = props.alt || 'Markdown image';
+    const intrinsicSize = useImageIntrinsicSize(props.url);
+    // Size the image from its own aspect ratio rather than a fixed height: with
+    // a fixed height, `contain` makes height the binding constraint for any
+    // image taller than it is wide, so a portrait image is shrunk to a fraction
+    // of the message width. `maxWidth` caps the image at its source resolution
+    // so a small one is never upscaled to full bleed.
+    const sizing = React.useMemo(() => ({
+        aspectRatio: intrinsicSize ? intrinsicSize.width / intrinsicSize.height : DEFAULT_IMAGE_ASPECT_RATIO,
+        maxWidth: intrinsicSize?.width,
+    }), [intrinsicSize]);
 
     return (
         <View style={[style.imageBlock, props.first && style.first, props.last && style.last]}>
             <Image
                 source={{ uri: props.url }}
-                style={style.image}
+                style={[style.image, sizing]}
                 accessibilityLabel={accessibleLabel}
                 resizeMode="contain"
             />
@@ -539,8 +554,6 @@ const style = StyleSheet.create((theme) => ({
     },
     image: {
         width: '100%',
-        minHeight: 160,
-        height: 240,
         borderRadius: 12,
         backgroundColor: theme.colors.surfaceHighest,
     },

--- a/packages/happy-app/sources/hooks/useImageIntrinsicSize.ts
+++ b/packages/happy-app/sources/hooks/useImageIntrinsicSize.ts
@@ -1,0 +1,74 @@
+/**
+ * Resolves a remote image's intrinsic pixel size, so a caller can lay the image
+ * out at its own aspect ratio instead of inside a fixed-size box.
+ *
+ * Sizes are kept in a module-level LRU (max 200) that is read synchronously
+ * during render. The chat is a virtualized list, so a row scrolled out of view
+ * and back in remounts this hook; without the cache every remount would
+ * re-measure and the layout would jump again each time.
+ *
+ * Measurement uses the CALLBACK form of `Image.getSize` deliberately:
+ *  - react-native's types also expose a Promise overload, but react-native-web
+ *    only implements the callback form (`ImageWithStatics.getSize` in
+ *    react-native-web/dist/exports/Image/index.js), so an awaited call never
+ *    settles on web.
+ *  - `<Image onLoad>` is not usable either: react-native reports
+ *    `nativeEvent.source.{width,height}`, while react-native-web forwards the
+ *    raw DOM event (react-native-web/dist/modules/ImageLoader/index.js), so the
+ *    dimensions are undefined there.
+ *
+ * `Image.getSize` populates the same image cache the subsequent `<Image>` reads
+ * from, so measuring does not cost an extra network fetch in practice.
+ */
+import * as React from 'react';
+import { Image } from 'react-native';
+
+export type ImageIntrinsicSize = { width: number; height: number };
+
+const MAX_CACHE_ENTRIES = 200;
+const cache = new Map<string, ImageIntrinsicSize>();
+
+function rememberInCache(url: string, size: ImageIntrinsicSize) {
+    if (cache.has(url)) cache.delete(url);
+    cache.set(url, size);
+    while (cache.size > MAX_CACHE_ENTRIES) {
+        const oldest = cache.keys().next();
+        if (oldest.done) break;
+        cache.delete(oldest.value);
+    }
+}
+
+export function useImageIntrinsicSize(url: string | null): ImageIntrinsicSize | null {
+    const [resolved, setResolved] = React.useState<{ url: string, size: ImageIntrinsicSize } | null>(null);
+
+    React.useEffect(() => {
+        if (!url || cache.has(url)) {
+            return;
+        }
+        let cancelled = false;
+        Image.getSize(
+            url,
+            (width, height) => {
+                if (cancelled || !width || !height) {
+                    return;
+                }
+                const size = { width, height };
+                rememberInCache(url, size);
+                setResolved({ url, size });
+            },
+            () => {
+                // Unreachable image: leave the caller on its placeholder ratio.
+            }
+        );
+        return () => { cancelled = true; };
+    }, [url]);
+
+    if (!url) {
+        return null;
+    }
+    const cached = cache.get(url);
+    if (cached) {
+        return cached;
+    }
+    return resolved && resolved.url === url ? resolved.size : null;
+}


### PR DESCRIPTION
A markdown image in chat is rendered inside a fixed 240pt-tall box with `resizeMode="contain"`, so for any image taller than it is wide the height is the binding constraint and the picture is shrunk to a fraction of the message width — a 760×1151 screenshot paints 158pt wide in a 358pt column on a phone, 44% of the space available to it. This makes the block size itself from the image's own aspect ratio instead: a new `useImageIntrinsicSize` hook resolves the intrinsic dimensions via `Image.getSize` and caches them in a module-level LRU that is read synchronously during render, and `RenderImageBlock` passes `{ aspectRatio, maxWidth: intrinsicWidth }` in place of `minHeight: 160, height: 240`. The cache is load-bearing rather than an optimisation: the chat list is virtualized, so without it a row scrolled out of view and back in re-measures and the layout jumps again every time. `maxWidth` keeps a small image capped at its source resolution instead of being upscaled to full bleed — the old fixed box upscaled those too.

Two platform details worth flagging for review, both verified against the pinned dependencies rather than assumed:

- `Image.getSize` is called in its **callback** form deliberately. react-native's types also expose a `Promise<ImageSize>` overload, but react-native-web implements only the callback form (`ImageWithStatics.getSize`, `react-native-web/dist/exports/Image/index.js`), so an awaited call never settles on web.
- `<Image onLoad>` is not usable for this. react-native reports `nativeEvent.source.{width,height}`, while react-native-web forwards the raw DOM event (`react-native-web/dist/modules/ImageLoader/index.js`), so the dimensions are `undefined` there.

No height clamp is applied: a tall image grows tall and the chat scrolls, which keeps all of the content reachable. The pre-measurement placeholder is a 4:3 reserved box, matching the ratio `FileView` already uses for attachments whose dimensions the wire format omits.

## Proof

Measured on Expo web at a 390×844 viewport (phone width — a desktop viewport does not show the symptom), same fixture and same 358pt container in both states, toggling only `MarkdownView.tsx` on one running instance:

| | painted picture | fill of message width | h/w |
|---|---|---|---|
| before | 158 × 240 | 44% | 1.514 |
| after | 358 × 542 | 100% | 1.514 (0.03% from the source 1151/760) |

The painted region is what had to be measured, not the element box. react-native-web renders `<Image>` as a host div that paints via `background-image` + `background-size: contain`, so the host div is `358×240` in the before state and its own fill ratio reads 1.0 whether the bug is present or not — the letterboxing happens inside it. The numbers above were obtained two independent ways that agree to within 0.5px: analytically from the measured box and intrinsic size under `contain` semantics, and by thresholding saturated pixels in an element screenshot. The served bundle was confirmed to contain the change before the "after" measurement.
