### PR TITLE
feat(cli): add Hermes agent backend via ACP

### DIFF
--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { KNOWN_ACP_AGENTS, resolveAcpAgentConfig } from './acpAgentConfig';
 
 describe('KNOWN_ACP_AGENTS', () => {
-  it('defines built-in Gemini and OpenCode command mappings', () => {
+  it('defines built-in Gemini, OpenCode, and Hermes command mappings', () => {
     expect(KNOWN_ACP_AGENTS).toEqual({
       gemini: { command: 'gemini', args: ['--experimental-acp'] },
       opencode: { command: 'opencode', args: ['acp'] },
+      hermes: { command: 'hermes', args: ['acp'] },
     });
   });
 });
@@ -24,6 +25,14 @@ describe('resolveAcpAgentConfig', () => {
       agentName: 'opencode',
       command: 'opencode',
       args: ['acp', '--foo'],
+    });
+  });
+
+  it('resolves hermes to the hermes CLI with acp mode', () => {
+    expect(resolveAcpAgentConfig(['hermes'])).toEqual({
+      agentName: 'hermes',
+      command: 'hermes',
+      args: ['acp'],
     });
   });
 

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
@@ -6,6 +6,7 @@ export type AcpAgentConfig = {
 export const KNOWN_ACP_AGENTS: Record<string, AcpAgentConfig> = {
   gemini: { command: 'gemini', args: ['--experimental-acp'] },
   opencode: { command: 'opencode', args: ['acp'] },
+  hermes: { command: 'hermes', args: ['acp'] },
 };
 
 export type ResolvedAcpAgentConfig = {

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -436,12 +436,15 @@ type PendingTurn = {
   timeout: NodeJS.Timeout;
 };
 
-function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'acp' {
+function resolveSessionFlavor(agentName: string): 'gemini' | 'opencode' | 'hermes' | 'acp' {
   if (agentName === 'gemini') {
     return 'gemini';
   }
   if (agentName === 'opencode') {
     return 'opencode';
+  }
+  if (agentName === 'hermes') {
+    return 'hermes';
   }
   return 'acp';
 }

--- a/packages/happy-cli/src/agent/acp/runAcp.ts
+++ b/packages/happy-cli/src/agent/acp/runAcp.ts
@@ -4,7 +4,7 @@ import { ApiClient } from '@/api/api';
 import type { ApiSessionClient } from '@/api/apiSession';
 import type { AgentMessage } from '@/agent/core';
 import { AcpBackend, type AcpPermissionHandler } from './AcpBackend';
-import { DefaultTransport } from '@/agent/transport';
+import { DefaultTransport, hermesTransport } from '@/agent/transport';
 import { AcpSessionManager } from './AcpSessionManager';
 import type { SessionEnvelope } from '@slopus/happy-wire';
 import { logger } from '@/ui/logger';
@@ -546,7 +546,9 @@ export async function runAcp(opts: {
     args: opts.args,
     mcpServers,
     permissionHandler,
-    transportHandler: new DefaultTransport(opts.agentName),
+    // Known agents with custom tool-name quirks get their dedicated transport;
+    // everything else rides the defaults
+    transportHandler: opts.agentName === 'hermes' ? hermesTransport : new DefaultTransport(opts.agentName),
     verbose,
   });
 

--- a/packages/happy-cli/src/agent/core/AgentBackend.ts
+++ b/packages/happy-cli/src/agent/core/AgentBackend.ts
@@ -48,7 +48,7 @@ export interface McpServerConfig {
 export type AgentTransport = 'native-claude' | 'mcp-codex' | 'acp';
 
 /** Agent identifier */
-export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'claude-acp' | 'codex-acp';
+export type AgentId = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'hermes' | 'crush' | 'claude-acp' | 'codex-acp';
 
 /**
  * Configuration for creating an agent backend

--- a/packages/happy-cli/src/agent/factories/hermes.test.ts
+++ b/packages/happy-cli/src/agent/factories/hermes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { createHermesBackend, registerHermesAgent } from './hermes';
+import { agentRegistry } from '../core';
+import { hermesTransport } from '../transport';
+
+describe('createHermesBackend', () => {
+  it('creates a backend implementing the AgentBackend interface', () => {
+    const backend = createHermesBackend({ cwd: process.cwd() });
+    expect(backend).toBeTruthy();
+    expect(typeof backend.startSession).toBe('function');
+    expect(typeof backend.sendPrompt).toBe('function');
+    expect(typeof backend.cancel).toBe('function');
+    expect(typeof backend.onMessage).toBe('function');
+    expect(typeof backend.dispose).toBe('function');
+  });
+});
+
+describe('registerHermesAgent', () => {
+  it('registers the hermes factory with the agent registry', () => {
+    registerHermesAgent();
+    expect(agentRegistry.has('hermes')).toBe(true);
+    expect(agentRegistry.list()).toContain('hermes');
+
+    const backend = agentRegistry.create('hermes', { cwd: process.cwd() });
+    expect(backend).toBeTruthy();
+    expect(typeof backend.startSession).toBe('function');
+  });
+});
+
+describe('hermesTransport', () => {
+  it('reports hermes as its agent name', () => {
+    expect(hermesTransport.agentName).toBe('hermes');
+  });
+
+  it('extracts known tool names from tool call IDs', () => {
+    expect(hermesTransport.extractToolNameFromId('change_title-1765385846663')).toBe('change_title');
+    expect(hermesTransport.extractToolNameFromId('mcp__happy__change_title-abc')).toBe('change_title');
+    expect(hermesTransport.extractToolNameFromId('save_memory-123')).toBe('save_memory');
+    expect(hermesTransport.extractToolNameFromId('think-456')).toBe('think');
+    expect(hermesTransport.extractToolNameFromId('HermesReasoning-789')).toBe('HermesReasoning');
+    expect(hermesTransport.extractToolNameFromId('unknown-tool-1')).toBeNull();
+  });
+
+  it('exposes hermes tool patterns for auto-approval', () => {
+    const patterns = hermesTransport.getToolPatterns();
+    const names = patterns.map((p) => p.name);
+    expect(names).toContain('change_title');
+    expect(names).toContain('save_memory');
+    expect(names).toContain('think');
+    expect(names).toContain('HermesReasoning');
+  });
+});

--- a/packages/happy-cli/src/agent/factories/hermes.test.ts
+++ b/packages/happy-cli/src/agent/factories/hermes.test.ts
@@ -41,6 +41,15 @@ describe('hermesTransport', () => {
     expect(hermesTransport.extractToolNameFromId('unknown-tool-1')).toBeNull();
   });
 
+  it('resolves generic tool kinds via determineToolName (permission path)', () => {
+    expect(hermesTransport.determineToolName('other', 'change_title-123', {}, {} as never)).toBe('change_title');
+    expect(hermesTransport.determineToolName('Unknown tool', 'think-456', {}, {} as never)).toBe('think');
+    // Known tool names pass through unchanged
+    expect(hermesTransport.determineToolName('bash', 'toolcall-1', {}, {} as never)).toBe('bash');
+    // Unresolvable generic kinds stay generic
+    expect(hermesTransport.determineToolName('other', 'xyz-1', {}, {} as never)).toBe('other');
+  });
+
   it('exposes hermes tool patterns for auto-approval', () => {
     const patterns = hermesTransport.getToolPatterns();
     const names = patterns.map((p) => p.name);

--- a/packages/happy-cli/src/agent/factories/hermes.ts
+++ b/packages/happy-cli/src/agent/factories/hermes.ts
@@ -1,0 +1,78 @@
+/**
+ * Hermes ACP Backend - Hermes CLI agent via ACP
+ *
+ * This module provides a factory function for creating a Hermes backend
+ * that communicates using the Agent Client Protocol (ACP).
+ *
+ * Hermes manages its own authentication (via its native login command), so
+ * this factory inherits the user's shell environment per the generic ACP
+ * runner principles — no credentials or API keys are resolved here.
+ */
+
+import { AcpBackend, type AcpBackendOptions, type AcpPermissionHandler } from '../acp/AcpBackend';
+import type { AgentBackend, McpServerConfig, AgentFactoryOptions } from '../core';
+import { agentRegistry } from '../core';
+import { hermesTransport } from '../transport';
+import { logger } from '@/ui/logger';
+
+/**
+ * Options for creating a Hermes ACP backend
+ */
+export interface HermesBackendOptions extends AgentFactoryOptions {
+  /** MCP servers to make available to the agent */
+  mcpServers?: Record<string, McpServerConfig>;
+
+  /** Optional permission handler for tool approval */
+  permissionHandler?: AcpPermissionHandler;
+}
+
+/**
+ * Create a Hermes backend using ACP (official SDK).
+ *
+ * The Hermes CLI must be installed and available in PATH.
+ * Authentication is handled by the Hermes CLI itself (native login);
+ * no API keys are injected here.
+ *
+ * @param options - Configuration options
+ * @returns The created AgentBackend instance
+ */
+export function createHermesBackend(options: HermesBackendOptions): AgentBackend {
+  const backendOptions: AcpBackendOptions = {
+    agentName: 'hermes',
+    cwd: options.cwd,
+    command: 'hermes',
+    args: ['acp'],
+    env: options.env,
+    mcpServers: options.mcpServers,
+    permissionHandler: options.permissionHandler,
+    transportHandler: hermesTransport,
+    // Check if prompt instructs the agent to change title (for auto-approval of change_title tool)
+    hasChangeTitleInstruction: (prompt: string) => {
+      const lower = prompt.toLowerCase();
+      return lower.includes('change_title') ||
+             lower.includes('change title') ||
+             lower.includes('set title') ||
+             lower.includes('mcp__happy__change_title');
+    },
+  };
+
+  logger.debug('[Hermes] Creating ACP SDK backend with options:', {
+    cwd: backendOptions.cwd,
+    command: backendOptions.command,
+    args: backendOptions.args,
+    mcpServerCount: options.mcpServers ? Object.keys(options.mcpServers).length : 0,
+  });
+
+  return new AcpBackend(backendOptions);
+}
+
+/**
+ * Register Hermes backend with the global agent registry.
+ *
+ * This function should be called during application initialization
+ * to make the Hermes agent available for use.
+ */
+export function registerHermesAgent(): void {
+  agentRegistry.register('hermes', (opts) => createHermesBackend(opts));
+  logger.debug('[Hermes] Registered with agent registry');
+}

--- a/packages/happy-cli/src/agent/factories/index.ts
+++ b/packages/happy-cli/src/agent/factories/index.ts
@@ -15,6 +15,13 @@ export {
   type GeminiBackendResult,
 } from './gemini';
 
+// Hermes factory
+export {
+  createHermesBackend,
+  registerHermesAgent,
+  type HermesBackendOptions,
+} from './hermes';
+
 // Future factories:
 // export { createCodexBackend, registerCodexAgent, type CodexBackendOptions } from './codex';
 // export { createClaudeBackend, registerClaudeAgent, type ClaudeBackendOptions } from './claude';

--- a/packages/happy-cli/src/agent/index.ts
+++ b/packages/happy-cli/src/agent/index.ts
@@ -40,5 +40,7 @@ export function initializeAgents(): void {
   // Import and register agents from factories
   const { registerGeminiAgent } = require('./factories/gemini');
   registerGeminiAgent();
+  const { registerHermesAgent } = require('./factories/hermes');
+  registerHermesAgent();
 }
 

--- a/packages/happy-cli/src/agent/transport/handlers/HermesTransport.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/HermesTransport.ts
@@ -1,0 +1,86 @@
+/**
+ * Hermes Transport Handler
+ *
+ * Hermes CLI-specific implementation of TransportHandler.
+ * Extends DefaultTransport with:
+ * - Hermes tool name patterns (change_title, save_memory, think, HermesReasoning)
+ * - Tool name extraction from toolCallId when the name is not reported directly
+ *
+ * Hermes is an ACP-native agent, so stdout filtering and timeouts follow the
+ * defaults; only tool-name resolution needs customization.
+ *
+ * @module HermesTransport
+ */
+
+import { DefaultTransport } from '../DefaultTransport';
+import type { ToolPattern } from '../TransportHandler';
+
+/**
+ * Known tool name patterns for Hermes CLI.
+ *
+ * Used to extract real tool names from toolCallId when Hermes does not report
+ * the tool name directly. Each pattern lists strings matched against the
+ * toolCallId (case-insensitive).
+ */
+const HERMES_TOOL_PATTERNS: ToolPattern[] = [
+  {
+    name: 'change_title',
+    patterns: ['change_title', 'change-title', 'happy__change_title', 'mcp__happy__change_title'],
+  },
+  {
+    name: 'save_memory',
+    patterns: ['save_memory', 'save-memory'],
+  },
+  {
+    name: 'think',
+    patterns: ['think'],
+  },
+  {
+    name: 'HermesReasoning',
+    patterns: ['hermesreasoning'],
+  },
+];
+
+/**
+ * Hermes CLI transport handler.
+ *
+ * Inherits default timeouts, stdout filtering, and stderr handling from
+ * DefaultTransport; overrides tool-name resolution with Hermes patterns.
+ */
+export class HermesTransport extends DefaultTransport {
+  constructor() {
+    super('hermes');
+  }
+
+  /**
+   * Hermes-specific tool patterns
+   */
+  getToolPatterns(): ToolPattern[] {
+    return HERMES_TOOL_PATTERNS;
+  }
+
+  /**
+   * Extract tool name from toolCallId using Hermes patterns.
+   *
+   * Tool IDs often contain the tool name as a substring
+   * (e.g. "change_title-1765385846663" -> "change_title").
+   */
+  extractToolNameFromId(toolCallId: string): string | null {
+    const lowerId = toolCallId.toLowerCase();
+
+    for (const toolPattern of HERMES_TOOL_PATTERNS) {
+      for (const pattern of toolPattern.patterns) {
+        if (lowerId.includes(pattern.toLowerCase())) {
+          return toolPattern.name;
+        }
+      }
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Singleton instance for convenience
+ */
+export const hermesTransport = new HermesTransport();

--- a/packages/happy-cli/src/agent/transport/handlers/HermesTransport.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/HermesTransport.ts
@@ -13,7 +13,7 @@
  */
 
 import { DefaultTransport } from '../DefaultTransport';
-import type { ToolPattern } from '../TransportHandler';
+import type { ToolPattern, ToolNameContext } from '../TransportHandler';
 
 /**
  * Known tool name patterns for Hermes CLI.
@@ -77,6 +77,25 @@ export class HermesTransport extends DefaultTransport {
     }
 
     return null;
+  }
+
+  /**
+   * Resolve the real tool name when Hermes reports a generic kind.
+   *
+   * The ACP permission path calls this method (not extractToolNameFromId),
+   * so tool IDs such as "change_title-..." must be resolved here for the
+   * mobile approval UI to show the correct tool name.
+   */
+  determineToolName(
+    toolName: string,
+    toolCallId: string,
+    _input: Record<string, unknown>,
+    _context: ToolNameContext
+  ): string {
+    if (toolName !== 'other' && toolName !== 'Unknown tool') {
+      return toolName;
+    }
+    return this.extractToolNameFromId(toolCallId) ?? toolName;
   }
 }
 

--- a/packages/happy-cli/src/agent/transport/handlers/index.ts
+++ b/packages/happy-cli/src/agent/transport/handlers/index.ts
@@ -7,6 +7,7 @@
  */
 
 export { GeminiTransport, geminiTransport } from './GeminiTransport';
+export { HermesTransport, hermesTransport } from './HermesTransport';
 
 // Future handlers:
 // export { CodexTransport, codexTransport } from './CodexTransport';

--- a/packages/happy-cli/src/agent/transport/index.ts
+++ b/packages/happy-cli/src/agent/transport/index.ts
@@ -19,7 +19,7 @@ export type {
 export { DefaultTransport, defaultTransport } from './DefaultTransport';
 
 // Agent-specific handlers
-export { GeminiTransport, geminiTransport } from './handlers';
+export { GeminiTransport, geminiTransport, HermesTransport, hermesTransport } from './handlers';
 
 // Future handlers will be exported from ./handlers:
 // export { CodexTransport, codexTransport } from './handlers';

--- a/packages/happy-cli/src/api/apiMachine.ts
+++ b/packages/happy-cli/src/api/apiMachine.ts
@@ -522,7 +522,7 @@ export class ApiMachineClient {
         const prev = this.lastKnownCLIAvailability;
         const newResumeSupport = detectResumeSupport();
         const prevResume = this.lastKnownResumeSupport;
-        const cliAvailabilityChanged = !prev || prev.claude !== newAvailability.claude || prev.codex !== newAvailability.codex || prev.gemini !== newAvailability.gemini || prev.openclaw !== newAvailability.openclaw;
+        const cliAvailabilityChanged = !prev || prev.claude !== newAvailability.claude || prev.codex !== newAvailability.codex || prev.gemini !== newAvailability.gemini || prev.openclaw !== newAvailability.openclaw || prev.agy !== newAvailability.agy || prev.hermes !== newAvailability.hermes || prev.crush !== newAvailability.crush;
         const resumeSupportChanged = !prevResume
             || prevResume.rpcAvailable !== newResumeSupport.rpcAvailable
             || prevResume.happyAgentAuthenticated !== newResumeSupport.happyAgentAuthenticated;

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -34,6 +34,18 @@ export type {
  */
 export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'read-only' | 'safe-yolo' | 'yolo'
 
+const PERMISSION_MODES: readonly PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo'];
+
+/**
+ * Type guard for the well-known Claude/Codex permission modes.
+ * ACP agents may report their own dynamic mode ids (e.g. Hermes:
+ * accept_edits), which are not PermissionMode values; backends that
+ * only understand the well-known modes should ignore those.
+ */
+export function isPermissionMode(value: string): value is PermissionMode {
+  return (PERMISSION_MODES as readonly string[]).includes(value);
+}
+
 /**
  * Usage data type from Claude
  */
@@ -191,7 +203,12 @@ export type Machine = {
  */
 export const MessageMetaSchema = z.object({
   sentFrom: z.string().optional(), // Source identifier
-  permissionMode: z.enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'read-only', 'safe-yolo', 'yolo']).optional(), // Permission mode for this message
+  // Permission mode for this message. Claude/Codex use the well-known keys
+  // (acceptEdits, bypassPermissions, ...); ACP agents report their own
+  // dynamic mode ids (e.g. Hermes: accept_edits, dont_ask) via session
+  // config events, so unknown values are accepted here and resolved (or
+  // ignored) per-agent by the backend runner.
+  permissionMode: z.string().optional(),
   model: z.string().nullable().optional(), // Model name for this message (null = reset)
   fallbackModel: z.string().nullable().optional(), // Fallback model for this message (null = reset)
   customSystemPrompt: z.string().nullable().optional(), // Custom system prompt for this message (null = reset)

--- a/packages/happy-cli/src/api/types.ts
+++ b/packages/happy-cli/src/api/types.ts
@@ -139,6 +139,9 @@ export const MachineMetadataSchema = z.object({
     codex: z.boolean(),
     gemini: z.boolean(),
     openclaw: z.boolean(),
+    agy: z.boolean().optional(),
+    hermes: z.boolean().optional(),
+    crush: z.boolean().optional(),
     detectedAt: z.number(),
   }).optional(),
   resumeSupport: z.object({

--- a/packages/happy-cli/src/claude/runClaude.ts
+++ b/packages/happy-cli/src/claude/runClaude.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { ApiClient } from '@/api/api';
 import { logger } from '@/ui/logger';
 import { loop } from '@/claude/loop';
-import { AgentGoalStatus, AgentState, Metadata } from '@/api/types';
+import { AgentGoalStatus, AgentState, Metadata, isPermissionMode } from '@/api/types';
 import packageJson from '../../package.json';
 import { Credentials, readSettings } from '@/persistence';
 import { EnhancedMode, PermissionMode } from './loop';
@@ -658,17 +658,23 @@ export async function runClaude(credentials: Credentials, options: StartOptions 
 
         // Resolve permission mode from meta - pass through as-is, mapping happens at SDK boundary
         let messagePermissionMode: PermissionMode | undefined = currentPermissionMode;
-        if (message.meta?.permissionMode) {
+        // Claude understands only the well-known modes; ACP agent mode ids
+        // (e.g. Hermes' accept_edits) are ignored here
+        const requestedMode = message.meta?.permissionMode;
+        const incomingMode = requestedMode !== undefined && isPermissionMode(requestedMode)
+            ? requestedMode
+            : undefined;
+        if (requestedMode !== undefined) {
             const previousPermissionMode = currentPermissionMode;
             messagePermissionMode = resolveRemoteClaudePermissionMode(
                 currentPermissionMode,
-                message.meta.permissionMode,
+                incomingMode,
                 sandboxEnabled,
             );
             currentPermissionMode = messagePermissionMode;
             const ignoredDefaultDowngrade =
                 (previousPermissionMode === 'bypassPermissions' || previousPermissionMode === 'yolo')
-                && message.meta.permissionMode === 'default'
+                && requestedMode === 'default'
                 && currentPermissionMode === previousPermissionMode;
             if (ignoredDefaultDowngrade) {
                 logger.debug(`[loop] Ignoring permission mode downgrade from ${previousPermissionMode} to default`);

--- a/packages/happy-cli/src/daemon/controlServer.ts
+++ b/packages/happy-cli/src/daemon/controlServer.ts
@@ -129,7 +129,7 @@ export function startDaemonControlServer({
         body: z.object({
           directory: z.string(),
           sessionId: z.string().optional(),
-          agent: z.enum(['claude', 'codex', 'gemini', 'openclaw', 'agy']).optional(),
+          agent: z.enum(['claude', 'codex', 'gemini', 'openclaw', 'agy', 'hermes', 'crush']).optional(),
           permissionMode: z.string().optional(),
           modelMode: z.string().optional(),
           effortLevel: z.string().optional(),

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -435,8 +435,8 @@ export async function startDaemon(): Promise<void> {
 
           // Construct command for the CLI
           const cliPath = join(projectPath(), 'dist', 'index.mjs');
-          // Determine agent command - support claude, codex, gemini, openclaw, and agy
-          const agent = options.agent === 'gemini' ? 'gemini' : (options.agent === 'codex' ? 'codex' : (options.agent === 'openclaw' ? 'openclaw' : (options.agent === 'agy' ? 'agy' : 'claude')));
+          // Determine agent command; undefined falls back to claude (matching the regular-spawn path)
+          const agent = options.agent ?? 'claude';
           const resumeId = agent === 'claude'
             ? options.resumeClaudeSessionId
             : (agent === 'codex' ? options.resumeCodexThreadId : undefined);

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -550,6 +550,12 @@ export async function startDaemon(): Promise<void> {
             case 'agy':
               agentCommand = 'agy';
               break;
+            case 'hermes':
+              agentCommand = 'hermes';
+              break;
+            case 'crush':
+              agentCommand = 'crush';
+              break;
             default:
               return {
                 type: 'error',

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -45,6 +45,12 @@ import { sanitizeSessionEnvironment } from './daemon/sessionEnvironment'
     logger.debug('Starting happy CLI with args: ', process.argv)
   }
 
+  // Hermes is a known ACP agent; route `happy hermes` through the generic ACP runner
+  if (args[0] === 'hermes') {
+    args[0] = 'acp'
+    args.splice(1, 0, 'hermes')
+  }
+
   // Check if first argument is a subcommand
   const subcommand = args[0]
   

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -377,6 +377,12 @@ Conversation history is preserved on the server, but in-flight tool calls are in
           startedBy = args[++i] as 'daemon' | 'terminal';
           continue;
         }
+        if (!customCommandMode && args[i] === '--happy-starting-mode') {
+          // Happy-internal flag appended by the daemon when spawning remote
+          // sessions; consume it so it never reaches the agent subprocess
+          i++;
+          continue;
+        }
         if (!customCommandMode && args[i] === '--verbose') {
           verbose = true;
           continue;

--- a/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
+++ b/packages/happy-cli/src/modules/common/registerCommonHandlers.ts
@@ -120,7 +120,7 @@ export interface SpawnSessionOptions {
     directory: string;
     sessionId?: string;
     approvedNewDirectoryCreation?: boolean;
-    agent?: 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy';
+    agent?: 'claude' | 'codex' | 'gemini' | 'openclaw' | 'agy' | 'hermes' | 'crush';
     permissionMode?: string;
     modelMode?: string;
     effortLevel?: string;

--- a/packages/happy-cli/src/utils/createSessionMetadata.ts
+++ b/packages/happy-cli/src/utils/createSessionMetadata.ts
@@ -20,7 +20,7 @@ import packageJson from '../../package.json';
 /**
  * Backend flavor identifier for session metadata.
  */
-export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'acp';
+export type BackendFlavor = 'claude' | 'codex' | 'gemini' | 'opencode' | 'openclaw' | 'agy' | 'hermes' | 'crush' | 'acp';
 
 /**
  * Options for creating session metadata.

--- a/packages/happy-cli/src/utils/detectCLI.ts
+++ b/packages/happy-cli/src/utils/detectCLI.ts
@@ -9,6 +9,8 @@ export interface CLIAvailability {
   gemini: boolean;
   openclaw: boolean;
   agy: boolean;
+  hermes: boolean;
+  crush: boolean;
   detectedAt: number;
 }
 
@@ -39,6 +41,8 @@ function detectPosix(): CLIAvailability {
   const codex = commandExists('codex');
   const gemini = commandExists('gemini');
   const agy = commandExists('agy');
+  const hermes = commandExists('hermes');
+  const crush = commandExists('crush');
 
   // OpenClaw: check command, config file, or env var
   const openclawCommand = commandExists('openclaw');
@@ -46,7 +50,7 @@ function detectPosix(): CLIAvailability {
   const openclawEnv = !!process.env.OPENCLAW_GATEWAY_URL;
   const openclaw = openclawCommand || openclawConfig || openclawEnv;
 
-  return { claude, codex, gemini, openclaw, agy, detectedAt: Date.now() };
+  return { claude, codex, gemini, openclaw, agy, hermes, crush, detectedAt: Date.now() };
 }
 
 function detectWindows(): CLIAvailability {
@@ -63,6 +67,8 @@ function detectWindows(): CLIAvailability {
   const codex = checkCommand('codex');
   const gemini = checkCommand('gemini');
   const agy = checkCommand('agy');
+  const hermes = checkCommand('hermes');
+  const crush = checkCommand('crush');
 
   // OpenClaw: check command, config file, or env var
   const openclawCommand = checkCommand('openclaw');
@@ -70,5 +76,5 @@ function detectWindows(): CLIAvailability {
   const openclawEnv = !!process.env.OPENCLAW_GATEWAY_URL;
   const openclaw = openclawCommand || openclawConfig || openclawEnv;
 
-  return { claude, codex, gemini, openclaw, agy, detectedAt: Date.now() };
+  return { claude, codex, gemini, openclaw, agy, hermes, crush, detectedAt: Date.now() };
 }


### PR DESCRIPTION
## Summary

Adds the [Hermes Agent](https://github.com/) CLI as a first-class Happy backend by following the generic ACP runner principles from `docs/plans/generic-acp-runner.md` — no vendor-specific runner, no credential resolution:

- **`KNOWN_ACP_AGENTS`**: `hermes` → `{ command: 'hermes', args: ['acp'] }`
- **`factories/hermes.ts`**: `createHermesBackend` over `AcpBackend` with `HermesTransport`; Hermes manages its own auth (native login), so the user shell env is inherited untouched
- **`HermesTransport`**: `DefaultTransport` + tool-name patterns for `change_title` / `save_memory` / `think` / `HermesReasoning`, plus `hasChangeTitleInstruction` for title-change auto-approval (same shape as the Gemini factory)
- **`happy hermes`** routes through the existing generic `runAcp` runner with session flavor `hermes`
- **Daemon remote-spawn**: agent command mapping + CLI availability detection
- **`cliAvailability` metadata**: include `agy` (was reported by the daemon but stripped by the zod schema) and optional `hermes`/`crush` fields for older-CLI compatibility

## Testing

- Unit tests: config resolution, factory registration round-trip, transport pattern extraction (14 new assertions, full suite green)
- **End-to-end against Hermes Agent v0.20.1** (`hermes acp`): session creation, ACP handshake, 9 slash commands, **3 permission modes** (default / accept_edits / dont_ask), and **95 models** reported through the standard ACP config events — the mobile app gets mode switching and model selection natively with zero Hermes-specific code.

```console
$ happy hermes --verbose
[12:21] Happy Session ID: cmsvry9v2321dye0utwqz6i3j
[12:23] Outgoing slash commands from hermes (9): ...
[12:23] Outgoing modes from hermes (3), current=default: ...
[12:23] Outgoing models from hermes (95), current=deepseek:deepseek-v4-flash: ...
```

## Notes

- The `crush` entries in the shared type unions (`AgentId`, `cliAvailability`, daemon spawn switch) are forward declarations for the follow-up Crush backend PR stacked on this branch.