### PR TITLE
feat(agy): dynamic model discovery and dangerously-skip-permissions s…

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -168,6 +168,9 @@ export function getOpenClawModelModes(): ModelMode[] {
 // Keys are the exact display names `agy --model` accepts (as printed by `agy models`).
 export function getAgyModelModes(): ModelMode[] {
     return [
+        { key: 'Gemini 3.7 Flash (High)', name: 'gemini 3.7 flash (high)', description: null },
+        { key: 'Gemini 3.7 Flash (Medium)', name: 'gemini 3.7 flash (medium)', description: null },
+        { key: 'Gemini 3.7 Flash (Low)', name: 'gemini 3.7 flash (low)', description: null },
         { key: 'Gemini 3.6 Flash (High)', name: 'gemini 3.6 flash (high)', description: null },
         { key: 'Gemini 3.6 Flash (Medium)', name: 'gemini 3.6 flash (medium)', description: null },
         { key: 'Gemini 3.6 Flash (Low)', name: 'gemini 3.6 flash (low)', description: null },

--- a/packages/happy-cli/src/agy/AgyBackend.test.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.test.ts
@@ -313,4 +313,68 @@ describe('AgyBackend', () => {
     child.emit('close', null);
     await expect(turn).rejects.toThrow();
   });
+
+  it('resolves model slug and passes canonical display name to spawn', async () => {
+    const spawnCalls: string[][] = [];
+    const child = makeFakeChild();
+    const spawnFn = vi.fn((_bin: string, args: string[]) => {
+      spawnCalls.push(args);
+      return child.child;
+    }) as unknown as SpawnFn;
+
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      model: 'gemini-3.7-flash-high',
+      spawnFn,
+      resolveConversationId: () => null,
+    });
+
+    await backend.startSession();
+    const turn = backend.sendPrompt('/work', 'hi');
+    child.child.emit('close', 0);
+    await turn;
+
+    expect(backend.getModel()).toBe('Gemini 3.7 Flash (High)');
+    const modelIdx = spawnCalls[0].indexOf('--model');
+    expect(modelIdx).toBeGreaterThanOrEqual(0);
+    expect(spawnCalls[0][modelIdx + 1]).toBe('Gemini 3.7 Flash (High)');
+  });
+
+  it('updates model when setModel is called', async () => {
+    const spawnCalls: string[][] = [];
+    let child = makeFakeChild();
+    const spawnFn = vi.fn((_bin: string, args: string[]) => {
+      spawnCalls.push(args);
+      return child.child;
+    }) as unknown as SpawnFn;
+
+    const backend = new AgyBackend({
+      cwd: '/work',
+      permissionMode: 'default',
+      model: 'Gemini 3.1 Pro (High)',
+      spawnFn,
+      resolveConversationId: () => null,
+    });
+
+    await backend.startSession();
+
+    // First turn with initial model
+    const t1 = backend.sendPrompt('/work', 'first');
+    child.child.emit('close', 0);
+    await t1;
+    expect(spawnCalls[0][spawnCalls[0].indexOf('--model') + 1]).toBe('Gemini 3.1 Pro (High)');
+
+    // Switch model via slug
+    backend.setModel('gemini-3.7-flash-medium');
+    expect(backend.getModel()).toBe('Gemini 3.7 Flash (Medium)');
+
+    // Second turn with updated model
+    child = makeFakeChild();
+    const t2 = backend.sendPrompt('/work', 'second');
+    child.child.emit('close', 0);
+    await t2;
+    expect(spawnCalls[1][spawnCalls[1].indexOf('--model') + 1]).toBe('Gemini 3.7 Flash (Medium)');
+  });
 });
+

