### PR TITLE
feat(server): add encrypted project schema

### DIFF
--- a/packages/happy-server/prisma/migrations/20260611120000_add_projects/migration.sql
+++ b/packages/happy-server/prisma/migrations/20260611120000_add_projects/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable
+CREATE TABLE "Project" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "metadata" TEXT NOT NULL,
+    "metadataVersion" INTEGER NOT NULL DEFAULT 1,
+    "dataEncryptionKey" BYTEA,
+    "avatarRef" TEXT,
+    "avatarPreview" TEXT,
+    "avatarVersion" INTEGER NOT NULL DEFAULT 0,
+    "seq" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Project_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "Session" ADD COLUMN "projectId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_accountId_externalId_key" ON "Project"("accountId", "externalId");
+
+-- CreateIndex
+CREATE INDEX "Project_accountId_updatedAt_idx" ON "Project"("accountId", "updatedAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Session_projectId_idx" ON "Session"("projectId");
+
+-- AddForeignKey
+ALTER TABLE "Project" ADD CONSTRAINT "Project_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/happy-server/prisma/schema.prisma
+++ b/packages/happy-server/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Account {
     AccountAuthRequest  AccountAuthRequest[]
     UsageReport         UsageReport[]
     Machine             Machine[]
+    Project             Project[]
     UploadedFile        UploadedFile[]
     ServiceAccountToken ServiceAccountToken[]
     RelationshipsFrom   UserRelationship[]    @relation("RelationshipsFrom")
@@ -96,6 +97,8 @@ model Session {
     tag               String
     accountId         String
     account           Account          @relation(fields: [accountId], references: [id])
+    projectId         String?
+    project           Project?         @relation(fields: [projectId], references: [id], onDelete: SetNull)
     metadata          String
     metadataVersion   Int              @default(0)
     agentState        String?
@@ -111,6 +114,31 @@ model Session {
     accessKeys        AccessKey[]
 
     @@unique([accountId, tag])
+    @@index([accountId, updatedAt(sort: Desc)])
+    @@index([projectId])
+}
+
+//
+// Projects
+//
+
+model Project {
+    id                 String      @id @default(cuid())
+    accountId          String
+    account            Account     @relation(fields: [accountId], references: [id], onDelete: Cascade)
+    externalId         String
+    metadata           String
+    metadataVersion    Int         @default(1)
+    dataEncryptionKey  Bytes?
+    avatarRef          String?
+    avatarPreview      String?
+    avatarVersion      Int         @default(0)
+    seq                Int         @default(0)
+    createdAt          DateTime    @default(now())
+    updatedAt          DateTime    @updatedAt
+    sessions           Session[]
+
+    @@unique([accountId, externalId])
     @@index([accountId, updatedAt(sort: Desc)])
 }
 


### PR DESCRIPTION
## Summary

- add the account-scoped `Project` table
- add nullable `Session.projectId` with `ON DELETE SET NULL`
- keep the migration additive for the currently deployed server

## Rollout

Merge and deploy this before the project-avatar backend feature PR. The existing runtime does not use the new table or column.

## Validation

- `pnpm --filter happy-server run typecheck`
- `prisma validate --schema prisma/schema.prisma`