### PR TITLE
fix(app): restore collapsing a checkout on the home session list

### DIFF
--- a/packages/happy-app/sources/components/ProjectGroup.tsx
+++ b/packages/happy-app/sources/components/ProjectGroup.tsx
@@ -6,7 +6,8 @@ import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Text } from '@/components/StyledText';
 import { Typography } from '@/constants/Typography';
 import { t } from '@/text';
-import { ProjectGroupData, ProjectWorkspaceGroup, useSessionGitStatus } from '@/sync/storage';
+import { ProjectGroupData, ProjectWorkspaceGroup, useLocalSettingMutable, useSessionGitStatus } from '@/sync/storage';
+import { projectWorkspaceCollapseKey } from '@/sync/projectGroups';
 import { CompactSessionRow } from './ActiveSessionsGroupCompact';
 import { Avatar } from './Avatar';
 import { requestHomeDockFocus } from './homeDockFocus';
@@ -81,6 +82,16 @@ const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId }: 
             })
             : null;
 
+    // Collapsing follows the header, and the header is per checkout: a project
+    // with three worktrees renders four of these sections, so one toggle folds
+    // exactly the card it sits on rather than every checkout of the project.
+    const collapseKey = projectWorkspaceCollapseKey(project.id, workspace.id);
+    const [collapsedProjects, setCollapsedProjects] = useLocalSettingMutable('collapsedProjects');
+    const collapsed = !!collapsedProjects[collapseKey];
+    const toggleCollapsed = React.useCallback(() => {
+        setCollapsedProjects({ ...collapsedProjects, [collapseKey]: !collapsed });
+    }, [collapsed, collapsedProjects, collapseKey, setCollapsedProjects]);
+
     // Point the draft at this exact checkout before opening the composer, so
     // the dock's machine, project and worktree rows already read correctly.
     // `setMachineId` clears the path and worktree, so the order matters.
@@ -109,32 +120,51 @@ const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId }: 
     return (
         <View style={styles.section}>
             <View style={styles.header}>
-                {firstSession && (
-                    <Avatar id={firstSession.avatarId} size={HEADER_AVATAR_SIZE} flavor={null} imageUrl={firstSession.projectAvatarUri} thumbhash={firstSession.projectAvatarThumbhash} />
-                )}
-                <View style={styles.headerText}>
-                    <Text style={styles.title} numberOfLines={1}>
-                        {project.name}
-                    </Text>
-                    <View style={styles.branchLine}>
-                        <Text style={styles.branchText} numberOfLines={1}>
-                            {branchName}
+                <Pressable
+                    onPress={toggleCollapsed}
+                    hitSlop={{ top: 8, bottom: 8 }}
+                    accessibilityRole="button"
+                    accessibilityState={{ expanded: !collapsed }}
+                    accessibilityLabel={worktreeName ? `${project.name} / ${worktreeName}` : project.name}
+                    style={styles.headerPress}
+                >
+                    <Ionicons
+                        name={collapsed ? 'chevron-forward' : 'chevron-down'}
+                        size={14}
+                        color={theme.colors.textSecondary}
+                    />
+                    {firstSession && (
+                        <Avatar id={firstSession.avatarId} size={HEADER_AVATAR_SIZE} flavor={null} imageUrl={firstSession.projectAvatarUri} thumbhash={firstSession.projectAvatarThumbhash} />
+                    )}
+                    <View style={styles.headerText}>
+                        <Text style={styles.title} numberOfLines={1}>
+                            {project.name}
                         </Text>
-                        {changes && (
-                            <View style={styles.branchChanges}>
-                                {changes.approximate && (
-                                    <Text style={styles.approximateText}>≈</Text>
-                                )}
-                                {changes.insertions > 0 && (
-                                    <Text style={styles.addedText}>+{compactCount(changes.insertions)}</Text>
-                                )}
-                                {changes.deletions > 0 && (
-                                    <Text style={styles.removedText}>-{compactCount(changes.deletions)}</Text>
-                                )}
-                            </View>
-                        )}
+                        <View style={styles.branchLine}>
+                            <Text style={styles.branchText} numberOfLines={1}>
+                                {branchName}
+                            </Text>
+                            {changes && (
+                                <View style={styles.branchChanges}>
+                                    {changes.approximate && (
+                                        <Text style={styles.approximateText}>≈</Text>
+                                    )}
+                                    {changes.insertions > 0 && (
+                                        <Text style={styles.addedText}>+{compactCount(changes.insertions)}</Text>
+                                    )}
+                                    {changes.deletions > 0 && (
+                                        <Text style={styles.removedText}>-{compactCount(changes.deletions)}</Text>
+                                    )}
+                                </View>
+                            )}
+                        </View>
                     </View>
-                </View>
+                    {collapsed && (
+                        <Text style={styles.count}>
+                            {workspace.sessions.length}
+                        </Text>
+                    )}
+                </Pressable>
                 <Pressable
                     onPress={handleNewSession}
                     hitSlop={12}
@@ -146,16 +176,18 @@ const WorkspaceSection = React.memo(({ project, workspace, selectedSessionId }: 
                 </Pressable>
             </View>
 
-            <View style={styles.workspaceCard}>
-                {workspace.sessions.map((session, index) => (
-                    <CompactSessionRow
-                        key={session.id}
-                        session={session}
-                        selected={session.id === selectedSessionId}
-                        showBorder={index < workspace.sessions.length - 1}
-                    />
-                ))}
-            </View>
+            {!collapsed && (
+                <View style={styles.workspaceCard}>
+                    {workspace.sessions.map((session, index) => (
+                        <CompactSessionRow
+                            key={session.id}
+                            session={session}
+                            selected={session.id === selectedSessionId}
+                            showBorder={index < workspace.sessions.length - 1}
+                        />
+                    ))}
+                </View>
+            )}
         </View>
     );
 });
