### PR TITLE
fix(codex): sync launch model to session metadata

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -11,6 +11,7 @@ import {
     getAvailablePermissionModes,
     getEffortLevelsForModel,
     getRigCurrentModelOptionKey,
+    resolveNonRigModelOption,
     resolveCurrentOption,
     EffortLevel,
 } from '@/components/modelModeOptions';
@@ -734,13 +735,20 @@ export function SessionViewLoaded({
         ])
     ), [availableModes, session.permissionMode, effectiveAgentDefaults.permissionMode, session.metadata?.currentOperatingModeCode, session.metadata?.permissionMode, session.metadata?.session?.permissionMode, isRig]);
 
-    const modelMode = React.useMemo<ModelMode | null>(() => (
-        resolveCurrentOption(availableModels, [
+    const modelMode = React.useMemo<ModelMode | null>(() => {
+        if (isRig) {
+            return resolveCurrentOption(availableModels, [
+                session.modelMode,
+                getRigCurrentModelOptionKey(session.metadata),
+            ]);
+        }
+        return resolveNonRigModelOption(
+            availableModels,
             session.modelMode,
-            isRig ? getRigCurrentModelOptionKey(session.metadata) : effectiveAgentDefaults.modelMode,
-            isRig ? undefined : session.metadata?.currentModelCode,
-        ])
-    ), [availableModels, session.modelMode, effectiveAgentDefaults.modelMode, session.metadata, isRig]);
+            session.metadata?.currentModelCode,
+            effectiveAgentDefaults.modelMode,
+        );
+    }, [availableModels, session.modelMode, effectiveAgentDefaults.modelMode, session.metadata, isRig]);
 
     // Effort level state
     const modelKey = modelMode?.key ?? 'default';

--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -10,6 +10,7 @@ import {
     getDefaultModelKey,
     getDefaultPermissionModeKey,
     mapMetadataOptions,
+    resolveNonRigModelOption,
     resolveCurrentOption,
 } from './modelModeOptions';
 import { rigMetadataFixture } from '@/sync/__testdata__/rigMetadata';
