### PR TITLE
fix(cli): exit after printing the version instead of opening a session

### DIFF
--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -769,7 +769,9 @@ ${chalk.bold.cyan('Claude Code Options (from `claude --help`):')}
     // Show version
     if (showVersion) {
       console.log(`happy version: ${packageJson.version}`)
-      // Don't exit - continue to pass --version to Claude Code
+      // Exit here, the same way the --help branch above does. Falling through runs
+      // auth, starts the daemon and opens a session just to answer a version query.
+      process.exit(0)
     }
 
     // Normal flow - auth and machine setup


### PR DESCRIPTION
`happy --version` prints the version and then deliberately falls through to auth, daemon startup and `runClaude`. On a machine without stored credentials that means a version query drops into the interactive login picker — which is what #1532 reports.

Exit right after printing, the same way the `--help` branch above already does.

Fixes #1532

## Proof

Run from source against an isolated `HAPPY_HOME_DIR` (no stored credentials), stdin closed, 20s hard timeout.

**Before — `main`:**
```
happy version: 1.2.1

How would you like to authenticate?

› 1. Mobile App
  2. Web Browser

Use arrows or 1-2 to select, Enter to confirm

  ERROR Raw mode is not supported on the current process.stdin, which Ink uses
```

**After — this branch:**
```
happy version: 1.2.1
```

Nothing else runs: no auth, no daemon, no session.

## Validation

- `happy-cli` typecheck: no new errors relative to `main`
- One behavioural line in `packages/happy-cli/src/index.ts`; no other file touched
- `index.ts` has not been modified upstream since this fix was written, so it applies without drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)
