### PR TITLE
fix(cli): user-initiated abort no longer kills the ACP runner process

### DIFF
--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -552,6 +552,11 @@ export async function runAcp(opts: {
   let shouldExit = false;
   let abortController = new AbortController();
   let pendingTurn: PendingTurn | null = null;
+  // A user-initiated abort makes AcpBackend.cancel() emit status 'stopped',
+  // which is indistinguishable from backend death. Track it so the runner
+  // survives user aborts and only exits on genuine backend failure.
+  let userAbortInFlight = false;
+  let turnCancelledByAbort = false;
 
   const clearPendingTurn = (error?: Error) => {
     if (!pendingTurn) {
@@ -815,7 +820,17 @@ export async function runAcp(opts: {
       if (msg.status === 'idle') {
         clearPendingTurn();
       }
-      if (msg.status === 'error' || msg.status === 'stopped') {
+      if (msg.status === 'stopped' && userAbortInFlight) {
+        // User-initiated abort: end the current turn as cancelled, keep the
+        // runner alive instead of treating it as backend death.
+        userAbortInFlight = false;
+        thinking = false;
+        session.keepAlive(false, 'remote');
+        if (pendingTurn) {
+          turnCancelledByAbort = true;
+          clearPendingTurn();
+        }
+      } else if (msg.status === 'error' || msg.status === 'stopped') {
         stopRunnerFromBackendStatus(msg.status, msg.detail);
       }
     }
@@ -859,11 +874,15 @@ export async function runAcp(opts: {
   async function handleAbort() {
     try {
       if (acpSessionId) {
+        userAbortInFlight = true;
         await backend.cancel(acpSessionId);
       }
       permissionHandler.reset();
       abortController.abort();
     } catch (error) {
+      // Cancel never reached the agent — don't let the flag mark a later
+      // genuine backend failure as user-initiated.
+      userAbortInFlight = false;
       logger.debug(`[${opts.agentName}] Abort failed:`, error);
     } finally {
       abortController = new AbortController();
@@ -912,6 +931,11 @@ export async function runAcp(opts: {
 
       logAcp('incoming', `Incoming prompt: ${formatUnknownForConsole(batch.message, ACP_EVENT_PREVIEW_CHARS)}`);
       sendEnvelopes(sessionManager.startTurn());
+      // Guard against a stale flag: an abort that arrives while idle (e.g. just
+      // after a turn ended naturally, or when cancel() throws) must not cause a
+      // later genuine backend failure to be misread as a user abort.
+      userAbortInFlight = false;
+      turnCancelledByAbort = false;
       const turnEnded = waitForTurnEnd();
       try {
         if (typeof batch.mode.permissionMode === 'string' && batch.mode.permissionMode.length > 0) {
@@ -922,7 +946,8 @@ export async function runAcp(opts: {
         }
         await backend.sendPrompt(acpSessionId, batch.message);
         await turnEnded;
-        sendEnvelopes(sessionManager.endTurn('completed'));
+        sendEnvelopes(sessionManager.endTurn(turnCancelledByAbort ? 'cancelled' : 'completed'));
+        turnCancelledByAbort = false;
         session.sendSessionEvent({ type: 'ready' });
         if (verbose) {
           logAcp('muted', `Outgoing prompt completion from ${opts.agentName}`);


### PR DESCRIPTION
### Problem

When the user taps "stop" in the mobile app during an ACP agent turn (gemini / opencode / any generic ACP backend), the CLI process crashes and the whole session dies, instead of just cancelling the in-flight turn.

### Root cause

`AcpBackend.cancel()` emits `status: 'stopped'` after a successful `session/cancel`:

```ts
// AcpBackend.ts
async cancel(sessionId: SessionId): Promise<void> {
  ...
  await this.connection.cancel({ sessionId: this.acpSessionId });
  this.emit({ type: 'status', status: 'stopped', detail: 'Cancelled by user' });
}
```

But `runAcp` treats **any** `stopped` status as fatal backend death:

```ts
if (msg.status === 'error' || msg.status === 'stopped') {
  stopRunnerFromBackendStatus(msg.status, msg.detail); // → shouldExit + reject pending turn → process exits
}
```

So a perfectly healthy user abort is indistinguishable from the backend dying, and the runner shuts the session down. The turn IS cancelled correctly on the agent side — the runner just kills itself right after.

### Fix

Track user-initiated aborts and treat the resulting `stopped` as a normal (cancelled) turn end:

- `handleAbort()` sets `userAbortInFlight = true` before calling `backend.cancel()`
- When a `stopped` status arrives with that flag set: reset thinking/keepAlive, resolve the pending turn (instead of rejecting it), and mark the turn `cancelled` — the runner stays alive and the next prompt works
- **The flag is cleared at every new turn start**, and also if `cancel()` throws (the abort never reached the agent). An abort that arrives while the session is idle — e.g. network latency delivers it right after the turn ended naturally — would otherwise leave the flag set, and a later *genuine* backend failure would be misread as a user abort, leaving the runner alive with a dead backend. Bounding the flag's effect to its own turn prevents that
- turn-end is reported as `'cancelled'` instead of `'completed'`

### Repro

1. `happy acp <agent>` (any ACP agent)
2. From the phone app, send a long-running prompt (e.g. "count from 1 to 1000, one per line")
3. While it streams, tap stop
4. Before: CLI process exits with `Error: <agent> backend stopped: Cancelled by user`. After: turn ends as cancelled, session stays online, next prompt works.

### Notes

- No behavior change for genuine backend failures: a `stopped` status without a preceding user abort (same-turn) still shuts the runner down
- `AcpSessionManager.endTurn` already accepts `'cancelled'` — no other files touched
- Verified against kimi-code 0.34.0 via the ACP protocol; patch compiles and passes the full upstream unit suite (792/792) on a clean upstream/main checkout