### PR TITLE
fix(self-host): apply the pglite-prisma-adapter Bytes patch on npm installs

### DIFF
--- a/packages/happy-server-self-host/scripts/postinstall.cjs
+++ b/packages/happy-server-self-host/scripts/postinstall.cjs
@@ -1,12 +1,13 @@
 'use strict';
 
 /**
- * Generates the Prisma client for installed copies of this package.
+ * Post-install steps for installed copies of this package.
  *
- * prisma/ is a build artifact here — it is copied from packages/happy-server by
- * build-runtime.cjs and only exists in the published tarball. In a fresh
- * monorepo checkout it is absent, so skip rather than fail the workspace
- * install.
+ * 1. Patches pglite-prisma-adapter's Bytes handling. The monorepo applies this
+ *    from patches/fix-pglite-prisma-bytes.cjs via the root postinstall, which
+ *    never runs for consumers who install this package from npm — so it has to
+ *    be applied here too, against whichever copy of the adapter npm resolved.
+ * 2. Generates the Prisma client.
  */
 
 const fs = require('node:fs');
@@ -14,6 +15,57 @@ const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 
 const root = path.resolve(__dirname, '..');
+
+/**
+ * The adapter's parsePgBytes/normalizeByteaArray return Uint8Array, which
+ * serializes as a JSON object {"0":104,"1":101,...} across the JS-WASM boundary
+ * to the Prisma query engine. The engine expects a plain number[] or a base64
+ * string, and rejects the object with P2023 "Inconsistent column data".
+ *
+ * Every Bytes column breaks, which in practice means every dataEncryptionKey:
+ * GET /v1/sessions and GET /v1/machines return 500 as soon as one encrypted
+ * session exists, and no session is ever listed in the app.
+ *
+ * Upstream fix: https://github.com/lucasthevenet/pglite-utils/pull/50
+ */
+function patchPgliteAdapterBytes() {
+  // The adapter exports no './package.json', so resolve its entry point (main,
+  // ./dist/index.cjs) and patch both bundles next to it.
+  let distDir;
+  try {
+    distDir = path.dirname(require.resolve('pglite-prisma-adapter', { paths: [root] }));
+  } catch {
+    return; // not installed yet (e.g. a fresh monorepo checkout)
+  }
+
+  let patched = 0;
+  for (const file of ['index.mjs', 'index.cjs']) {
+    const filePath = path.join(distDir, file);
+    if (!fs.existsSync(filePath)) continue;
+
+    const original = fs.readFileSync(filePath, 'utf8');
+    const content = original.replace(
+      /Uint8Array\.from\(\s*\{\s*length:\s*hexString\.length\s*\/\s*2\s*\}/g,
+      'Array.from({ length: hexString.length / 2 }'
+    );
+
+    if (content !== original) {
+      fs.writeFileSync(filePath, content, 'utf8');
+      patched++;
+    }
+  }
+
+  if (patched > 0) {
+    console.log(`happy-server-self-host: patched pglite-prisma-adapter Bytes handling (${patched} file(s))`);
+  }
+}
+
+patchPgliteAdapterBytes();
+
+// prisma/ is a build artifact here — it is copied from packages/happy-server by
+// build-runtime.cjs and only exists in the published tarball. In a fresh
+// monorepo checkout it is absent, so skip rather than fail the workspace
+// install.
 const schema = path.join(root, 'prisma', 'schema.prisma');
 
 if (!fs.existsSync(schema)) {


### PR DESCRIPTION
## Problem

`happy-server-self-host` installed from npm ships an **unpatched** `pglite-prisma-adapter`, so standalone PGlite self-hosting is broken as soon as the first encrypted session exists.

The repo already has the fix — `patches/fix-pglite-prisma-bytes.cjs`, added in 9e995836 — but it is wired into the **root** `scripts/postinstall.cjs`:

```js
require('../patches/fix-pglite-prisma-bytes.cjs');
```

That root script only runs for a monorepo checkout. Someone doing `npm i -g happy-server-self-host` runs `packages/happy-server-self-host/scripts/postinstall.cjs`, which today only does `prisma generate`. npm then resolves `pglite-prisma-adapter@^0.7.2` fresh from the registry, unpatched — lucasthevenet/pglite-utils#50 is still open, so there is no fixed release to bump to.

## Symptom

`parsePgBytes` returns a `Uint8Array`, which serializes as `{"0":104,"1":101,…}` across the JS→WASM boundary; the query engine wants `number[]`:

```
Invalid `prisma.session.findMany()` invocation:
Inconsistent column data: Conversion failed: expected a string or an array
in column 'dataEncryptionKey', found {"0":0,"1":73,"2":179,...}
errorCode: "P2023"   url: "/v1/sessions"   statusCode: 500
```

Every `Bytes` column is affected, which in practice means every `dataEncryptionKey`. `GET /v1/sessions` and `GET /v1/machines` return 500, the CLI reports `Machine registration failed: 500`, and no session ever appears in the app. Rows with a `NULL` key read fine, so a fresh server looks healthy right up to the first CLI session — then every listing containing that row fails, not just the row.

Same underlying bug as #612 and #686; this PR is about the npm distribution path specifically, which those don't cover.

## Fix

Apply the same replacement from the package's own `postinstall.cjs`, against whichever adapter copy npm resolved for it. `require.resolve('pglite-prisma-adapter', { paths: [root] })` handles hoisted and nested layouts alike (the adapter exports no `./package.json`, so its entry point is resolved instead and both bundles are patched next to it).

- Idempotent — the regex no longer matches once applied, so a monorepo install that already ran the root patch is a no-op.
- Silent no-op if the adapter isn't installed, matching the existing tolerance for a fresh checkout with no `prisma/schema.prisma`.
- No behaviour change for monorepo users; `patches/fix-pglite-prisma-bytes.cjs` is left alone.

## Verified

Against the real `pglite-prisma-adapter@0.7.2` tarball, in a layout mirroring an npm install:

```
--- run 1 ---
happy-server-self-host: patched pglite-prisma-adapter Bytes handling (2 file(s))
--- run 2 (idempotent) ---
(no patch line)
--- assert ---
Uint8Array.from({ length: hexString…  → 0 occurrences (dist/index.mjs, dist/index.cjs)
Array.from({ length: hexString…      → 2 occurrences each
```

Two per file: `parsePgBytes` and `normalizeByteaArray`.

Separately, this same replacement applied by hand to a live deployment (`happy-server-self-host` 1.1.11 behind Traefik, PGlite standalone) took `/v1/sessions` and `/v1/machines` from 500 to 200, with sessions listing on the phone and no P2023 in the logs.

## Note

This is a workaround for as long as lucasthevenet/pglite-utils#50 is unmerged. Once a fixed adapter ships, bumping the dependency and dropping both this and `patches/fix-pglite-prisma-bytes.cjs` would be the real cleanup.
