### PR TITLE
fix(cli): preserve `claude` as argv[0] when spawning the native binary

### DIFF
--- a/packages/happy-cli/scripts/claude_version_utils.cjs
+++ b/packages/happy-cli/scripts/claude_version_utils.cjs
@@ -636,9 +636,23 @@ function runClaudeCli(cliPath) {
     // (Investigation: ps showed orphan claude.exe with parent pid 1 still
     // attached to the same pts as the live one.)
     const args = process.argv.slice(2);
+    // Keep `claude` as argv[0]. findGlobalClaudeCliPath() realpaths every
+    // candidate it returns, so for a native install cliPath is
+    // ~/.local/share/claude/versions/<version> and argv[0] would otherwise be
+    // a bare version number like "2.1.238". Anything that identifies the
+    // running agent from argv[0] -- terminal workspace managers that label
+    // panes by the agent they detect, status lines, plain `pgrep claude` --
+    // then sees no claude at all, just an unrecognized process under a couple
+    // of `node` wrappers.
+    //
+    // cross-spawn passes options straight through to child_process.spawn on
+    // POSIX, where argv0 is honored. Skipped on Windows, where cross-spawn may
+    // route the call through cmd.exe and overriding argv[0] would misreport
+    // the command actually being run.
     const child = spawn(cliPath, args, {
         stdio: 'inherit',
-        env: process.env
+        env: process.env,
+        ...(process.platform !== 'win32' ? { argv0: 'claude' } : {})
     });
 
     let forwarded = false;

--- a/packages/happy-cli/scripts/claude_version_utils.test.ts
+++ b/packages/happy-cli/scripts/claude_version_utils.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   resolveClaudeEntrypoint,
   findGlobalClaudeCliPath,
@@ -15,6 +17,8 @@ import {
   compareVersions,
   shouldWarnAboutGoalHookJsonValidationRisk,
 } from '../scripts/claude_version_utils.cjs';
+
+const modulePath = fileURLToPath(new URL('./claude_version_utils.cjs', import.meta.url));
 
 describe('Claude Version Utils - Cross-Platform Detection', () => {
 
@@ -478,5 +482,42 @@ describe('HAPPY_CLAUDE_PATH env var', () => {
     process.env.HAPPY_CLAUDE_PATH = '/nonexistent/path/claude';
     const result = findGlobalClaudeCliPath();
     expect(result?.source).not.toBe('HAPPY_CLAUDE_PATH');
+  });
+});
+
+describe('runClaudeCli - argv[0] preservation', () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'happy-claude-argv0-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  // POSIX only: spawn's argv0 option is not applied on Windows, where
+  // cross-spawn may route the call through cmd.exe.
+  it.skipIf(process.platform === 'win32')('spawns the binary as "claude", not as its version number', () => {
+    // A native install resolves to ~/.local/share/claude/versions/<version>,
+    // so the file name carries no hint that this is Claude Code. Stand in for
+    // that binary with a symlink to node, which can report its own argv[0].
+    const versionsDir = path.join(workDir, 'versions');
+    fs.mkdirSync(versionsDir);
+    const claudeBinary = path.join(versionsDir, '9.9.9');
+    fs.symlinkSync(process.execPath, claudeBinary);
+
+    const argv0File = path.join(workDir, 'argv0.txt');
+    const binaryScript = `require('fs').writeFileSync(${JSON.stringify(argv0File)}, process.argv0)`;
+    // runClaudeCli forwards process.argv.slice(2) to the binary, so the args
+    // the stand-in needs have to look like the launcher's own arguments.
+    const launcherScript = [
+      `process.argv = [process.argv[0], 'launcher', '-e', ${JSON.stringify(binaryScript)}];`,
+      `require(${JSON.stringify(modulePath)}).runClaudeCli(${JSON.stringify(claudeBinary)});`,
+    ].join('\n');
+
+    execFileSync(process.execPath, ['-e', launcherScript], { stdio: 'ignore', timeout: 15_000 });
+
+    expect(fs.readFileSync(argv0File, 'utf8')).toBe('claude');
   });
 });


### PR DESCRIPTION
## Problem

Running Claude Code through happy makes it invisible to anything that identifies the running agent from `argv[0]`.

`findGlobalClaudeCliPath()` calls `resolvePathSafe()` (i.e. `fs.realpathSync`) on every candidate, so on a native install the `~/.local/bin/claude` symlink collapses to `~/.local/share/claude/versions/<version>`. `runClaudeCli()` then spawns that path, and `argv[0]` becomes a bare version number.

Same machine, same Claude Code version, as seen by a terminal workspace manager that labels panes by the agent it detects in them:

```
$ claude          ->  argv0="claude"     name="2.1.237"   -> detected: claude, idle
$ happy claude    ->  argv0="2.1.238"    name="2.1.238"   -> detected: nothing
                      argv0="node" x3 (happy wrappers)
```

So the pane shows up as an unrecognized process under a couple of `node` wrappers. This also breaks plain `pgrep claude` and status-line integrations that key on the process name. Nothing about the session is actually different -- only the label the OS reports.

## Fix

Pass `argv0: 'claude'` to the spawn in `runClaudeCli()`. cross-spawn forwards options straight through to `child_process.spawn` on POSIX, where `argv0` is honored, so this is a one-option change with no behavioral effect on the child beyond the reported name.

Skipped on Windows: cross-spawn may route the call through `cmd.exe`, and overriding `argv[0]` there would misreport the command actually being run.

## Verification

Before/after, spawning a stand-in binary that reports its own `process.argv0`:

```
before:  argv0 seen by spawned binary: /tmp/.../versions/9.9.9
after:   argv0 seen by spawned binary: claude
```

Confirmed on a real session too -- `happy claude` in a fresh pane goes from undetected to `agent: claude, status: idle`, and the agent's state (working / idle / blocked) tracks correctly from there.

## Tests

Added a regression test to `packages/happy-cli/scripts/claude_version_utils.test.ts` that stands in for the native binary with a symlink to `node` (a shell script cannot be used here -- the kernel discards `argv[0]` for `#!` scripts) and asserts the spawned process sees `claude`. It fails on `main` with the version path and passes with this change.

`vitest run --project unit scripts/claude_version_utils.test.ts` -> 51 passed.

## Note on the existing workaround

`HAPPY_CLAUDE_PATH` can work around this today, but only if it points at a *regular file* named `claude` that execs the real binary -- a symlink gets realpath'd away again by `resolvePathSafe()`. That is non-obvious enough that it probably should not be the requirement for being visible to a process-based detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
