### PR TITLE
fix(server): use privacyKit.encodeBase64 in randomKey utilities

### DIFF
--- a/packages/happy-server/sources/utils/randomKey.ts
+++ b/packages/happy-server/sources/utils/randomKey.ts
@@ -1,9 +1,10 @@
 import * as crypto from 'crypto';
+import * as privacyKit from 'privacy-kit';
 
 export function randomKey(prefix: string, length: number = 24): string {
     while (true) {
         const randomBytesBuffer = crypto.randomBytes(length * 2);
-        const normalized = randomBytesBuffer.toString('base64').replace(/[^a-zA-Z0-9]/g, '');
+        const normalized = privacyKit.encodeBase64(randomBytesBuffer).replace(/[^a-zA-Z0-9]/g, '');
         if (normalized.length < length) {
             continue;
         }

--- a/packages/happy-server/sources/utils/randomKeyNaked.ts
+++ b/packages/happy-server/sources/utils/randomKeyNaked.ts
@@ -1,9 +1,10 @@
 import * as crypto from 'crypto';
+import * as privacyKit from 'privacy-kit';
 
 export function randomKeyNaked(length: number = 24): string {
     while (true) {
         const randomBytesBuffer = crypto.randomBytes(length * 2);
-        const normalized = randomBytesBuffer.toString('base64').replace(/[^a-zA-Z0-9]/g, '');
+        const normalized = privacyKit.encodeBase64(randomBytesBuffer).replace(/[^a-zA-Z0-9]/g, '');
         if (normalized.length < length) {
             continue;
         }


### PR DESCRIPTION
Replaces `Buffer.toString('base64')` with `privacyKit.encodeBase64` in `randomKey.ts` and `randomKeyNaked.ts`, matching the repository convention for base64 handling.

Output format verified unchanged at runtime (same alphabet filter, same length semantics).