### PR TITLE
fix(cli): accept the app's `effort` key in MessageMetaSchema

### DIFF
--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -194,7 +194,8 @@ export const MessageMetaSchema = z.object({
   customSystemPrompt: z.string().nullable().optional(), // Custom system prompt for this message (null = reset)
   appendSystemPrompt: z.string().nullable().optional(), // Append to system prompt for this message (null = reset)
   allowedTools: z.array(z.string()).nullable().optional(), // Allowed tools for this message (null = reset)
-  disallowedTools: z.array(z.string()).nullable().optional() // Disallowed tools for this message (null = reset)
+  disallowedTools: z.array(z.string()).nullable().optional(), // Disallowed tools for this message (null = reset)
+  effort: z.string().nullable().optional() // Effort level for this message (null = reset). happy-app sends this key; without it Zod strips the value before runClaude reads it.
 })
 
 export type MessageMeta = z.infer<typeof MessageMetaSchema>


### PR DESCRIPTION
## The effort picker never reaches the SDK

happy-app sends the per-message effort under `meta.effort` ([`sync.ts:728`](https://github.com/slopus/happy/blob/main/packages/happy-app/sources/sync/sync.ts#L728)). The CLI parses incoming messages with `UserMessageSchema.safeParse` ([`apiSession.ts:552`](https://github.com/slopus/happy/blob/main/packages/happy-cli/src/api/apiSession.ts#L552)), and `MessageMetaSchema` does not declare `effort` — so Zod, which strips unknown keys by default, removes it before anything downstream sees it.

`runClaude` then gates on the key that is already gone:

```ts
if (message.meta?.hasOwnProperty('effort')) {          // always false
    const incoming = (message.meta as Record<string, unknown>).effort;
```

The cast is the tell. `effort` is read through `Record<string, unknown>` precisely because it is absent from `MessageMeta`, so typecheck passes while the branch that applies the picked effort is unreachable. Every user message falls through to the `else` and keeps whatever effort the session was spawned with.

## Reproduction

Parsing a message shaped exactly like the one the app sends, against this file before and after the change:

| | `meta` after parse | `meta?.hasOwnProperty('effort')` |
|---|---|---|
| `main` | `{"sentFrom":"app"}` | `false` |
| this branch | `{"sentFrom":"app","effort":"high"}` | `true` |

Input in both cases: `{"sentFrom":"app","effort":"high"}`.

## Why the tests don't catch it

`runClaude.test.ts` builds `meta` as a TypeScript object literal and hands it straight to the loop, so it never crosses the schema. The mismatch exists only on the wire path, which no test exercises.

## The change

One field on `MessageMetaSchema`. Nullable and optional to match the reset semantics the surrounding fields use, and the same `null = reset` behaviour `runClaude` already implements.

---

<sub>CI on this PR fails at the install step for the reason in #1663 (`pnpm-lock.yaml` out of sync with `happy-cli/package.json` since e7e0ff6b), not because of this change.</sub>
