### PR TITLE
feat(server): add encrypted project avatars

### DIFF
--- a/packages/happy-server/prisma/schema.prisma
+++ b/packages/happy-server/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Account {
     AccountAuthRequest  AccountAuthRequest[]
     UsageReport         UsageReport[]
     Machine             Machine[]
+    Project             Project[]
     UploadedFile        UploadedFile[]
     ServiceAccountToken ServiceAccountToken[]
     RelationshipsFrom   UserRelationship[]    @relation("RelationshipsFrom")
@@ -96,6 +97,8 @@ model Session {
     tag               String
     accountId         String
     account           Account          @relation(fields: [accountId], references: [id])
+    projectId         String?
+    project           Project?         @relation(fields: [projectId], references: [id], onDelete: SetNull)
     metadata          String
     metadataVersion   Int              @default(0)
     agentState        String?
@@ -111,6 +114,31 @@ model Session {
     accessKeys        AccessKey[]
 
     @@unique([accountId, tag])
+    @@index([accountId, updatedAt(sort: Desc)])
+    @@index([projectId])
+}
+
+//
+// Projects
+//
+
+model Project {
+    id                 String      @id @default(cuid())
+    accountId          String
+    account            Account     @relation(fields: [accountId], references: [id], onDelete: Cascade)
+    externalId         String
+    metadata           String
+    metadataVersion    Int         @default(1)
+    dataEncryptionKey  Bytes?
+    avatarRef          String?
+    avatarPreview      String?
+    avatarVersion      Int         @default(0)
+    seq                Int         @default(0)
+    createdAt          DateTime    @default(now())
+    updatedAt          DateTime    @updatedAt
+    sessions           Session[]
+
+    @@unique([accountId, externalId])
     @@index([accountId, updatedAt(sort: Desc)])
 }
 

--- a/packages/happy-server/sources/app/api/api.ts
+++ b/packages/happy-server/sources/app/api/api.ts
@@ -23,6 +23,7 @@ import { feedRoutes } from "./routes/feedRoutes";
 import { kvRoutes } from "./routes/kvRoutes";
 import { v3SessionRoutes } from "./routes/v3SessionRoutes";
 import { attachmentRoutes } from "./routes/attachmentRoutes";
+import { projectRoutes } from "./routes/projectRoutes";
 import { isLocalStorage, getLocalFilesDir } from "@/storage/files";
 import * as path from "path";
 import * as fs from "fs";
@@ -48,7 +49,7 @@ export async function startApi(opts: StartApiOptions = {}) {
     app.register(import('@fastify/cors'), {
         origin: '*',
         allowedHeaders: '*',
-        methods: ['GET', 'POST', 'PUT', 'DELETE']
+        methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
     });
 
     // Required for local-mode attachment uploads (PUT /v1/sessions/:id/attachments/:file).
@@ -113,6 +114,7 @@ export async function startApi(opts: StartApiOptions = {}) {
     kvRoutes(typed);
     v3SessionRoutes(typed);
     attachmentRoutes(typed);
+    projectRoutes(typed);
 
     // Static webapp (self-host mode)
     if (opts.staticDir) {

--- a/packages/happy-server/sources/app/api/routes/projectRoutes.spec.ts
+++ b/packages/happy-server/sources/app/api/routes/projectRoutes.spec.ts
@@ -1,0 +1,330 @@
+import fastify from 'fastify';
+import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Fastify } from '../types';
+
+const {
+    state,
+    dbMock,
+    filesMock,
+    emitUpdate,
+    resetState,
+} = vi.hoisted(() => {
+    type Project = {
+        id: string;
+        accountId: string;
+        externalId: string;
+        metadata: string;
+        metadataVersion: number;
+        dataEncryptionKey: Uint8Array | null;
+        avatarRef: string | null;
+        avatarPreview: string | null;
+        avatarVersion: number;
+        seq: number;
+        createdAt: Date;
+        updatedAt: Date;
+    };
+
+    const state = {
+        projects: [] as Project[],
+        sessions: [] as Array<{ id: string; accountId: string; projectId: string | null }>,
+        uploads: new Map<string, Buffer>(),
+        s3Objects: new Set<string>(),
+        useLocalStorage: true,
+        nextId: 1,
+    };
+
+    const resetState = () => {
+        state.projects = [];
+        state.sessions = [];
+        state.uploads = new Map();
+        state.s3Objects = new Set();
+        state.useLocalStorage = true;
+        state.nextId = 1;
+    };
+
+    const matches = (project: Project, where: any) => {
+        if (typeof where?.id === 'string' && project.id !== where.id) return false;
+        if (Array.isArray(where?.id?.in) && !where.id.in.includes(project.id)) return false;
+        if (where?.accountId && project.accountId !== where.accountId) return false;
+        if (where?.externalId && project.externalId !== where.externalId) return false;
+        return true;
+    };
+
+    const clone = (project: Project): Project => ({ ...project });
+    const projectFindFirst = vi.fn(async (args: any) => {
+        const project = state.projects.find((candidate) => matches(candidate, args?.where));
+        return project ? clone(project) : null;
+    });
+    const projectFindMany = vi.fn(async (args: any) => state.projects
+        .filter((project) => matches(project, args?.where))
+        .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+        .map(clone));
+    const projectCreate = vi.fn(async (args: any) => {
+        const now = new Date();
+        const project: Project = {
+            id: `p${state.nextId++}`,
+            accountId: args.data.accountId,
+            externalId: args.data.externalId,
+            metadata: args.data.metadata,
+            metadataVersion: args.data.metadataVersion ?? 1,
+            dataEncryptionKey: args.data.dataEncryptionKey ?? null,
+            avatarRef: null,
+            avatarPreview: null,
+            avatarVersion: 0,
+            seq: 0,
+            createdAt: now,
+            updatedAt: now,
+        };
+        state.projects.push(project);
+        return clone(project);
+    });
+    const projectUpdate = vi.fn(async (args: any) => {
+        const project = state.projects.find((candidate) => candidate.id === args.where.id)!;
+        const data = args.data;
+        if (data.metadata !== undefined) project.metadata = data.metadata;
+        if (data.metadataVersion?.increment) project.metadataVersion += data.metadataVersion.increment;
+        if (data.dataEncryptionKey !== undefined) project.dataEncryptionKey = data.dataEncryptionKey;
+        if (data.avatarRef !== undefined) project.avatarRef = data.avatarRef;
+        if (data.avatarPreview !== undefined) project.avatarPreview = data.avatarPreview;
+        if (data.avatarVersion?.increment) project.avatarVersion += data.avatarVersion.increment;
+        if (data.seq?.increment) project.seq += data.seq.increment;
+        project.updatedAt = new Date(project.updatedAt.getTime() + 1);
+        return clone(project);
+    });
+    const projectDelete = vi.fn(async (args: any) => {
+        const index = state.projects.findIndex((candidate) => candidate.id === args.where.id);
+        if (index >= 0) state.projects.splice(index, 1);
+    });
+    const sessionFindMany = vi.fn(async (args: any) => state.sessions
+        .filter((session) => session.projectId === args?.where?.projectId)
+        .map((session) => ({ id: session.id })));
+    const sessionUpdateMany = vi.fn(async (args: any) => {
+        for (const session of state.sessions) {
+            if (session.projectId === args.where.projectId) session.projectId = args.data.projectId;
+        }
+        return { count: state.sessions.length };
+    });
+
+    const dbMock = {
+        project: { findFirst: projectFindFirst, findMany: projectFindMany, create: projectCreate, update: projectUpdate, delete: projectDelete },
+        session: { findMany: sessionFindMany, updateMany: sessionUpdateMany },
+    };
+    const emitUpdate = vi.fn();
+    const filesMock = {
+        s3client: {
+            newPostPolicy: () => ({
+                setBucket: vi.fn(),
+                setKey: vi.fn(),
+                setExpires: vi.fn(),
+                setContentLengthRange: vi.fn(),
+            }),
+            presignedPostPolicy: vi.fn(async () => ({ postURL: 'https://s3.test/upload', formData: { policy: 'test' } })),
+            presignedGetObject: vi.fn(async () => 'https://s3.test/download'),
+            statObject: vi.fn(async (_bucket: string, ref: string) => {
+                if (!state.s3Objects.has(ref)) throw new Error('missing');
+                return { size: 3 };
+            }),
+        },
+        s3bucket: 'test-bucket',
+        isLocalStorage: vi.fn(() => state.useLocalStorage),
+        getLocalFilesDir: vi.fn(() => '/tmp/project-test-files'),
+        putLocalFile: vi.fn(async (filePath: string, data: Buffer) => state.uploads.set(filePath, data)),
+        deleteProjectAvatars: vi.fn(async () => undefined),
+    };
+
+    return { state, dbMock, filesMock, emitUpdate, resetState };
+});
+
+vi.mock('@/storage/db', () => ({ db: dbMock }));
+vi.mock('@/storage/files', () => filesMock);
+vi.mock('fs', async () => {
+    const actual = await vi.importActual<typeof import('fs')>('fs');
+    return {
+        ...actual,
+        existsSync: vi.fn((filePath: string) => {
+            const ref = filePath.replace(/^\/tmp\/project-test-files\//, '');
+            return state.uploads.has(ref);
+        }),
+        readFileSync: vi.fn((filePath: string) => {
+            const ref = filePath.replace(/^\/tmp\/project-test-files\//, '');
+            return state.uploads.get(ref) ?? Buffer.alloc(0);
+        }),
+    };
+});
+vi.mock('@/storage/seq', () => ({ allocateUserSeq: vi.fn(async () => 1) }));
+vi.mock('@/app/events/eventRouter', () => ({
+    eventRouter: { emitUpdate },
+    buildNewProjectUpdate: vi.fn((project: any) => ({ body: { t: 'new-project', projectId: project.id } })),
+    buildUpdateProjectUpdate: vi.fn((project: any) => ({ body: { t: 'update-project', projectId: project.id } })),
+    buildDeleteProjectUpdate: vi.fn((projectId: string) => ({ body: { t: 'delete-project', projectId } })),
+    buildUpdateSessionUpdate: vi.fn((sessionId: string) => ({ body: { t: 'update-session', id: sessionId } })),
+}));
+vi.mock('@/storage/inTx', () => ({
+    inTx: vi.fn(async (fn: (tx: any) => Promise<unknown>) => fn(dbMock)),
+    afterTx: vi.fn((_tx: any, callback: () => void) => { void callback(); }),
+}));
+
+import { projectRoutes } from './projectRoutes';
+
+async function createApp() {
+    const app = fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    const typed = app.withTypeProvider<ZodTypeProvider>() as unknown as Fastify;
+    typed.decorate('authenticate', async (request: any, reply: any) => {
+        const userId = request.headers['x-user-id'];
+        if (typeof userId !== 'string') return reply.code(401).send({ error: 'Unauthorized' });
+        request.userId = userId;
+    });
+    app.addContentTypeParser('application/octet-stream', { parseAs: 'buffer' }, (_req, body, done) => done(null, body));
+    projectRoutes(typed);
+    await typed.ready();
+    return typed;
+}
+
+describe('projectRoutes', () => {
+    let app: Fastify;
+
+    beforeEach(() => resetState());
+    afterEach(async () => { if (app) await app.close(); });
+
+    it('creates and idempotently loads an account-owned encrypted project', async () => {
+        app = await createApp();
+        const first = await app.inject({
+            method: 'POST',
+            url: '/v1/projects',
+            headers: { 'x-user-id': 'u1' },
+            payload: { externalId: 'checkout-a', metadata: 'encrypted-v1', dataEncryptionKey: 'AQI=' },
+        });
+        expect(first.statusCode).toBe(200);
+        expect(first.json()).toMatchObject({ externalId: 'checkout-a', metadata: 'encrypted-v1', metadataVersion: 1, dataEncryptionKey: 'AQI=', avatar: null });
+
+        const retry = await app.inject({
+            method: 'POST',
+            url: '/v1/projects',
+            headers: { 'x-user-id': 'u1' },
+            payload: { externalId: 'checkout-a', metadata: 'must-not-overwrite' },
+        });
+        expect(retry.statusCode).toBe(200);
+        expect(retry.json().metadata).toBe('encrypted-v1');
+
+        const legacy = await app.inject({
+            method: 'POST',
+            url: '/v1/projects',
+            headers: { 'x-user-id': 'u1' },
+            payload: { tag: 'checkout-a', metadata: 'must-not-overwrite' },
+        });
+        expect(legacy.statusCode).toBe(400);
+    });
+
+    it('does not expose another account project and uses optimistic metadata versions', async () => {
+        app = await createApp();
+        const one = await app.inject({ method: 'POST', url: '/v1/projects', headers: { 'x-user-id': 'u1' }, payload: { externalId: 'a', metadata: 'one' } });
+        const two = await app.inject({ method: 'POST', url: '/v1/projects', headers: { 'x-user-id': 'u2' }, payload: { externalId: 'b', metadata: 'two' } });
+        const three = await app.inject({ method: 'POST', url: '/v1/projects', headers: { 'x-user-id': 'u1' }, payload: { externalId: 'c', metadata: 'three' } });
+        expect(one.statusCode).toBe(200);
+        expect(two.statusCode).toBe(200);
+        expect(three.statusCode).toBe(200);
+
+        const list = await app.inject({
+            method: 'GET',
+            url: `/v1/projects?ids=${one.json().id},${two.json().id}`,
+            headers: { 'x-user-id': 'u1' },
+        });
+        expect(list.json().projects).toHaveLength(1);
+        expect(list.json().projects[0].id).toBe(one.json().id);
+        const projectId = one.json().id;
+        const legacyPatch = await app.inject({
+            method: 'PATCH',
+            url: `/v1/projects/${projectId}`,
+            headers: { 'x-user-id': 'u1' },
+            payload: { metadata: 'two', expectedVersion: 1 },
+        });
+        expect(legacyPatch.statusCode).toBe(400);
+        const conflict = await app.inject({
+            method: 'PATCH',
+            url: `/v1/projects/${projectId}`,
+            headers: { 'x-user-id': 'u1' },
+            payload: { metadata: 'two', expectedMetadataVersion: 99 },
+        });
+        expect(conflict.statusCode).toBe(409);
+        const update = await app.inject({
+            method: 'PATCH',
+            url: `/v1/projects/${projectId}`,
+            headers: { 'x-user-id': 'u1' },
+            payload: { metadata: 'two', expectedMetadataVersion: 1 },
+        });
+        expect(update.statusCode).toBe(200);
+        expect(update.json()).toMatchObject({ metadata: 'two', metadataVersion: 2 });
+    });
+
+    it('uploads locally, requires explicit avatar activation, and downloads only the current ref', async () => {
+        app = await createApp();
+        const created = await app.inject({ method: 'POST', url: '/v1/projects', headers: { 'x-user-id': 'u1' }, payload: { externalId: 'a', metadata: 'one', dataEncryptionKey: 'AQI=' } });
+        const projectId = created.json().id;
+        const upload = await app.inject({ method: 'POST', url: `/v1/projects/${projectId}/avatar/request-upload`, headers: { 'x-user-id': 'u1' }, payload: { size: 3 } });
+        expect(upload.statusCode).toBe(200);
+        expect(upload.json().method).toBe('PUT');
+        expect(upload.json().ref).toMatch(new RegExp(`^projects/${projectId}/avatar/.+\\.enc$`));
+
+        const ref = upload.json().ref as string;
+        const file = ref.slice(ref.lastIndexOf('/') + 1);
+        const bytes = await app.inject({ method: 'PUT', url: `/v1/projects/${projectId}/avatar/${file}`, headers: { 'x-user-id': 'u1', 'content-type': 'application/octet-stream' }, payload: Buffer.from('abc') });
+        expect(bytes.statusCode).toBe(200);
+        expect(state.uploads.get(ref)).toEqual(Buffer.from('abc'));
+
+        const missing = await app.inject({ method: 'PATCH', url: `/v1/projects/${projectId}/avatar`, headers: { 'x-user-id': 'u1' }, payload: { ref: `projects/${projectId}/avatar/00000000-0000-4000-8000-000000000000.enc`, preview: 'encrypted-preview' } });
+        expect(missing.statusCode).toBe(404);
+        const invalid = await app.inject({ method: 'PATCH', url: `/v1/projects/${projectId}/avatar`, headers: { 'x-user-id': 'u1' }, payload: { ref: 'projects/other/avatar/a.enc', preview: 'ciphertext' } });
+        expect(invalid.statusCode).toBe(400);
+        const active = await app.inject({ method: 'PATCH', url: `/v1/projects/${projectId}/avatar`, headers: { 'x-user-id': 'u1' }, payload: { ref, preview: 'encrypted-preview' } });
+        expect(active.statusCode).toBe(200);
+        expect(active.json().avatar).toMatchObject({ ref, preview: 'encrypted-preview', version: 1 });
+
+        const keyPatch = await app.inject({ method: 'PATCH', url: `/v1/projects/${projectId}`, headers: { 'x-user-id': 'u1' }, payload: { dataEncryptionKey: 'AgM=' } });
+        expect(keyPatch.statusCode).toBe(400);
+        const metadataPatch = await app.inject({ method: 'PATCH', url: `/v1/projects/${projectId}`, headers: { 'x-user-id': 'u1' }, payload: { metadata: 'one-updated', expectedMetadataVersion: 1 } });
+        expect(metadataPatch.statusCode).toBe(200);
+        expect(metadataPatch.json().dataEncryptionKey).toBe(created.json().dataEncryptionKey);
+
+        const historicalFile = '00000000-0000-4000-8000-000000000000.enc';
+        state.uploads.set(`projects/${projectId}/avatar/${historicalFile}`, Buffer.from('old'));
+        const historical = await app.inject({ method: 'GET', url: `/v1/projects/${projectId}/avatar/${historicalFile}`, headers: { 'x-user-id': 'u1' } });
+        expect(historical.statusCode).toBe(404);
+        const currentFile = await app.inject({ method: 'GET', url: `/v1/projects/${projectId}/avatar/${file}`, headers: { 'x-user-id': 'u1' } });
+        expect(currentFile.statusCode).toBe(200);
+
+        const download = await app.inject({ method: 'POST', url: `/v1/projects/${projectId}/avatar/request-download`, headers: { 'x-user-id': 'u1' } });
+        expect(download.statusCode).toBe(200);
+        expect(download.json().ref).toBe(ref);
+        expect(download.json().downloadUrl).toContain(`/v1/projects/${projectId}/avatar/${file}`);
+    });
+
+    it('uses a bounded S3 POST policy and presigned GET for activated avatars', async () => {
+        state.useLocalStorage = false;
+        app = await createApp();
+        const created = await app.inject({ method: 'POST', url: '/v1/projects', headers: { 'x-user-id': 'u1' }, payload: { externalId: 's3', metadata: 'one' } });
+        const projectId = created.json().id;
+        const upload = await app.inject({ method: 'POST', url: `/v1/projects/${projectId}/avatar/request-upload`, headers: { 'x-user-id': 'u1' }, payload: { size: 1024 } });
+        expect(upload.statusCode).toBe(200);
+        expect(upload.json()).toMatchObject({ method: 'POST', uploadUrl: 'https://s3.test/upload' });
+        state.s3Objects.add(upload.json().ref);
+        const active = await app.inject({ method: 'PATCH', url: `/v1/projects/${projectId}/avatar`, headers: { 'x-user-id': 'u1' }, payload: { ref: upload.json().ref, preview: 'encrypted-preview' } });
+        expect(active.statusCode).toBe(200);
+        const download = await app.inject({ method: 'POST', url: `/v1/projects/${projectId}/avatar/request-download`, headers: { 'x-user-id': 'u1' } });
+        expect(download.statusCode).toBe(200);
+        expect(download.json().downloadUrl).toBe('https://s3.test/download');
+    });
+
+    it('unlinks sessions and cleans avatar storage on project deletion', async () => {
+        app = await createApp();
+        const created = await app.inject({ method: 'POST', url: '/v1/projects', headers: { 'x-user-id': 'u1' }, payload: { externalId: 'a', metadata: 'one' } });
+        const projectId = created.json().id;
+        state.sessions.push({ id: 's1', accountId: 'u1', projectId });
+        const deleted = await app.inject({ method: 'DELETE', url: `/v1/projects/${projectId}`, headers: { 'x-user-id': 'u1' } });
+        expect(deleted.statusCode).toBe(200);
+        expect(state.sessions[0].projectId).toBeNull();
+        expect(filesMock.deleteProjectAvatars).toHaveBeenCalledWith(projectId);
+    });
+});

--- a/packages/happy-server/sources/app/api/routes/projectRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/projectRoutes.ts
@@ -1,0 +1,498 @@
+/**
+ * Account-owned encrypted project catalog and avatar transport.
+ *
+ * Project metadata, data keys, preview material, and avatar bytes are all
+ * client-encrypted. The server only indexes the caller-owned external id and
+ * stores/serves opaque values.
+ */
+import { z } from 'zod';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import * as privacyKit from 'privacy-kit';
+import { Fastify } from '../types';
+import { db } from '@/storage/db';
+import {
+    s3client,
+    s3bucket,
+    isLocalStorage,
+    getLocalFilesDir,
+    putLocalFile,
+    deleteProjectAvatars,
+} from '@/storage/files';
+import {
+    eventRouter,
+    buildNewProjectUpdate,
+    buildUpdateProjectUpdate,
+    buildDeleteProjectUpdate,
+    buildUpdateSessionUpdate,
+} from '@/app/events/eventRouter';
+import { allocateUserSeq } from '@/storage/seq';
+import { randomKeyNaked } from '@/utils/randomKeyNaked';
+import { inTx, afterTx } from '@/storage/inTx';
+
+const MAX_METADATA_SIZE = 4 * 1024 * 1024;
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const PRESIGNED_TTL_SECONDS = 15 * 60;
+const UPLOAD_RATE_WINDOW_MS = 60_000;
+const UPLOAD_RATE_MAX = 60;
+
+const uploadRateState = new Map<string, { count: number; windowStart: number }>();
+type StoredBytes = ReturnType<typeof privacyKit.decodeBase64>;
+
+const projectIdParams = z.object({ projectId: z.string().min(1) });
+const projectCreateBody = z.object({
+    externalId: z.string().min(1).max(512),
+    metadata: z.string().min(1).max(MAX_METADATA_SIZE),
+    dataEncryptionKey: z.string().nullish(),
+});
+
+const projectPatchBody = z.object({
+    metadata: z.string().min(1).max(MAX_METADATA_SIZE).optional(),
+    expectedMetadataVersion: z.number().int().min(0).optional(),
+}).strict();
+
+const avatarActivateBody = z.object({
+    ref: z.string().min(1).max(1024),
+    preview: z.string().min(1).max(MAX_METADATA_SIZE),
+});
+
+const uploadRequestBody = z.object({
+    size: z.number().int().min(0).max(MAX_FILE_SIZE),
+});
+
+type ProjectRecord = {
+    id: string;
+    externalId: string;
+    seq: number;
+    metadata: string;
+    metadataVersion: number;
+    dataEncryptionKey: StoredBytes | null;
+    avatarRef: string | null;
+    avatarPreview: string | null;
+    avatarVersion: number;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+function resolveBaseUrl(request: { headers: Record<string, string | string[] | undefined> }): string {
+    if (process.env.PUBLIC_URL) return process.env.PUBLIC_URL;
+    const forwardedHost = request.headers['x-forwarded-host'];
+    const forwardedProto = request.headers['x-forwarded-proto'];
+    const host = (Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost) ?? request.headers.host;
+    const proto = (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto) ?? 'http';
+    if (typeof host === 'string' && host.length > 0) return `${proto}://${host}`;
+    return `http://localhost:${process.env.PORT || '3005'}`;
+}
+
+function serializeProject(project: ProjectRecord) {
+    return {
+        id: project.id,
+        externalId: project.externalId,
+        metadata: project.metadata,
+        metadataVersion: project.metadataVersion,
+        dataEncryptionKey: project.dataEncryptionKey ? privacyKit.encodeBase64(project.dataEncryptionKey) : null,
+        avatar: project.avatarRef ? {
+            ref: project.avatarRef,
+            preview: project.avatarPreview || '',
+            version: project.avatarVersion,
+        } : null,
+        seq: project.seq,
+        createdAt: project.createdAt.getTime(),
+        updatedAt: project.updatedAt.getTime(),
+    };
+}
+
+function decodeDataKey(value: string | null | undefined): StoredBytes | null | undefined {
+    if (value === undefined) return undefined;
+    return value === null ? null : privacyKit.decodeBase64(value);
+}
+
+function checkUploadRate(userId: string): boolean {
+    const now = Date.now();
+    const current = uploadRateState.get(userId);
+    if (!current || now - current.windowStart >= UPLOAD_RATE_WINDOW_MS) {
+        uploadRateState.set(userId, { count: 1, windowStart: now });
+        return true;
+    }
+    if (current.count >= UPLOAD_RATE_MAX) return false;
+    current.count += 1;
+    return true;
+}
+
+function projectAvatarRef(projectId: string, ref: string): boolean {
+    const prefix = `projects/${projectId}/avatar/`;
+    if (!ref.startsWith(prefix)) return false;
+    const filename = ref.slice(prefix.length);
+    // The upload endpoint creates UUID v4 names. Do not allow callers to
+    // activate arbitrary objects from the project prefix.
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.enc$/i.test(filename);
+}
+
+function localProjectAvatarPath(projectId: string, ref: string): string | null {
+    if (!projectAvatarRef(projectId, ref)) return null;
+    const baseDir = path.resolve(getLocalFilesDir());
+    const fullPath = path.resolve(baseDir, ref);
+    if (!fullPath.startsWith(`${baseDir}${path.sep}`)) return null;
+    return fullPath;
+}
+
+async function emitNewProject(userId: string, project: ProjectRecord): Promise<void> {
+    const updateSeq = await allocateUserSeq(userId);
+    eventRouter.emitUpdate({
+        userId,
+        payload: buildNewProjectUpdate(project, updateSeq, randomKeyNaked(12)),
+        recipientFilter: { type: 'user-scoped-only' },
+    });
+}
+
+async function emitProjectUpdate(
+    userId: string,
+    project: ProjectRecord,
+): Promise<void> {
+    const updateSeq = await allocateUserSeq(userId);
+    eventRouter.emitUpdate({
+        userId,
+        payload: buildUpdateProjectUpdate(project, updateSeq, randomKeyNaked(12)),
+        recipientFilter: { type: 'user-scoped-only' },
+    });
+}
+
+export function projectRoutes(app: Fastify) {
+    app.post('/v1/projects', {
+        preHandler: app.authenticate,
+        schema: { body: projectCreateBody },
+    }, async (request, reply) => {
+        const userId = request.userId;
+        const { externalId } = request.body;
+        const existing = await db.project.findFirst({ where: { accountId: userId, externalId } });
+        if (existing) {
+            // POST is intentionally create-or-load. Metadata changes use PATCH
+            // so a retry cannot silently overwrite a newer encrypted record.
+            return reply.send(serializeProject(existing as ProjectRecord));
+        }
+
+        let project: ProjectRecord;
+        try {
+            project = await db.project.create({
+                data: {
+                    accountId: userId,
+                    externalId,
+                    metadata: request.body.metadata,
+                    metadataVersion: 1,
+                    dataEncryptionKey: decodeDataKey(request.body.dataEncryptionKey),
+                },
+            }) as ProjectRecord;
+        } catch (error: any) {
+            // A concurrent retry may win the unique (accountId, externalId)
+            // insert. Treat that race exactly like an idempotent load.
+            if (error?.code !== 'P2002') throw error;
+            const concurrent = await db.project.findFirst({ where: { accountId: userId, externalId } });
+            if (!concurrent) throw error;
+            return reply.send(serializeProject(concurrent as ProjectRecord));
+        }
+
+        await emitNewProject(userId, project);
+        return reply.send(serializeProject(project));
+    });
+
+    app.get('/v1/projects', {
+        preHandler: app.authenticate,
+        schema: {
+            querystring: z.object({
+                changedSince: z.coerce.number().int().positive().optional(),
+                ids: z.string().min(1).max(32_768).optional(),
+            }).optional(),
+        },
+    }, async (request, reply) => {
+        const query = (request.query || {}) as { changedSince?: number; ids?: string };
+        const ids = query.ids ? [...new Set(query.ids.split(','))] : undefined;
+        if (ids && (ids.length > 100 || ids.some((id) => id.length === 0 || id.length > 256))) {
+            return reply.code(400).send({ error: 'Invalid project ids' });
+        }
+        const projects = await db.project.findMany({
+            where: {
+                accountId: request.userId,
+                ...(ids ? { id: { in: ids } } : {}),
+                ...(query.changedSince ? { updatedAt: { gt: new Date(query.changedSince) } } : {}),
+            },
+            orderBy: { updatedAt: 'desc' },
+        });
+        return reply.send({
+            projects: projects.map((project) => serializeProject(project as ProjectRecord)),
+        });
+    });
+
+    app.get('/v1/projects/:projectId', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams },
+    }, async (request, reply) => {
+        const project = await db.project.findFirst({
+            where: { id: request.params.projectId, accountId: request.userId },
+        });
+        if (!project) return reply.code(404).send({ error: 'Project not found' });
+        return reply.send(serializeProject(project as ProjectRecord));
+    });
+
+    app.patch('/v1/projects/:projectId', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams, body: projectPatchBody },
+    }, async (request, reply) => {
+        const userId = request.userId;
+        const { projectId } = request.params;
+        const current = await db.project.findFirst({ where: { id: projectId, accountId: userId } });
+        if (!current) return reply.code(404).send({ error: 'Project not found' });
+
+        const expectedMetadataVersion = request.body.expectedMetadataVersion;
+
+        if (expectedMetadataVersion !== undefined && expectedMetadataVersion !== current.metadataVersion) {
+            return reply.code(409).send({
+                error: 'Project metadata version mismatch',
+                project: serializeProject(current as ProjectRecord),
+            });
+        }
+
+        const { metadata } = request.body;
+        if (metadata === undefined || metadata === current.metadata) {
+            return reply.send(serializeProject(current as ProjectRecord));
+        }
+
+        let project: ProjectRecord;
+        try {
+            project = await db.project.update({
+                where: {
+                    id: projectId,
+                    ...(expectedMetadataVersion !== undefined
+                        ? { metadataVersion: expectedMetadataVersion }
+                        : {}),
+                },
+                data: {
+                    metadata,
+                    metadataVersion: { increment: 1 },
+                    seq: { increment: 1 },
+                },
+            }) as ProjectRecord;
+        } catch (error: any) {
+            if (error?.code === 'P2025' && expectedMetadataVersion !== undefined) {
+                const latest = await db.project.findFirst({ where: { id: projectId, accountId: userId } });
+                return reply.code(409).send({
+                    error: 'Project metadata version mismatch',
+                    project: latest ? serializeProject(latest as ProjectRecord) : null,
+                });
+            }
+            throw error;
+        }
+        await emitProjectUpdate(userId, project);
+        return reply.send(serializeProject(project));
+    });
+
+    app.patch('/v1/projects/:projectId/avatar', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams, body: avatarActivateBody },
+    }, async (request, reply) => {
+        const userId = request.userId;
+        const { projectId } = request.params;
+        const current = await db.project.findFirst({ where: { id: projectId, accountId: userId } });
+        if (!current) return reply.code(404).send({ error: 'Project not found' });
+        if (!projectAvatarRef(projectId, request.body.ref)) {
+            return reply.code(400).send({ error: 'Invalid project avatar ref' });
+        }
+        if (isLocalStorage()) {
+            const fullPath = localProjectAvatarPath(projectId, request.body.ref);
+            if (!fullPath || !fs.existsSync(fullPath)) {
+                return reply.code(404).send({ error: 'Project avatar upload not found' });
+            }
+        } else {
+            try {
+                await s3client.statObject(s3bucket, request.body.ref);
+            } catch {
+                return reply.code(404).send({ error: 'Project avatar upload not found' });
+            }
+        }
+
+        const unchanged = current.avatarRef === request.body.ref && current.avatarPreview === request.body.preview;
+        if (unchanged) return reply.send(serializeProject(current as ProjectRecord));
+
+        const project = await db.project.update({
+            where: { id: projectId },
+            data: {
+                avatarRef: request.body.ref,
+                avatarPreview: request.body.preview,
+                avatarVersion: { increment: 1 },
+                seq: { increment: 1 },
+            },
+        }) as ProjectRecord;
+        await emitProjectUpdate(userId, project);
+        return reply.send(serializeProject(project));
+    });
+
+    app.delete('/v1/projects/:projectId/avatar', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams },
+    }, async (request, reply) => {
+        const userId = request.userId;
+        const { projectId } = request.params;
+        const current = await db.project.findFirst({ where: { id: projectId, accountId: userId } });
+        if (!current) return reply.code(404).send({ error: 'Project not found' });
+        if (!current.avatarRef && !current.avatarPreview) return reply.send(serializeProject(current as ProjectRecord));
+
+        const project = await db.project.update({
+            where: { id: projectId },
+            data: {
+                avatarRef: null,
+                avatarPreview: null,
+                avatarVersion: { increment: 1 },
+                seq: { increment: 1 },
+            },
+        }) as ProjectRecord;
+        await emitProjectUpdate(userId, project);
+        try {
+            await deleteProjectAvatars(projectId);
+        } catch {
+            // Database state is authoritative; stale encrypted blobs are
+            // harmless and will be removed with the project prefix later.
+        }
+        return reply.send(serializeProject(project));
+    });
+
+    app.delete('/v1/projects/:projectId', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams },
+    }, async (request, reply) => {
+        const userId = request.userId;
+        const { projectId } = request.params;
+        const deleted = await inTx(async (tx) => {
+            const project = await tx.project.findFirst({ where: { id: projectId, accountId: userId } });
+            if (!project) return false;
+            const linkedSessions = await tx.session.findMany({
+                where: { projectId },
+                select: { id: true },
+            });
+
+            // Unlink first so linked sessions can receive project-link updates.
+            await tx.session.updateMany({ where: { projectId }, data: { projectId: null } });
+            await tx.project.delete({ where: { id: projectId } });
+            afterTx(tx, async () => {
+                for (const session of linkedSessions) {
+                    const sessionUpdateSeq = await allocateUserSeq(userId);
+                    eventRouter.emitUpdate({
+                        userId,
+                        payload: buildUpdateSessionUpdate(
+                            session.id,
+                            sessionUpdateSeq,
+                            randomKeyNaked(12),
+                            undefined,
+                            undefined,
+                            null,
+                        ),
+                        recipientFilter: { type: 'user-scoped-only' },
+                    });
+                }
+                const updateSeq = await allocateUserSeq(userId);
+                eventRouter.emitUpdate({
+                    userId,
+                    payload: buildDeleteProjectUpdate(projectId, updateSeq, randomKeyNaked(12)),
+                    recipientFilter: { type: 'user-scoped-only' },
+                });
+                try {
+                    await deleteProjectAvatars(projectId);
+                } catch {
+                    // Storage cleanup is best effort; the database deletion
+                    // and user-visible event have already committed.
+                }
+            });
+            return true;
+        });
+
+        if (!deleted) return reply.code(404).send({ error: 'Project not found' });
+        return reply.send({ success: true });
+    });
+
+    app.post('/v1/projects/:projectId/avatar/request-upload', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams, body: uploadRequestBody },
+    }, async (request, reply) => {
+        const userId = request.userId;
+        if (!checkUploadRate(userId)) {
+            return reply.code(429).send({ error: 'Too many upload requests. Try again in a minute.' });
+        }
+        const project = await db.project.findFirst({ where: { id: request.params.projectId, accountId: userId } });
+        if (!project) return reply.code(404).send({ error: 'Project not found' });
+
+        const ref = `projects/${project.id}/avatar/${crypto.randomUUID()}.enc`;
+        if (isLocalStorage()) {
+            const baseUrl = resolveBaseUrl(request);
+            return reply.send({
+                ref,
+                uploadUrl: `${baseUrl}/v1/projects/${project.id}/avatar/${ref.slice(ref.lastIndexOf('/') + 1)}`,
+                method: 'PUT',
+            });
+        }
+
+        const policy = s3client.newPostPolicy();
+        policy.setBucket(s3bucket);
+        policy.setKey(ref);
+        policy.setExpires(new Date(Date.now() + PRESIGNED_TTL_SECONDS * 1000));
+        policy.setContentLengthRange(0, MAX_FILE_SIZE);
+        const { postURL, formData } = await s3client.presignedPostPolicy(policy);
+        return reply.send({ ref, uploadUrl: postURL, method: 'POST', formFields: formData as Record<string, string> });
+    });
+
+    app.put('/v1/projects/:projectId/avatar/:avatarFile', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams.extend({ avatarFile: z.string() }) },
+    }, async (request, reply) => {
+        if (!isLocalStorage()) return reply.code(404).send({ error: 'Direct upload not available in S3 mode' });
+        const { projectId, avatarFile } = request.params;
+        const project = await db.project.findFirst({ where: { id: projectId, accountId: request.userId } });
+        if (!project) return reply.code(404).send({ error: 'Project not found' });
+        if (!projectAvatarRef(projectId, `projects/${projectId}/avatar/${avatarFile}`)) {
+            return reply.code(404).send({ error: 'Invalid project avatar file' });
+        }
+        const body = request.body as Buffer;
+        if (!Buffer.isBuffer(body) || body.length > MAX_FILE_SIZE) {
+            return reply.code(413).send({ error: 'File too large (max 10MB)' });
+        }
+        await putLocalFile(`projects/${projectId}/avatar/${avatarFile}`, body);
+        return reply.send({ ok: true });
+    });
+
+    // Download always resolves the currently activated ref. Callers cannot
+    // use this endpoint as an arbitrary project-prefix file oracle.
+    app.post('/v1/projects/:projectId/avatar/request-download', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams },
+    }, async (request, reply) => {
+        const project = await db.project.findFirst({ where: { id: request.params.projectId, accountId: request.userId } });
+        if (!project) return reply.code(404).send({ error: 'Project not found' });
+        if (!project.avatarRef || !projectAvatarRef(project.id, project.avatarRef)) {
+            return reply.code(404).send({ error: 'Project avatar not found' });
+        }
+        if (isLocalStorage()) {
+            const baseUrl = resolveBaseUrl(request);
+            return reply.send({
+                ref: project.avatarRef,
+                downloadUrl: `${baseUrl}/v1/projects/${project.id}/avatar/${project.avatarRef.slice(project.avatarRef.lastIndexOf('/') + 1)}`,
+            });
+        }
+        const downloadUrl = await s3client.presignedGetObject(s3bucket, project.avatarRef, PRESIGNED_TTL_SECONDS);
+        return reply.send({ ref: project.avatarRef, downloadUrl });
+    });
+
+    app.get('/v1/projects/:projectId/avatar/:avatarFile', {
+        preHandler: app.authenticate,
+        schema: { params: projectIdParams.extend({ avatarFile: z.string() }) },
+    }, async (request, reply) => {
+        if (!isLocalStorage()) return reply.code(404).send({ error: 'Direct download not available in S3 mode' });
+        const { projectId, avatarFile } = request.params;
+        const project = await db.project.findFirst({ where: { id: projectId, accountId: request.userId } });
+        if (!project) return reply.code(404).send({ error: 'Project not found' });
+        const ref = `projects/${projectId}/avatar/${avatarFile}`;
+        if (!projectAvatarRef(projectId, ref)) return reply.code(404).send({ error: 'Invalid project avatar file' });
+        if (project.avatarRef !== ref) return reply.code(404).send({ error: 'Project avatar not found' });
+        const fullPath = localProjectAvatarPath(projectId, ref);
+        if (!fullPath) return reply.code(404).send({ error: 'Invalid project avatar file' });
+        if (!fs.existsSync(fullPath)) return reply.code(404).send({ error: 'Project avatar not found' });
+        return reply.type('application/octet-stream').send(fs.readFileSync(fullPath));
+    });
+}

