### PR TITLE
fix(app): keep the home dock's config rows legible over the focus scrim

### DIFF
--- a/packages/happy-app/sources/components/HomeDock.tsx
+++ b/packages/happy-app/sources/components/HomeDock.tsx
@@ -65,6 +65,14 @@ type AgentSetting = 'agent' | 'model' | 'permission' | 'effort';
 
 const CUSTOM_PROJECT_PATH_KEY = '__custom_project_path__';
 
+// Focus mode dims the screen behind a fixed dark scrim (see `focusBackdrop`) in
+// BOTH themes, and the machine / project / worktree rows are drawn straight onto
+// it with no surface of their own — unlike the composer and the options sheet,
+// which each sit on light glass. So those rows have to be coloured for the
+// scrim, not for the theme: `theme.colors.text` is #000000 in the light theme,
+// which makes them black-on-black and reads as "the picker got dimmed too".
+const FOCUS_SCRIM_TEXT = '#FFFFFF';
+
 const AGENTS: Array<{ key: NewSessionAgentType; name: string }> = [
     { key: 'rig', name: 'Rig' },
     { key: 'claude', name: 'Claude Code' },
@@ -298,7 +306,7 @@ const styles = StyleSheet.create((theme) => ({
     focusConfigValue: {
         flex: 1,
         minWidth: 0,
-        color: theme.colors.text,
+        color: FOCUS_SCRIM_TEXT,
         fontSize: 17,
         ...Typography.default(),
     },
@@ -979,7 +987,7 @@ export const HomeDock = React.memo(({
                     <Ionicons
                         name={row.icon}
                         size={compact ? 21 : 18}
-                        color={theme.colors.text}
+                        color={compact ? FOCUS_SCRIM_TEXT : theme.colors.text}
                     />
                 </View>
                 {compact ? (


### PR DESCRIPTION
Tapping the session list's dock composer opens focus mode, which covers the screen with a `rgba(0, 0, 0, 0.88)` scrim. The machine / project / worktree rows sit above that scrim, and they are the only part of focus mode drawn with no surface of their own — the composer and the options sheet each render on `MobileGlassSurface`. Their text and icons still take `theme.colors.text`, which is `#000000` in the light theme, so they come out black on near-black and read as though the picker had been dimmed along with the background. That is how it was reported to me: "the part where I choose the cwd gets dimmed too."

The scrim is the same colour in both themes, so content painted directly on it cannot take its colour from the theme. Colouring those rows for the scrim fixes the light theme and leaves dark mode byte-identical — its `theme.colors.text` was already `#FFFFFF`.

Scoped to the compact (focus-mode) rows; the non-compact branch, which renders on light glass, keeps the theme colour.

Device capture to follow in a comment.