### PR TITLE
fix(app): surface the home dock's custom path entry above the path list

### DIFF
--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -889,11 +889,16 @@ export const HomeDock = React.memo(({
             return {
                 title: 'Project',
                 options: [
-                    ...projectOptions,
+                    // First, not last: projectOptions grows with every distinct
+                    // path the machine has ever run a session in, so appending
+                    // the only way to type a path buries it below a list with no
+                    // bound. The /new screen already puts its path field above
+                    // the same suggestions.
                     {
                         key: CUSTOM_PROJECT_PATH_KEY,
                         name: t('machineLauncher.enterCustomPath'),
                     },
+                    ...projectOptions,
                 ],
                 selectedKey: currentProject?.key,
                 onSelect: (key) => {


### PR DESCRIPTION
The session list's dock composer lets you pick where a new session runs, and typing a directory that has no session yet is the `Enter custom path` row in its PROJECT picker — but that row is appended *after* every distinct path the selected machine has ever run a session in. That list has no bound: on my machine it is 18 entries, the sheet shows four rows at a time, and the only way to type a directory ends up five swipes down. It reads as absent, which is how I hit this — I went looking for a way to set the cwd from the dock and concluded there wasn't one.

Moving the action to the top of the options list is the whole change. It costs nothing when the list is short, and it makes the two new-session entry points agree: the `/new` screen already puts its path field above the same recent-path suggestions (`PathPickerContent`), so only the dock ordered them the other way round.

Both platforms read the same array — iOS renders it as a `NativeOptionsPicker` menu, Android as the in-modal sheet — so the one change covers both.

Device capture on an Android emulator to follow in a comment.