@@ -149,6 +150,39 @@ describe('modelModeOptions', () => {
 
         expect(resolveCurrentOption(options, ['missing', 'b', 'a'])).toEqual({ key: 'b', name: 'B' });
         expect(resolveCurrentOption(options, ['missing'])).toBeNull();
+    });
+
+    it('resolves an explicit session model before metadata and configured defaults', () => {
+        const models = getCodexModelModes();
+
+        expect(resolveNonRigModelOption(
+            models,
+            'gpt-5.4',
+            'gpt-5.6-sol',
+            'gpt-5.5',
+        )?.key).toBe('gpt-5.4');
+    });
+
+    it('resolves the metadata current model before the configured default', () => {
+        const models = getCodexModelModes();
+
+        expect(resolveNonRigModelOption(
+            models,
+            undefined,
+            'gpt-5.6-sol',
+            'gpt-5.5',
+        )?.key).toBe('gpt-5.6-sol');
+    });
+
+    it('resolves the configured default when session and metadata models are absent', () => {
+        const models = getCodexModelModes();
+
+        expect(resolveNonRigModelOption(
+            models,
+            undefined,
+            undefined,
+            'gpt-5.5',
+        )?.key).toBe('gpt-5.5');
     });
 
     it('builds the Rig catalog dynamically with provider-qualified keys', () => {

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -323,6 +323,24 @@ export function resolveCurrentOption<T extends ModeOption>(
     return null;
 }
 
+/**
+ * Resolves a non-Rig model from the session pick, agent metadata, then the configured default.
+ *
+ * @param options - Models currently available to the session.
+ * @param sessionModelMode - Explicit model selected for this session.
+ * @param currentModelCode - Model reported by the agent in session metadata.
+ * @param configuredModelMode - User-configured or code-defined fallback model.
+ * @returns The first matching model option, or null when none of the keys is available.
+ */
+export function resolveNonRigModelOption(
+    options: ModelMode[],
+    sessionModelMode: string | null | undefined,
+    currentModelCode: string | null | undefined,
+    configuredModelMode: string | null | undefined,
+): ModelMode | null {
+    return resolveCurrentOption(options, [sessionModelMode, currentModelCode, configuredModelMode]);
+}
+
 export function getDefaultModelKey(flavor: AgentFlavor): string {
     return getCodeAgentDefaults(flavor).modelMode;
 }

--- a/packages/happy-cli/src/codex/runCodex.test.ts
+++ b/packages/happy-cli/src/codex/runCodex.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    createSessionMetadata: vi.fn(),
+    getOrCreateMachine: vi.fn(),
+    getOrCreateSession: vi.fn(),
+    readSettings: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => ({
+    ...await importOriginal<typeof import('node:child_process')>(),
+    execSync: vi.fn(),
+}));
+
+vi.mock('@/api/api', () => ({
+    ApiClient: {
+        create: vi.fn(async () => ({
+            getOrCreateMachine: mocks.getOrCreateMachine,
+            getOrCreateSession: mocks.getOrCreateSession,
+        })),
+    },
+}));
+
+vi.mock('@/persistence', () => ({
+    readSettings: mocks.readSettings,
+}));
+
+vi.mock('@/daemon/run', () => ({
+    initialMachineMetadata: {},
+}));
+
+vi.mock('@/utils/createSessionMetadata', () => ({
+    createSessionMetadata: mocks.createSessionMetadata,
+}));
+
+import { runCodex } from './runCodex';
+
+describe('runCodex', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.HAPPY_RECONNECT_SESSION_ID;
+        delete process.env.HAPPY_RECONNECT_ENCRYPTION_KEY;
+        delete process.env.HAPPY_RECONNECT_ENCRYPTION_VARIANT;
+        delete process.env.HAPPY_RECONNECT_SEQ;
+        delete process.env.HAPPY_RECONNECT_METADATA_VERSION;
+        delete process.env.HAPPY_RECONNECT_AGENT_STATE_VERSION;
+        mocks.readSettings.mockResolvedValue({ machineId: 'machine-1' });
+        mocks.getOrCreateMachine.mockResolvedValue(undefined);
+        mocks.createSessionMetadata.mockReturnValue({
+            state: { controlledByUser: false },
+            metadata: {
+                path: '/tmp/project',
+                host: 'host',
+                homeDir: '/home/user',
+                happyHomeDir: '/home/user/.happy',
+                happyLibDir: '/tmp/lib',
+                happyToolsDir: '/tmp/tools',
+            },
+        });
+        mocks.getOrCreateSession.mockRejectedValue(new Error('stop after session creation'));
+    });
+
+    it('includes an explicit Codex launch model in initial session metadata', async () => {
+        await expect(runCodex({
+            credentials: { token: 'token' } as any,
+            model: 'gpt-5.6-sol',
+        })).rejects.toThrow('stop after session creation');
+
+        expect(mocks.getOrCreateSession).toHaveBeenCalledWith(expect.objectContaining({
+            metadata: expect.objectContaining({ currentModelCode: 'gpt-5.6-sol' }),
+        }));
+        const metadata = mocks.getOrCreateSession.mock.calls[0][0].metadata;
+        expect(metadata.models).toBeUndefined();
+        expect(metadata.currentModelCode).toBe('gpt-5.6-sol');
+    });
+
+    it('does not publish a default model when no launch model was supplied', async () => {
+        await expect(runCodex({
+            credentials: { token: 'token' } as any,
+        })).rejects.toThrow('stop after session creation');
+
+        const metadata = mocks.getOrCreateSession.mock.calls[0][0].metadata;
+        expect(metadata.models).toBeUndefined();
+        expect(metadata.currentModelCode).toBeUndefined();
+    });
+});

--- a/packages/happy-cli/src/codex/runCodex.ts
+++ b/packages/happy-cli/src/codex/runCodex.ts
@@ -164,6 +164,9 @@ export async function runCodex(opts: {
         ...(forkedFromMessageId ? { forkedFromMessageId } : {}),
         ...(isSideChat ? { isSideChat: true } : {}),
     });
+    if (opts.model) {
+        metadata.currentModelCode = opts.model;
+    }
 
     const skillCommands = await discoverCodexSkillCommands();
     if (skillCommands.length > 0) {


### PR DESCRIPTION
## Summary

Fixes the Codex model picker showing a different model from the one selected with `happy codex --model`.

- publish an explicit Codex launch model as `metadata.currentModelCode`
- resolve non-Rig model selection as session override → metadata model → configured default
- preserve explicit in-app model selections as the highest priority
- leave `metadata.models`, resume behavior, and default-model behavior unchanged

Fixes #1698

## Verification

- `pnpm --filter happy test` — 84 test files, 794 tests passed
- `pnpm --filter happy-app typecheck`
- focused CLI regression tests
- focused app model-resolution regression tests
- `git diff --check`
- manually verified with `happy codex --yolo --model gpt-5.6-sol --effort medium`; the corresponding Happy Web session shows `gpt-5.6 sol` in the model picker

## Demo


https://github.com/user-attachments/assets/f1714f29-acd1-4cf7-9714-6cefb69c1048

