### PR TITLE
feat(cli,app): surface the model-scoped weekly limit in the usage popup

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -895,13 +895,15 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     const contextStatus = props.usageData?.contextSize
         ? getContextStatus(props.usageData.contextSize, props.alwaysShowContextSize ?? false, theme, props.usageData.contextWindow)
         : null;
-    // Only Session and Week are user-meaningful; provider-internal windows
-    // (nimbus_quill and friends) stay out of the popup.
+    // Session, Week, and any allotment the backend bothered to name (the
+    // model-scoped weekly caps) are user-meaningful; provider-internal windows
+    // (nimbus_quill and friends) arrive unnamed and stay out of the popup.
     const usageRows = React.useMemo(() => {
         const rows = getUsageLimitRows(props.sessionStatusUsageLimits ?? null);
         const session = rows.find((row) => row.id === 'five_hour') ?? null;
         const week = rows.find((row) => row.id === 'seven_day') ?? null;
-        return { session, week };
+        const scoped = rows.filter((row) => row.scoped);
+        return { session, week, scoped };
     }, [props.sessionStatusUsageLimits]);
     const weekPercent = usageRows.week?.utilization != null && (props.alwaysShowContextSize || contextStatus != null)
         ? getUsageLimitDisplayPercentage(usageRows.week.utilization, usageLimitShowRemaining)
@@ -919,6 +921,11 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
         };
         push('session', t('agentInput.usagePopup.session'), usageRows.session);
         push('week', t('agentInput.usagePopup.week'), usageRows.week);
+        // The scope name is the model's own display name ("Fable") — a proper
+        // noun that reads the same in every locale, so it needs no string key.
+        for (const row of usageRows.scoped) {
+            push(row.id, row.label, row);
+        }
         return options;
     }, [usageRows, usageLimitShowRemaining]);
 

--- a/packages/happy-app/sources/utils/sessionStatusBar.test.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.test.ts
@@ -70,6 +70,26 @@ describe('usage limit helpers', () => {
         expect(chips[0].id).toBe('seven_day');
     });
 
+    it('marks backend-named windows as scoped and leaves wire-only ids alone', () => {
+        const rows = getUsageLimitRows({
+            capturedAt: 1,
+            windows: [
+                { id: 'five_hour', status: 'allowed', utilization: 52, resetsAt: 100 },
+                { id: 'seven_day', status: 'allowed', utilization: 10, resetsAt: 200 },
+                { id: 'nimbus_quill', status: 'allowed', utilization: 3, resetsAt: 200 },
+                { id: 'weekly_fable', label: 'Fable', status: 'allowed', utilization: 17, resetsAt: 200 },
+            ],
+        });
+        const scoped = rows.filter(r => r.scoped);
+        expect(scoped.map(r => r.id)).toEqual(['weekly_fable']);
+        // The popup labels the row with the display name the backend sent.
+        expect(scoped[0].label).toBe('Fable');
+        expect(scoped[0].utilization).toBe(17);
+        // Plan and provider-internal windows carry no name, so they stay out.
+        expect(rows.find(r => r.id === 'nimbus_quill')?.scoped).toBe(false);
+        expect(rows.find(r => r.id === 'seven_day')?.scoped).toBe(false);
+    });
+
     it('hides chips for windows without numeric utilization and for absent data', () => {
         expect(getUsageLimitChips({ capturedAt: 1, windows: [{ id: 'five_hour', utilization: null }] }, false)).toEqual([]);
         expect(getUsageLimitChips(undefined, false)).toEqual([]);

--- a/packages/happy-app/sources/utils/sessionStatusBar.ts
+++ b/packages/happy-app/sources/utils/sessionStatusBar.ts
@@ -140,6 +140,13 @@ export type UsageLimitRow = {
     utilization: number | null;
     resetsAt: number | null;
     status: UsageLimitStatus;
+    /**
+     * The backend named this window (a model-scoped allotment like the Fable
+     * weekly cap carries its display name); plan and provider-internal windows
+     * arrive with an id only. Callers use this to tell "worth showing a human"
+     * apart from wire noise without hardcoding ids.
+     */
+    scoped: boolean;
 };
 
 /** All windows for the detail popover, well-known ids first. */
@@ -161,6 +168,7 @@ export function getUsageLimitRows(limits: UsageLimitsLike): UsageLimitRow[] {
             : null,
         resetsAt: typeof w.resetsAt === 'number' && Number.isFinite(w.resetsAt) ? w.resetsAt : null,
         status: getUsageLimitStatus(w),
+        scoped: typeof w.label === 'string' && w.label.trim().length > 0,
     }));
 }
 

