### PR TITLE
fix(app): stop the composer showing a mic while it holds text

### DIFF
--- a/packages/happy-app/sources/components/AgentInput.tsx
+++ b/packages/happy-app/sources/components/AgentInput.tsx
@@ -701,10 +701,12 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
     const activeSendIconColor = compactMobileComposer ? theme.colors.text : theme.colors.button.primary.tint;
     const isSendBlocked = props.blockSend ?? false;
 
-    // `hasText` drives only the send-button appearance/enabled state. It's
-    // updated via startTransition from the keystroke handler so a busy reducer
-    // never blocks the next character from landing in the textarea.
+    // `hasText` drives only the send-button appearance/enabled state, and it
+    // only ever changes at the empty/non-empty boundary — so the keystroke
+    // handler compares against this ref and calls setState at most twice per
+    // message, instead of handing React an update per character.
     const [hasText, setHasText] = React.useState(() => props.initialValue.trim().length > 0);
+    const hasTextRef = React.useRef(hasText);
     const hasImages = (props.selectedImages?.length ?? 0) > 0;
     const hasComposerContent = hasText || hasImages;
 
@@ -888,9 +890,18 @@ export const AgentInput = React.memo(React.forwardRef<MultiTextInputHandle, Agen
 
     const onChangeTextProp = props.onChangeText;
     const handleTextChange = React.useCallback((text: string) => {
-        React.startTransition(() => {
-            setHasText(text.trim().length > 0);
-        });
+        // Urgent, not a transition: this decides whether the button renders as
+        // send or as the mic, so a deferred update can leave a composer that
+        // clearly has text showing a mic. The press handlers already read the
+        // live text and send anyway, which makes the stale icon a lie about
+        // what the button will do rather than a brief cosmetic lag — and it
+        // lasts as long as React keeps deprioritising the transition, so a busy
+        // session (one streaming a reply) is exactly when it shows.
+        const next = text.trim().length > 0;
+        if (next !== hasTextRef.current) {
+            hasTextRef.current = next;
+            setHasText(next);
+        }
         onChangeTextProp?.(text);
     }, [onChangeTextProp]);
 


### PR DESCRIPTION
The mobile composer folds send, stop and the mic into one button, and which one it draws comes from `hasText` — state the keystroke handler sets inside `React.startTransition`. React may defer that update for as long as higher-priority work keeps arriving, so the composer can hold a typed message while the button still shows a mic. A session streaming a reply is exactly that kind of work, which is why it surfaces mid-conversation and is hard to attribute to any one action; I only found it because a user reported "the send button shows up as the voice button" and could not say when.

What makes it worth fixing rather than tolerating is that the button's *behaviour* is already correct — `handleMobilePrimaryPress` and `handleSendPress` both read the live text and send. The comment above the first one says as much. So the stale icon is not a brief cosmetic lag; it is the button advertising dictation while it would in fact send. The user confirmed that: tapping the mic-looking button sent the message.

`hasText` only ever changes at the empty/non-empty boundary, so the handler now compares against a ref and calls setState only on the flip. Ordinary keystrokes hand React nothing at all — strictly less work than the transition they used to schedule, which was the reason the transition was there — and the one update that matters is urgent.

Every path that changes the text funnels through `onChangeText`, including the imperative `setTextAndSelection` on both the native and web `MultiTextInput` (autocomplete insert, Escape, and SessionView's post-send clear), so the ref cannot drift out of step with the field.