### PR TITLE
feat(app): long-press option chips to pick several and run them in sequence

### DIFF
--- a/packages/happy-app/sources/components/markdown/MarkdownView.tsx
+++ b/packages/happy-app/sources/components/markdown/MarkdownView.tsx
@@ -1,6 +1,7 @@
 import { MarkdownSpan, parseMarkdown } from './parseMarkdown';
 import * as React from 'react';
 import { Image, Pressable, View, Platform } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { HorizontalScrollView } from '../HorizontalScrollView';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { StyleSheet } from 'react-native-unistyles';
@@ -225,28 +226,95 @@ function RenderImageBlock(props: { url: string, alt: string, first: boolean, las
     );
 }
 
-function RenderOptionsBlock(props: { 
-    items: string[], 
-    first: boolean, 
-    last: boolean, 
+function RenderOptionsBlock(props: {
+    items: string[],
+    first: boolean,
+    last: boolean,
     selectable: boolean,
-    onOptionPress?: (option: Option) => void 
+    onOptionPress?: (option: Option) => void
 }) {
+    // Multi-select mode is per-block local state only: null == off, a Set of
+    // selected indices == on. Not persisted, not synced, dies on unmount.
+    // Single tap keeps sending immediately; long-press enters selection mode
+    // so the user can batch several options into one "run in sequence" message.
+    const [selected, setSelected] = React.useState<Set<number> | null>(null);
+    const inSelectionMode = selected !== null;
+
+    const enterSelection = React.useCallback((index: number) => {
+        setSelected(new Set([index]));
+    }, []);
+
+    const toggle = React.useCallback((index: number) => {
+        setSelected((prev) => {
+            const next = new Set(prev ?? []);
+            if (next.has(index)) {
+                next.delete(index);
+            } else {
+                next.add(index);
+            }
+            return next;
+        });
+    }, []);
+
+    const cancel = React.useCallback(() => {
+        setSelected(null);
+    }, []);
+
+    const runInSequence = React.useCallback(() => {
+        if (!props.onOptionPress || !selected || selected.size === 0) {
+            return;
+        }
+        // Compose one message from the selected options in display order.
+        const chosen = props.items.filter((_, index) => selected.has(index));
+        const combined = [t('markdown.optionsSequencePrompt'), ...chosen.map((text, i) => `${i + 1}. ${text}`)].join('\n');
+        props.onOptionPress({ title: combined });
+        setSelected(null);
+    }, [props.onOptionPress, props.items, selected]);
+
     return (
         <View style={[style.optionsContainer, props.first && style.first, props.last && style.last]}>
             {props.items.map((item, index) => {
                 if (props.onOptionPress) {
+                    const isSelected = selected?.has(index) ?? false;
                     return (
-                        <Pressable 
-                            key={index} 
+                        <Pressable
+                            key={index}
                             style={({ pressed }) => [
                                 style.optionPressable,
                                 style.optionItem,
+                                isSelected && style.optionItemSelected,
                                 pressed && style.optionItemPressed
                             ]}
-                            onPress={() => props.onOptionPress?.({ title: item })}
+                            onPress={() => {
+                                if (inSelectionMode) {
+                                    toggle(index);
+                                } else {
+                                    props.onOptionPress?.({ title: item });
+                                }
+                            }}
+                            onLongPress={() => enterSelection(index)}
+                            // Web: mouse-hold fires onLongPress, but the browser also pops
+                            // its native context menu on right-click / long-press. Suppress it
+                            // and enter selection mode, mirroring SessionsList's precedent.
+                            {...(Platform.OS === 'web' ? ({
+                                onContextMenu: (event: any) => {
+                                    event.preventDefault?.();
+                                    event.stopPropagation?.();
+                                    enterSelection(index);
+                                },
+                            } as any) : {})}
                         >
-                            <Text selectable={props.selectable} style={style.optionText}>{item}</Text>
+                            <View style={style.optionRow}>
+                                {inSelectionMode ? (
+                                    <Ionicons
+                                        name={isSelected ? 'checkmark-circle' : 'ellipse-outline'}
+                                        size={20}
+                                        color={isSelected ? style.optionCheckSelected.color : style.optionCheck.color}
+                                        style={style.optionCheckIcon}
+                                    />
+                                ) : null}
+                                <Text selectable={props.selectable && !inSelectionMode} style={style.optionText}>{item}</Text>
+                            </View>
                         </Pressable>
                     );
                 } else {
@@ -257,6 +325,32 @@ function RenderOptionsBlock(props: {
                     );
                 }
             })}
+            {inSelectionMode ? (
+                <View style={style.optionsActionsRow}>
+                    <Pressable
+                        style={({ pressed }) => [
+                            style.optionsActionButton,
+                            style.optionsActionRun,
+                            (selected?.size ?? 0) === 0 && style.optionsActionDisabled,
+                            pressed && style.optionItemPressed,
+                        ]}
+                        disabled={(selected?.size ?? 0) === 0}
+                        onPress={runInSequence}
+                    >
+                        <Text style={style.optionsActionRunText}>{t('markdown.optionsRunInSequence')}</Text>
+                    </Pressable>
+                    <Pressable
+                        style={({ pressed }) => [
+                            style.optionsActionButton,
+                            style.optionsActionCancel,
+                            pressed && style.optionItemPressed,
+                        ]}
+                        onPress={cancel}
+                    >
+                        <Text style={style.optionsActionCancelText}>{t('common.cancel')}</Text>
+                    </Pressable>
+                </View>
+            ) : null}
         </View>
     );
 }
@@ -615,6 +709,58 @@ const style = StyleSheet.create((theme) => ({
         fontSize: 16,
         lineHeight: 24,
         color: theme.colors.text,
+    },
+    optionItemSelected: {
+        borderColor: theme.colors.textLink,
+    },
+    optionRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+    },
+    optionCheckIcon: {
+        marginLeft: -2,
+    },
+    optionCheck: {
+        color: theme.colors.textSecondary,
+    },
+    optionCheckSelected: {
+        color: theme.colors.textLink,
+    },
+    optionsActionsRow: {
+        flexDirection: 'row',
+        gap: 8,
+        marginTop: 4,
+    },
+    optionsActionButton: {
+        borderRadius: Platform.select({ web: 8, default: 18 }),
+        paddingHorizontal: 20,
+        paddingVertical: Platform.select({ web: 12, default: 14 }),
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    optionsActionRun: {
+        backgroundColor: theme.colors.textLink,
+    },
+    optionsActionRunText: {
+        ...Typography.default('semiBold'),
+        fontSize: 16,
+        lineHeight: 20,
+        color: theme.colors.button.primary.tint,
+    },
+    optionsActionCancel: {
+        backgroundColor: Platform.select({ web: theme.colors.surfaceHighest, default: theme.colors.surface }),
+        borderWidth: Platform.select({ web: 1, default: StyleSheet.hairlineWidth }),
+        borderColor: theme.colors.divider,
+    },
+    optionsActionCancelText: {
+        ...Typography.default(),
+        fontSize: 16,
+        lineHeight: 20,
+        color: theme.colors.text,
+    },
+    optionsActionDisabled: {
+        opacity: 0.5,
     },
 
     //

--- a/packages/happy-app/sources/text/_default.ts
+++ b/packages/happy-app/sources/text/_default.ts
@@ -965,6 +965,9 @@ export const en = {
         codeCopied: 'Code copied',
         copyFailed: 'Copy failed',
         mermaidRenderFailed: 'Failed to render mermaid diagram',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Run in sequence',
+        optionsSequencePrompt: 'Please do the following in order:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/ca.ts
+++ b/packages/happy-app/sources/text/translations/ca.ts
@@ -949,6 +949,9 @@ export const ca: TranslationStructure = {
         codeCopied: 'Codi copiat',
         copyFailed: 'Error al copiar',
         mermaidRenderFailed: 'Error al renderitzar el diagrama mermaid',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Executa en seqüència',
+        optionsSequencePrompt: 'Fes el següent en ordre:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/en.ts
+++ b/packages/happy-app/sources/text/translations/en.ts
@@ -963,6 +963,9 @@ export const en: TranslationStructure = {
         codeCopied: 'Code copied',
         copyFailed: 'Failed to copy',
         mermaidRenderFailed: 'Failed to render mermaid diagram',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Run in sequence',
+        optionsSequencePrompt: 'Please do the following in order:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/es.ts
+++ b/packages/happy-app/sources/text/translations/es.ts
@@ -949,6 +949,9 @@ export const es: TranslationStructure = {
         codeCopied: 'Código copiado',
         copyFailed: 'Error al copiar',
         mermaidRenderFailed: 'Error al renderizar el diagrama mermaid',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Ejecutar en secuencia',
+        optionsSequencePrompt: 'Haz lo siguiente en orden:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/it.ts
+++ b/packages/happy-app/sources/text/translations/it.ts
@@ -947,6 +947,9 @@ export const it: TranslationStructure = {
         codeCopied: 'Codice copiato',
         copyFailed: 'Copia non riuscita',
         mermaidRenderFailed: 'Impossibile renderizzare il diagramma mermaid',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Esegui in sequenza',
+        optionsSequencePrompt: 'Esegui quanto segue nell\'ordine indicato:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/ja.ts
+++ b/packages/happy-app/sources/text/translations/ja.ts
@@ -950,6 +950,9 @@ export const ja: TranslationStructure = {
         codeCopied: 'コードをコピーしました',
         copyFailed: 'コピーに失敗しました',
         mermaidRenderFailed: 'Mermaidダイアグラムのレンダリングに失敗しました',
+        // Multi-select on option chips
+        optionsRunInSequence: '順番に実行',
+        optionsSequencePrompt: '以下を順番に実行してください：',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/pl.ts
+++ b/packages/happy-app/sources/text/translations/pl.ts
@@ -965,6 +965,9 @@ export const pl: TranslationStructure = {
         codeCopied: 'Kod skopiowany',
         copyFailed: 'Błąd kopiowania',
         mermaidRenderFailed: 'Nie udało się wyświetlić diagramu mermaid',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Wykonaj po kolei',
+        optionsSequencePrompt: 'Wykonaj kolejno następujące czynności:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/pt.ts
+++ b/packages/happy-app/sources/text/translations/pt.ts
@@ -948,6 +948,9 @@ export const pt: TranslationStructure = {
         codeCopied: 'Código copiado',
         copyFailed: 'Falha ao copiar',
         mermaidRenderFailed: 'Falha ao renderizar diagrama mermaid',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Executar em sequência',
+        optionsSequencePrompt: 'Faça o seguinte em ordem:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/ru.ts
+++ b/packages/happy-app/sources/text/translations/ru.ts
@@ -965,6 +965,9 @@ export const ru: TranslationStructure = {
         codeCopied: 'Код скопирован',
         copyFailed: 'Ошибка копирования',
         mermaidRenderFailed: 'Не удалось отобразить диаграмму mermaid',
+        // Multi-select on option chips
+        optionsRunInSequence: 'Выполнить по порядку',
+        optionsSequencePrompt: 'Выполни следующее по порядку:',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/zh-Hans.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hans.ts
@@ -950,6 +950,9 @@ export const zhHans: TranslationStructure = {
         codeCopied: '代码已复制',
         copyFailed: '复制失败',
         mermaidRenderFailed: '渲染 mermaid 图表失败',
+        // Multi-select on option chips
+        optionsRunInSequence: '依次执行',
+        optionsSequencePrompt: '请依次完成以下事项：',
     },
 
     artifacts: {

--- a/packages/happy-app/sources/text/translations/zh-Hant.ts
+++ b/packages/happy-app/sources/text/translations/zh-Hant.ts
@@ -949,6 +949,9 @@ export const zhHant: TranslationStructure = {
         codeCopied: '程式碼已複製',
         copyFailed: '複製失敗',
         mermaidRenderFailed: '渲染 mermaid 圖表失敗',
+        // Multi-select on option chips
+        optionsRunInSequence: '依序執行',
+        optionsSequencePrompt: '請依序完成以下事項：',
     },
 
     artifacts: {


### PR DESCRIPTION
Option chips send one option per tap, which is right most of the time. But agents routinely offer options that aren't mutually exclusive — "run the tests / update the docs / open a PR" — and picking three today means three round trips, waiting out a full turn between each.

Long-press a chip to enter selection mode: checkmarks appear, tap to toggle, and **Run in sequence** composes the picked options into one numbered message so the agent works through them in order. A single tap outside selection mode behaves exactly as before.

The scope is deliberately small: selection is `useState` local to the one options block. Nothing is persisted, nothing is synced, and it clears on send, cancel, or unmount. No wire, storage, or settings change.

On web the chips suppress the browser's native context menu so a right-click or mouse-hold enters selection mode instead of popping the OS menu — the same approach already used in `SessionsList`.

Both new strings go through `t()` (`markdown.optionsRunInSequence`, `markdown.optionsSequencePrompt`) and are filled in for all 10 locales.

## Visual proof

Captured from this branch in the web app, via the app's own `/dev/messages-demo` route with one temporary `<options>` message in the demo data (that edit is **not** part of this PR — it was reverted after the screenshots). The component, press handlers and send path are the real ones.

Before — single tap untouched:

![option chips, normal state](https://raw.githubusercontent.com/charliezong18/happy/assets-pr1660-1661/1661-before.png)

Long-press (right-click on web) enters selection mode; two of three picked:

![two options selected with Run in sequence](https://raw.githubusercontent.com/charliezong18/happy/assets-pr1660-1661/1661-multiselect.png)

After sending, selection clears:

![selection cleared after sending](https://raw.githubusercontent.com/charliezong18/happy/assets-pr1660-1661/1661-after-send.png)

## Validation

- `happy-app` typecheck ✅
- app suite 909/909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