--- a/packages/happy-cli/src/agy/AgyBackend.ts
+++ b/packages/happy-cli/src/agy/AgyBackend.ts
@@ -27,6 +27,7 @@ import type {
 import { resolveAgyBin, AGY_PRINT_TIMEOUT } from './constants';
 import { buildAgyArgs } from './cliArgs';
 import { readAgyConversationId } from './conversationStore';
+import { resolveAgyModelName, type DiscoveredModel } from './discoverModels';
 
 /** Signature of node's `spawn`, injectable so tests can supply a fake process. */
 export type SpawnFn = typeof spawn;
@@ -36,8 +37,10 @@ export interface AgyBackendOptions {
   cwd: string;
   /** Initial permission mode; updated per turn from message meta. */
   permissionMode: PermissionMode;
-  /** Initial model display name; updated per turn from message meta. */
+  /** Initial model display name or slug; updated per turn from message meta. */
   model?: string;
+  /** List of discovered models for resolving slugs to display names. */
+  models?: DiscoveredModel[];
   /** Value for `--print-timeout`. Defaults to AGY_PRINT_TIMEOUT. */
   printTimeout?: string;
   /** Optional logger. */
@@ -66,13 +69,15 @@ export class AgyBackend implements AgentBackend {
 
   private permissionMode: PermissionMode;
   private model?: string;
+  private models?: DiscoveredModel[];
   private conversationId: string | null = null;
   private child: ChildProcess | null = null;
 
   constructor(opts: AgyBackendOptions) {
     this.cwd = opts.cwd;
     this.permissionMode = opts.permissionMode;
-    this.model = opts.model;
+    this.models = opts.models;
+    this.model = resolveAgyModelName(opts.model, this.models);
     this.printTimeout = opts.printTimeout ?? AGY_PRINT_TIMEOUT;
     this.log = opts.log ?? (() => {});
     this.spawnFn = opts.spawnFn ?? spawn;
@@ -84,9 +89,22 @@ export class AgyBackend implements AgentBackend {
     this.permissionMode = mode;
   }
 
-  /** Update the model applied to subsequent turns. */
+  /** Update the model applied to subsequent turns (resolves slugs to display names). */
   setModel(model: string | undefined): void {
-    this.model = model;
+    this.model = resolveAgyModelName(model, this.models);
+  }
+
+  /** Update the discovered model catalog. */
+  setDiscoveredModels(models: DiscoveredModel[]): void {
+    this.models = models;
+    if (this.model) {
+      this.model = resolveAgyModelName(this.model, this.models);
+    }
+  }
+
+  /** Get the current resolved model display name. */
+  getModel(): string | undefined {
+    return this.model;
   }
 
   async startSession(): Promise<StartSessionResult> {

--- a/packages/happy-cli/src/agy/constants.ts
+++ b/packages/happy-cli/src/agy/constants.ts
@@ -58,14 +58,17 @@ export function resolveAgyBin(): string {
  * agy expects the full display string, not a slug.
  */
 export const AGY_MODELS = [
-  'Gemini 3.6 Flash (Medium)',
+  'Gemini 3.7 Flash (High)',
+  'Gemini 3.7 Flash (Medium)',
+  'Gemini 3.7 Flash (Low)',
   'Gemini 3.6 Flash (High)',
+  'Gemini 3.6 Flash (Medium)',
   'Gemini 3.6 Flash (Low)',
-  'Gemini 3.5 Flash (Medium)',
   'Gemini 3.5 Flash (High)',
+  'Gemini 3.5 Flash (Medium)',
   'Gemini 3.5 Flash (Low)',
-  'Gemini 3.1 Pro (Low)',
   'Gemini 3.1 Pro (High)',
+  'Gemini 3.1 Pro (Low)',
   'Claude Sonnet 4.6 (Thinking)',
   'Claude Opus 4.6 (Thinking)',
   'GPT-OSS 120B (Medium)',

--- a/packages/happy-cli/src/agy/discoverModels.test.ts
+++ b/packages/happy-cli/src/agy/discoverModels.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  discoverAgyModels,
+  getStaticAgyModels,
+  parseAgyModelsOutput,
+  resolveAgyModelName,
+  type ExecFileFn,
+} from './discoverModels';
+import { AGY_MODELS } from './constants';
+
+describe('discoverModels', () => {
+  describe('parseAgyModelsOutput', () => {
+    it('parses tab-separated agy models output', () => {
+      const sample = `Fetching available models...
+gemini-3.7-flash-high\tGemini 3.7 Flash (High)
+gemini-3.7-flash-medium\tGemini 3.7 Flash (Medium)
+gemini-3.6-flash-high\tGemini 3.6 Flash (High)
+claude-opus-4-6-thinking\tClaude Opus 4.6 (Thinking)
+`;
+      const models = parseAgyModelsOutput(sample);
+      expect(models).toEqual([
+        {
+          code: 'Gemini 3.7 Flash (High)',
+          value: 'Gemini 3.7 Flash (High)',
+          slug: 'gemini-3.7-flash-high',
+          description: null,
+        },
+        {
+          code: 'Gemini 3.7 Flash (Medium)',
+          value: 'Gemini 3.7 Flash (Medium)',
+          slug: 'gemini-3.7-flash-medium',
+          description: null,
+        },
+        {
+          code: 'Gemini 3.6 Flash (High)',
+          value: 'Gemini 3.6 Flash (High)',
+          slug: 'gemini-3.6-flash-high',
+          description: null,
+        },
+        {
+          code: 'Claude Opus 4.6 (Thinking)',
+          value: 'Claude Opus 4.6 (Thinking)',
+          slug: 'claude-opus-4-6-thinking',
+          description: null,
+        },
+      ]);
+    });
+
+    it('parses space-aligned agy models output and ignores spinners/headers', () => {
+      const sample = `⠋ Fetching available models...⠙ Fetching available models...
+gemini-3.7-flash-high     Gemini 3.7 Flash (High)
+gemini-3.7-flash-low      Gemini 3.7 Flash (Low)
+gpt-oss-120b-medium       GPT-OSS 120B (Medium)
+`;
+      const models = parseAgyModelsOutput(sample);
+      expect(models).toEqual([
+        {
+          code: 'Gemini 3.7 Flash (High)',
+          value: 'Gemini 3.7 Flash (High)',
+          slug: 'gemini-3.7-flash-high',
+          description: null,
+        },
+        {
+          code: 'Gemini 3.7 Flash (Low)',
+          value: 'Gemini 3.7 Flash (Low)',
+          slug: 'gemini-3.7-flash-low',
+          description: null,
+        },
+        {
+          code: 'GPT-OSS 120B (Medium)',
+          value: 'GPT-OSS 120B (Medium)',
+          slug: 'gpt-oss-120b-medium',
+          description: null,
+        },
+      ]);
+    });
+
+    it('deduplicates duplicate model entries', () => {
+      const sample = `
+gemini-3.7-flash-high\tGemini 3.7 Flash (High)
+gemini-3.7-flash-high\tGemini 3.7 Flash (High)
+`;
+      const models = parseAgyModelsOutput(sample);
+      expect(models).toHaveLength(1);
+    });
+
+    it('returns empty array on empty or invalid input', () => {
+      expect(parseAgyModelsOutput('')).toEqual([]);
+      expect(parseAgyModelsOutput(null as unknown as string)).toEqual([]);
+    });
+  });
+
+  describe('getStaticAgyModels', () => {
+    it('returns all static AGY_MODELS formatted for session metadata', () => {
+      const staticModels = getStaticAgyModels();
+      expect(staticModels.map((m) => m.code)).toEqual(AGY_MODELS);
+      expect(staticModels.some((m) => m.code === 'Gemini 3.7 Flash (High)')).toBe(true);
+    });
+  });
+
+  describe('discoverAgyModels', () => {
+    it('returns parsed models when agy models succeeds', async () => {
+      const mockExecFile: ExecFileFn = ((
+        _bin: string,
+        _args: string[],
+        _opts: any,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(
+          null,
+          'gemini-3.7-flash-high\tGemini 3.7 Flash (High)\ngemini-3.7-flash-medium\tGemini 3.7 Flash (Medium)\n',
+          '',
+        );
+      }) as unknown as ExecFileFn;
+
+      const models = await discoverAgyModels({ execFileFn: mockExecFile });
+      expect(models).toHaveLength(2);
+      expect(models[0].code).toBe('Gemini 3.7 Flash (High)');
+      expect(models[1].code).toBe('Gemini 3.7 Flash (Medium)');
+    });
+
+    it('falls back to static models when agy models fails', async () => {
+      const mockExecFile: ExecFileFn = ((
+        _bin: string,
+        _args: string[],
+        _opts: any,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(new Error('command not found: agy'), '', '');
+      }) as unknown as ExecFileFn;
+
+      const log = vi.fn();
+      const models = await discoverAgyModels({ execFileFn: mockExecFile, log });
+      expect(models.map((m) => m.code)).toEqual(AGY_MODELS);
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Failed to discover agy models dynamically'));
+    });
+  });
+
+  describe('resolveAgyModelName', () => {
+    const customModels = [
+      { code: 'Gemini 3.7 Flash (High)', value: 'Gemini 3.7 Flash (High)', slug: 'gemini-3.7-flash-high' },
+      { code: 'Claude Opus 4.6 (Thinking)', value: 'Claude Opus 4.6 (Thinking)', slug: 'claude-opus-4-6-thinking' },
+    ];
+
+    it('resolves slug to canonical display name', () => {
+      expect(resolveAgyModelName('gemini-3.7-flash-high', customModels)).toBe('Gemini 3.7 Flash (High)');
+      expect(resolveAgyModelName('claude-opus-4-6-thinking', customModels)).toBe('Claude Opus 4.6 (Thinking)');
+    });
+
+    it('preserves exact display name', () => {
+      expect(resolveAgyModelName('Gemini 3.7 Flash (High)', customModels)).toBe('Gemini 3.7 Flash (High)');
+    });
+
+    it('handles case-insensitive display name match', () => {
+      expect(resolveAgyModelName('gemini 3.7 flash (high)', customModels)).toBe('Gemini 3.7 Flash (High)');
+    });
+
+    it('returns unknown model as-is', () => {
+      expect(resolveAgyModelName('custom-model-9', customModels)).toBe('custom-model-9');
+      expect(resolveAgyModelName(undefined, customModels)).toBeUndefined();
+    });
+  });
+});

--- a/packages/happy-cli/src/agy/discoverModels.ts
+++ b/packages/happy-cli/src/agy/discoverModels.ts
@@ -1,0 +1,245 @@
+/**
+ * Agy Model Discovery
+ *
+ * Dynamically queries `agy models` to discover available models supported by the
+ * local Antigravity CLI installation, and transforms them into Happy Session metadata
+ * models format:
+ *   [
+ *     { code: 'Gemini 3.7 Flash (High)', value: 'Gemini 3.7 Flash (High)', description: null },
+ *     ...
+ *   ]
+ *
+ * If `agy models` fails or is unavailable, falls back to the static AGY_MODELS list.
+ */
+
+import { execFile } from 'node:child_process';
+import { AGY_MODELS, resolveAgyBin } from './constants';
+
+export interface DiscoveredModel {
+  code: string;
+  value: string;
+  slug?: string;
+  description?: string | null;
+}
+
+/**
+ * Parse output from `agy models`.
+ * Handles tab-separated (`<slug>\t<Display Name>`) and space-aligned formats,
+ * strips ANSI escape codes and spinner text, and ignores headers/help text.
+ */
+export function parseAgyModelsOutput(output: string): DiscoveredModel[] {
+  if (!output || typeof output !== 'string') {
+    return [];
+  }
+
+  // Strip ANSI escape codes
+  const cleaned = output.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+  const lines = cleaned.split('\n');
+  const models: DiscoveredModel[] = [];
+  const seenCodes = new Set<string>();
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    // Skip spinner / loading / header / help lines
+    if (
+      line.startsWith('Fetching') ||
+      line.startsWith('Available') ||
+      line.startsWith('Usage:') ||
+      line.startsWith('Flags:') ||
+      /^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(line)
+    ) {
+      continue;
+    }
+
+    // Try splitting by tab first
+    if (line.includes('\t')) {
+      const parts = line.split('\t').map((p) => p.trim()).filter(Boolean);
+      if (parts.length >= 2) {
+        const slug = parts[0];
+        const displayName = parts[1];
+        if (!seenCodes.has(displayName)) {
+          seenCodes.add(displayName);
+          models.push({
+            code: displayName,
+            value: displayName,
+            slug,
+            description: null,
+          });
+        }
+        continue;
+      } else if (parts.length === 1) {
+        const name = parts[0];
+        if (!seenCodes.has(name)) {
+          seenCodes.add(name);
+          models.push({
+            code: name,
+            value: name,
+            description: null,
+          });
+        }
+        continue;
+      }
+    }
+
+    // Try splitting by 2 or more spaces (column alignment)
+    const multiSpaceMatch = line.match(/^(\S+)\s{2,}(.+)$/);
+    if (multiSpaceMatch) {
+      const slug = multiSpaceMatch[1].trim();
+      const displayName = multiSpaceMatch[2].trim();
+      if (!seenCodes.has(displayName)) {
+        seenCodes.add(displayName);
+        models.push({
+          code: displayName,
+          value: displayName,
+          slug,
+          description: null,
+        });
+      }
+      continue;
+    }
+
+    // Fallback: single line display name
+    if (!seenCodes.has(line)) {
+      seenCodes.add(line);
+      models.push({
+        code: line,
+        value: line,
+        description: null,
+      });
+    }
+  }
+
+  return models;
+}
+
+/**
+ * Generate a canonical slug for a model display name.
+ * e.g. "Gemini 3.7 Flash (High)" -> "gemini-3.7-flash-high"
+ */
+export function slugifyModelName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[()]/g, '')
+    .trim()
+    .replace(/[\s_]+/g, '-');
+}
+
+/**
+ * Normalize a model name or slug for fuzzy matching by stripping all punctuation and whitespace.
+ * e.g. "Gemini 3.7 Flash (High)" -> "gemini37flashhigh"
+ *      "gemini-3.7-flash-high"   -> "gemini37flashhigh"
+ *      "gemini-3-7-flash-high"   -> "gemini37flashhigh"
+ */
+export function normalizeModelKey(str: string): string {
+  return str.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Returns the fallback static model list formatted as DiscoveredModel items.
+ */
+export function getStaticAgyModels(): DiscoveredModel[] {
+  return AGY_MODELS.map((name) => ({
+    code: name,
+    value: name,
+    slug: slugifyModelName(name),
+    description: null,
+  }));
+}
+
+export type ExecFileFn = typeof execFile;
+
+export interface DiscoverAgyModelsOptions {
+  bin?: string;
+  timeoutMs?: number;
+  log?: (msg: string) => void;
+  execFileFn?: ExecFileFn;
+}
+
+/**
+ * Discover models by running `agy models`.
+ * Falls back to static AGY_MODELS on error, timeout, or empty output.
+ */
+export async function discoverAgyModels(
+  opts: DiscoverAgyModelsOptions = {},
+): Promise<DiscoveredModel[]> {
+  const bin = opts.bin ?? resolveAgyBin();
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const log = opts.log ?? (() => {});
+  const execFileFn = opts.execFileFn ?? execFile;
+
+  return new Promise<DiscoveredModel[]>((resolve) => {
+    try {
+      execFileFn(
+        bin,
+        ['models'],
+        {
+          timeout: timeoutMs,
+          encoding: 'utf8',
+          windowsHide: true,
+        },
+        (error, stdout) => {
+          if (error) {
+            log(`Failed to discover agy models dynamically (${error.message}); falling back to static list`);
+            resolve(getStaticAgyModels());
+            return;
+          }
+
+          const parsed = parseAgyModelsOutput(stdout);
+          if (parsed.length > 0) {
+            log(`Discovered ${parsed.length} agy models dynamically`);
+            resolve(parsed);
+          } else {
+            log('No models parsed from `agy models`; falling back to static list');
+            resolve(getStaticAgyModels());
+          }
+        },
+      );
+    } catch (err) {
+      log(`Error running agy models: ${err instanceof Error ? err.message : String(err)}`);
+      resolve(getStaticAgyModels());
+    }
+  });
+}
+
+/**
+ * Resolve a model string (slug or display name) to the canonical display name
+ * accepted by `agy --model`.
+ */
+export function resolveAgyModelName(
+  model: string | undefined,
+  models?: DiscoveredModel[],
+): string | undefined {
+  if (!model) return undefined;
+  const list = models && models.length > 0 ? models : getStaticAgyModels();
+
+  const trimmed = model.trim();
+  const lower = trimmed.toLowerCase();
+  const normalized = normalizeModelKey(trimmed);
+
+  // Exact code or value match
+  const exact = list.find((m) => m.code === trimmed || m.value === trimmed);
+  if (exact) return exact.code;
+
+  // Slug match (e.g. 'gemini-3.7-flash-high' -> 'Gemini 3.7 Flash (High)')
+  const slugMatch = list.find((m) => m.slug && m.slug.toLowerCase() === lower);
+  if (slugMatch) return slugMatch.code;
+
+  // Case-insensitive match on code or value
+  const ciMatch = list.find(
+    (m) => m.code.toLowerCase() === lower || m.value.toLowerCase() === lower,
+  );
+  if (ciMatch) return ciMatch.code;
+
+  // Normalized key match (strips punctuation/spaces: 'gemini-3.7-flash-high' <-> 'Gemini 3.7 Flash (High)')
+  const normMatch = list.find(
+    (m) =>
+      normalizeModelKey(m.code) === normalized ||
+      normalizeModelKey(m.value) === normalized ||
+      (m.slug && normalizeModelKey(m.slug) === normalized),
+  );
+  if (normMatch) return normMatch.code;
+
+  return trimmed;
+}

--- a/packages/happy-cli/src/agy/runAgy.ts
+++ b/packages/happy-cli/src/agy/runAgy.ts
@@ -33,11 +33,15 @@ import type { AgentMessage } from '@/agent/core';
 import type { PermissionMode } from '@/api/types';
 import { AgyBackend } from './AgyBackend';
 import { DEFAULT_AGY_MODEL } from './constants';
+import { discoverAgyModels, resolveAgyModelName } from './discoverModels';
 
 export interface RunAgyOptions {
   credentials: Credentials;
   startedBy?: 'daemon' | 'terminal';
   verbose?: boolean;
+  model?: string;
+  permissionMode?: PermissionMode;
+  dangerouslySkipPermissions?: boolean;
 }
 
 export async function runAgy(opts: RunAgyOptions): Promise<void> {
@@ -63,11 +67,29 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
     metadata: initialMachineMetadata,
   });
 
+  const discoveredModels = await discoverAgyModels({ log });
+
+  const initialModel = resolveAgyModelName(opts.model, discoveredModels) ?? DEFAULT_AGY_MODEL;
+  const isSkipPermissions =
+    opts.dangerouslySkipPermissions === true ||
+    opts.permissionMode === 'bypassPermissions' ||
+    opts.permissionMode === 'yolo';
+  const initialPermissionMode: PermissionMode =
+    opts.permissionMode ?? (isSkipPermissions ? 'bypassPermissions' : 'default');
+
   const { state, metadata } = createSessionMetadata({
     flavor: 'agy',
     machineId: settings.machineId,
     startedBy: opts.startedBy,
+    dangerouslySkipPermissions: isSkipPermissions,
   });
+  metadata.models = discoveredModels.map((m) => ({
+    code: m.code,
+    value: m.value,
+    description: m.description ?? null,
+  }));
+  metadata.currentModelCode = initialModel;
+
   const response = await api.getOrCreateSession({ tag: sessionTag, metadata, state });
   if (response) {
     log(`Happy Session ID: ${response.id}`);
@@ -106,12 +128,13 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
   let abortController = new AbortController();
   let thinking = false;
 
-  let displayedModel = DEFAULT_AGY_MODEL;
+  let displayedModel = initialModel;
 
   const backend = new AgyBackend({
     cwd: process.cwd(),
-    permissionMode: 'default',
-    model: DEFAULT_AGY_MODEL,
+    permissionMode: initialPermissionMode,
+    model: initialModel,
+    models: discoveredModels,
     log,
   });
 
@@ -182,8 +205,13 @@ export async function runAgy(opts: RunAgyOptions): Promise<void> {
       backend.setPermissionMode(message.meta.permissionMode as PermissionMode);
     }
     if (message.meta?.hasOwnProperty('model') && message.meta.model) {
-      backend.setModel(message.meta.model);
-      displayedModel = message.meta.model;
+      const canonicalModel = resolveAgyModelName(message.meta.model, discoveredModels) ?? message.meta.model;
+      backend.setModel(canonicalModel);
+      displayedModel = canonicalModel;
+      session.updateMetadata((currentMetadata) => ({
+        ...currentMetadata,
+        currentModelCode: displayedModel,
+      }));
       if (hasTTY) {
         messageBuffer.addMessage(`[MODEL:${displayedModel}]`, 'system');
       }

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -40,10 +40,10 @@ function shellescape(s: string): string {
 }
 
 function appendDaemonSpawnModeArgs(args: string[], options: SpawnSessionOptions, agent: string): void {
-  if (agent !== 'claude' && agent !== 'codex') {
+  if (agent !== 'claude' && agent !== 'codex' && agent !== 'agy') {
     return;
   }
-  // For claude, 'default' is the app's ambient "no override" value — forwarding
+  // For claude/agy, 'default' is the app's ambient "no override" value — forwarding
   // it would pin the session to prompting mode and lose the CLI's own default
   // (e.g. a --yolo setup where sessions must bypass permissions). For codex,
   // 'default' IS a concrete ask-first mode (untrusted + workspace-write)

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -449,11 +449,21 @@ Conversation history is preserved on the server, but in-flight tool calls are in
 
       let startedBy: 'daemon' | 'terminal' | undefined = undefined;
       let verbose = false;
+      let model: string | undefined = undefined;
+      let permissionMode: any = undefined;
+      let dangerouslySkipPermissions = false;
       for (let i = 1; i < args.length; i++) {
         if (args[i] === '--started-by') {
           startedBy = args[++i] as 'daemon' | 'terminal';
         } else if (args[i] === '--verbose') {
           verbose = true;
+        } else if (args[i] === '--model') {
+          model = args[++i];
+        } else if (args[i] === '--permission-mode') {
+          permissionMode = args[++i];
+        } else if (args[i] === '--dangerously-skip-permissions' || args[i] === '--yolo' || args[i] === '-y') {
+          dangerouslySkipPermissions = true;
+          permissionMode = 'bypassPermissions';
         }
       }
 
@@ -464,6 +474,9 @@ Conversation history is preserved on the server, but in-flight tool calls are in
         credentials,
         startedBy,
         verbose,
+        model,
+        permissionMode,
+        dangerouslySkipPermissions,
       });
     } catch (error) {
       console.error(chalk.red('Error:'), error instanceof Error ? error.message : 'Unknown error')


### PR DESCRIPTION
 ### Summary
    This PR enhances the `agy` (Antigravity CLI) backend in Happy with dynamic model discovery and proper flag/metadata support:

    1. **Dynamic Model Discovery (`discoverModels.ts`)**:
       - Queries `agy models` on session startup and parses available models dynamically into `session.metadata.models`.
       - Allows Happy iOS / Web clients to dynamically display newly released models (e.g. Gemini 3.7 Flash High / Medium / Low and future releases) without requiring app or server updates.
       - Includes graceful fallback to static models and fuzzy slug/display-name resolution (`resolveAgyModelName`).

    2. **Flag & Permission Forwarding (`index.ts`, `runAgy.ts`, `daemon/run.ts`)**:
       - Parses `--dangerously-skip-permissions`, `--yolo`, `-y`, `--model`, and `--permission-mode` flags for the `agy` subcommand.
       - Sets `dangerouslySkipPermissions: true` in session metadata and maps to `bypassPermissions` so clients accurately reflect the permission state.
       - Forwards `--model` and `--permission-mode` when spawned by the daemon.

    3. **Tests**:
       - Added unit test suites for `discoverModels.test.ts` and expanded `AgyBackend.test.ts`.

    ### Testing
    - `npx vitest run src/agy` (all 31 tests passed).
    - Tested dynamic model discovery and model switching end-to-end with Happy iOS App.
    - Verified `--dangerously-skip-permissions` properly sets `metadata.dangerouslySkipPermissions = true`.