### PR TITLE
fix(app): stop cropping tall mermaid diagrams on native

### DIFF
--- a/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
+++ b/packages/happy-app/sources/components/markdown/MermaidRenderer.tsx
@@ -5,8 +5,13 @@ import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Typography } from '@/constants/Typography';
 import { t } from '@/text';
 
-// Tall diagrams scroll inside a capped container instead of taking over the chat
-const MAX_DIAGRAM_HEIGHT = 600;
+// Runaway guard on the WebView-reported height, NOT a design cap. It used to be
+// 600, which silently cropped any diagram taller than that: the container is a
+// fixed-height WebView, so the excess was only reachable by scrolling *inside*
+// it, and the chat list swallows that gesture on Android. Web has never capped
+// the diagram (see webStyle below), so the two platforms disagreed as well.
+// Keep a ceiling only so a bad measurement cannot produce an absurd box.
+const MAX_DIAGRAM_HEIGHT = 8000;
 
 // Style for Web platform
 const webStyle: any = {


### PR DESCRIPTION
A mermaid diagram taller than 600dp is silently cropped on native: `MermaidRenderer` sizes its container to `Math.min(dimensions.height, MAX_DIAGRAM_HEIGHT)` with `MAX_DIAGRAM_HEIGHT = 600`, so everything past that line is simply not shown, with no scrollbar, fade, or any other indication that the diagram continues. The constant's comment says tall diagrams "scroll inside a capped container", and the `WebView` does set `scrollEnabled` — but on Android the chat list takes the vertical gesture, so dragging over the diagram scrolls the message list and never the diagram. The cropped part is unreachable in practice. This raises the ceiling to 8000 and restates it as what it should be: a guard against a bad height measurement producing an absurd box, rather than a layout decision about how tall a diagram is allowed to be.

Two things make this more than a constant that was tuned too low:

- **Web was never capped.** `webStyle` sets no height, so the same diagram renders in full in the browser and cropped on a phone. The platforms disagreed about the content, not just the presentation.
- **Sizing the container to its content removes the gesture conflict rather than relying on it.** Once the container is as tall as the diagram there is nothing to scroll inside the `WebView`, so the nested-scroll ambiguity that made the capped version unusable does not arise.

The measurement this feeds is already bounded by real content — `reportHeight()` reads the rendered SVG's `getBoundingClientRect().height` rather than `document.body.scrollHeight`, which is what an earlier fix in this file corrected — so the ceiling is only there for the pathological case.

## Proof

Reported and confirmed on a physical Android device (Samsung, 1080×2340) running a self-hosted build of this app. The diagram was a 15-node `flowchart TD` laying out to roughly 650dp at the message column width: before the change its bottom two nodes and their incoming edges were missing, and the fullscreen viewer — a fork-only affordance that does not exist on this code path upstream — showed them present, which is what identified the crop rather than a rendering failure. After the change the same diagram renders complete. `pnpm typecheck` is clean and `pnpm exec vitest run` passes 909/909 on this branch.

I did not attach a capture: the behaviour is native-only (web has no cap, so a browser recording shows the same thing before and after), and I don't have an Android capture rig that reaches the chat surface. Happy to produce one on an emulator if that would help review.