@@ -181,9 +213,22 @@ const stylesheet = StyleSheet.create((theme) => ({
         paddingRight: Platform.select({ ios: 26, default: 22 }),
         gap: 8,
     },
+    headerPress: {
+        flex: 1,
+        minWidth: 0,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
     headerText: {
         flex: 1,
         minWidth: 0,
+    },
+    count: {
+        fontSize: 12,
+        lineHeight: 16,
+        color: theme.colors.textSecondary,
+        ...Typography.default('regular'),
     },
     title: {
         color: theme.colors.groupped.sectionTitle,

--- a/packages/happy-app/sources/sync/projectGroups.spec.ts
+++ b/packages/happy-app/sources/sync/projectGroups.spec.ts
@@ -4,6 +4,7 @@ import {
     buildPathProjectGroups,
     buildProjectGroups,
     filterProjectGroupSessions,
+    projectWorkspaceCollapseKey,
 } from './projectGroups';
 import type { ProjectGroupData } from './projectGroups';
 import type { Session } from './storageTypes';
@@ -247,5 +248,22 @@ describe('filterProjectGroupSessions', () => {
             activeCount: 0,
             workspaces: [{ sessions: [{ id: 'disconnected' }] }],
         });
+    });
+});
+
+describe('projectWorkspaceCollapseKey', () => {
+    it('keys the primary checkout on the project alone, so existing state survives', () => {
+        expect(projectWorkspaceCollapseKey('path:["m1","/repo"]', '')).toBe('path:["m1","/repo"]');
+    });
+
+    it('gives every worktree its own key', () => {
+        const primary = projectWorkspaceCollapseKey('p', '');
+        const a = projectWorkspaceCollapseKey('p', '/repo-wt-a');
+        const b = projectWorkspaceCollapseKey('p', '/repo-wt-b');
+        expect(new Set([primary, a, b]).size).toBe(3);
+    });
+
+    it('does not collide across projects that share a worktree path', () => {
+        expect(projectWorkspaceCollapseKey('p1', '/wt')).not.toBe(projectWorkspaceCollapseKey('p2', '/wt'));
     });
 });

--- a/packages/happy-app/sources/sync/projectGroups.ts
+++ b/packages/happy-app/sources/sync/projectGroups.ts
@@ -182,3 +182,16 @@ export function buildProjectGroups(
 
     return [...projects.values()];
 }
+
+/**
+ * The key a workspace's collapsed state is stored under. The primary checkout
+ * IS the project, so it keys on the project id alone — that keeps whatever
+ * state a user already has for a project with no worktrees. A worktree appends
+ * its own path, so each checkout collapses independently.
+ */
+export function projectWorkspaceCollapseKey(
+    projectId: string,
+    workspaceId: string,
+): string {
+    return workspaceId ? projectId + '\u0000' + workspaceId : projectId;
+}


### PR DESCRIPTION
The home session list could be folded per project until `c63c80ff` rebuilt it around projects and worktrees: that commit replaced the project header the chevron lived on, and the collapse went with it. Nothing in the commit says it was meant to go — and the `collapsedProjects` local setting is still in the schema with nothing reading it any more, so whatever people had already folded is sitting there intact. This puts the toggle back, on the header the rebuild left us.

Because that header is now per checkout, a tap folds exactly the card it sits on. A project with two worktrees renders three sections, and folding all three from one chevron would hide sessions the user never pointed at — so each collapses on its own, and you can fold the worktrees you are not working in while the main checkout stays open. The primary checkout keys on the project id, which is the key the old code used, so a project someone had already collapsed comes back collapsed.

Two smaller decisions. The `+` button stays its own pressable beside the toggle, so starting a session in a project never folds it. And a collapsed header shows how many sessions it is hiding, since a folded card otherwise tells you nothing about what is inside.

Worth noting that #1706, filed two days before the rebuild and still open, was leaning on this: *"Collapsing cards helps (and the collapsed state is nicely persisted)"*. That issue asks for something further — a switch that drops the grouping entirely — and this PR does not attempt it. It only restores what that issue was already building on.

## Proof

Driven against the running app (standalone `happy-server` + Expo web + Playwright), on a project with a main checkout and two worktrees so the per-checkout behaviour is actually visible. Frames and the full assertion log are in the comment below; in short: folding the `alpha` worktree left the main checkout and `beta` expanded, folding the main checkout as well left `beta` still expanded, and a real page reload (`performance.getEntriesByType('navigation')[0].type === "reload"`) brought that three-way state back. The persisted setting held exactly two keys — the bare project id and the project id plus the `alpha` path — and none mentioning `beta`.

`pnpm typecheck` is clean and `vitest` passes 922 tests, three of them new for the key derivation.
