### PR TITLE
fix(app): cap the inline-diff compute by line length

### DIFF
--- a/packages/happy-app/sources/components/diff/calculateDiff.ts
+++ b/packages/happy-app/sources/components/diff/calculateDiff.ts
@@ -1,5 +1,17 @@
 import { diffLines, diffWordsWithSpace, diffChars } from 'diff';
 
+// Per-line character-length cap for the inline-diff path. Lines longer than
+// this skip word-level tokenization (`diffWordsWithSpace`, O(n·m)) and the
+// common-substring similarity scan (`findCommonSubstrings`, O(n³)). A single
+// very long line — e.g. settings.json's `permissions.allow`/`deny` arrays, or
+// a minified blob — would otherwise peg the JS thread synchronously on the
+// first render of a pending-permission Edit and freeze the whole UI (dead
+// taps, unresponsive back button, blank message history). Long lines fall
+// back to plain add/remove with no inline highlighting, which is
+// imperceptible at that length anyway. Distinct from `INLINE_DIFF_MAX_LINES`
+// in ToolDiffView, which caps the line *count*, not the per-line length.
+const MAX_INLINE_DIFF_LINE_LENGTH = 200;
+
 export interface DiffToken {
     value: string;
     added?: boolean;
@@ -139,6 +151,14 @@ export function calculateUnifiedDiff(
  * Calculate inline diff between two lines
  */
 function calculateInlineDiff(oldLine: string, newLine: string): DiffToken[] {
+    // Skip word-level tokenization for long lines — `diffWordsWithSpace` is
+    // O(n·m) and part of the same first-render freeze. Returning no tokens
+    // makes the pair render as plain add/remove (DiffView treats an empty
+    // token list the same as none), which is what we want at this length.
+    if (oldLine.length > MAX_INLINE_DIFF_LINE_LENGTH || newLine.length > MAX_INLINE_DIFF_LINE_LENGTH) {
+        return [];
+    }
+
     // Use word-level diff for better readability
     const wordDiff = diffWordsWithSpace(oldLine, newLine);
 
@@ -190,6 +210,13 @@ function calculateSimilarity(str1: string, str2: string): number {
 
     for (let i = 0; i < minLen; i++) {
         if (chars1[i] === chars2[i]) matches++;
+    }
+
+    // Skip the O(n³) common-substring scan for long lines (the core of the
+    // first-render freeze). Char-prefix similarity alone is enough to pick a
+    // pairing, and the substring bonus is imperceptible at this length.
+    if (str1.length > MAX_INLINE_DIFF_LINE_LENGTH || str2.length > MAX_INLINE_DIFF_LINE_LENGTH) {
+        return matches / maxLen;
     }
 
     // Also check for common substrings


### PR DESCRIPTION
## One long line freezes the app while a diff renders

`calculateDiff` runs two similarity passes per changed line pair:

- `findCommonSubstrings` — **O(n³)** in line length
- `diffWordsWithSpace` — O(n·m)

Both run synchronously on the JS thread, on the **first render of a pending Edit** — the moment the user is being asked to approve it. Taps stop landing, the back button stops responding, and the message list goes blank until it finishes.

## Measurement

Same input through this file with and without the cap. One long line that changes near the middle, shaped like a single-line JSON array. Run on an M-series Mac, so a phone is meaningfully worse:

| changed line | capped | **uncapped** | ratio |
|---:|---:|---:|---:|
| 200 chars | 0.5 ms | 3.8 ms | 8× |
| 416 | 0.0 ms | 16.0 ms | 366× |
| 812 | 0.1 ms | **102.6 ms** | 1,923× |
| 1,604 | 0.1 ms | **734.5 ms** | 13,794× |
| 3,208 | 0.1 ms | **5,475.9 ms** | 55,057× |
| 6,400 | 0.1 ms | >5,000 ms | — |

Doubling the length multiplies the cost by roughly 8 — the cubic term, visible directly in the numbers (102 → 734 → 5,476).

A 3.2k-character line costs five and a half seconds of frozen UI.

## The change

Past 200 characters, both similarity passes are skipped and the pair renders as plain add/remove. Inline word highlighting is imperceptible at that length anyway, so nothing legible is lost — only the highlighting inside a line nobody can read at a glance.

One file, 27 added lines, no new dependency, no behaviour change below the threshold.

## How often does a line get that long?

Not exotic. Minified bundles, single-line JSON, SVG path data and base64 blobs all produce them. This repository alone has **656 tracked files** whose longest line exceeds 200 characters; the longest is 352,130 characters (`sources/assets/animations/robot.json`). Editing any of them triggers the path.

## Scope note

This is the compute half only. The fork this comes from also caps how many diff **lines** render inline, but that one adds a "+N more" affordance and its translations, so it is a separate change and not included here.

## Verification

`pnpm typecheck` clean; app suite 909/909.

---

<sub>CI on this PR fails at the install step for the reason in #1663 (`pnpm-lock.yaml` out of sync with `happy-cli/package.json` since e7e0ff6b), not because of this change.</sub>
