### PR TITLE
test(app): expect the Opus 5 1M row the model list actually returns

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -130,11 +130,13 @@ describe('modelModeOptions', () => {
         expect(models.map((model) => model.key)).toEqual([
             'claude-fable-5',
             'claude-opus-5',
+            'claude-opus-5[1m]',
             'claude-sonnet-5',
         ]);
         expect(models.map((model) => model.name)).toEqual([
             'Fable 5',
             'Opus 5',
+            'Opus 5 [1M]',
             'Sonnet 5',
         ]);
         // No `default model` row, and no alias keys: an alias would silently


### PR DESCRIPTION
`packages/happy-app`'s unit tests have been red since ac68e914 (`feat(app): add Opus 5 1M and polish changelog`). That commit added a fourth row to `getClaudeModelModes()`:

```ts
{ key: 'claude-opus-5[1m]', name: 'Opus 5 [1M]', description: '1M context' },
```

but the assertion in `modelModeOptions.test.ts` that enumerates the list still names three. The test file's blob is byte-identical at `ac68e914^`, `ac68e914` and `main`, so it was never updated — before or since.

## Reproduce

On `main` (b16b23c5b), nothing else changed:

```
$ cd packages/happy-app && pnpm exec vitest run

 FAIL  sources/components/modelModeOptions.test.ts > modelModeOptions > only offers the current-generation claude models
AssertionError: expected [ 'claude-fable-5', …(3) ] to deeply equal [ 'claude-fable-5', …(2) ]
+   "claude-opus-5[1m]"

 Test Files  1 failed | 102 passed (103)
      Tests  1 failed | 1090 passed (1091)
```

With this patch:

```
 Test Files  103 passed (103)
      Tests  1091 passed (1091)
```

It is the only failing test on `main`.

## Why add the row rather than relax the assertion

The assertion exists to keep alias keys and a `default` row out of the Claude picker — `opus`/`sonnet` resolve to older models than the row would claim. `claude-opus-5[1m]` is a full model ID rather than an alias, and ac68e914's own comment says the `[1m]` suffix is honored by the CLI (#1721), so the row belongs in the list and it was the expectation that went stale. The `default`/alias assertions below it are untouched.

## Why CI didn't catch it

No workflow runs `happy-app`'s tests. `typecheck.yml` runs `pnpm --filter happy-app typecheck` only, and the repo's single test step is `pnpm --filter happy-server … test` in `server.yml` — so a red vitest in the app package is invisible to Actions. Happy to send a follow-up PR adding an app-test job if you'd like one; kept out of here so this stays a two-line change.