--- a/packages/happy-cli/src/claude/utils/usageLimits.test.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.test.ts
@@ -33,6 +33,31 @@ describe('windowsFromGetUsage', () => {
         expect(windows[0].utilization).toBeNull();
         expect(windows[0].status).toBeUndefined();
     });
+
+    it('maps model-scoped limits[] entries into windows and skips unscoped kinds', () => {
+        const windows = windowsFromGetUsage({
+            five_hour: { utilization: 52, resets_at: '2026-07-31T04:50:00Z' },
+            seven_day_opus: null,
+            limits: [
+                { kind: 'session', group: 'session', percent: 52, severity: 'normal', resets_at: '2026-07-31T04:50:00Z', scope: null, is_active: true },
+                { kind: 'weekly_all', group: 'weekly', percent: 10, severity: 'normal', resets_at: '2026-08-07T01:00:00Z', scope: null, is_active: false },
+                { kind: 'weekly_scoped', group: 'weekly', percent: 17, severity: 'normal', resets_at: '2026-08-07T01:00:00Z', scope: { model: { id: null, display_name: 'Fable' }, surface: null }, is_active: false },
+            ],
+        });
+        expect(windows.map(w => w.id)).toEqual(['five_hour', 'weekly_fable']);
+        const fable = windows.find(w => w.id === 'weekly_fable')!;
+        expect(fable.label).toBe('Fable');
+        expect(fable.utilization).toBe(17);
+        expect(fable.status).toBe('allowed');
+        expect(fable.resetsAt).toBe(Date.parse('2026-08-07T01:00:00Z'));
+    });
+
+    it('tolerates malformed or scope-less limits entries', () => {
+        expect(windowsFromGetUsage({ limits: {} })).toEqual([]);
+        expect(windowsFromGetUsage({
+            limits: [null, 'x', {}, { kind: 'weekly_scoped', group: 'weekly', percent: 5, scope: { model: { display_name: '  ' } } }],
+        })).toEqual([]);
+    });
 });
 
 describe('fromRateLimitEvent', () => {

--- a/packages/happy-cli/src/claude/utils/usageLimits.ts
+++ b/packages/happy-cli/src/claude/utils/usageLimits.ts
@@ -7,7 +7,10 @@
  *   fraction, `resetsAt` is unix seconds (derived from the
  *   anthropic-ratelimit-unified-reset header).
  * - `get_usage` (pull): all windows at once. Utilization is 0-100,
- *   `resets_at` is an ISO 8601 string, and windows carry no status.
+ *   `resets_at` is an ISO 8601 string, and windows carry no status. Newer
+ *   backends additionally report model-scoped allotments (e.g. the Fable 5
+ *   weekly cap) as `{kind, group, percent, scope}` entries in a `limits`
+ *   array, while the legacy per-model buckets (`seven_day_opus`, …) stay null.
  */
 import type { UsageLimits, UsageLimitWindow, UsageLimitWindowStatus } from '@/api/types';
 
@@ -61,6 +64,44 @@ function normalizeIsoResetsAt(iso: string | null | undefined): number | null {
 
 type GetUsageWindow = { utilization: number | null, resets_at: string | null } | null | undefined;
 
+type ScopedLimitEntry = {
+    group?: unknown,
+    percent?: unknown,
+    resets_at?: unknown,
+    scope?: { model?: { display_name?: unknown } | null, surface?: unknown } | null,
+}
+
+/**
+ * Unscoped entries (kind `session` / `weekly_all`) mirror the top-level
+ * `five_hour` / `seven_day` buckets, so only scoped entries become windows.
+ * The id is derived from group + scope name (`weekly_fable`) to stay stable
+ * across snapshots, and the scope name doubles as the display label.
+ */
+function windowsFromScopedLimits(limits: unknown): UsageLimitWindow[] {
+    if (!Array.isArray(limits)) return [];
+    const windows: UsageLimitWindow[] = [];
+    for (const entry of limits) {
+        if (!entry || typeof entry !== 'object') continue;
+        const { group, percent, resets_at, scope } = entry as ScopedLimitEntry;
+        const rawName = scope?.model?.display_name ?? scope?.surface;
+        if (typeof rawName !== 'string' || !rawName.trim()) continue;
+        const label = rawName.trim();
+        const groupKey = typeof group === 'string' && group ? group : 'scoped';
+        const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+        const utilization = typeof percent === 'number' && Number.isFinite(percent)
+            ? Math.min(100, Math.max(0, percent))
+            : null;
+        windows.push({
+            id: `${groupKey}_${slug}`,
+            label,
+            utilization,
+            resetsAt: normalizeIsoResetsAt(typeof resets_at === 'string' ? resets_at : null),
+            status: synthesizeStatus(utilization),
+        });
+    }
+    return windows;
+}
+
 export function windowsFromGetUsage(rateLimits: Record<string, unknown>): UsageLimitWindow[] {
     const windows: UsageLimitWindow[] = [];
     for (const [id, value] of Object.entries(rateLimits)) {
@@ -80,6 +121,7 @@ export function windowsFromGetUsage(rateLimits: Record<string, unknown>): UsageL
             status: synthesizeStatus(utilization),
         });
     }
+    windows.push(...windowsFromScopedLimits(rateLimits['limits']));
     return windows;
 }
 


### PR DESCRIPTION
Since #1556 the usage row reads plan rate limits from `get_usage`. That response still carries the top-level `five_hour` / `seven_day` buckets, but the legacy per-model buckets (`seven_day_opus`, …) now come back `null` — the backend reports model-scoped allotments (currently the Fable weekly cap) as entries in a `limits` array instead. Nothing reads that array, so a user who has burned through their Fable weekly allowance sees no sign of it anywhere in Happy.

**Before:** with a `weekly_scoped` entry at 17% in the payload, the usage popup lists Session and Week only.
**After:** it lists a third row under the backend's own display name — `Fable · 17%`, with its reset time.

**CLI** — `windowsFromGetUsage` maps scoped `limits[]` entries into windows keyed group + scope (`weekly_fable`), using the scope's display name as the label. Unscoped kinds (`session`, `weekly_all`) duplicate the top-level buckets and are skipped, so nothing double-counts.

**App** — `getUsageLimitRows` now reports whether the backend named a window. `label` is assigned in exactly one place in the CLI (the scoped-limits mapper), so a name is a reliable "a human asked for this allotment" signal. The popup lists named rows after Session and Week. That keeps provider-internal windows (`nimbus_quill` and friends) out — they arrive unnamed — without an id whitelist every future scope would have to be added to.

**Rebased onto current `main`.** This PR predates c15eeee9. Its original app half added a chip to the status bar; that status bar is gone, so the app half now targets the usage popup instead. `CHIP_WINDOW_LABELS` is left exactly as `main` has it.

**Disclosure — the id is derived, not declared.** The payload gives no stable key for a scoped limit, so the id is built from the scope's display name (`"Fable"` → `weekly_fable`). Rendering is label-driven, so if that display name changes the id changes with it but the row still appears under the new name; only cross-snapshot id continuity is lost. A backend-declared id would be better; this is what the payload offers today.

## Validation

- `happy-app` typecheck clean
- `happy-cli` typecheck: no new errors relative to `main` (same check run on a pristine `main` checkout for comparison)
- `usageLimits` 17/17, `sessionStatusBar` 13/13
- 3 tests: CLI scoped-limit mapping, CLI malformed/scope-less entries, app named-vs-unnamed row classification

The two screenshots that were here showed the status-bar chip, which `main` no longer has, so they're removed rather than left misleading. Happy to attach a fresh popup capture if that helps review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
