### PR TITLE
fix(session-list): show every quick-action on an Android long-press

### DIFF
--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -15,7 +15,6 @@ import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { useHappyAction } from '@/hooks/useHappyAction';
 import { HappyError } from '@/utils/errors';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
-import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
 import { sessionKill } from '@/sync/ops';
 import { isWorktreePath, getRepoPath, getWorktreeName } from '@/utils/worktree';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
@@ -264,11 +263,20 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
         });
     }, []);
 
-    const showActionAlert = useSessionActionAlert(session.id);
+    // Native long-press opens the cross-platform actions sheet (SessionActionsPopover),
+    // NOT Modal.alert → RN Alert.alert: Android caps Alert at 3 buttons, which silently
+    // drops most quick-actions (e.g. "Copy session ID"). The popover renders all items.
+    const handleLongPress = React.useCallback((event: any) => {
+        setActionsAnchor({
+            type: 'point',
+            x: event?.nativeEvent?.pageX ?? 0,
+            y: event?.nativeEvent?.pageY ?? 0,
+        });
+    }, []);
     const menuProps = Platform.OS === 'web' ? {
         onContextMenu: handleContextMenu,
     } as any : {
-        onLongPress: showActionAlert,
+        onLongPress: handleLongPress,
     };
 
     const renderLeadingIndicator = () => {
@@ -379,14 +387,23 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
     );
 
     return (
-        <Swipeable
-            ref={swipeableRef}
-            renderRightActions={renderRightActions}
-            overshootRight={false}
-            enabled={!archivingSession}
-        >
-            {itemContent}
-        </Swipeable>
+        <>
+            <Swipeable
+                ref={swipeableRef}
+                renderRightActions={renderRightActions}
+                overshootRight={false}
+                enabled={!archivingSession}
+            >
+                {itemContent}
+            </Swipeable>
+            {/* Native long-press opens this sheet; must be mounted in the swipe branch too. */}
+            <SessionActionsPopover
+                anchor={actionsAnchor}
+                onClose={() => setActionsAnchor(null)}
+                sessionId={session.id}
+                visible={!!actionsAnchor}
+            />
+        </>
     );
 });
 

--- a/packages/happy-app/sources/components/FlatSessionRow.tsx
+++ b/packages/happy-app/sources/components/FlatSessionRow.tsx
@@ -10,7 +10,6 @@ import { StatusDot } from './StatusDot';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
 import { SessionShortcutHintBadge } from './ShortcutHints';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
-import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
 import { useHappyAction } from '@/hooks/useHappyAction';
 import { HappyError } from '@/utils/errors';
 import { sessionKill } from '@/sync/ops';
@@ -131,11 +130,17 @@ export const FlatSessionRow = React.memo(({ row, selected, showBorder, archived 
         });
     }, []);
 
-    const showActionAlert = useSessionActionAlert(session.id);
+    const handleLongPress = React.useCallback((event: any) => {
+        setActionsAnchor({
+            type: 'point',
+            x: event?.nativeEvent?.pageX ?? 0,
+            y: event?.nativeEvent?.pageY ?? 0,
+        });
+    }, []);
     const menuProps = Platform.OS === 'web' ? {
         onContextMenu: handleContextMenu,
     } as any : {
-        onLongPress: showActionAlert,
+        onLongPress: handleLongPress,
     };
 
     const content = (
@@ -266,14 +271,23 @@ export const FlatSessionRow = React.memo(({ row, selected, showBorder, archived 
     );
 
     return (
-        <Swipeable
-            ref={swipeableRef}
-            renderRightActions={renderRightActions}
-            overshootRight={false}
-            enabled={!archiving}
-        >
-            {content}
-        </Swipeable>
+        <>
+            <Swipeable
+                ref={swipeableRef}
+                renderRightActions={renderRightActions}
+                overshootRight={false}
+                enabled={!archiving}
+            >
+                {content}
+            </Swipeable>
+            {/* Native long-press opens this sheet; the swipe branch is the native default. */}
+            <SessionActionsPopover
+                anchor={actionsAnchor}
+                onClose={() => setActionsAnchor(null)}
+                sessionId={session.id}
+                visible={!!actionsAnchor}
+            />
+        </>
     );
 });
 

--- a/packages/happy-app/sources/components/SessionsList.tsx
+++ b/packages/happy-app/sources/components/SessionsList.tsx
@@ -22,7 +22,6 @@ import { UpdateBanner } from './UpdateBanner';
 import { layout } from './layout';
 import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
-import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
 import { t } from '@/text';
 import { SessionShortcutHintBadge } from './ShortcutHints';
 import { ProviderIcon } from './ProviderIcon';
@@ -649,11 +648,20 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
         });
     }, []);
 
