### PR TITLE
feat(app): start a session in a project straight from its card

### DIFF
--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -18,7 +18,7 @@ import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPop
 import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
 import { sessionKill } from '@/sync/ops';
 import { isWorktreePath, getRepoPath, getWorktreeName } from '@/utils/worktree';
-import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
+import { seedNewSessionDraftFrom } from '@/utils/newSessionFromProject';
 import { useRouter } from 'expo-router';
 import { SessionShortcutHintBadge } from './ShortcutHints';
 import { buildActiveSessionDisplayGroups } from '@/utils/sessionDisplayOrder';
@@ -61,7 +61,6 @@ const SectionHeader = React.memo(({ session, displayPath }: { session: SessionRo
     const styles = stylesheet;
     const { theme } = useUnistyles();
     const router = useRouter();
-    const draft = useNewSessionDraft();
 
     const sessionPath = session.path || '';
     const isWorktree = isWorktreePath(sessionPath);
@@ -77,16 +76,9 @@ const SectionHeader = React.memo(({ session, displayPath }: { session: SessionRo
     const hasBranch = !!branchName;
 
     const handleAdd = React.useCallback(() => {
-        const machineId = session.machineId;
-        if (machineId) {
-            draft.setMachineId(machineId);
-        }
-        const pathToSet = formatPathRelativeToHome(repoPath, session.homeDir ?? undefined);
-        draft.setPath(pathToSet);
-        draft.setSessionType(isWorktree ? 'worktree' : 'simple');
-        draft.setWorktreeKey(isWorktree ? sessionPath : null);
+        seedNewSessionDraftFrom(session);
         router.navigate('/new');
-    }, [session.machineId, session.homeDir, repoPath, isWorktree, sessionPath, draft, router]);
+    }, [router, session]);
 
     const [isHovered, setIsHovered] = React.useState(false);
 

--- a/packages/happy-app/sources/components/ProjectGroup.tsx
+++ b/packages/happy-app/sources/components/ProjectGroup.tsx
@@ -4,7 +4,10 @@ import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Text } from '@/components/StyledText';
 import { Typography } from '@/constants/Typography';
+import { useRouter } from 'expo-router';
 import { ProjectGroupData, ProjectWorkspaceGroup, useAllMachines, useLocalSettingMutable } from '@/sync/storage';
+import { t } from '@/text';
+import { seedNewSessionDraftFrom } from '@/utils/newSessionFromProject';
 import { CompactSessionRow } from './ActiveSessionsGroupCompact';
 
 interface ProjectGroupProps {
@@ -36,6 +39,20 @@ export const ProjectGroup = React.memo(({ project, selectedSessionId }: ProjectG
     // Worktrees only need naming when the project actually has more than one
     const showWorkspaceLabels = project.workspaces.length > 1;
 
+    // A card carries no working directory of its own — the cards keyed by path
+    // are grouped on (machine, path), so every session under one shares both and
+    // any of them answers "where would a new session here run".
+    const seedSession = React.useMemo(
+        () => project.workspaces.flatMap(w => w.sessions).find(s => s.path) ?? null,
+        [project.workspaces],
+    );
+    const router = useRouter();
+    const handleNewSession = React.useCallback(() => {
+        if (!seedSession) return;
+        seedNewSessionDraftFrom(seedSession);
+        router.navigate('/new');
+    }, [router, seedSession]);
+
     return (
         <View style={styles.container}>
             <Pressable style={styles.header} onPress={toggleCollapsed} hitSlop={8}>
@@ -55,6 +72,17 @@ export const ProjectGroup = React.memo(({ project, selectedSessionId }: ProjectG
                         </Text>
                     )}
                 </View>
+                {seedSession && (
+                    <Pressable
+                        onPress={handleNewSession}
+                        hitSlop={{ top: 15, bottom: 15, left: 8, right: 8 }}
+                        style={styles.addButton}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('sidebar.newSession')}
+                    >
+                        <Ionicons name="add" size={16} color={theme.colors.textSecondary} />
+                    </Pressable>
+                )}
                 <Text style={styles.count}>
                     {project.activeCount > 0 ? `${project.activeCount}/${project.sessionCount}` : project.sessionCount}
                 </Text>
@@ -138,6 +166,11 @@ const stylesheet = StyleSheet.create((theme) => ({
         color: theme.colors.textSecondary,
         marginTop: 1,
         ...Typography.default(),
+    },
+    addButton: {
+        paddingHorizontal: 4,
+        justifyContent: 'center',
+        alignItems: 'center',
     },
     count: {
         fontSize: 12,

--- a/packages/happy-app/sources/utils/newSessionFromProject.ts
+++ b/packages/happy-app/sources/utils/newSessionFromProject.ts
@@ -1,0 +1,29 @@
+import type { SessionRowData } from '@/sync/storage';
+import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
+import { formatPathRelativeToHome } from '@/utils/sessionUtils';
+import { getRepoPath, isWorktreePath } from '@/utils/worktree';
+
+/**
+ * Points the new-session draft at the project an existing session runs in, so
+ * "start another session here" needs no machine or path picking.
+ *
+ * A worktree session seeds the repository it belongs to plus the worktree, not
+ * the worktree path as a plain directory — otherwise the new session would be
+ * created as if the worktree were an unrelated project.
+ *
+ * Order matters: setMachineId clears the path (switching machines must not keep
+ * a directory from the previous one), so the path is set after it.
+ */
+export function seedNewSessionDraftFrom(session: SessionRowData): void {
+    const draft = useNewSessionDraft.getState();
+    const sessionPath = session.path || '';
+    const isWorktree = isWorktreePath(sessionPath);
+    const repoPath = isWorktree ? getRepoPath(sessionPath) : sessionPath;
+
+    if (session.machineId) {
+        draft.setMachineId(session.machineId);
+    }
+    draft.setPath(formatPathRelativeToHome(repoPath, session.homeDir ?? undefined));
+    draft.setSessionType(isWorktree ? 'worktree' : 'simple');
+    draft.setWorktreeKey(isWorktree ? sessionPath : null);
+}


### PR DESCRIPTION
Every project card in the session list already knows which machine and directory its sessions run in, and shows that directory as its title. Starting another session there still meant opening `/new` and picking the same machine and the same path by hand — for a folder the list was displaying at that moment.

This gives each card the `+` the active-sessions header already has. It seeds the new-session draft from one of the card's own sessions and opens `/new` with the machine and path filled in, leaving only the prompt to type.

The seeding moves into one function both call. It was written inline in the header, and a second copy would have been the second place that has to remember two non-obvious things: `setMachineId` clears the path (so the path must be set after it), and a worktree session seeds the repository *plus* the worktree rather than the worktree path as a plain directory.

Cards are seeded from a session rather than from a path field on the group, so this also covers Rig cards, which carry a durable project identity instead of one working directory. A card whose sessions have no path shows no `+`.

![proof](https://github.com/chphch/happy/releases/download/pr-proofs/proof-projectadd.png)

Captured on a Pixel 5 AVD (arm64, 393 dp, API 30) paired to a real `happy` daemon with two sessions in two directories. The star next to the `+` is from #1581 and is not part of this PR.