### PR TITLE
fix(cli): resolve agy chat title stuck at Nuova chat by extracting it from first user prompt

### DIFF
--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -105,6 +105,7 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
   let shouldExit = false;
   let abortController = new AbortController();
   let thinking = false;
+  let sessionTitleSet = false;
 
   let displayedModel = DEFAULT_AGY_MODEL;
 
@@ -236,6 +237,25 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
       try {
         await backend.sendPrompt(process.cwd(), batch.message);
         sendEnvelopes(sessionManager.endTurn('completed'));
+        if (!sessionTitleSet) {
+          const userMessages = messageBuffer.getMessages().filter((m) => m.type === 'user');
+          if (userMessages.length > 0) {
+            const firstPrompt = userMessages[0].content;
+            let title = firstPrompt.trim().split('\n')[0];
+            if (title.length > 35) {
+              title = title.substring(0, 32) + '...';
+            }
+            if (title) {
+              log(`Setting session title from first prompt: "${title}"`);
+              session.sendClaudeSessionMessage({
+                type: 'summary',
+                summary: title,
+                leafUuid: randomUUID(),
+              });
+              sessionTitleSet = true;
+            }
+          }
+        }
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         log(`Turn ended: ${msg}`);


### PR DESCRIPTION
  This PR resolves an issue in the `agy` (Antigravity CLI) backend integration where the chat session title gets stuck as "Nuova chat" (or "New chat").

  ### Details:
I updated the turn-ending logic in `runAgy.ts` to automatically extract the title from the first user prompt (truncated to 35 characters).