### PR TITLE
fix(cli): delegate happy update/upgrade to claude

### DIFF
--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -29,7 +29,11 @@ import { handleSandboxCommand } from './commands/sandbox'
 import { handleServerCommand } from './commands/server'
 import { spawnHappyCLI } from './utils/spawnHappyCLI'
 import { claudeCliPath } from './claude/claudeLocal'
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
+import os from 'node:os'
+import { join } from 'node:path'
+import { createRequire } from 'node:module'
+import { projectPath } from '@/projectPath'
 import { extractNoSandboxFlag } from './utils/sandboxFlags'
 import { handleResumeCommand } from '@/resume/handleResumeCommand'
 import { ensureDaemonRunning } from './daemon/ensureDaemonRunning'
@@ -125,6 +129,40 @@ Conversation history is preserved on the server, but in-flight tool calls are in
   } else if (subcommand === 'bye') {
     console.log('Bye!');
     process.exit(0);
+  } else if (subcommand === 'update' || subcommand === 'upgrade') {
+    // Delegate straight to claude. Without this branch it falls through to the
+    // session launcher, which appends Happy's hook `--settings` — an option
+    // claude's update command doesn't accept, so it always fails.
+    //
+    // This resolves the claude binary rather than going through
+    // claude_local_launcher.cjs: the launcher sets DISABLE_AUTOUPDATER=1 and
+    // replaces global.fetch to report progress over fd 3, and neither belongs in
+    // a one-shot update that isn't part of a session.
+    const require_ = createRequire(import.meta.url)
+    const { findGlobalClaudeCliPath } = require_(join(projectPath(), 'scripts', 'claude_version_utils.cjs'))
+    const found = findGlobalClaudeCliPath()
+    if (!found?.path) {
+      console.error(chalk.red('Error:'), 'Could not find the claude CLI. Install it with: npm install -g @anthropic-ai/claude-code')
+      process.exit(1)
+    }
+    // A JS entrypoint has to go to node; a native binary runs on its own.
+    const isJsFile = found.path.endsWith('.js') || found.path.endsWith('.cjs')
+    const rest = [subcommand, ...args.slice(1)]
+    const result = spawnSync(
+      isJsFile ? process.execPath : found.path,
+      isJsFile ? [found.path, ...rest] : rest,
+      { stdio: 'inherit', windowsHide: true }
+    )
+    if (result.error) {
+      console.error(chalk.red('Error:'), result.error.message)
+      process.exit(1)
+    }
+    if (result.signal) {
+      // Report the signal the way a shell would, so Ctrl+C stays distinguishable
+      // from claude exiting 1 on its own.
+      process.exit(128 + (os.constants.signals[result.signal] ?? 0))
+    }
+    process.exit(result.status ?? 1)
   } else if (subcommand === 'resume') {
     try {
       await handleResumeCommand(args.slice(1));


### PR DESCRIPTION
Neither `update` nor `upgrade` is in the subcommand chain, so both fall through to the session launcher, which appends Happy's hook `--settings` — an option `claude`'s update command rejects. That is the failure #1529 reports.

Route both aliases straight to `claude`, propagating exit status and signals.

**Why not reuse `claudeCliPath` (as the `--help` path at index.ts:798 does):** that constant points at `scripts/claude_local_launcher.cjs`, which sets `DISABLE_AUTOUPDATER = '1'` (line 4) and replaces `global.fetch` to report progress over fd 3 (lines 16-19). Running the updater through a launcher that disables the auto-updater is not what anyone wants, so this branch resolves the claude binary itself.

Fixes #1529

## Proof

Isolated `HAPPY_HOME_DIR`, and `HAPPY_CLAUDE_PATH` pointed at a stub that prints its argv and exits with a chosen code — so the real claude is never invoked.

**Before — `main`, `happy update`:** never reaches claude at all; `update` is treated as a session launch.
```
How would you like to authenticate?

› 1. Mobile App
  2. Web Browser
```

**After — this branch:**
```
$ happy update
FAKE-CLAUDE received argv: update

$ happy upgrade --some-flag
FAKE-CLAUDE received argv: upgrade --some-flag
```

No `--settings`, alias and trailing flags pass through. Exit status propagates — with the stub exiting 7, `happy` exits 7.

## Validation

- `happy-cli` typecheck: no new errors relative to `main`
- Single file, `packages/happy-cli/src/index.ts`
- `index.ts` has not been modified upstream since this fix was written

🤖 Generated with [Claude Code](https://claude.com/claude-code)