--- a/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
+++ b/packages/happy-server/sources/app/api/routes/sessionRoutes.ts
@@ -1,4 +1,4 @@
-import { eventRouter, buildNewSessionUpdate, buildSessionActivityEphemeral } from "@/app/events/eventRouter";
+import { eventRouter, buildNewSessionUpdate, buildUpdateSessionUpdate, buildSessionActivityEphemeral } from "@/app/events/eventRouter";
 import { type Fastify } from "../types";
 import { db } from "@/storage/db";
 import { z } from "zod";
@@ -31,6 +31,7 @@ export function sessionRoutes(app: Fastify) {
                 agentState: true,
                 agentStateVersion: true,
                 dataEncryptionKey: true,
+                projectId: true,
                 active: true,
                 lastActiveAt: true,
                 // messages: {
@@ -65,6 +66,7 @@ export function sessionRoutes(app: Fastify) {
                     agentState: v.agentState,
                     agentStateVersion: v.agentStateVersion,
                     dataEncryptionKey: v.dataEncryptionKey ? Buffer.from(v.dataEncryptionKey).toString('base64') : null,
+                    projectId: v.projectId,
                     lastMessage: null
                 };
             })
@@ -101,6 +103,7 @@ export function sessionRoutes(app: Fastify) {
                 agentState: true,
                 agentStateVersion: true,
                 dataEncryptionKey: true,
+                projectId: true,
                 active: true,
                 lastActiveAt: true,
             }
