### PR TITLE
fix(ci): record @slopus/happy-wire under devDependencies in the lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,9 +927,6 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.3.1
-      '@slopus/happy-wire':
-        specifier: workspace:*
-        version: link:../happy-wire
       '@stablelib/base64':
         specifier: ^2.0.1
         version: 2.0.1
@@ -1018,6 +1015,9 @@ importers:
       '@eslint/compat':
         specifier: ^1
         version: 1.4.1(eslint@9.39.2(jiti@2.6.1))
+      '@slopus/happy-wire':
+        specifier: workspace:*
+        version: link:../happy-wire
       '@types/inquirer':
         specifier: ^9.0.9
         version: 9.0.9


### PR DESCRIPTION
## main is red at the install step

`pnpm install --frozen-lockfile` fails on `main` as of 38767705, so CI stops before any check runs — on main itself and on every PR opened against it.

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/happy-cli/package.json

Failure reason:
  "devDependencies" in the lockfile ({"@eslint/compat":…}) doesn't match the
  same field in package.json ({"@eslint/compat":"^1",
  "@slopus/happy-wire":"workspace:*", …})
```

## Cause

e7e0ff6b moved `@slopus/happy-wire` from `dependencies` to `devDependencies` in `packages/happy-cli/package.json` — which is the right fix for the DOA `1.2.1-beta.0`, since `dependencies` is pkgroll's externals policy. The lockfile still records it under `dependencies` for that importer, and pnpm compares the two field by field.

## The change

The three lockfile lines move from `dependencies` to `devDependencies`. Nothing else changes — resolution is `link:../happy-wire` either way; only the field recording it moves.

A plain `pnpm install --lockfile-only` regeneration also clears the mismatch, but it drags in unrelated churn from re-resolved floating ranges — +76/-96 on my machine, including a `typescript` resolution moving 5.9.3 → 6.0.3 under `@prisma/client`. That did not belong in a CI unblock, so the entry is moved by hand.

## Verification

Clean checkout, pinned pnpm 10.11.0 (the `packageManager` version):

- `pnpm install --frozen-lockfile` on 38767705 → `ERR_PNPM_OUTDATED_LOCKFILE`
- same command on this branch → `Done in 13.4s`, exit 0
- the install leaves `pnpm-lock.yaml` byte-identical afterwards (no drift hiding in it)
- `packages/happy-wire` and `packages/happy-cli` both build clean
- `packages/happy-cli/dist` carries no `import` or `require` of `@slopus/happy-wire` — the only occurrences are the bundled copy of package.json's own text — so the inlining e7e0ff6b was after still holds with the entry in `devDependencies`

For cross-reference: `main`'s own CLI Smoke Test is failing on 38767705 and passing on 9ac022f1, which brackets the change.