-    const showActionAlert = useSessionActionAlert(session.id);
+    // Native long-press opens the cross-platform actions sheet (SessionActionsPopover),
+    // NOT Modal.alert → RN Alert.alert: Android caps Alert at 3 buttons, which silently
+    // drops most quick-actions (e.g. "Copy session ID"). The popover renders all items.
+    const handleLongPress = React.useCallback((event: any) => {
+        setActionsAnchor({
+            type: 'point',
+            x: event?.nativeEvent?.pageX ?? 0,
+            y: event?.nativeEvent?.pageY ?? 0,
+        });
+    }, []);
     const menuProps = Platform.OS === 'web' ? {
         onContextMenu: handleContextMenu,
     } as any : {
-        onLongPress: showActionAlert,
+        onLongPress: handleLongPress,
     };
 
     return (
@@ -732,14 +740,13 @@ const SessionItem = React.memo(({ session, selected, isFirst, isLast, isSingle }
                 </View>
             </View>
         </Pressable>
-        {Platform.OS === 'web' && (
-            <SessionActionsPopover
-                anchor={actionsAnchor}
-                onClose={() => setActionsAnchor(null)}
-                sessionId={session.id}
-                visible={!!actionsAnchor}
-            />
-        )}
+        {/* Mounted on all platforms: web opens it via onContextMenu, native via onLongPress. */}
+        <SessionActionsPopover
+            anchor={actionsAnchor}
+            onClose={() => setActionsAnchor(null)}
+            sessionId={session.id}
+            visible={!!actionsAnchor}
+        />
         </View>
     );
 });


### PR DESCRIPTION
## Android drops five of the eight long-press actions

Long-pressing a session on Android shows three entries. The rest are discarded with no error and no indication that anything is missing, so the menu just looks shorter than it is.

The path:

| | |
|---|---|
| `SessionsList.tsx:472`, `ActiveSessionsGroupCompact.tsx:268` | `onLongPress: showActionAlert` |
| `useSessionQuickActions.ts:298-305` | builds one button per action, calls `Modal.alert('Session', undefined, buttons)` |
| `ModalManager.ts:42` | on native that is RN `Alert.alert(title, message, buttons)` |

Android renders `Alert.alert` through the platform AlertDialog, which has exactly three button slots — positive, negative, neutral. Anything past the third is dropped.

The list currently holds seven actions plus Cancel:

`details` · `resume` · `fork` · `duplicate` · `copy metadata` · `copy metadata & logs` · `archive` · Cancel

Five of them never render.

## The change

Route the native long-press to `SessionActionsPopover`, which already exists and already handles this case: its native branch is a bottom sheet built from the same shared `actionItems` array, with no button cap. The Android menu then matches what the web context menu has always shown.

- Web (`onContextMenu`) is untouched.
- iOS gains the same completeness, since it shared the Alert path — its AlertController does not have Android's hard cap, but it stacks poorly past a few buttons.
- No new component, no new dependency; the sheet is the one the web path uses.

## Verification

`pnpm typecheck` clean; app suite 909/909.

Not captured on a device: the failure is a platform dialog limit, so a web capture would show the working path and prove nothing. Happy to attach an emulator recording if that would help review.

---

<sub>CI on this PR fails at the install step for the reason in #1663 (`pnpm-lock.yaml` out of sync with `happy-cli/package.json` since e7e0ff6b), not because of this change.</sub>