@@ -119,6 +122,7 @@ export function sessionRoutes(app: Fastify) {
                 agentState: v.agentState,
                 agentStateVersion: v.agentStateVersion,
                 dataEncryptionKey: v.dataEncryptionKey ? Buffer.from(v.dataEncryptionKey).toString('base64') : null,
+                projectId: v.projectId,
             }))
         });
     });
@@ -181,6 +185,7 @@ export function sessionRoutes(app: Fastify) {
                 agentState: true,
                 agentStateVersion: true,
                 dataEncryptionKey: true,
+                projectId: true,
                 active: true,
                 lastActiveAt: true,
             }
@@ -210,6 +215,7 @@ export function sessionRoutes(app: Fastify) {
                 agentState: v.agentState,
                 agentStateVersion: v.agentStateVersion,
                 dataEncryptionKey: v.dataEncryptionKey ? Buffer.from(v.dataEncryptionKey).toString('base64') : null,
+                projectId: v.projectId,
             })),
             nextCursor,
             hasNext
@@ -223,13 +229,22 @@ export function sessionRoutes(app: Fastify) {
                 tag: z.string(),
                 metadata: z.string(),
                 agentState: z.string().nullish(),
-                dataEncryptionKey: z.string().nullish()
+                dataEncryptionKey: z.string().nullish(),
+                projectId: z.string().nullish()
             })
         },
         preHandler: app.authenticate
     }, async (request, reply) => {
         const userId = request.userId;
-        const { tag, metadata, dataEncryptionKey } = request.body;
+        const { tag, metadata, dataEncryptionKey, projectId } = request.body;
+
+        if (projectId !== undefined && projectId !== null) {
+            const project = await db.project.findFirst({
+                where: { id: projectId, accountId: userId },
+                select: { id: true }
+            });
+            if (!project) return reply.code(404).send({ error: 'Project not found' });
+        }
 
         const session = await db.session.findFirst({
             where: {
@@ -240,22 +255,37 @@ export function sessionRoutes(app: Fastify) {
         if (session) {
             log({ module: 'session-create', sessionId: session.id, userId, tag }, `Found existing session: ${session.id} for tag ${tag}`);
 
+            let sessionForResponse = session;
+            if (projectId !== undefined && projectId !== session.projectId) {
+                sessionForResponse = await db.session.update({
+                    where: { id: session.id },
+                    data: { projectId }
+                });
+                const updateSeq = await allocateUserSeq(userId);
+                eventRouter.emitUpdate({
+                    userId,
+                    payload: buildUpdateSessionUpdate(session.id, updateSeq, randomKeyNaked(12), undefined, undefined, projectId),
+                    recipientFilter: { type: 'user-scoped-only' }
+                });
+            }
+
             // Session is starting back up - stop ignoring its heartbeats if it was stopped
             activityCache.resumeSessionUpdates(session.id);
 
             return reply.send({
                 session: {
-                    id: session.id,
-                    seq: session.seq,
-                    metadata: session.metadata,
-                    metadataVersion: session.metadataVersion,
-                    agentState: session.agentState,
-                    agentStateVersion: session.agentStateVersion,
-                    dataEncryptionKey: session.dataEncryptionKey ? Buffer.from(session.dataEncryptionKey).toString('base64') : null,
-                    active: session.active,
-                    activeAt: session.lastActiveAt.getTime(),
-                    createdAt: session.createdAt.getTime(),
-                    updatedAt: session.updatedAt.getTime(),
+                    id: sessionForResponse.id,
+                    seq: sessionForResponse.seq,
+                    metadata: sessionForResponse.metadata,
+                    metadataVersion: sessionForResponse.metadataVersion,
+                    agentState: sessionForResponse.agentState,
+                    agentStateVersion: sessionForResponse.agentStateVersion,
+                    dataEncryptionKey: sessionForResponse.dataEncryptionKey ? Buffer.from(sessionForResponse.dataEncryptionKey).toString('base64') : null,
+                    projectId: sessionForResponse.projectId,
+                    active: sessionForResponse.active,
+                    activeAt: sessionForResponse.lastActiveAt.getTime(),
+                    createdAt: sessionForResponse.createdAt.getTime(),
+                    updatedAt: sessionForResponse.updatedAt.getTime(),
                     lastMessage: null
                 }
             });
@@ -271,7 +301,8 @@ export function sessionRoutes(app: Fastify) {
                     accountId: userId,
                     tag: tag,
                     metadata: metadata,
-                    dataEncryptionKey: dataEncryptionKey ? new Uint8Array(Buffer.from(dataEncryptionKey, 'base64')) : undefined
+                    dataEncryptionKey: dataEncryptionKey ? new Uint8Array(Buffer.from(dataEncryptionKey, 'base64')) : undefined,
+                    projectId: projectId ?? null
                 }
             });
             log({ module: 'session-create', sessionId: session.id, userId }, `Session created: ${session.id}`);
@@ -300,6 +331,7 @@ export function sessionRoutes(app: Fastify) {
                     agentState: session.agentState,
                     agentStateVersion: session.agentStateVersion,
                     dataEncryptionKey: session.dataEncryptionKey ? Buffer.from(session.dataEncryptionKey).toString('base64') : null,
+                    projectId: session.projectId,
                     active: session.active,
                     activeAt: session.lastActiveAt.getTime(),
                     createdAt: session.createdAt.getTime(),

--- a/packages/happy-server/sources/app/events/eventRouter.ts
+++ b/packages/happy-server/sources/app/events/eventRouter.ts
@@ -68,10 +68,20 @@ export type UpdateEvent = {
     agentState: string | null;
     agentStateVersion: number;
     dataEncryptionKey: string | null;
+    projectId: string | null;
     active: boolean;
     activeAt: number;
     createdAt: number;
     updatedAt: number;
+} | {
+    type: 'new-project';
+    projectId: string;
+} | {
+    type: 'update-project';
+    projectId: string;
+} | {
+    type: 'delete-project';
+    projectId: string;
 } | {
     type: 'update-session';
     sessionId: string;
@@ -361,6 +371,7 @@ export function buildNewSessionUpdate(session: {
     agentState: string | null;
     agentStateVersion: number;
     dataEncryptionKey: Uint8Array | null;
+    projectId: string | null;
     active: boolean;
     lastActiveAt: Date;
     createdAt: Date;
@@ -378,10 +389,47 @@ export function buildNewSessionUpdate(session: {
             agentState: session.agentState,
             agentStateVersion: session.agentStateVersion,
             dataEncryptionKey: session.dataEncryptionKey ? Buffer.from(session.dataEncryptionKey).toString('base64') : null,
+            projectId: session.projectId,
             active: session.active,
             activeAt: session.lastActiveAt.getTime(),
             createdAt: session.createdAt.getTime(),
             updatedAt: session.updatedAt.getTime()
+        },
+        createdAt: Date.now()
+    };
+}
+
+export function buildNewProjectUpdate(project: { id: string }, updateSeq: number, updateId: string): UpdatePayload {
+    return {
+        id: updateId,
+        seq: updateSeq,
+        body: {
+            t: 'new-project',
+            projectId: project.id,
+        },
+        createdAt: Date.now()
+    };
+}
+
+export function buildUpdateProjectUpdate(project: { id: string }, updateSeq: number, updateId: string): UpdatePayload {
+    return {
+        id: updateId,
+        seq: updateSeq,
+        body: {
+            t: 'update-project',
+            projectId: project.id,
+        },
+        createdAt: Date.now()
+    };
+}
+
+export function buildDeleteProjectUpdate(projectId: string, updateSeq: number, updateId: string): UpdatePayload {
+    return {
+        id: updateId,
+        seq: updateSeq,
+        body: {
+            t: 'delete-project',
+            projectId
         },
         createdAt: Date.now()
     };
@@ -414,7 +462,7 @@ export function buildNewMessageUpdate(message: {
     };
 }
 
-export function buildUpdateSessionUpdate(sessionId: string, updateSeq: number, updateId: string, metadata?: { value: string; version: number }, agentState?: { value: string; version: number }): UpdatePayload {
+export function buildUpdateSessionUpdate(sessionId: string, updateSeq: number, updateId: string, metadata?: { value: string; version: number }, agentState?: { value: string; version: number }, projectId?: string | null): UpdatePayload {
     return {
         id: updateId,
         seq: updateSeq,
@@ -422,7 +470,8 @@ export function buildUpdateSessionUpdate(sessionId: string, updateSeq: number, u
             t: 'update-session',
             id: sessionId,
             metadata,
-            agentState
+            agentState,
+            ...(projectId !== undefined ? { projectId } : {})
         },
         createdAt: Date.now()
     };

--- a/packages/happy-server/sources/storage/files.ts
+++ b/packages/happy-server/sources/storage/files.ts
@@ -90,6 +90,34 @@ export async function deleteSessionAttachments(sessionId: string): Promise<void>
     }
 }
 
+/**
+ * Delete all avatar blobs for a project. Avatar refs are deliberately kept
+ * outside the database: the encrypted bytes are opaque and the active ref is
+ * stored on Project, while this prefix cleanup handles old replacements too.
+ */
+export async function deleteProjectAvatars(projectId: string): Promise<void> {
+    const prefix = `projects/${projectId}/avatar`;
+    if (useLocalStorage) {
+        const dir = path.join(localFilesDir, prefix);
+        if (fs.existsSync(dir)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+        return;
+    }
+
+    const stream = s3client.listObjects(s3bucket, prefix + '/', true);
+    const keys: string[] = await new Promise((resolve, reject) => {
+        const collected: string[] = [];
+        stream.on('data', (obj: { name: string }) => { if (obj.name) collected.push(obj.name); });
+        stream.on('end', () => resolve(collected));
+        stream.on('error', reject);
+    });
+
+    if (keys.length > 0) {
+        await s3client.removeObjects(s3bucket, keys);
+    }
+}
+
 export type ImageRef = {
     width: number;
     height: number;

--- a/packages/happy-server/sources/storage/types.ts
+++ b/packages/happy-server/sources/storage/types.ts
@@ -39,6 +39,7 @@ declare global {
             agentState: string | null;
             agentStateVersion: number;
             dataEncryptionKey: string | null;
+            projectId: string | null;
             active: boolean;
             activeAt: number;
             createdAt: number;
@@ -54,6 +55,7 @@ declare global {
                 value: string | null;
                 version: number;
             } | null | undefined
+            projectId?: string | null;
         } | {
             t: 'update-account';
             id: string;
@@ -75,6 +77,15 @@ declare global {
             activeAt: number;
             createdAt: number;
             updatedAt: number;
+        } | {
+            t: 'new-project';
+            projectId: string;
+        } | {
+            t: 'update-project';
+            projectId: string;
+        } | {
+            t: 'delete-project';
+            projectId: string;
         } | {
             t: 'update-machine';
             machineId: string;


### PR DESCRIPTION
## Depends on

- https://github.com/slopus/happy/pull/1713 must be merged and deployed first

## Summary

- add idempotent account-scoped project create/update/delete APIs
- support account-filtered batch lookup with `GET /v1/projects?ids=...`
- upload and download encrypted project avatars with encrypted previews
- link sessions through optional top-level `projectId` and emit invalidations

This PR intentionally contains no SQL migration.

## Validation

Integration-tested in isolated minikube with Postgres, Redis, and MinIO: migration/no-op, encrypted avatar round-trip, and cross-replica events.