### PR TITLE
fix(cli): preserve daemon ownership across health check races

### DIFF
--- a/packages/happy-cli/src/commands/codexCommand.test.ts
+++ b/packages/happy-cli/src/commands/codexCommand.test.ts
@@ -51,7 +51,7 @@ describe('handleCodexCommand', () => {
   it('ensures the daemon is running before starting a codex session', async () => {
     await handleCodexCommand(['--started-by', 'terminal'])
 
-    expect(mocks.mockEnsureDaemonRunning).toHaveBeenCalledTimes(1)
+    expect(mocks.mockEnsureDaemonRunning).toHaveBeenCalledWith('terminal')
     expect(mocks.mockRunCodex).toHaveBeenCalledWith({
       credentials: { token: 'token' },
       startedBy: 'terminal',
@@ -78,6 +78,7 @@ describe('handleCodexCommand', () => {
 
     await handleCodexCommand(['--no-sandbox', '--resume', 'thread-123', '--started-by', 'daemon'])
 
+    expect(mocks.mockEnsureDaemonRunning).toHaveBeenCalledWith('daemon')
     expect(mocks.mockRunCodex).toHaveBeenCalledWith({
       credentials: { token: 'token' },
       startedBy: 'daemon',

--- a/packages/happy-cli/src/commands/codexCommand.ts
+++ b/packages/happy-cli/src/commands/codexCommand.ts
@@ -29,7 +29,7 @@ export async function handleCodexCommand(args: string[]): Promise<void> {
   }
 
   const { credentials } = await authAndSetupMachineIfNeeded()
-  await ensureDaemonRunning()
+  await ensureDaemonRunning(startedBy)
 
   await runCodex({
     credentials,

--- a/packages/happy-cli/src/daemon/controlClient.test.ts
+++ b/packages/happy-cli/src/daemon/controlClient.test.ts
@@ -148,24 +148,72 @@ describe('checkIfDaemonRunningAndCleanupStaleState', () => {
     )
   })
 
-  it('refuses to stop a legacy snapshot that has no generation token', async () => {
+  it('gracefully stops a live legacy owner after stable HTTP identity evidence', async () => {
     vi.useFakeTimers()
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({ status: 'stopping' }),
-    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ children: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ status: 'stopping' }),
+      })
     vi.stubGlobal('fetch', fetchMock)
-
-    const stopPromise = stopDaemon({
+    const legacyState = {
       pid: 1111,
       httpPort: 4111,
       startTime: 'legacy',
       startedWithCliVersion: '1.0.0',
-    })
+    }
+    mocks.mockReadDaemonState.mockResolvedValue(legacyState)
+
+    const stopPromise = stopDaemon(legacyState)
     await vi.advanceTimersByTimeAsync(2100)
     await stopPromise
 
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:4111/list', expect.anything())
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:4111/stop', expect.objectContaining({
+      body: JSON.stringify({}),
+    }))
+    expect(process.kill).not.toHaveBeenCalledWith(1111, 'SIGKILL')
+  })
+
+  it('refuses a legacy stop when the fixed snapshot changes before the request', async () => {
+    const legacyState = {
+      pid: 1111,
+      httpPort: 4111,
+      startTime: 'legacy',
+      startedWithCliVersion: '1.0.0',
+    }
+    mocks.mockReadDaemonState.mockResolvedValue({ ...legacyState, pid: 2222 })
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await stopDaemon(legacyState)
+
     expect(fetchMock).not.toHaveBeenCalled()
+    expect(process.kill).not.toHaveBeenCalledWith(1111, 'SIGKILL')
+  })
+
+  it('refuses a legacy stop when a 2xx response has the wrong list shape', async () => {
+    const legacyState = {
+      pid: 1111,
+      httpPort: 4111,
+      startTime: 'legacy',
+      startedWithCliVersion: '1.0.0',
+    }
+    mocks.mockReadDaemonState.mockResolvedValue(legacyState)
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({}),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await stopDaemon(legacyState)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('http://127.0.0.1:4111/list', expect.anything())
     expect(process.kill).not.toHaveBeenCalledWith(1111, 'SIGKILL')
   })
 })

--- a/packages/happy-cli/src/daemon/controlClient.test.ts
+++ b/packages/happy-cli/src/daemon/controlClient.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   mockClearDaemonState: vi.fn(),
   mockReadDaemonState: vi.fn(),
   mockLoggerDebug: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }))
 
 vi.mock('@/persistence', () => ({
@@ -14,6 +15,7 @@ vi.mock('@/persistence', () => ({
 vi.mock('@/ui/logger', () => ({
   logger: {
     debug: mocks.mockLoggerDebug,
+    warn: mocks.mockLoggerWarn,
   },
 }))
 
@@ -23,7 +25,7 @@ vi.mock('@/configuration', () => ({
   },
 }))
 
-import { checkIfDaemonRunningAndCleanupStaleState } from './controlClient'
+import { checkIfDaemonRunningAndCleanupStaleState, stopDaemon } from './controlClient'
 
 describe('checkIfDaemonRunningAndCleanupStaleState', () => {
   beforeEach(() => {
@@ -33,12 +35,14 @@ describe('checkIfDaemonRunningAndCleanupStaleState', () => {
       httpPort: 4321,
       startTime: 'now',
       startedWithCliVersion: '1.2.2',
+      ownerToken: 'generation-current',
     })
     mocks.mockClearDaemonState.mockResolvedValue(undefined)
     vi.spyOn(process, 'kill').mockReturnValue(true)
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -51,10 +55,117 @@ describe('checkIfDaemonRunningAndCleanupStaleState', () => {
     expect(mocks.mockClearDaemonState).not.toHaveBeenCalled()
   })
 
-  it('clears stale state when a live PID is not accepting daemon connections', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
+  it('preserves ownership when the PID probe is denied', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    vi.mocked(process.kill).mockImplementation(() => {
+      const error = new Error('operation not permitted') as NodeJS.ErrnoException
+      error.code = 'EPERM'
+      throw error
+    })
+
+    await expect(checkIfDaemonRunningAndCleanupStaleState()).resolves.toBe(true)
+    expect(mocks.mockClearDaemonState).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('cleans generation-scoped state only when the PID is definitely absent', async () => {
+    vi.mocked(process.kill).mockImplementation(() => {
+      const error = new Error('no such process') as NodeJS.ErrnoException
+      error.code = 'ESRCH'
+      throw error
+    })
 
     await expect(checkIfDaemonRunningAndCleanupStaleState()).resolves.toBe(false)
-    expect(mocks.mockClearDaemonState).toHaveBeenCalledWith(1234)
+    expect(mocks.mockClearDaemonState).toHaveBeenCalledWith({
+      pid: 1234,
+      httpPort: 4321,
+      startTime: 'now',
+      startedWithCliVersion: '1.2.2',
+      ownerToken: 'generation-current',
+    })
+  })
+
+  it('preserves ownership when a live PID has a transient connection failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
+
+    await expect(checkIfDaemonRunningAndCleanupStaleState()).resolves.toBe(true)
+    expect(mocks.mockClearDaemonState).not.toHaveBeenCalled()
+  })
+
+  it('preserves ownership after one non-success control response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+
+    await expect(checkIfDaemonRunningAndCleanupStaleState()).resolves.toBe(true)
+    expect(mocks.mockClearDaemonState).not.toHaveBeenCalled()
+  })
+
+  it('does not force kill a PID when graceful stop cannot be verified', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new TypeError('stop endpoint unavailable')))
+
+    const stopPromise = stopDaemon()
+    await vi.advanceTimersByTimeAsync(2100)
+    await stopPromise
+
+    expect(process.kill).not.toHaveBeenCalledWith(1234, 'SIGKILL')
+  })
+
+  it('binds a replacement stop to the generation whose version was checked', async () => {
+    vi.useFakeTimers()
+    const observedGeneration = {
+      pid: 1111,
+      httpPort: 4111,
+      startTime: 'old',
+      startedWithCliVersion: '1.0.0',
+      ownerToken: 'generation-g',
+    }
+    mocks.mockReadDaemonState.mockResolvedValue({
+      pid: 2222,
+      httpPort: 4222,
+      startTime: 'successor',
+      startedWithCliVersion: '1.2.2',
+      ownerToken: 'generation-h',
+    })
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ status: 'stopping' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const stopPromise = (stopDaemon as any)(observedGeneration)
+    await vi.advanceTimersByTimeAsync(2100)
+    await stopPromise
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:4111/stop',
+      expect.objectContaining({ body: JSON.stringify({ expectedOwnerToken: 'generation-g' }) }),
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'http://127.0.0.1:4222/stop',
+      expect.anything(),
+    )
+  })
+
+  it('refuses to stop a legacy snapshot that has no generation token', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ status: 'stopping' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const stopPromise = stopDaemon({
+      pid: 1111,
+      httpPort: 4111,
+      startTime: 'legacy',
+      startedWithCliVersion: '1.0.0',
+    })
+    await vi.advanceTimersByTimeAsync(2100)
+    await stopPromise
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(process.kill).not.toHaveBeenCalledWith(1111, 'SIGKILL')
   })
 })

--- a/packages/happy-cli/src/daemon/controlClient.test.ts
+++ b/packages/happy-cli/src/daemon/controlClient.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  mockClearDaemonState: vi.fn(),
+  mockReadDaemonState: vi.fn(),
+  mockLoggerDebug: vi.fn(),
+}))
+
+vi.mock('@/persistence', () => ({
+  clearDaemonState: mocks.mockClearDaemonState,
+  readDaemonState: mocks.mockReadDaemonState,
+}))
+
+vi.mock('@/ui/logger', () => ({
+  logger: {
+    debug: mocks.mockLoggerDebug,
+  },
+}))
+
+vi.mock('@/configuration', () => ({
+  configuration: {
+    currentCliVersion: '1.2.2',
+  },
+}))
+
+import { checkIfDaemonRunningAndCleanupStaleState } from './controlClient'
+
+describe('checkIfDaemonRunningAndCleanupStaleState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.mockReadDaemonState.mockResolvedValue({
+      pid: 1234,
+      httpPort: 4321,
+      startTime: 'now',
+      startedWithCliVersion: '1.2.2',
+    })
+    mocks.mockClearDaemonState.mockResolvedValue(undefined)
+    vi.spyOn(process, 'kill').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps a live daemon owner after one transient control timeout', async () => {
+    const timeoutError = new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(timeoutError))
+
+    await expect(checkIfDaemonRunningAndCleanupStaleState()).resolves.toBe(true)
+    expect(mocks.mockClearDaemonState).not.toHaveBeenCalled()
+  })
+
+  it('clears stale state when a live PID is not accepting daemon connections', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
+
+    await expect(checkIfDaemonRunningAndCleanupStaleState()).resolves.toBe(false)
+    expect(mocks.mockClearDaemonState).toHaveBeenCalledWith(1234)
+  })
+})

--- a/packages/happy-cli/src/daemon/controlClient.ts
+++ b/packages/happy-cli/src/daemon/controlClient.ts
@@ -110,12 +110,11 @@ export async function spawnDaemonSession(directory: string, sessionId?: string):
 }
 
 export async function stopDaemonHttp(state: DaemonLocallyPersistedState): Promise<void> {
-  if (!state.ownerToken) {
-    throw new Error('Refusing to stop a daemon without generation ownership proof');
-  }
-  const result = await daemonPost('/stop', {
-    expectedOwnerToken: state.ownerToken,
-  }, state);
+  const result = await daemonPost(
+    '/stop',
+    state.ownerToken ? { expectedOwnerToken: state.ownerToken } : {},
+    state,
+  );
   if (result?.error) {
     throw new Error(result.error);
   }
@@ -246,8 +245,21 @@ export async function stopDaemon(expectedState?: DaemonLocallyPersistedState) {
       return;
     }
     if (!state.ownerToken) {
-      logger.warn('Legacy daemon state has no generation proof; refusing automatic stop. Stop the old daemon manually before retrying.');
-      return;
+      const stableBefore = await readDaemonState();
+      if (!sameLegacyDaemonSnapshot(state, stableBefore)) {
+        logger.warn('Legacy daemon ownership changed before identity verification; refusing automatic stop.');
+        return;
+      }
+      const evidence = await daemonPost('/list', {}, state);
+      if (!isLegacyDaemonListEvidence(evidence)) {
+        logger.warn('Legacy daemon did not provide positive HTTP identity evidence; refusing automatic stop.');
+        return;
+      }
+      const stableAfter = await readDaemonState();
+      if (!sameLegacyDaemonSnapshot(state, stableAfter)) {
+        logger.warn('Legacy daemon ownership changed during identity verification; refusing automatic stop.');
+        return;
+      }
     }
 
     logger.debug(`Stopping daemon with PID ${state.pid}`);
@@ -276,9 +288,38 @@ async function waitForProcessDeath(pid: number, timeout: number): Promise<void> 
     try {
       process.kill(pid, 0);
       await new Promise(resolve => setTimeout(resolve, 100));
-    } catch {
-      return; // Process is dead
+    } catch (error: any) {
+      if (error?.code === 'ESRCH') {
+        return; // Process is affirmatively dead
+      }
+      throw error;
     }
   }
   throw new Error('Process did not die within timeout');
+}
+
+function isLegacyDaemonListEvidence(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || !Array.isArray((value as any).children)) {
+    return false;
+  }
+  return (value as any).children.every((child: unknown) => {
+    if (!child || typeof child !== 'object') return false;
+    const candidate = child as Record<string, unknown>;
+    return typeof candidate.startedBy === 'string'
+      && typeof candidate.happySessionId === 'string'
+      && Number.isSafeInteger(candidate.pid)
+      && (candidate.pid as number) > 0;
+  });
+}
+
+function sameLegacyDaemonSnapshot(
+  expected: DaemonLocallyPersistedState,
+  observed: DaemonLocallyPersistedState | null,
+): boolean {
+  return observed !== null
+    && !observed.ownerToken
+    && observed.pid === expected.pid
+    && observed.httpPort === expected.httpPort
+    && observed.startTime === expected.startTime
+    && observed.startedWithCliVersion === expected.startedWithCliVersion;
 }

--- a/packages/happy-cli/src/daemon/controlClient.ts
+++ b/packages/happy-cli/src/daemon/controlClient.ts
@@ -4,12 +4,16 @@
  */
 
 import { logger } from '@/ui/logger';
-import { clearDaemonState, readDaemonState } from '@/persistence';
+import { clearDaemonState, readDaemonState, type DaemonLockHandle, type DaemonLocallyPersistedState } from '@/persistence';
 import { Metadata } from '@/api/types';
 import { configuration } from '@/configuration';
 
-async function daemonPost(path: string, body?: any): Promise<{ error?: string } | any> {
-  const state = await readDaemonState();
+async function daemonPost(
+  path: string,
+  body?: any,
+  targetState?: DaemonLocallyPersistedState,
+): Promise<{ error?: string } | any> {
+  const state = targetState ?? await readDaemonState();
   if (!state?.httpPort) {
     const errorMessage = 'No daemon running, no state file found';
     logger.debug(`[CONTROL CLIENT] ${errorMessage}`);
@@ -105,8 +109,16 @@ export async function spawnDaemonSession(directory: string, sessionId?: string):
   return result;
 }
 
-export async function stopDaemonHttp(): Promise<void> {
-  await daemonPost('/stop');
+export async function stopDaemonHttp(state: DaemonLocallyPersistedState): Promise<void> {
+  if (!state.ownerToken) {
+    throw new Error('Refusing to stop a daemon without generation ownership proof');
+  }
+  const result = await daemonPost('/stop', {
+    expectedOwnerToken: state.ownerToken,
+  }, state);
+  if (result?.error) {
+    throw new Error(result.error);
+  }
 }
 
 /**
@@ -136,19 +148,23 @@ export async function stopDaemonHttp(): Promise<void> {
  * We can destructure the response on the caller for richer output.
  * For instance when running `happy daemon status` we can show more information.
  */
-export async function checkIfDaemonRunningAndCleanupStaleState(): Promise<boolean> {
+export async function readRunningDaemonStateAndCleanupStaleState(): Promise<DaemonLocallyPersistedState | null> {
   const state = await readDaemonState();
   if (!state) {
-    return false;
+    return null;
   }
 
   // Check if the PID is alive
   try {
     process.kill(state.pid, 0);
-  } catch {
-    logger.debug('[DAEMON RUN] Daemon PID not running, cleaning up state');
-    await cleanupDaemonState(state.pid);
-    return false;
+  } catch (probeError: any) {
+    if (probeError?.code === 'ESRCH') {
+      logger.debug('[DAEMON RUN] Daemon PID not running, cleaning up state');
+      await cleanupDaemonState(state);
+      return null;
+    }
+    logger.debug('[DAEMON RUN] Daemon PID could not be probed; preserving ownership state', probeError);
+    return state;
   }
 
   // PID is alive, but on Windows PIDs get reused after reboot.
@@ -162,23 +178,21 @@ export async function checkIfDaemonRunningAndCleanupStaleState(): Promise<boolea
         signal: AbortSignal.timeout(2000)
       });
       if (response.ok) {
-        return true;
+        return state;
       }
+      logger.debug(`[DAEMON RUN] PID ${state.pid} responded with HTTP ${response.status} on port ${state.httpPort}; preserving ownership after an inconclusive health check`);
+      return state;
     } catch (error) {
-      if (error instanceof Error && error.name === 'TimeoutError') {
-        logger.debug(`[DAEMON RUN] PID ${state.pid} is alive but HTTP health check timed out on port ${state.httpPort}; preserving daemon ownership state`);
-        return true;
-      }
-
-      // A non-timeout connection failure means the live PID is not listening as
-      // our daemon (most commonly a PID reused by Windows after reboot).
-      logger.debug(`[DAEMON RUN] PID ${state.pid} is alive but HTTP health check failed on port ${state.httpPort}, cleaning up stale state`);
-      await cleanupDaemonState(state.pid);
-      return false;
+      logger.debug(`[DAEMON RUN] PID ${state.pid} is alive but HTTP health check failed on port ${state.httpPort}; preserving ownership after an inconclusive health check`, error);
+      return state;
     }
   }
 
-  return true;
+  return state;
+}
+
+export async function checkIfDaemonRunningAndCleanupStaleState(): Promise<boolean> {
+  return (await readRunningDaemonStateAndCleanupStaleState()) !== null;
 }
 
 /**
@@ -190,15 +204,9 @@ export async function checkIfDaemonRunningAndCleanupStaleState(): Promise<boolea
  */
 export async function isDaemonRunningCurrentlyInstalledHappyVersion(): Promise<boolean> {
   logger.debug('[DAEMON CONTROL] Checking if daemon is running same version');
-  const runningDaemon = await checkIfDaemonRunningAndCleanupStaleState();
-  if (!runningDaemon) {
-    logger.debug('[DAEMON CONTROL] No daemon running, returning false');
-    return false;
-  }
-
-  const state = await readDaemonState();
+  const state = await readRunningDaemonStateAndCleanupStaleState();
   if (!state) {
-    logger.debug('[DAEMON CONTROL] No daemon state found, returning false');
+    logger.debug('[DAEMON CONTROL] No daemon running, returning false');
     return false;
   }
   
@@ -221,20 +229,24 @@ export async function isDaemonRunningCurrentlyInstalledHappyVersion(): Promise<b
   return currentCliVersion === state.startedWithCliVersion;
 }
 
-export async function cleanupDaemonState(expectedOwnerPid: number): Promise<void> {
+export async function cleanupDaemonState(expectedOwner: DaemonLockHandle | DaemonLocallyPersistedState): Promise<void> {
   try {
-    await clearDaemonState(expectedOwnerPid);
-    logger.debug(`[DAEMON RUN] Daemon state cleanup completed for PID ${expectedOwnerPid}`);
+    await clearDaemonState(expectedOwner);
+    logger.debug(`[DAEMON RUN] Daemon state cleanup completed for PID ${expectedOwner.pid}`);
   } catch (error) {
     logger.debug('[DAEMON RUN] Error cleaning up daemon metadata', error);
   }
 }
 
-export async function stopDaemon() {
+export async function stopDaemon(expectedState?: DaemonLocallyPersistedState) {
   try {
-    const state = await readDaemonState();
+    const state = expectedState ?? await readRunningDaemonStateAndCleanupStaleState();
     if (!state) {
-      logger.debug('No daemon state found');
+      logger.debug('Daemon identity could not be verified; refusing to stop an unrelated process');
+      return;
+    }
+    if (!state.ownerToken) {
+      logger.warn('Legacy daemon state has no generation proof; refusing automatic stop. Stop the old daemon manually before retrying.');
       return;
     }
 
@@ -242,22 +254,16 @@ export async function stopDaemon() {
 
     // Try HTTP graceful stop
     try {
-      await stopDaemonHttp();
+      await stopDaemonHttp(state);
 
       // Wait for daemon to die
       await waitForProcessDeath(state.pid, 2000);
       logger.debug('Daemon stopped gracefully via HTTP');
       return;
     } catch (error) {
-      logger.debug('HTTP stop failed, will force kill', error);
-    }
-
-    // Force kill
-    try {
-      process.kill(state.pid, 'SIGKILL');
-      logger.debug('Force killed daemon');
-    } catch (error) {
-      logger.debug('Daemon already dead');
+      // A PID plus failed HTTP identity is not enough evidence to send a kill
+      // signal on Windows, where PIDs are routinely reused after reboot.
+      logger.debug('HTTP stop failed; refusing to force kill an unverified PID', error);
     }
   } catch (error) {
     logger.debug('Error stopping daemon', error);

--- a/packages/happy-cli/src/daemon/controlClient.ts
+++ b/packages/happy-cli/src/daemon/controlClient.ts
@@ -147,7 +147,7 @@ export async function checkIfDaemonRunningAndCleanupStaleState(): Promise<boolea
     process.kill(state.pid, 0);
   } catch {
     logger.debug('[DAEMON RUN] Daemon PID not running, cleaning up state');
-    await cleanupDaemonState();
+    await cleanupDaemonState(state.pid);
     return false;
   }
 
@@ -164,10 +164,16 @@ export async function checkIfDaemonRunningAndCleanupStaleState(): Promise<boolea
       if (response.ok) {
         return true;
       }
-    } catch {
-      // HTTP check failed - the PID is not our daemon (likely reused by OS after reboot)
+    } catch (error) {
+      if (error instanceof Error && error.name === 'TimeoutError') {
+        logger.debug(`[DAEMON RUN] PID ${state.pid} is alive but HTTP health check timed out on port ${state.httpPort}; preserving daemon ownership state`);
+        return true;
+      }
+
+      // A non-timeout connection failure means the live PID is not listening as
+      // our daemon (most commonly a PID reused by Windows after reboot).
       logger.debug(`[DAEMON RUN] PID ${state.pid} is alive but HTTP health check failed on port ${state.httpPort}, cleaning up stale state`);
-      await cleanupDaemonState();
+      await cleanupDaemonState(state.pid);
       return false;
     }
   }
@@ -215,10 +221,10 @@ export async function isDaemonRunningCurrentlyInstalledHappyVersion(): Promise<b
   return currentCliVersion === state.startedWithCliVersion;
 }
 
-export async function cleanupDaemonState(): Promise<void> {
+export async function cleanupDaemonState(expectedOwnerPid: number): Promise<void> {
   try {
-    await clearDaemonState();
-    logger.debug('[DAEMON RUN] Daemon state file removed');
+    await clearDaemonState(expectedOwnerPid);
+    logger.debug(`[DAEMON RUN] Daemon state cleanup completed for PID ${expectedOwnerPid}`);
   } catch (error) {
     logger.debug('[DAEMON RUN] Error cleaning up daemon metadata', error);
   }

--- a/packages/happy-cli/src/daemon/controlServer.test.ts
+++ b/packages/happy-cli/src/daemon/controlServer.test.ts
@@ -30,4 +30,28 @@ describe('daemon control server ownership', () => {
     expect(response.status).toBe(409);
     expect(requestShutdown).not.toHaveBeenCalled();
   });
+
+  it('accepts the empty stop payload sent by an older CLI', async () => {
+    vi.useFakeTimers();
+    const requestShutdown = vi.fn();
+    const server = await startDaemonControlServer({
+      ownerToken: 'generation-current',
+      getChildren: () => [],
+      stopSession: () => false,
+      spawnSession: vi.fn(),
+      requestShutdown,
+      onHappySessionWebhook: vi.fn(),
+    });
+    stopServer = server.stop;
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/stop`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(response.status).toBe(200);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(requestShutdown).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
 });

--- a/packages/happy-cli/src/daemon/controlServer.test.ts
+++ b/packages/happy-cli/src/daemon/controlServer.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { startDaemonControlServer } from './controlServer';
+
+describe('daemon control server ownership', () => {
+  let stopServer: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await stopServer?.();
+    stopServer = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('rejects a stop request bound to a predecessor generation', async () => {
+    const requestShutdown = vi.fn();
+    const server = await startDaemonControlServer({
+      ownerToken: 'generation-h',
+      getChildren: () => [],
+      stopSession: () => false,
+      spawnSession: vi.fn(),
+      requestShutdown,
+      onHappySessionWebhook: vi.fn(),
+    });
+    stopServer = server.stop;
+
+    const response = await fetch(`http://127.0.0.1:${server.port}/stop`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ expectedOwnerToken: 'generation-g' }),
+    });
+    expect(response.status).toBe(409);
+    expect(requestShutdown).not.toHaveBeenCalled();
+  });
+});

--- a/packages/happy-cli/src/daemon/controlServer.ts
+++ b/packages/happy-cli/src/daemon/controlServer.ts
@@ -13,12 +13,14 @@ import { TrackedSession, SessionEncryptionData } from './types';
 import { SpawnSessionOptions, SpawnSessionResult } from '@/modules/common/registerCommonHandlers';
 
 export function startDaemonControlServer({
+  ownerToken,
   getChildren,
   stopSession,
   spawnSession,
   requestShutdown,
   onHappySessionWebhook
 }: {
+  ownerToken: string;
   getChildren: () => TrackedSession[];
   stopSession: (sessionId: string) => boolean;
   spawnSession: (options: SpawnSessionOptions) => Promise<SpawnSessionResult>;
@@ -196,13 +198,24 @@ export function startDaemonControlServer({
     // Stop daemon
     typed.post('/stop', {
       schema: {
+        body: z.object({
+          expectedOwnerToken: z.string()
+        }),
         response: {
           200: z.object({
             status: z.string()
+          }),
+          409: z.object({
+            error: z.string()
           })
         }
       }
-    }, async () => {
+    }, async (request, reply) => {
+      if (request.body.expectedOwnerToken !== ownerToken) {
+        logger.debug('[CONTROL SERVER] Refusing stop request for a different daemon generation');
+        reply.code(409);
+        return { error: 'Daemon generation changed; stop request refused' };
+      }
       logger.debug('[CONTROL SERVER] Stop daemon request received');
 
       // Give time for response to arrive

--- a/packages/happy-cli/src/daemon/controlServer.ts
+++ b/packages/happy-cli/src/daemon/controlServer.ts
@@ -199,7 +199,7 @@ export function startDaemonControlServer({
     typed.post('/stop', {
       schema: {
         body: z.object({
-          expectedOwnerToken: z.string()
+          expectedOwnerToken: z.string().optional()
         }),
         response: {
           200: z.object({
@@ -211,7 +211,10 @@ export function startDaemonControlServer({
         }
       }
     }, async (request, reply) => {
-      if (request.body.expectedOwnerToken !== ownerToken) {
+      if (
+        request.body.expectedOwnerToken !== undefined
+        && request.body.expectedOwnerToken !== ownerToken
+      ) {
         logger.debug('[CONTROL SERVER] Refusing stop request for a different daemon generation');
         reply.code(409);
         return { error: 'Daemon generation changed; stop request refused' };

--- a/packages/happy-cli/src/daemon/daemon.integration.test.ts
+++ b/packages/happy-cli/src/daemon/daemon.integration.test.ts
@@ -9,7 +9,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { execSync, spawn } from 'child_process';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import type { Metadata } from '@/api/types';
 import { getIntegrationEnv } from '@/testing/currentIntegrationEnv';
@@ -22,7 +22,7 @@ import {
   stopDaemonHttp,
   stopDaemonSession,
 } from '@/daemon/controlClient';
-import { clearDaemonState, readDaemonState } from '@/persistence';
+import { clearDaemonStateForTests, readDaemonState } from '@/persistence';
 import { getLatestDaemonLog } from '@/ui/logger';
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI';
 
@@ -158,10 +158,12 @@ describe('Daemon Integration Tests', { timeout: 180_000 }, () => {
   });
 
   it('should handle daemon stop request gracefully', async () => {    
-    await stopDaemonHttp();
+    const state = await readDaemonState();
+    expect(state).not.toBeNull();
+    await stopDaemonHttp(state!);
 
-    // Verify metadata file is cleaned up
-    await waitFor(async () => !existsSync(configuration.daemonStateFile), 1000);
+    // Verify the retired generation is no longer observable as current state.
+    await waitFor(async () => await readDaemonState() === null, 1000);
   });
 
   it('should track both daemon-spawned and terminal sessions', async () => {
@@ -320,7 +322,7 @@ describe('Daemon Integration Tests', { timeout: 180_000 }, () => {
     console.log('[TEST] Daemon killed with SIGKILL - no cleanup logs expected');
     
     // Clean up state file manually since daemon couldn't do it
-    await clearDaemonState();
+    await clearDaemonStateForTests();
   });
 
   it('should die with cleanup logs when SIGTERM is sent', async () => {
@@ -355,7 +357,7 @@ describe('Daemon Integration Tests', { timeout: 180_000 }, () => {
     console.log('[TEST] Daemon terminated gracefully with SIGTERM - cleanup logs written');
     
     // Clean up state file if it still exists (should have been cleaned by SIGTERM handler)
-    await clearDaemonState();
+    await clearDaemonStateForTests();
   });
 
   /**

--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.test.ts
@@ -38,10 +38,18 @@ describe('ensureDaemonRunning', () => {
     mocks.mockCheckIfDaemonRunningAndCleanupStaleState.mockResolvedValue(true)
   })
 
+  it('does not inspect or replace the daemon that started this session', async () => {
+    await ensureDaemonRunning('daemon')
+
+    expect(mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion).not.toHaveBeenCalled()
+    expect(mocks.mockCheckIfDaemonRunningAndCleanupStaleState).not.toHaveBeenCalled()
+    expect(mocks.mockSpawnHappyCLI).not.toHaveBeenCalled()
+  })
+
   it('returns without spawning when the daemon is already running', async () => {
     mocks.mockIsDaemonRunningCurrentlyInstalledHappyVersion.mockResolvedValue(true)
 
-    await ensureDaemonRunning()
+    await ensureDaemonRunning('terminal')
 
     expect(mocks.mockSpawnHappyCLI).not.toHaveBeenCalled()
     expect(mocks.mockCheckIfDaemonRunningAndCleanupStaleState).not.toHaveBeenCalled()
@@ -65,7 +73,7 @@ describe('ensureDaemonRunning', () => {
     }
     vi.stubEnv('HAPPY_SAFE_ENV', 'kept')
 
-    await ensureDaemonRunning()
+    await ensureDaemonRunning(undefined)
 
     expect(mocks.mockSpawnHappyCLI).toHaveBeenCalledWith(['daemon', 'start-sync'], expect.objectContaining({
       detached: true,

--- a/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
+++ b/packages/happy-cli/src/daemon/ensureDaemonRunning.ts
@@ -6,8 +6,13 @@ import { sanitizeSessionEnvironment } from './sessionEnvironment'
 const DAEMON_READY_TIMEOUT_MS = 5000
 const DAEMON_READY_POLL_INTERVAL_MS = 100
 
-export async function ensureDaemonRunning(): Promise<void> {
+export async function ensureDaemonRunning(startedBy: 'daemon' | 'terminal' | undefined): Promise<void> {
   logger.debug('Ensuring Happy background service is running & matches our version...')
+
+  if (startedBy === 'daemon') {
+    logger.debug('Skipping daemon check for a session started by the daemon')
+    return
+  }
 
   if (await isDaemonRunningCurrentlyInstalledHappyVersion()) {
     return

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -14,7 +14,7 @@ import { startCaffeinate, stopCaffeinate } from '@/utils/caffeinate';
 import packageJson from '../../package.json';
 import { getEnvironmentInfo } from '@/ui/doctor';
 import { spawnHappyCLI } from '@/utils/spawnHappyCLI';
-import { writeDaemonState, DaemonLocallyPersistedState, readDaemonState, acquireDaemonLock, releaseDaemonLock, readPersistedSessions, persistSession } from '@/persistence';
+import { writeDaemonState, writeDaemonStateIfOwned, DaemonLocallyPersistedState, acquireDaemonLock, releaseDaemonLock, readPersistedSessions, persistSession } from '@/persistence';
 import type { PersistedSession } from '@/persistence';
 
 import { cleanupDaemonState, isDaemonRunningCurrentlyInstalledHappyVersion, stopDaemon } from './controlClient';
@@ -944,7 +944,7 @@ export async function startDaemon(): Promise<void> {
         // leaving nothing running once we also exit.
         apiMachine.shutdown();
         await stopControlServer();
-        await cleanupDaemonState();
+        await cleanupDaemonState(process.pid);
         await releaseDaemonLock(daemonLockHandle);
         await stopCaffeinate();
 
@@ -961,14 +961,6 @@ export async function startDaemon(): Promise<void> {
         process.exit(0);
       }
 
-      // Before wrecklessly overriting the daemon state file, we should check if we are the ones who own it
-      // Race condition is possible, but thats okay for the time being :D
-      const daemonState = await readDaemonState();
-      if (daemonState && daemonState.pid !== process.pid) {
-        logger.debug('[DAEMON RUN] Somehow a different daemon was started without killing us. We should kill ourselves.')
-        requestShutdown('exception', 'A different daemon was started without killing us. We should kill ourselves.')
-      }
-
       // Heartbeat
       try {
         const updatedState: DaemonLocallyPersistedState = {
@@ -979,7 +971,13 @@ export async function startDaemon(): Promise<void> {
           lastHeartbeat: new Date().toLocaleString(),
           daemonLogPath: fileState.daemonLogPath
         };
-        writeDaemonState(updatedState);
+        const wroteHeartbeat = await writeDaemonStateIfOwned(updatedState);
+        if (!wroteHeartbeat) {
+          logger.debug('[DAEMON RUN] A different daemon owns the state. Stopping before writing this daemon PID back.')
+          requestShutdown('exception', 'A different daemon was started without killing us. We should kill ourselves.')
+          heartbeatRunning = false;
+          return;
+        }
         if (process.env.DEBUG) {
           logger.debug(`[DAEMON RUN] Health check completed at ${updatedState.lastHeartbeat}`);
         }
@@ -1013,7 +1011,7 @@ export async function startDaemon(): Promise<void> {
 
       apiMachine.shutdown();
       await stopControlServer();
-      await cleanupDaemonState();
+      await cleanupDaemonState(process.pid);
       await stopCaffeinate();
       await releaseDaemonLock(daemonLockHandle);
 

--- a/packages/happy-cli/src/daemon/run.ts
+++ b/packages/happy-cli/src/daemon/run.ts
@@ -17,7 +17,7 @@ import { spawnHappyCLI } from '@/utils/spawnHappyCLI';
 import { writeDaemonState, writeDaemonStateIfOwned, DaemonLocallyPersistedState, acquireDaemonLock, releaseDaemonLock, readPersistedSessions, persistSession } from '@/persistence';
 import type { PersistedSession } from '@/persistence';
 
-import { cleanupDaemonState, isDaemonRunningCurrentlyInstalledHappyVersion, stopDaemon } from './controlClient';
+import { cleanupDaemonState, readRunningDaemonStateAndCleanupStaleState, stopDaemon } from './controlClient';
 import { startDaemonControlServer } from './controlServer';
 import { statSync } from 'fs';
 import { join } from 'path';
@@ -130,14 +130,17 @@ export async function startDaemon(): Promise<void> {
 
   // Check if already running
   // Check if running daemon version matches current CLI version
-  const runningDaemonVersionMatches = await isDaemonRunningCurrentlyInstalledHappyVersion();
+  const runningDaemonState = await readRunningDaemonStateAndCleanupStaleState();
+  const runningDaemonVersionMatches = runningDaemonState?.startedWithCliVersion === packageJson.version;
   if (!runningDaemonVersionMatches) {
     // TODO: This hand-rolled self-restart path is awkward to reason about and awkward to test.
     // We should probably migrate this daemon to native system service management
     // (launchd/systemd, similar to OpenClaw's model), so startup/start-at-login and upgrades
     // are owned by the OS instead of by the daemon trying to replace itself in-process.
     logger.debug('[DAEMON RUN] Daemon version mismatch detected, restarting daemon with current CLI version');
-    await stopDaemon();
+    if (runningDaemonState) {
+      await stopDaemon(runningDaemonState);
+    }
   } else {
     logger.debug('[DAEMON RUN] Daemon version matches, keeping existing daemon');
     console.log('Daemon already running with matching version');
@@ -822,6 +825,7 @@ export async function startDaemon(): Promise<void> {
 
     // Start control server
     const { port: controlPort, stop: stopControlServer } = await startDaemonControlServer({
+      ownerToken: daemonLockHandle.ownerToken,
       getChildren: getCurrentChildren,
       stopSession,
       spawnSession,
@@ -837,7 +841,7 @@ export async function startDaemon(): Promise<void> {
       startedWithCliVersion: packageJson.version,
       daemonLogPath: logger.logFilePath
     };
-    writeDaemonState(fileState);
+    writeDaemonState(daemonLockHandle, fileState);
     logger.debug('[DAEMON RUN] Daemon state written');
 
     // Capture the bundled CLI's mtime at startup so the heartbeat can detect
@@ -944,7 +948,7 @@ export async function startDaemon(): Promise<void> {
         // leaving nothing running once we also exit.
         apiMachine.shutdown();
         await stopControlServer();
-        await cleanupDaemonState(process.pid);
+        await cleanupDaemonState(daemonLockHandle);
         await releaseDaemonLock(daemonLockHandle);
         await stopCaffeinate();
 
@@ -971,7 +975,7 @@ export async function startDaemon(): Promise<void> {
           lastHeartbeat: new Date().toLocaleString(),
           daemonLogPath: fileState.daemonLogPath
         };
-        const wroteHeartbeat = await writeDaemonStateIfOwned(updatedState);
+        const wroteHeartbeat = await writeDaemonStateIfOwned(daemonLockHandle, updatedState);
         if (!wroteHeartbeat) {
           logger.debug('[DAEMON RUN] A different daemon owns the state. Stopping before writing this daemon PID back.')
           requestShutdown('exception', 'A different daemon was started without killing us. We should kill ourselves.')
@@ -1011,7 +1015,7 @@ export async function startDaemon(): Promise<void> {
 
       apiMachine.shutdown();
       await stopControlServer();
-      await cleanupDaemonState(process.pid);
+      await cleanupDaemonState(daemonLockHandle);
       await stopCaffeinate();
       await releaseDaemonLock(daemonLockHandle);
 

--- a/packages/happy-cli/src/index.ts
+++ b/packages/happy-cli/src/index.ts
@@ -347,7 +347,7 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       const {
         credentials
       } = await authAndSetupMachineIfNeeded();
-      await ensureDaemonRunning()
+      await ensureDaemonRunning(startedBy)
 
       await runGemini({credentials, startedBy});
     } catch (error) {
@@ -383,7 +383,7 @@ Conversation history is preserved on the server, but in-flight tool calls are in
 
       const resolved = resolveAcpAgentConfig(acpArgs);
       const { credentials } = await authAndSetupMachineIfNeeded();
-      await ensureDaemonRunning()
+      await ensureDaemonRunning(startedBy)
 
       await runAcp({
         credentials,
@@ -425,7 +425,7 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       }
 
       const { credentials } = await authAndSetupMachineIfNeeded();
-      await ensureDaemonRunning()
+      await ensureDaemonRunning(startedBy)
 
       await runOpenClaw({
         credentials,
@@ -458,7 +458,7 @@ Conversation history is preserved on the server, but in-flight tool calls are in
       }
 
       const { credentials } = await authAndSetupMachineIfNeeded();
-      await ensureDaemonRunning()
+      await ensureDaemonRunning(startedBy)
 
       await runAgy({
         credentials,
@@ -776,7 +776,7 @@ ${chalk.bold.cyan('Claude Code Options (from `claude --help`):')}
     const {
       credentials
     } = await authAndSetupMachineIfNeeded();
-    await ensureDaemonRunning()
+    await ensureDaemonRunning(options.startedBy)
 
     // Start the CLI
     try {

--- a/packages/happy-cli/src/persistence.test.ts
+++ b/packages/happy-cli/src/persistence.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, linkSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -28,6 +28,13 @@ vi.mock('node:fs', async (importOriginal) => {
             }
             return actual.mkdirSync(path, options as any);
         },
+        linkSync: (existingPath: Parameters<typeof actual.linkSync>[0], newPath: Parameters<typeof actual.linkSync>[1]) => {
+            if (String(newPath) === mixedVersionRace.lockPath && !mixedVersionRace.installed) {
+                actual.writeFileSync(newPath, String(mixedVersionRace.legacyPid), 'utf-8');
+                mixedVersionRace.installed = true;
+            }
+            return actual.linkSync(existingPath, newPath);
+        },
     };
 });
 import {
@@ -36,6 +43,7 @@ import {
     readDaemonState,
     releaseDaemonLock,
     SandboxConfigSchema,
+    setDaemonPersistenceTestHooksForTests,
     writeDaemonState,
     writeDaemonStateIfOwned,
 } from './persistence';
@@ -127,6 +135,7 @@ describe('acquireDaemonLock', () => {
 
     beforeEach(() => {
         testDir = mkdtempSync(join(tmpdir(), 'happy-daemon-lock-'));
+        mockConfiguration.daemonStateFile = join(testDir, 'daemon.state.json');
         mockConfiguration.daemonLockFile = join(testDir, 'daemon.state.json.lock');
         mixedVersionRace.lockPath = '';
         mixedVersionRace.legacyPid = 0;
@@ -150,15 +159,40 @@ describe('acquireDaemonLock', () => {
         expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(lockContent);
     });
 
-    it('claims the shared directory atomically and publishes its generation payload before returning', async () => {
+    it('keeps the legacy fixed lock and state paths as regular files', async () => {
         const lockHandle = await acquireDaemonLock(1, 0);
 
         expect(lockHandle).not.toBeNull();
-        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8'))).toEqual({
+        expect(statSync(mockConfiguration.daemonLockFile).isFile()).toBe(true);
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
+
+        writeDaemonState(lockHandle!, {
             pid: process.pid,
+            httpPort: 4000,
+            startTime: 'fixed-path-compatible',
+            startedWithCliVersion: '1.2.2',
+        });
+        expect(statSync(mockConfiguration.daemonStateFile).isFile()).toBe(true);
+        expect(JSON.parse(readFileSync(mockConfiguration.daemonStateFile, 'utf-8'))).toMatchObject({
+            pid: process.pid,
+            httpPort: 4000,
             ownerToken: lockHandle!.ownerToken,
         });
-        expect(readdirSync(testDir).some(name => name.includes('.candidate.'))).toBe(false);
+        await releaseDaemonLock(lockHandle!);
+    });
+
+    it('clears a stale fixed state immediately after acquiring the fixed lock', async () => {
+        writeFileSync(mockConfiguration.daemonStateFile, JSON.stringify({
+            pid: 313131,
+            httpPort: 4999,
+            startTime: 'stale-predecessor',
+            startedWithCliVersion: '1.0.0',
+        }), 'utf-8');
+
+        const lockHandle = await acquireDaemonLock(1, 0);
+
+        expect(lockHandle).not.toBeNull();
+        expect(existsSync(mockConfiguration.daemonStateFile)).toBe(false);
         await releaseDaemonLock(lockHandle!);
     });
 
@@ -189,14 +223,63 @@ describe('acquireDaemonLock', () => {
         expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
     });
 
-    it('does not probe or reclaim legacy ownership without a generation token', async () => {
+    it('reclaims a dead legacy lock and its matching fixed state', async () => {
         const legacyPid = 424242;
+        writeFileSync(mockConfiguration.daemonStateFile, JSON.stringify({
+            pid: legacyPid,
+            httpPort: 4000,
+            startTime: 'legacy-dead',
+            startedWithCliVersion: '1.0.0',
+        }), 'utf-8');
         writeFileSync(mockConfiguration.daemonLockFile, String(legacyPid), 'utf-8');
-        const killSpy = vi.spyOn(process, 'kill');
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === legacyPid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
 
-        await expect(acquireDaemonLock(1, 0)).resolves.toBeNull();
-        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(legacyPid));
-        expect(killSpy).not.toHaveBeenCalled();
+        const lockHandle = await acquireDaemonLock(2, 0);
+
+        expect(lockHandle).not.toBeNull();
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
+        expect(existsSync(mockConfiguration.daemonStateFile)).toBe(false);
+        await releaseDaemonLock(lockHandle!);
+    });
+
+    it('recovers a dead legacy cleanup claimant after a crash', async () => {
+        const legacyPid = 424246;
+        const crashedReclaimerPid = 424247;
+        writeFileSync(mockConfiguration.daemonStateFile, JSON.stringify({
+            pid: legacyPid,
+            httpPort: 4000,
+            startTime: 'legacy-dead',
+            startedWithCliVersion: '1.0.0',
+        }), 'utf-8');
+        writeFileSync(mockConfiguration.daemonLockFile, String(legacyPid), 'utf-8');
+        const lockStat = statSync(mockConfiguration.daemonLockFile);
+        const fingerprint = `${lockStat.dev}:${lockStat.ino}:${lockStat.birthtimeMs}:${lockStat.size}`
+            .replace(/[^A-Za-z0-9._-]/g, '-');
+        const claimPath = `${mockConfiguration.daemonLockFile}.legacy-claim.${fingerprint}`;
+        linkSync(mockConfiguration.daemonLockFile, claimPath);
+        writeFileSync(`${claimPath}.guard`, JSON.stringify({ pid: crashedReclaimerPid, token: 'crashed' }), 'utf-8');
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === legacyPid || pid === crashedReclaimerPid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
+
+        const lockHandle = await acquireDaemonLock(2, 0);
+
+        expect(lockHandle).not.toBeNull();
+        expect(existsSync(claimPath)).toBe(false);
+        expect(existsSync(`${claimPath}.guard`)).toBe(false);
+        await releaseDaemonLock(lockHandle!);
     });
 
     it('does not treat an EPERM process probe as proof that the owner died', async () => {
@@ -209,18 +292,39 @@ describe('acquireDaemonLock', () => {
         });
 
         await expect(acquireDaemonLock(1, 0)).resolves.toBeNull();
-        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8')))
-            .toMatchObject({ ownerToken: lockHandle!.ownerToken });
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
+        expect(existsSync(lockHandle!.generationPath)).toBe(true);
     });
 });
 
 describe('daemon state ownership', () => {
     let testDir: string;
 
+    const createDeadGeneration = (pid: number, ownerToken: string, publishState: boolean) => {
+        const generationPath = join(testDir, `daemon.state.json.generation.${pid}.${ownerToken}`);
+        mkdirSync(generationPath);
+        const privateLock = join(generationPath, 'lock.pid');
+        writeFileSync(privateLock, String(pid), 'utf-8');
+        linkSync(privateLock, mockConfiguration.daemonLockFile);
+        if (publishState) {
+            const privateState = join(generationPath, 'state.json');
+            writeFileSync(privateState, JSON.stringify({
+                pid,
+                httpPort: 4000,
+                startTime: 'dead-generation',
+                startedWithCliVersion: '1.0.0',
+                ownerToken,
+            }), 'utf-8');
+            linkSync(privateState, mockConfiguration.daemonStateFile);
+        }
+        return generationPath;
+    };
+
     beforeEach(() => {
         testDir = mkdtempSync(join(tmpdir(), 'happy-daemon-state-'));
         mockConfiguration.daemonStateFile = join(testDir, 'daemon.state.json');
         mockConfiguration.daemonLockFile = join(testDir, 'daemon.state.json.lock');
+        setDaemonPersistenceTestHooksForTests({});
     });
 
     afterEach(() => {
@@ -228,7 +332,7 @@ describe('daemon state ownership', () => {
         rmSync(testDir, { recursive: true, force: true });
     });
 
-    it('refreshes state while both state and lock still belong to this daemon', async () => {
+    it('uses heartbeat as an ownership probe without rewriting immutable state', async () => {
         const lockHandle = await acquireDaemonLock(1, 0);
         expect(lockHandle).not.toBeNull();
         const ownedState = {
@@ -246,241 +350,314 @@ describe('daemon state ownership', () => {
         await expect(readDaemonState()).resolves.toEqual({
             ...ownedState,
             ownerToken: lockHandle!.ownerToken,
-            lastHeartbeat: 'later',
         });
         await releaseDaemonLock(lockHandle!);
     });
 
-    it('does not delete a successor lock generation that reused the predecessor PID', async () => {
-        const predecessorHandle = await acquireDaemonLock(1, 0);
-        expect(predecessorHandle).not.toBeNull();
-
-        const delayedRelease = releaseDaemonLock(predecessorHandle!);
-        expect(existsSync(mockConfiguration.daemonLockFile)).toBe(true);
-
-        renameSync(
-            mockConfiguration.daemonLockFile,
-            `${mockConfiguration.daemonLockFile}.retired.${predecessorHandle!.ownerToken}`,
-        );
-        const successorToken = 'same-pid-successor';
-        mkdirSync(mockConfiguration.daemonLockFile);
-        writeFileSync(
-            join(mockConfiguration.daemonLockFile, 'owner.json'),
-            JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
-            'utf-8',
-        );
-
-        await delayedRelease;
-        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8'))).toEqual({
-            pid: process.pid,
-            ownerToken: successorToken,
-        });
-    });
-
-    it('does not let a delayed stale-lock reclaimer retire the successor generation', async () => {
-        const staleHandle = await acquireDaemonLock(1, 0);
-        expect(staleHandle).not.toBeNull();
-        writeDaemonState(staleHandle!, {
-            pid: process.pid,
-            httpPort: 4000,
-            startTime: 'stale',
-            startedWithCliVersion: '1.2.2',
-        });
-        writeFileSync(
-            join(mockConfiguration.daemonLockFile, 'owner.json'),
-            JSON.stringify({ pid: Number.MAX_SAFE_INTEGER, ownerToken: staleHandle!.ownerToken }),
-            'utf-8',
-        );
-        vi.spyOn(process, 'kill').mockImplementation(() => {
-            const error = new Error('no such process') as NodeJS.ErrnoException;
-            error.code = 'ESRCH';
-            throw error;
-        });
-
-        const successorHandle = await acquireDaemonLock(2, 0);
-        expect(successorHandle).not.toBeNull();
-        expect(existsSync(staleHandle!.stateFile)).toBe(false);
-
-        // This models a reclaimer that observed the stale generation before
-        // the successor acquired the shared lock path, then resumes late.
-        await releaseDaemonLock(staleHandle!);
-
-        const contenderHandle = await acquireDaemonLock(1, 0);
-        expect(contenderHandle).toBeNull();
-
-        await releaseDaemonLock(successorHandle!);
-    });
-
-    it('does not retire a successor installed while stale ownership is being validated', async () => {
-        const staleHandle = await acquireDaemonLock(1, 0);
-        expect(staleHandle).not.toBeNull();
-        const stalePid = Number.MAX_SAFE_INTEGER;
-        writeFileSync(
-            join(mockConfiguration.daemonLockFile, 'owner.json'),
-            JSON.stringify({ pid: stalePid, ownerToken: staleHandle!.ownerToken }),
-            'utf-8',
-        );
-
-        const successorToken = 'successor-generation';
+    it('cannot let a delayed reclaimer touch successor H after final validation of G', async () => {
+        const stalePid = 424241;
+        createDeadGeneration(stalePid, 'generation-g', true);
         vi.spyOn(process, 'kill').mockImplementation((pid) => {
             if (pid === stalePid) {
-                renameSync(
-                    mockConfiguration.daemonLockFile,
-                    `${mockConfiguration.daemonLockFile}.retired.${staleHandle!.ownerToken}`,
-                );
-                mkdirSync(mockConfiguration.daemonLockFile);
-                writeFileSync(
-                    join(mockConfiguration.daemonLockFile, 'owner.json'),
-                    JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
-                    'utf-8',
-                );
-                const error = new Error('stale owner is dead') as NodeJS.ErrnoException;
+                const error = new Error('no such process') as NodeJS.ErrnoException;
                 error.code = 'ESRCH';
                 throw error;
             }
             return true;
         });
 
-        await expect(acquireDaemonLock(1, 0)).resolves.toBeNull();
-        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8'))).toEqual({
-            pid: process.pid,
-            ownerToken: successorToken,
+        let releaseDelayed!: () => void;
+        const delayedGate = new Promise<void>((resolve) => { releaseDelayed = resolve; });
+        let enteredFinalBoundary!: () => void;
+        const atFinalBoundary = new Promise<void>((resolve) => { enteredFinalBoundary = resolve; });
+        let hookCalls = 0;
+        setDaemonPersistenceTestHooksForTests({
+            beforeGenerationClaim: async () => {
+                hookCalls++;
+                if (hookCalls === 1) {
+                    enteredFinalBoundary();
+                    await delayedGate;
+                }
+            },
         });
+
+        const delayedReclaimer = acquireDaemonLock(1, 0);
+        await atFinalBoundary;
+        const successor = await acquireDaemonLock(2, 0);
+        expect(successor).not.toBeNull();
+        releaseDelayed();
+        await expect(delayedReclaimer).resolves.toBeNull();
+        expect(statSync(mockConfiguration.daemonLockFile).ino).toBe(statSync(successor!.lockFile).ino);
+
+        await releaseDaemonLock(successor!);
     });
 
-    it('does not publish a predecessor heartbeat after the same PID acquires a successor generation', async () => {
-        const predecessorHandle = await acquireDaemonLock(1, 0);
-        expect(predecessorHandle).not.toBeNull();
-        const predecessorState = {
-            pid: process.pid,
-            httpPort: 4000,
-            startTime: 'predecessor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(predecessorHandle!, predecessorState);
-
-        await releaseDaemonLock(predecessorHandle!);
-        const successorHandle = await acquireDaemonLock(1, 0);
-        expect(successorHandle).not.toBeNull();
-        const successorState = {
-            pid: process.pid,
-            httpPort: 4001,
-            startTime: 'successor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(successorHandle!, successorState);
-
-        await expect(writeDaemonStateIfOwned(predecessorHandle!, {
-            ...predecessorState,
-            lastHeartbeat: 'late',
-        })).resolves.toBe(false);
-        await expect(readDaemonState()).resolves.toEqual({
-            ...successorState,
-            ownerToken: successorHandle!.ownerToken,
+    it('allows exactly one of two real reclaimers to clean a dead generation', async () => {
+        const stalePid = 424242;
+        createDeadGeneration(stalePid, 'generation-race', true);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
         });
 
-        await releaseDaemonLock(successorHandle!);
+        const results = await Promise.all([
+            acquireDaemonLock(2, 0),
+            acquireDaemonLock(2, 0),
+        ]);
+        expect(results.filter(Boolean)).toHaveLength(1);
+        await releaseDaemonLock(results.find(Boolean)!);
     });
 
-    it('rejects a heartbeat when ownership changes after its initial validation', async () => {
-        const predecessorHandle = await acquireDaemonLock(1, 0);
-        expect(predecessorHandle).not.toBeNull();
-        const predecessorState = {
-            pid: process.pid,
-            httpPort: 4000,
-            startTime: 'predecessor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(predecessorHandle!, predecessorState);
-
-        const lateHeartbeat = writeDaemonStateIfOwned(predecessorHandle!, {
-            ...predecessorState,
-            lastHeartbeat: 'late',
+    it('recovers a dead generation that crashed after fixed-lock publication', async () => {
+        const stalePid = 424243;
+        createDeadGeneration(stalePid, 'lock-only', false);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
         });
-        renameSync(
-            mockConfiguration.daemonLockFile,
-            `${mockConfiguration.daemonLockFile}.retired.${predecessorHandle!.ownerToken}`,
-        );
-        const successorToken = 'heartbeat-successor';
-        mkdirSync(mockConfiguration.daemonLockFile);
-        writeFileSync(
-            join(mockConfiguration.daemonLockFile, 'owner.json'),
-            JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
-            'utf-8',
-        );
-        const successorHandle = {
-            ownerToken: successorToken,
-            pid: process.pid,
-            stateFile: `${mockConfiguration.daemonStateFile}.owner.${successorToken}`,
-            released: false,
-        };
-        const successorState = {
-            pid: process.pid,
-            httpPort: 4001,
-            startTime: 'successor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(successorHandle!, successorState);
 
-        await expect(lateHeartbeat).resolves.toBe(false);
-        await expect(readDaemonState()).resolves.toEqual({
-            ...successorState,
-            ownerToken: successorHandle.ownerToken,
-        });
+        const successor = await acquireDaemonLock(2, 0);
+        expect(successor).not.toBeNull();
+        expect(existsSync(mockConfiguration.daemonStateFile)).toBe(false);
+        await releaseDaemonLock(successor!);
     });
 
-    it('does not expose predecessor state while a successor generation is starting', async () => {
-        const predecessorHandle = await acquireDaemonLock(1, 0);
-        expect(predecessorHandle).not.toBeNull();
-        const predecessorState = {
-            pid: process.pid,
-            httpPort: 4000,
-            startTime: 'predecessor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(predecessorHandle!, predecessorState);
+    it('removes stale predecessor state while publishing a new fixed lock', async () => {
+        const stalePid = 424251;
+        writeFileSync(mockConfiguration.daemonStateFile, JSON.stringify({
+            pid: 313131,
+            httpPort: 4999,
+            startTime: 'stale-predecessor',
+            startedWithCliVersion: '1.0.0',
+        }), 'utf-8');
+        createDeadGeneration(stalePid, 'lock-with-stale-state', false);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
 
-        await releaseDaemonLock(predecessorHandle!);
-        const successorHandle = await acquireDaemonLock(1, 0);
-        expect(successorHandle).not.toBeNull();
+        const successor = await acquireDaemonLock(2, 0);
 
-        await expect(writeDaemonStateIfOwned(predecessorHandle!, {
-            ...predecessorState,
-            lastHeartbeat: 'late',
-        })).resolves.toBe(false);
-        await expect(readDaemonState()).resolves.toBeNull();
-
-        await releaseDaemonLock(successorHandle!);
+        expect(successor).not.toBeNull();
+        expect(existsSync(mockConfiguration.daemonStateFile)).toBe(false);
+        await releaseDaemonLock(successor!);
     });
 
-    it('retries a state read when ownership changes during the asynchronous read', async () => {
-        const predecessorHandle = await acquireDaemonLock(1, 0);
-        expect(predecessorHandle).not.toBeNull();
-        writeDaemonState(predecessorHandle!, {
-            pid: process.pid,
+    it('recovers state written privately before its fixed alias was published', async () => {
+        const stalePid = 424249;
+        const generationPath = createDeadGeneration(stalePid, 'private-state-only', false);
+        writeFileSync(join(generationPath, 'state.json'), JSON.stringify({
+            pid: stalePid,
             httpPort: 4000,
-            startTime: 'predecessor',
-            startedWithCliVersion: '1.2.2',
+            startTime: 'private-state-only',
+            startedWithCliVersion: '1.0.0',
+            ownerToken: 'private-state-only',
+        }), 'utf-8');
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
         });
 
-        const stateRead = readDaemonState();
-        await releaseDaemonLock(predecessorHandle!);
-        const successorHandle = await acquireDaemonLock(1, 0);
-        expect(successorHandle).not.toBeNull();
-        const successorState = {
-            pid: process.pid,
-            httpPort: 4001,
-            startTime: 'successor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(successorHandle!, successorState);
+        const successor = await acquireDaemonLock(2, 0);
+        expect(successor).not.toBeNull();
+        expect(existsSync(generationPath)).toBe(false);
+        await releaseDaemonLock(successor!);
+    });
 
-        await expect(stateRead).resolves.toEqual({
-            ...successorState,
-            ownerToken: successorHandle!.ownerToken,
+    it('resumes retirement immediately after the generation-directory claim', async () => {
+        const stalePid = 424250;
+        const generationPath = createDeadGeneration(stalePid, 'retirement-start', true);
+        const retiringPath = join(testDir, `daemon.state.json.retiring.${stalePid}.retirement-start`);
+        renameSync(generationPath, retiringPath);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
         });
 
-        await releaseDaemonLock(successorHandle!);
+        const successor = await acquireDaemonLock(2, 0);
+        expect(successor).not.toBeNull();
+        expect(existsSync(retiringPath)).toBe(false);
+        await releaseDaemonLock(successor!);
+    });
+
+    it('resumes retirement after fixed state was removed but before fixed lock', async () => {
+        const stalePid = 424244;
+        const generationPath = createDeadGeneration(stalePid, 'retirement-crash', true);
+        const retiringPath = join(testDir, `daemon.state.json.retiring.${stalePid}.retirement-crash`);
+        renameSync(generationPath, retiringPath);
+        unlinkSync(mockConfiguration.daemonStateFile);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
+
+        const successor = await acquireDaemonLock(2, 0);
+        expect(successor).not.toBeNull();
+        expect(existsSync(retiringPath)).toBe(false);
+        await releaseDaemonLock(successor!);
+    });
+
+    it('gives exactly one delayed reclaimer authority over an already-retiring generation', async () => {
+        const stalePid = 424252;
+        const generationPath = createDeadGeneration(stalePid, 'retiring-race', true);
+        const retiringPath = join(testDir, `daemon.state.json.retiring.${stalePid}.retiring-race`);
+        renameSync(generationPath, retiringPath);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
+
+        let releaseDelayed!: () => void;
+        const delayedGate = new Promise<void>((resolve) => { releaseDelayed = resolve; });
+        let enteredClaim!: () => void;
+        const atClaim = new Promise<void>((resolve) => { enteredClaim = resolve; });
+        let hookCalls = 0;
+        setDaemonPersistenceTestHooksForTests({
+            beforeGenerationClaim: async () => {
+                hookCalls++;
+                if (hookCalls === 1) {
+                    enteredClaim();
+                    await delayedGate;
+                }
+            },
+        });
+
+        const delayedReclaimer = acquireDaemonLock(1, 0);
+        await atClaim;
+        const successor = await acquireDaemonLock(2, 0);
+        expect(successor).not.toBeNull();
+        releaseDelayed();
+        await expect(delayedReclaimer).resolves.toBeNull();
+        expect(statSync(mockConfiguration.daemonLockFile).ino).toBe(statSync(successor!.lockFile).ino);
+        await releaseDaemonLock(successor!);
+    });
+
+    it('does not let delayed orphan GC remove a concurrently published successor state', async () => {
+        const stalePid = 424253;
+        const orphanPath = join(testDir, `daemon.state.json.generation.${stalePid}.orphan-g`);
+        mkdirSync(orphanPath);
+        writeFileSync(join(orphanPath, 'lock.pid'), String(stalePid), 'utf-8');
+        writeFileSync(join(orphanPath, 'state.json'), JSON.stringify({ pid: stalePid }), 'utf-8');
+        linkSync(join(orphanPath, 'state.json'), mockConfiguration.daemonStateFile);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
+
+        let resumeGc!: () => void;
+        const gcGate = new Promise<void>((resolve) => { resumeGc = resolve; });
+        let gcObserved!: () => void;
+        const atOrphanBoundary = new Promise<void>((resolve) => { gcObserved = resolve; });
+        setDaemonPersistenceTestHooksForTests({
+            beforeOrphanClaim: async () => {
+                gcObserved();
+                await gcGate;
+            },
+        });
+        const delayedGc = acquireDaemonLock(1, 0);
+        await atOrphanBoundary;
+
+        const successorPath = join(testDir, `daemon.state.json.generation.${process.pid}.successor-h`);
+        mkdirSync(successorPath);
+        writeFileSync(join(successorPath, 'lock.pid'), String(process.pid), 'utf-8');
+        linkSync(join(successorPath, 'lock.pid'), mockConfiguration.daemonLockFile);
+        unlinkSync(mockConfiguration.daemonStateFile);
+        const successorState = join(successorPath, 'state.json');
+        writeFileSync(successorState, JSON.stringify({ pid: process.pid, ownerToken: 'successor-h' }), 'utf-8');
+        linkSync(successorState, mockConfiguration.daemonStateFile);
+
+        resumeGc();
+        await expect(delayedGc).resolves.toBeNull();
+        expect(statSync(mockConfiguration.daemonLockFile).ino).toBe(statSync(join(successorPath, 'lock.pid')).ino);
+        expect(statSync(mockConfiguration.daemonStateFile).ino).toBe(statSync(successorState).ino);
+        expect(existsSync(orphanPath)).toBe(false);
+    });
+
+    it('garbage-collects dead temp and rollback orphans but preserves live ones', async () => {
+        const deadPid = 424245;
+        const deadTemp = join(testDir, `daemon.state.json.generation.${deadPid}.temp-crash.tmp`);
+        const deadRollback = join(testDir, `daemon.state.json.generation.${deadPid}.rollback-orphan`);
+        const liveOrphan = join(testDir, `daemon.state.json.generation.${process.pid}.live-orphan`);
+        for (const path of [deadTemp, deadRollback, liveOrphan]) {
+            mkdirSync(path);
+            const pid = path === liveOrphan ? process.pid : deadPid;
+            if (path !== deadTemp) {
+                writeFileSync(join(path, 'lock.pid'), String(pid), 'utf-8');
+            }
+        }
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === deadPid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
+
+        const handle = await acquireDaemonLock(1, 0);
+
+        expect(handle).not.toBeNull();
+        expect(existsSync(deadTemp)).toBe(false);
+        expect(existsSync(deadRollback)).toBe(false);
+        expect(existsSync(liveOrphan)).toBe(true);
+        await releaseDaemonLock(handle!);
+    });
+
+    it('supports old-binary fixed-path reads and cleans its rollback orphan later', async () => {
+        const stalePid = 424248;
+        const generationPath = createDeadGeneration(stalePid, 'rollback-smoke', true);
+        const oldBinaryState = JSON.parse(readFileSync(mockConfiguration.daemonStateFile, 'utf-8'));
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(stalePid));
+        expect(oldBinaryState).toMatchObject({ pid: stalePid, httpPort: 4000 });
+
+        // Baseline release behavior removes only the two historical fixed files.
+        unlinkSync(mockConfiguration.daemonStateFile);
+        unlinkSync(mockConfiguration.daemonLockFile);
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                const error = new Error('no such process') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
+
+        const successor = await acquireDaemonLock(1, 0);
+        expect(successor).not.toBeNull();
+        expect(existsSync(generationPath)).toBe(false);
+        await releaseDaemonLock(successor!);
     });
 
     it('leaves PID-only legacy ownership untouched because a PID is not a generation', async () => {
@@ -511,7 +688,7 @@ describe('daemon state ownership', () => {
         await expect(readDaemonState()).resolves.toBeNull();
     });
 
-    it('makes the current generation unreadable as soon as scoped cleanup retires it', async () => {
+    it('makes the current generation unreadable when scoped cleanup retires it', async () => {
         const lockHandle = await acquireDaemonLock(1, 0);
         expect(lockHandle).not.toBeNull();
         writeDaemonState(lockHandle!, {
@@ -528,52 +705,18 @@ describe('daemon state ownership', () => {
         expect(existsSync(lockHandle!.stateFile)).toBe(false);
     });
 
-    it('cleans only the predecessor generation after the same PID acquires a successor', async () => {
-        const predecessorHandle = await acquireDaemonLock(1, 0);
-        expect(predecessorHandle).not.toBeNull();
-        writeDaemonState(predecessorHandle!, {
-            pid: process.pid,
-            httpPort: 4000,
-            startTime: 'predecessor',
-            startedWithCliVersion: '1.2.2',
-        });
-
-        const delayedCleanup = clearDaemonState(predecessorHandle!);
-        expect(existsSync(predecessorHandle!.stateFile)).toBe(true);
-
-        renameSync(
-            mockConfiguration.daemonLockFile,
-            `${mockConfiguration.daemonLockFile}.retired.${predecessorHandle!.ownerToken}`,
-        );
-        const successorToken = 'cleanup-successor';
-        mkdirSync(mockConfiguration.daemonLockFile);
-        writeFileSync(
-            join(mockConfiguration.daemonLockFile, 'owner.json'),
-            JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
-            'utf-8',
-        );
-        const successorHandle = {
-            ownerToken: successorToken,
-            pid: process.pid,
-            stateFile: `${mockConfiguration.daemonStateFile}.owner.${successorToken}`,
-            released: false,
-        };
-        const successorState = {
-            pid: process.pid,
-            httpPort: 4001,
-            startTime: 'successor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(successorHandle, successorState);
-
-        await delayedCleanup;
-
-        expect(existsSync(predecessorHandle!.stateFile)).toBe(false);
-        await expect(readDaemonState()).resolves.toEqual({
-            ...successorState,
-            ownerToken: successorHandle.ownerToken,
-        });
-        const contenderHandle = await acquireDaemonLock(1, 0);
-        expect(contenderHandle).toBeNull();
+    it('keeps generation artifacts bounded across repeated acquire and release', async () => {
+        for (let index = 0; index < 10; index++) {
+            const handle = await acquireDaemonLock(1, 0);
+            expect(handle).not.toBeNull();
+            writeDaemonState(handle!, {
+                pid: process.pid,
+                httpPort: 4000 + index,
+                startTime: `iteration-${index}`,
+                startedWithCliVersion: '1.2.2',
+            });
+            await releaseDaemonLock(handle!);
+        }
+        expect(readdirSync(testDir).filter((name) => name.includes('.generation.') || name.includes('.retiring.'))).toEqual([]);
     });
 });

--- a/packages/happy-cli/src/persistence.test.ts
+++ b/packages/happy-cli/src/persistence.test.ts
@@ -1,7 +1,35 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mixedVersionRace = vi.hoisted(() => ({
+    lockPath: '',
+    legacyPid: 0,
+    installed: false,
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:fs')>();
+    return {
+        ...actual,
+        existsSync: (path: Parameters<typeof actual.existsSync>[0]) => {
+            const existed = actual.existsSync(path);
+            if (String(path) === mixedVersionRace.lockPath && !existed && !mixedVersionRace.installed) {
+                actual.writeFileSync(path, String(mixedVersionRace.legacyPid), 'utf-8');
+                mixedVersionRace.installed = true;
+            }
+            return existed;
+        },
+        mkdirSync: (path: Parameters<typeof actual.mkdirSync>[0], options?: Parameters<typeof actual.mkdirSync>[1]) => {
+            if (String(path) === mixedVersionRace.lockPath && !mixedVersionRace.installed) {
+                actual.writeFileSync(path, String(mixedVersionRace.legacyPid), 'utf-8');
+                mixedVersionRace.installed = true;
+            }
+            return actual.mkdirSync(path, options as any);
+        },
+    };
+});
 import {
     acquireDaemonLock,
     clearDaemonState,
@@ -100,6 +128,9 @@ describe('acquireDaemonLock', () => {
     beforeEach(() => {
         testDir = mkdtempSync(join(tmpdir(), 'happy-daemon-lock-'));
         mockConfiguration.daemonLockFile = join(testDir, 'daemon.state.json.lock');
+        mixedVersionRace.lockPath = '';
+        mixedVersionRace.legacyPid = 0;
+        mixedVersionRace.installed = false;
     });
 
     afterEach(() => {
@@ -110,26 +141,24 @@ describe('acquireDaemonLock', () => {
         ['empty', ''],
         ['non-numeric', 'not-a-pid'],
         ['zero-pid', '0'],
-    ])('treats a %s lock file as stale and acquires a fresh lock', async (_label, lockContent) => {
+    ])('does not reclaim an untrusted %s lock observation', async (_label, lockContent) => {
         writeFileSync(mockConfiguration.daemonLockFile, lockContent, 'utf-8');
 
-        // Lock creation is atomic including the PID payload (temp file +
-        // hard link), so a payload-less lock can never belong to a live
-        // acquirer and is reclaimed on first sight.
-        const lockHandle = await acquireDaemonLock(2, 0);
+        const lockHandle = await acquireDaemonLock(1, 0);
 
-        expect(lockHandle).not.toBeNull();
-        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
-        await releaseDaemonLock(lockHandle!);
-        expect(existsSync(mockConfiguration.daemonLockFile)).toBe(false);
+        expect(lockHandle).toBeNull();
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(lockContent);
     });
 
-    it('creates the lock with its PID payload atomically (no temp file left behind)', async () => {
+    it('claims the shared directory atomically and publishes its generation payload before returning', async () => {
         const lockHandle = await acquireDaemonLock(1, 0);
 
         expect(lockHandle).not.toBeNull();
-        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
-        expect(existsSync(`${mockConfiguration.daemonLockFile}.${process.pid}.tmp`)).toBe(false);
+        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8'))).toEqual({
+            pid: process.pid,
+            ownerToken: lockHandle!.ownerToken,
+        });
+        expect(readdirSync(testDir).some(name => name.includes('.candidate.'))).toBe(false);
         await releaseDaemonLock(lockHandle!);
     });
 
@@ -140,6 +169,48 @@ describe('acquireDaemonLock', () => {
 
         expect(lockHandle).toBeNull();
         expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
+    });
+
+    it('does not reclaim an ownerless directory left during generation publication', async () => {
+        mkdirSync(mockConfiguration.daemonLockFile);
+
+        await expect(acquireDaemonLock(1, 0)).resolves.toBeNull();
+        expect(existsSync(mockConfiguration.daemonLockFile)).toBe(true);
+        expect(readdirSync(mockConfiguration.daemonLockFile)).toEqual([]);
+    });
+
+    it('does not overwrite a legacy lock installed at the mixed-version acquisition boundary', async () => {
+        mixedVersionRace.lockPath = mockConfiguration.daemonLockFile;
+        mixedVersionRace.legacyPid = process.pid;
+
+        const lockHandle = await acquireDaemonLock(1, 0);
+
+        expect(lockHandle).toBeNull();
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
+    });
+
+    it('does not probe or reclaim legacy ownership without a generation token', async () => {
+        const legacyPid = 424242;
+        writeFileSync(mockConfiguration.daemonLockFile, String(legacyPid), 'utf-8');
+        const killSpy = vi.spyOn(process, 'kill');
+
+        await expect(acquireDaemonLock(1, 0)).resolves.toBeNull();
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(legacyPid));
+        expect(killSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not treat an EPERM process probe as proof that the owner died', async () => {
+        const lockHandle = await acquireDaemonLock(1, 0);
+        expect(lockHandle).not.toBeNull();
+        vi.spyOn(process, 'kill').mockImplementation(() => {
+            const error = new Error('operation not permitted') as NodeJS.ErrnoException;
+            error.code = 'EPERM';
+            throw error;
+        });
+
+        await expect(acquireDaemonLock(1, 0)).resolves.toBeNull();
+        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8')))
+            .toMatchObject({ ownerToken: lockHandle!.ownerToken });
     });
 });
 
@@ -153,112 +224,356 @@ describe('daemon state ownership', () => {
     });
 
     afterEach(() => {
+        vi.restoreAllMocks();
         rmSync(testDir, { recursive: true, force: true });
     });
 
     it('refreshes state while both state and lock still belong to this daemon', async () => {
+        const lockHandle = await acquireDaemonLock(1, 0);
+        expect(lockHandle).not.toBeNull();
         const ownedState = {
             pid: process.pid,
             httpPort: 4000,
             startTime: 'owner',
             startedWithCliVersion: '1.2.2',
         };
-        writeDaemonState(ownedState);
-        writeFileSync(mockConfiguration.daemonLockFile, String(process.pid), 'utf-8');
+        writeDaemonState(lockHandle!, ownedState);
 
-        await expect(writeDaemonStateIfOwned({
+        await expect(writeDaemonStateIfOwned(lockHandle!, {
             ...ownedState,
             lastHeartbeat: 'later',
         })).resolves.toBe(true);
         await expect(readDaemonState()).resolves.toEqual({
             ...ownedState,
+            ownerToken: lockHandle!.ownerToken,
             lastHeartbeat: 'later',
+        });
+        await releaseDaemonLock(lockHandle!);
+    });
+
+    it('does not delete a successor lock generation that reused the predecessor PID', async () => {
+        const predecessorHandle = await acquireDaemonLock(1, 0);
+        expect(predecessorHandle).not.toBeNull();
+
+        const delayedRelease = releaseDaemonLock(predecessorHandle!);
+        expect(existsSync(mockConfiguration.daemonLockFile)).toBe(true);
+
+        renameSync(
+            mockConfiguration.daemonLockFile,
+            `${mockConfiguration.daemonLockFile}.retired.${predecessorHandle!.ownerToken}`,
+        );
+        const successorToken = 'same-pid-successor';
+        mkdirSync(mockConfiguration.daemonLockFile);
+        writeFileSync(
+            join(mockConfiguration.daemonLockFile, 'owner.json'),
+            JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
+            'utf-8',
+        );
+
+        await delayedRelease;
+        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8'))).toEqual({
+            pid: process.pid,
+            ownerToken: successorToken,
         });
     });
 
-    it('does not overwrite state owned by a successor daemon', async () => {
-        const successorState = {
-            pid: process.pid + 1,
-            httpPort: 4001,
-            startTime: 'successor',
-            startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(successorState);
-
-        const wroteHeartbeat = await writeDaemonStateIfOwned({
+    it('does not let a delayed stale-lock reclaimer retire the successor generation', async () => {
+        const staleHandle = await acquireDaemonLock(1, 0);
+        expect(staleHandle).not.toBeNull();
+        writeDaemonState(staleHandle!, {
             pid: process.pid,
             httpPort: 4000,
-            startTime: 'predecessor',
+            startTime: 'stale',
             startedWithCliVersion: '1.2.2',
-            lastHeartbeat: 'later',
+        });
+        writeFileSync(
+            join(mockConfiguration.daemonLockFile, 'owner.json'),
+            JSON.stringify({ pid: Number.MAX_SAFE_INTEGER, ownerToken: staleHandle!.ownerToken }),
+            'utf-8',
+        );
+        vi.spyOn(process, 'kill').mockImplementation(() => {
+            const error = new Error('no such process') as NodeJS.ErrnoException;
+            error.code = 'ESRCH';
+            throw error;
         });
 
-        expect(wroteHeartbeat).toBe(false);
-        await expect(readDaemonState()).resolves.toEqual(successorState);
+        const successorHandle = await acquireDaemonLock(2, 0);
+        expect(successorHandle).not.toBeNull();
+        expect(existsSync(staleHandle!.stateFile)).toBe(false);
+
+        // This models a reclaimer that observed the stale generation before
+        // the successor acquired the shared lock path, then resumes late.
+        await releaseDaemonLock(staleHandle!);
+
+        const contenderHandle = await acquireDaemonLock(1, 0);
+        expect(contenderHandle).toBeNull();
+
+        await releaseDaemonLock(successorHandle!);
     });
 
-    it('does not write a heartbeat after lock ownership moves to a successor', async () => {
+    it('does not retire a successor installed while stale ownership is being validated', async () => {
+        const staleHandle = await acquireDaemonLock(1, 0);
+        expect(staleHandle).not.toBeNull();
+        const stalePid = Number.MAX_SAFE_INTEGER;
+        writeFileSync(
+            join(mockConfiguration.daemonLockFile, 'owner.json'),
+            JSON.stringify({ pid: stalePid, ownerToken: staleHandle!.ownerToken }),
+            'utf-8',
+        );
+
+        const successorToken = 'successor-generation';
+        vi.spyOn(process, 'kill').mockImplementation((pid) => {
+            if (pid === stalePid) {
+                renameSync(
+                    mockConfiguration.daemonLockFile,
+                    `${mockConfiguration.daemonLockFile}.retired.${staleHandle!.ownerToken}`,
+                );
+                mkdirSync(mockConfiguration.daemonLockFile);
+                writeFileSync(
+                    join(mockConfiguration.daemonLockFile, 'owner.json'),
+                    JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
+                    'utf-8',
+                );
+                const error = new Error('stale owner is dead') as NodeJS.ErrnoException;
+                error.code = 'ESRCH';
+                throw error;
+            }
+            return true;
+        });
+
+        await expect(acquireDaemonLock(1, 0)).resolves.toBeNull();
+        expect(JSON.parse(readFileSync(join(mockConfiguration.daemonLockFile, 'owner.json'), 'utf-8'))).toEqual({
+            pid: process.pid,
+            ownerToken: successorToken,
+        });
+    });
+
+    it('does not publish a predecessor heartbeat after the same PID acquires a successor generation', async () => {
+        const predecessorHandle = await acquireDaemonLock(1, 0);
+        expect(predecessorHandle).not.toBeNull();
         const predecessorState = {
             pid: process.pid,
             httpPort: 4000,
             startTime: 'predecessor',
             startedWithCliVersion: '1.2.2',
         };
-        writeDaemonState(predecessorState);
-        writeFileSync(mockConfiguration.daemonLockFile, String(process.pid + 1), 'utf-8');
+        writeDaemonState(predecessorHandle!, predecessorState);
 
-        const wroteHeartbeat = await writeDaemonStateIfOwned({
-            ...predecessorState,
-            lastHeartbeat: 'later',
-        });
-
-        expect(wroteHeartbeat).toBe(false);
-        await expect(readDaemonState()).resolves.toEqual(predecessorState);
-    });
-
-    it('does not clear state or lock owned by a successor daemon', async () => {
-        const successorPid = process.pid + 1;
+        await releaseDaemonLock(predecessorHandle!);
+        const successorHandle = await acquireDaemonLock(1, 0);
+        expect(successorHandle).not.toBeNull();
         const successorState = {
-            pid: successorPid,
+            pid: process.pid,
             httpPort: 4001,
             startTime: 'successor',
             startedWithCliVersion: '1.2.2',
         };
-        writeDaemonState(successorState);
-        writeFileSync(mockConfiguration.daemonLockFile, String(successorPid), 'utf-8');
+        writeDaemonState(successorHandle!, successorState);
 
-        await clearDaemonState(process.pid);
+        await expect(writeDaemonStateIfOwned(predecessorHandle!, {
+            ...predecessorState,
+            lastHeartbeat: 'late',
+        })).resolves.toBe(false);
+        await expect(readDaemonState()).resolves.toEqual({
+            ...successorState,
+            ownerToken: successorHandle!.ownerToken,
+        });
 
-        await expect(readDaemonState()).resolves.toEqual(successorState);
-        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(successorPid));
+        await releaseDaemonLock(successorHandle!);
     });
 
-    it('clears state and lock that still belong to the expected daemon', async () => {
-        const ownedState = {
+    it('rejects a heartbeat when ownership changes after its initial validation', async () => {
+        const predecessorHandle = await acquireDaemonLock(1, 0);
+        expect(predecessorHandle).not.toBeNull();
+        const predecessorState = {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'predecessor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(predecessorHandle!, predecessorState);
+
+        const lateHeartbeat = writeDaemonStateIfOwned(predecessorHandle!, {
+            ...predecessorState,
+            lastHeartbeat: 'late',
+        });
+        renameSync(
+            mockConfiguration.daemonLockFile,
+            `${mockConfiguration.daemonLockFile}.retired.${predecessorHandle!.ownerToken}`,
+        );
+        const successorToken = 'heartbeat-successor';
+        mkdirSync(mockConfiguration.daemonLockFile);
+        writeFileSync(
+            join(mockConfiguration.daemonLockFile, 'owner.json'),
+            JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
+            'utf-8',
+        );
+        const successorHandle = {
+            ownerToken: successorToken,
+            pid: process.pid,
+            stateFile: `${mockConfiguration.daemonStateFile}.owner.${successorToken}`,
+            released: false,
+        };
+        const successorState = {
+            pid: process.pid,
+            httpPort: 4001,
+            startTime: 'successor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(successorHandle!, successorState);
+
+        await expect(lateHeartbeat).resolves.toBe(false);
+        await expect(readDaemonState()).resolves.toEqual({
+            ...successorState,
+            ownerToken: successorHandle.ownerToken,
+        });
+    });
+
+    it('does not expose predecessor state while a successor generation is starting', async () => {
+        const predecessorHandle = await acquireDaemonLock(1, 0);
+        expect(predecessorHandle).not.toBeNull();
+        const predecessorState = {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'predecessor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(predecessorHandle!, predecessorState);
+
+        await releaseDaemonLock(predecessorHandle!);
+        const successorHandle = await acquireDaemonLock(1, 0);
+        expect(successorHandle).not.toBeNull();
+
+        await expect(writeDaemonStateIfOwned(predecessorHandle!, {
+            ...predecessorState,
+            lastHeartbeat: 'late',
+        })).resolves.toBe(false);
+        await expect(readDaemonState()).resolves.toBeNull();
+
+        await releaseDaemonLock(successorHandle!);
+    });
+
+    it('retries a state read when ownership changes during the asynchronous read', async () => {
+        const predecessorHandle = await acquireDaemonLock(1, 0);
+        expect(predecessorHandle).not.toBeNull();
+        writeDaemonState(predecessorHandle!, {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'predecessor',
+            startedWithCliVersion: '1.2.2',
+        });
+
+        const stateRead = readDaemonState();
+        await releaseDaemonLock(predecessorHandle!);
+        const successorHandle = await acquireDaemonLock(1, 0);
+        expect(successorHandle).not.toBeNull();
+        const successorState = {
+            pid: process.pid,
+            httpPort: 4001,
+            startTime: 'successor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(successorHandle!, successorState);
+
+        await expect(stateRead).resolves.toEqual({
+            ...successorState,
+            ownerToken: successorHandle!.ownerToken,
+        });
+
+        await releaseDaemonLock(successorHandle!);
+    });
+
+    it('leaves PID-only legacy ownership untouched because a PID is not a generation', async () => {
+        const legacyState = {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'legacy',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeFileSync(mockConfiguration.daemonStateFile, JSON.stringify(legacyState), 'utf-8');
+        writeFileSync(mockConfiguration.daemonLockFile, String(process.pid), 'utf-8');
+
+        await clearDaemonState(legacyState);
+
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
+        await expect(readDaemonState()).resolves.toEqual(legacyState);
+    });
+
+    it('does not combine a legacy lock owner with a predecessor fixed-state snapshot', async () => {
+        writeFileSync(mockConfiguration.daemonStateFile, JSON.stringify({
+            pid: 1111,
+            httpPort: 4000,
+            startTime: 'predecessor',
+            startedWithCliVersion: '1.0.0',
+        }), 'utf-8');
+        writeFileSync(mockConfiguration.daemonLockFile, '2222', 'utf-8');
+
+        await expect(readDaemonState()).resolves.toBeNull();
+    });
+
+    it('makes the current generation unreadable as soon as scoped cleanup retires it', async () => {
+        const lockHandle = await acquireDaemonLock(1, 0);
+        expect(lockHandle).not.toBeNull();
+        writeDaemonState(lockHandle!, {
             pid: process.pid,
             httpPort: 4000,
             startTime: 'owner',
             startedWithCliVersion: '1.2.2',
-        };
-        writeDaemonState(ownedState);
-        writeFileSync(mockConfiguration.daemonLockFile, String(process.pid), 'utf-8');
+        });
 
-        await clearDaemonState(process.pid);
+        await clearDaemonState(lockHandle!);
 
+        await expect(readDaemonState()).resolves.toBeNull();
         expect(existsSync(mockConfiguration.daemonStateFile)).toBe(false);
-        expect(existsSync(mockConfiguration.daemonLockFile)).toBe(false);
+        expect(existsSync(lockHandle!.stateFile)).toBe(false);
     });
 
-    it('does not delete a successor lock when releasing a predecessor handle', async () => {
+    it('cleans only the predecessor generation after the same PID acquires a successor', async () => {
         const predecessorHandle = await acquireDaemonLock(1, 0);
         expect(predecessorHandle).not.toBeNull();
+        writeDaemonState(predecessorHandle!, {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'predecessor',
+            startedWithCliVersion: '1.2.2',
+        });
 
-        unlinkSync(mockConfiguration.daemonLockFile);
-        const successorPid = process.pid + 1;
-        writeFileSync(mockConfiguration.daemonLockFile, String(successorPid), 'utf-8');
+        const delayedCleanup = clearDaemonState(predecessorHandle!);
+        expect(existsSync(predecessorHandle!.stateFile)).toBe(true);
 
-        await releaseDaemonLock(predecessorHandle!);
+        renameSync(
+            mockConfiguration.daemonLockFile,
+            `${mockConfiguration.daemonLockFile}.retired.${predecessorHandle!.ownerToken}`,
+        );
+        const successorToken = 'cleanup-successor';
+        mkdirSync(mockConfiguration.daemonLockFile);
+        writeFileSync(
+            join(mockConfiguration.daemonLockFile, 'owner.json'),
+            JSON.stringify({ pid: process.pid, ownerToken: successorToken }),
+            'utf-8',
+        );
+        const successorHandle = {
+            ownerToken: successorToken,
+            pid: process.pid,
+            stateFile: `${mockConfiguration.daemonStateFile}.owner.${successorToken}`,
+            released: false,
+        };
+        const successorState = {
+            pid: process.pid,
+            httpPort: 4001,
+            startTime: 'successor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(successorHandle, successorState);
 
-        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(successorPid));
+        await delayedCleanup;
+
+        expect(existsSync(predecessorHandle!.stateFile)).toBe(false);
+        await expect(readDaemonState()).resolves.toEqual({
+            ...successorState,
+            ownerToken: successorHandle.ownerToken,
+        });
+        const contenderHandle = await acquireDaemonLock(1, 0);
+        expect(contenderHandle).toBeNull();
     });
 });

--- a/packages/happy-cli/src/persistence.test.ts
+++ b/packages/happy-cli/src/persistence.test.ts
@@ -1,8 +1,16 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { acquireDaemonLock, releaseDaemonLock, SandboxConfigSchema } from './persistence';
+import {
+    acquireDaemonLock,
+    clearDaemonState,
+    readDaemonState,
+    releaseDaemonLock,
+    SandboxConfigSchema,
+    writeDaemonState,
+    writeDaemonStateIfOwned,
+} from './persistence';
 
 const mockConfiguration = vi.hoisted(() => ({
     daemonLockFile: '',
@@ -132,5 +140,125 @@ describe('acquireDaemonLock', () => {
 
         expect(lockHandle).toBeNull();
         expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(process.pid));
+    });
+});
+
+describe('daemon state ownership', () => {
+    let testDir: string;
+
+    beforeEach(() => {
+        testDir = mkdtempSync(join(tmpdir(), 'happy-daemon-state-'));
+        mockConfiguration.daemonStateFile = join(testDir, 'daemon.state.json');
+        mockConfiguration.daemonLockFile = join(testDir, 'daemon.state.json.lock');
+    });
+
+    afterEach(() => {
+        rmSync(testDir, { recursive: true, force: true });
+    });
+
+    it('refreshes state while both state and lock still belong to this daemon', async () => {
+        const ownedState = {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'owner',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(ownedState);
+        writeFileSync(mockConfiguration.daemonLockFile, String(process.pid), 'utf-8');
+
+        await expect(writeDaemonStateIfOwned({
+            ...ownedState,
+            lastHeartbeat: 'later',
+        })).resolves.toBe(true);
+        await expect(readDaemonState()).resolves.toEqual({
+            ...ownedState,
+            lastHeartbeat: 'later',
+        });
+    });
+
+    it('does not overwrite state owned by a successor daemon', async () => {
+        const successorState = {
+            pid: process.pid + 1,
+            httpPort: 4001,
+            startTime: 'successor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(successorState);
+
+        const wroteHeartbeat = await writeDaemonStateIfOwned({
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'predecessor',
+            startedWithCliVersion: '1.2.2',
+            lastHeartbeat: 'later',
+        });
+
+        expect(wroteHeartbeat).toBe(false);
+        await expect(readDaemonState()).resolves.toEqual(successorState);
+    });
+
+    it('does not write a heartbeat after lock ownership moves to a successor', async () => {
+        const predecessorState = {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'predecessor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(predecessorState);
+        writeFileSync(mockConfiguration.daemonLockFile, String(process.pid + 1), 'utf-8');
+
+        const wroteHeartbeat = await writeDaemonStateIfOwned({
+            ...predecessorState,
+            lastHeartbeat: 'later',
+        });
+
+        expect(wroteHeartbeat).toBe(false);
+        await expect(readDaemonState()).resolves.toEqual(predecessorState);
+    });
+
+    it('does not clear state or lock owned by a successor daemon', async () => {
+        const successorPid = process.pid + 1;
+        const successorState = {
+            pid: successorPid,
+            httpPort: 4001,
+            startTime: 'successor',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(successorState);
+        writeFileSync(mockConfiguration.daemonLockFile, String(successorPid), 'utf-8');
+
+        await clearDaemonState(process.pid);
+
+        await expect(readDaemonState()).resolves.toEqual(successorState);
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(successorPid));
+    });
+
+    it('clears state and lock that still belong to the expected daemon', async () => {
+        const ownedState = {
+            pid: process.pid,
+            httpPort: 4000,
+            startTime: 'owner',
+            startedWithCliVersion: '1.2.2',
+        };
+        writeDaemonState(ownedState);
+        writeFileSync(mockConfiguration.daemonLockFile, String(process.pid), 'utf-8');
+
+        await clearDaemonState(process.pid);
+
+        expect(existsSync(mockConfiguration.daemonStateFile)).toBe(false);
+        expect(existsSync(mockConfiguration.daemonLockFile)).toBe(false);
+    });
+
+    it('does not delete a successor lock when releasing a predecessor handle', async () => {
+        const predecessorHandle = await acquireDaemonLock(1, 0);
+        expect(predecessorHandle).not.toBeNull();
+
+        unlinkSync(mockConfiguration.daemonLockFile);
+        const successorPid = process.pid + 1;
+        writeFileSync(mockConfiguration.daemonLockFile, String(successorPid), 'utf-8');
+
+        await releaseDaemonLock(predecessorHandle!);
+
+        expect(readFileSync(mockConfiguration.daemonLockFile, 'utf-8')).toBe(String(successorPid));
     });
 });

--- a/packages/happy-cli/src/persistence.ts
+++ b/packages/happy-cli/src/persistence.ts
@@ -5,10 +5,10 @@
  */
 
 import { readFile, writeFile, mkdir, open, unlink, rename, stat } from 'node:fs/promises'
-import { existsSync, writeFileSync, readFileSync, unlinkSync, renameSync, mkdirSync, rmSync, statSync } from 'node:fs'
+import { existsSync, writeFileSync, readFileSync, unlinkSync, renameSync, mkdirSync, rmSync, lstatSync, linkSync, readdirSync } from 'node:fs'
 import { constants } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { configuration } from '@/configuration'
 import * as z from 'zod';
 import { encodeBase64, decodeBase64 } from '@/api/encryption';
@@ -299,32 +299,27 @@ export async function clearMachineId(): Promise<void> {
  */
 export async function readDaemonState(): Promise<DaemonLocallyPersistedState | null> {
   for (let attempt = 0; attempt < 3; attempt++) {
-    const before = readDaemonLockObservation();
-    if (!before?.owner) {
+    const before = observeDaemonLock();
+    if (!before || before.kind === 'invalid') {
       return null;
     }
-
-    const isLegacy = before.owner.ownerToken.startsWith('legacy-');
-    const stateFile = isLegacy
-      ? configuration.daemonStateFile
-      : `${configuration.daemonStateFile}.owner.${before.owner.ownerToken}`;
 
     let content: string;
     try {
-      content = await readFile(stateFile, 'utf-8');
+      content = await readFile(configuration.daemonStateFile, 'utf-8');
     } catch (error: any) {
-      const after = readDaemonLockObservation();
-      if (after?.generationToken !== before.generationToken) {
+      const after = observeDaemonLock();
+      if (!sameObservation(before, after)) {
         continue;
       }
       if (error?.code !== 'ENOENT') {
-        console.error(`[PERSISTENCE] Daemon state file corrupted: ${stateFile}`, error);
+        console.error(`[PERSISTENCE] Daemon state file corrupted: ${configuration.daemonStateFile}`, error);
       }
       return null;
     }
 
-    const after = readDaemonLockObservation();
-    if (after?.generationToken !== before.generationToken) {
+    const after = observeDaemonLock();
+    if (!sameObservation(before, after)) {
       continue;
     }
 
@@ -333,16 +328,25 @@ export async function readDaemonState(): Promise<DaemonLocallyPersistedState | n
       if (
         !Number.isSafeInteger(state.pid)
         || state.pid <= 0
-        || state.pid !== before.owner.pid
+        || state.pid !== before.pid
       ) {
         return null;
       }
-      if (!isLegacy && state.ownerToken !== before.owner.ownerToken) {
-        return null;
+      if (before.kind === 'generation') {
+        if (
+          state.ownerToken !== before.ownerToken
+          || !sameFile(configuration.daemonStateFile, join(before.path, daemonPrivateStateFile))
+        ) {
+          return null;
+        }
+        return state;
       }
-      return state;
+      // A PID-only fixed lock is legacy even if its JSON happens to contain an
+      // ownerToken copied from a newer generation by an older binary.
+      const { ownerToken: _ignored, ...legacyState } = state;
+      return legacyState;
     } catch (error) {
-      console.error(`[PERSISTENCE] Daemon state file corrupted: ${stateFile}`, error);
+      console.error(`[PERSISTENCE] Daemon state file corrupted: ${configuration.daemonStateFile}`, error);
       return null;
     }
   }
@@ -351,23 +355,18 @@ export async function readDaemonState(): Promise<DaemonLocallyPersistedState | n
 }
 
 /**
- * Publish the initial state for one lock generation.
- *
- * New generations never mutate the legacy fixed path. State lives only at the
- * owner-token path selected by the current generation lock.
+ * Publish immutable private state and expose it through the historical fixed
+ * regular-file path. Older CLIs and fixed-path consumers keep seeing exactly
+ * the files they understand.
  */
 export function writeDaemonState(
   lockHandle: DaemonLockHandle,
   state: DaemonLocallyPersistedState,
 ): void {
-  writeDaemonGenerationState(lockHandle, state);
-}
-
-function writeDaemonGenerationState(
-  lockHandle: DaemonLockHandle,
-  state: DaemonLocallyPersistedState,
-): void {
-  const tempPath = `${lockHandle.stateFile}.tmp.${randomUUID()}`;
+  if (!handleOwnsFixedLock(lockHandle)) {
+    throw new Error('Daemon lock ownership changed before state publication');
+  }
+  const tempPath = join(lockHandle.generationPath, `${daemonPrivateStateFile}.tmp.${randomUUID()}`);
   try {
     writeFileSync(
       tempPath,
@@ -375,6 +374,14 @@ function writeDaemonGenerationState(
       'utf-8',
     );
     renameSync(tempPath, lockHandle.stateFile);
+    // The fixed lock still fences successors, so a leftover fixed state belongs
+    // to an older completed/partial publication and is safe to replace here.
+    try {
+      unlinkSync(configuration.daemonStateFile);
+    } catch (error: any) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+    linkSync(lockHandle.stateFile, configuration.daemonStateFile);
   } finally {
     try {
       unlinkSync(tempPath);
@@ -385,90 +392,339 @@ function writeDaemonGenerationState(
 export interface DaemonLockHandle {
   ownerToken: string;
   pid: number;
+  generationPath: string;
+  lockFile: string;
   stateFile: string;
   released: boolean;
 }
 
-type PersistedDaemonLockOwner = {
-  pid: number;
-  ownerToken: string;
+const daemonPrivateLockFile = 'lock.pid';
+const daemonPrivateStateFile = 'state.json';
+
+type DaemonPersistenceTestHooks = {
+  beforeGenerationClaim?: (ownerToken: string) => Promise<void> | void;
+  beforeOrphanClaim?: (ownerToken: string) => Promise<void> | void;
 };
 
-const daemonLockOwnerFile = 'owner.json';
-const daemonOwnerTokenPattern = /^[A-Za-z0-9._-]{1,200}$/;
+let daemonPersistenceTestHooks: DaemonPersistenceTestHooks = {};
 
-function isSafeDaemonOwnerToken(ownerToken: string): boolean {
-  return daemonOwnerTokenPattern.test(ownerToken);
+export function setDaemonPersistenceTestHooksForTests(hooks: DaemonPersistenceTestHooks): void {
+  if (!process.env.VITEST) {
+    throw new Error('Daemon persistence test hooks are only available under Vitest');
+  }
+  daemonPersistenceTestHooks = hooks;
 }
 
 type DaemonLockObservation = {
-  owner: PersistedDaemonLockOwner | null;
-  generationToken: string;
-};
+  identity: string;
+  pid: number;
+} & ({
+  kind: 'legacy';
+} | {
+  kind: 'generation';
+  ownerToken: string;
+  path: string;
+  phase: 'generation' | 'retiring';
+} | {
+  kind: 'invalid';
+});
 
-function readDaemonLockObservation(): DaemonLockObservation | null {
+function fileIdentity(path: string): string | null {
   try {
-    const lockStat = statSync(configuration.daemonLockFile);
-    const kind = lockStat.isDirectory() ? 'dir' : 'file';
-    const unknownGenerationToken = `unknown-${kind}-${lockStat.dev}-${lockStat.ino}-${lockStat.birthtimeMs}`;
-
-    if (lockStat.isDirectory()) {
-      try {
-        const owner = JSON.parse(
-          readFileSync(join(configuration.daemonLockFile, daemonLockOwnerFile), 'utf-8'),
-        ) as PersistedDaemonLockOwner;
-        if (
-          Number.isSafeInteger(owner.pid)
-          && owner.pid > 0
-          && isSafeDaemonOwnerToken(owner.ownerToken)
-        ) {
-          return { owner, generationToken: owner.ownerToken };
-        }
-      } catch { }
-      return { owner: null, generationToken: unknownGenerationToken };
-    }
-
-    try {
-      // Compatibility with the legacy PID-only lock file. New acquisitions use
-      // generation-specific lock directories, but a running older daemon must
-      // still block a replacement after an upgrade.
-      const pid = Number(readFileSync(configuration.daemonLockFile, 'utf-8').trim());
-      if (Number.isSafeInteger(pid) && pid > 0) {
-        const owner = {
-          pid,
-          ownerToken: `legacy-${pid}-${lockStat.birthtimeMs}-${lockStat.ino}`,
-        };
-        return { owner, generationToken: owner.ownerToken };
-      }
-    } catch { }
-    return { owner: null, generationToken: unknownGenerationToken };
+    const value = lstatSync(path);
+    if (!value.isFile()) return null;
+    return `${value.dev}:${value.ino}:${value.birthtimeMs}:${value.size}`;
   } catch {
     return null;
   }
 }
 
-function readDaemonLockOwner(): PersistedDaemonLockOwner | null {
-  return readDaemonLockObservation()?.owner ?? null;
+function sameFile(left: string, right: string): boolean {
+  const leftIdentity = fileIdentity(left);
+  return leftIdentity !== null && leftIdentity === fileIdentity(right);
 }
 
-function daemonLockIsOwnedBy(owner: PersistedDaemonLockOwner): boolean {
-  const persistedOwner = readDaemonLockOwner();
-  return persistedOwner?.pid === owner.pid && persistedOwner.ownerToken === owner.ownerToken;
-}
-
-function retireDaemonLock(ownerToken: string): boolean {
-  if (!isSafeDaemonOwnerToken(ownerToken)) {
-    return false;
-  }
-  const retiredPath = `${configuration.daemonLockFile}.retired.${ownerToken}`;
+function daemonArtifactEntries(): string[] {
   try {
-    // The generation-specific destination is deliberately retained as a
-    // tombstone. A delayed operation for this generation then fails instead of
-    // renaming or deleting a successor that occupies the shared lock path.
-    renameSync(configuration.daemonLockFile, retiredPath);
-    return true;
+    return readdirSync(dirname(configuration.daemonStateFile));
+  } catch {
+    return [];
+  }
+}
+
+function findGenerationForLock(lockPath: string): Extract<DaemonLockObservation, { kind: 'generation' }> | null {
+  const stateBase = basename(configuration.daemonStateFile);
+  const parent = dirname(configuration.daemonStateFile);
+  for (const name of daemonArtifactEntries()) {
+    let phase: 'generation' | 'retiring';
+    let suffix: string;
+    if (name.startsWith(`${stateBase}.generation.`) && !name.endsWith('.tmp')) {
+      phase = 'generation';
+      suffix = name.slice(`${stateBase}.generation.`.length);
+    } else if (name.startsWith(`${stateBase}.retiring.`)) {
+      phase = 'retiring';
+      suffix = name.slice(`${stateBase}.retiring.`.length);
+    } else {
+      continue;
+    }
+    const parts = suffix.split('.');
+    if (parts.length < 2) continue;
+    const pid = Number(parts[0]);
+    const ownerToken = parts[1];
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !ownerToken) continue;
+    const path = join(parent, name);
+    try {
+      if (!lstatSync(path).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const privateLock = join(path, daemonPrivateLockFile);
+    if (sameFile(lockPath, privateLock)) {
+      return {
+        kind: 'generation',
+        identity: fileIdentity(lockPath)!,
+        pid,
+        ownerToken,
+        path,
+        phase,
+      };
+    }
+  }
+  return null;
+}
+
+function observeDaemonLock(): DaemonLockObservation | null {
+  try {
+    const identity = fileIdentity(configuration.daemonLockFile);
+    if (!identity) {
+      return existsSync(configuration.daemonLockFile)
+        ? { kind: 'invalid', identity: 'non-file', pid: 0 }
+        : null;
+    }
+    const pid = Number(readFileSync(configuration.daemonLockFile, 'utf-8').trim());
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      return { kind: 'invalid', identity, pid: 0 };
+    }
+    return findGenerationForLock(configuration.daemonLockFile) ?? { kind: 'legacy', identity, pid };
+  } catch {
+    return null;
+  }
+}
+
+function sameObservation(before: DaemonLockObservation, after: DaemonLockObservation | null): boolean {
+  return after !== null && before.kind === after.kind && before.identity === after.identity && before.pid === after.pid;
+}
+
+function handleOwnsFixedLock(handle: DaemonLockHandle): boolean {
+  try {
+    return !handle.released
+      && existsSync(handle.generationPath)
+      && sameFile(configuration.daemonLockFile, handle.lockFile)
+      && readFileSync(configuration.daemonLockFile, 'utf-8').trim() === String(handle.pid);
   } catch {
     return false;
+  }
+}
+
+async function claimAndRemoveGeneration(observation: Extract<DaemonLockObservation, { kind: 'generation' }>): Promise<boolean> {
+  const retiringPath = join(
+    dirname(configuration.daemonStateFile),
+    `${basename(configuration.daemonStateFile)}.retiring.${observation.pid}.${observation.ownerToken}.${randomUUID()}`,
+  );
+  // Every cleanup attempt, including recovery of an already-retiring
+  // generation, first renames the exact observed directory to its own unique
+  // claim. Only one delayed reclaimer can therefore retain authority over G.
+  if (!sameFile(configuration.daemonLockFile, join(observation.path, daemonPrivateLockFile))) return false;
+  await daemonPersistenceTestHooks.beforeGenerationClaim?.(observation.ownerToken);
+  try {
+    renameSync(observation.path, retiringPath);
+  } catch {
+    return false;
+  }
+
+  const privateLock = join(retiringPath, daemonPrivateLockFile);
+  if (!sameFile(configuration.daemonLockFile, privateLock)) return false;
+  // While this exact private lock still owns the fixed lock, no successor can
+  // publish. Any fixed state is either G's state or stale predecessor state
+  // left by a crash between fixed-lock publication and state removal.
+  if (existsSync(configuration.daemonStateFile)) {
+    unlinkSync(configuration.daemonStateFile);
+  }
+  if (!sameFile(configuration.daemonLockFile, privateLock)) return false;
+  unlinkSync(configuration.daemonLockFile);
+  rmSync(retiringPath, { recursive: true, force: true });
+  return true;
+}
+
+function claimAndRemoveLegacy(observation: Extract<DaemonLockObservation, { kind: 'legacy' }>): boolean {
+  const fingerprint = observation.identity.replace(/[^A-Za-z0-9._-]/g, '-');
+  const claimPath = `${configuration.daemonLockFile}.legacy-claim.${fingerprint}`;
+  const guardPath = `${claimPath}.guard`;
+  const guardToken = randomUUID();
+  let retiredGuardPath: string | null = null;
+  try {
+    // The deterministic destination is the cleanup CAS: two reclaimers may
+    // observe the same dead legacy PID, but only one can create this hard link.
+    linkSync(configuration.daemonLockFile, claimPath);
+  } catch (error: any) {
+    if (error?.code !== 'EEXIST' || !sameFile(configuration.daemonLockFile, claimPath)) {
+      return false;
+    }
+    // Recover a claimant that crashed after publishing the deterministic hard
+    // link. A live/ambiguous guard is never stolen; a definitely dead guard is
+    // renamed as the recovery CAS before a new guard is installed.
+    if (existsSync(guardPath)) {
+      try {
+        const guard = JSON.parse(readFileSync(guardPath, 'utf-8')) as { pid: number };
+        if (!Number.isSafeInteger(guard.pid) || guard.pid <= 0 || !processIsAffirmativelyDead(guard.pid)) {
+          return false;
+        }
+        retiredGuardPath = `${guardPath}.retired.${randomUUID()}`;
+        renameSync(guardPath, retiredGuardPath);
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  try {
+    writeFileSync(guardPath, JSON.stringify({ pid: process.pid, token: guardToken }), { flag: 'wx' });
+  } catch {
+    return false;
+  }
+
+  try {
+    const confirmed = observeDaemonLock();
+    if (
+      confirmed?.kind !== 'legacy'
+      || confirmed.identity !== observation.identity
+      || confirmed.pid !== observation.pid
+      || !sameFile(configuration.daemonLockFile, claimPath)
+    ) {
+      return false;
+    }
+
+    if (existsSync(configuration.daemonStateFile)) {
+      const stateIdentity = fileIdentity(configuration.daemonStateFile);
+      if (!stateIdentity) return false;
+      let state: DaemonLocallyPersistedState;
+      try {
+        state = JSON.parse(readFileSync(configuration.daemonStateFile, 'utf-8')) as DaemonLocallyPersistedState;
+      } catch {
+        return false;
+      }
+      if (state.pid !== observation.pid || fileIdentity(configuration.daemonStateFile) !== stateIdentity) {
+        return false;
+      }
+      unlinkSync(configuration.daemonStateFile);
+    }
+
+    if (!sameFile(configuration.daemonLockFile, claimPath)) return false;
+    unlinkSync(configuration.daemonLockFile);
+    return true;
+  } finally {
+    try {
+      const guard = JSON.parse(readFileSync(guardPath, 'utf-8')) as { token?: string };
+      if (guard.token === guardToken) unlinkSync(guardPath);
+    } catch { }
+    try { if (retiredGuardPath) unlinkSync(retiredGuardPath); } catch { }
+    if (!existsSync(guardPath)) {
+      try { unlinkSync(claimPath); } catch { }
+    }
+  }
+}
+
+function processIsAffirmativelyDead(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error: any) {
+    return error?.code === 'ESRCH';
+  }
+}
+
+async function garbageCollectDaemonArtifacts(): Promise<void> {
+  const stateBase = basename(configuration.daemonStateFile);
+  const lockBase = basename(configuration.daemonLockFile);
+  const parent = dirname(configuration.daemonStateFile);
+  for (const name of daemonArtifactEntries()) {
+    if (name.startsWith(`${lockBase}.legacy-claim.`)) {
+      // Once the canonical lock is gone, claim/guard links cannot identify an
+      // owner and cannot affect a successor. They are safe rollback leftovers.
+      if (!existsSync(configuration.daemonLockFile)) {
+        try { rmSync(join(parent, name), { force: true }); } catch { }
+      }
+      continue;
+    }
+    const match = name.match(new RegExp(`^${stateBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.(generation|retiring)\\.(\\d+)\\.(.+?)(\\.tmp)?$`));
+    if (!match) continue;
+    const pidText = match[2];
+    const pid = Number(pidText);
+    if (!Number.isSafeInteger(pid) || pid <= 0 || !processIsAffirmativelyDead(pid)) continue;
+
+    const artifactPath = join(parent, name);
+    try {
+      if (!lstatSync(artifactPath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const privateLock = join(artifactPath, daemonPrivateLockFile);
+    try {
+      if (readFileSync(privateLock, 'utf-8').trim() !== String(pid)) continue;
+    } catch {
+      if (name.endsWith('.tmp')) {
+        // The PID is encoded before mkdir, so even a crash between mkdir and
+        // lock.pid publication leaves a temp artifact with a provably dead owner.
+        rmSync(artifactPath, { recursive: true, force: true });
+      }
+      continue;
+    }
+
+    const lockAliases = sameFile(configuration.daemonLockFile, privateLock);
+    if (lockAliases) {
+      // Active fixed ownership is reclaimed through the normal generation CAS,
+      // including a retirement that crashed after its directory rename.
+      const observation = observeDaemonLock();
+      if (observation?.kind === 'generation' && observation.path === artifactPath) {
+        await claimAndRemoveGeneration(observation);
+      }
+      continue;
+    }
+
+    const ownerToken = match[3].split('.')[0];
+    await daemonPersistenceTestHooks.beforeOrphanClaim?.(ownerToken);
+    const claimedPath = join(
+      parent,
+      `${stateBase}.retiring.${pid}.${ownerToken}.${randomUUID()}`,
+    );
+    try {
+      renameSync(artifactPath, claimedPath);
+    } catch {
+      continue;
+    }
+    const claimedLock = join(claimedPath, daemonPrivateLockFile);
+    const claimedState = join(claimedPath, daemonPrivateStateFile);
+    try {
+      // Reserve the fixed lock with G's exact inode before touching fixed
+      // state. A concurrently acquired H makes this fail with EEXIST, fencing
+      // the collector away from H's state.
+      linkSync(claimedLock, configuration.daemonLockFile);
+    } catch {
+      if (!sameFile(configuration.daemonLockFile, claimedLock)) {
+        if (!sameFile(configuration.daemonStateFile, claimedState)) {
+          try { rmSync(claimedPath, { recursive: true, force: true }); } catch { }
+        }
+        continue;
+      }
+    }
+    await claimAndRemoveGeneration({
+      kind: 'generation',
+      identity: fileIdentity(claimedLock)!,
+      pid,
+      ownerToken,
+      path: claimedPath,
+      phase: 'retiring',
+    });
   }
 }
 
@@ -478,45 +734,30 @@ function retireDaemonLock(ownerToken: string): boolean {
  */
 export async function writeDaemonStateIfOwned(
   lockHandle: DaemonLockHandle,
-  state: DaemonLocallyPersistedState,
+  _state: DaemonLocallyPersistedState,
 ): Promise<boolean> {
-  if (!daemonLockIsOwnedBy(lockHandle)) {
-    return false;
-  }
-
-  // Intentional scheduling seam: correctness must survive ownership changing
-  // after validation, not merely the ordered-before-call test case.
-  await Promise.resolve();
-  writeDaemonGenerationState(lockHandle, state);
-  return daemonLockIsOwnedBy(lockHandle);
+  return handleOwnsFixedLock(lockHandle)
+    && sameFile(configuration.daemonStateFile, lockHandle.stateFile);
 }
 
 /**
- * Retire one daemon generation and remove only its private state. PID-only
- * callers are deliberately ignored because they cannot prove a generation.
+ * Retire one daemon generation. Legacy callers are reclaimed by acquisition
+ * only after an affirmative process-death probe and deterministic file claim.
  */
 export async function clearDaemonState(
   expectedOwner: DaemonLockHandle | DaemonLocallyPersistedState | number,
 ): Promise<void> {
   if (typeof expectedOwner === 'number') {
-    // PID-only cleanup cannot distinguish a reused PID or legacy successor.
-    // Leave it for generation-aware acquisition to reclaim once safely stale.
     return;
   }
-
-  const ownerToken = expectedOwner.ownerToken;
-  if (!ownerToken || !isSafeDaemonOwnerToken(ownerToken)) {
+  const observation = observeDaemonLock();
+  if (!observation || observation.kind === 'invalid' || observation.pid !== expectedOwner.pid) {
     return;
   }
-  await Promise.resolve();
-  retireDaemonLock(ownerToken);
-
-  const ownerStateFile = 'stateFile' in expectedOwner
-    ? expectedOwner.stateFile
-    : `${configuration.daemonStateFile}.owner.${ownerToken}`;
-  try {
-    await unlink(ownerStateFile);
-  } catch { }
+  if (observation.kind === 'generation' && expectedOwner.ownerToken === observation.ownerToken) {
+    const removed = await claimAndRemoveGeneration(observation);
+    if ('released' in expectedOwner && removed) expectedOwner.released = true;
+  }
 }
 
 /**
@@ -533,76 +774,89 @@ export async function clearDaemonStateForTests(): Promise<void> {
   try {
     rmSync(configuration.daemonLockFile, { recursive: true, force: true });
   } catch { }
+  const stateBase = basename(configuration.daemonStateFile);
+  const lockBase = basename(configuration.daemonLockFile);
+  const parent = dirname(configuration.daemonStateFile);
+  for (const name of daemonArtifactEntries()) {
+    if (
+      name.startsWith(`${stateBase}.generation.`)
+      || name.startsWith(`${stateBase}.retiring.`)
+      || name.startsWith(`${stateBase}.owner.`)
+      || name.startsWith(`${lockBase}.retired.`)
+      || name.startsWith(`${lockBase}.legacy-claim.`)
+    ) {
+      try { rmSync(join(parent, name), { recursive: true, force: true }); } catch { }
+    }
+  }
 }
 
 /**
- * Acquire an exclusive generation lock for the daemon. Creating the shared
- * directory is the cross-platform no-replace CAS, including against legacy
- * PID files. An ownerless/partial directory is untrusted and never reclaimed.
+ * Acquire an exclusive generation lease while preserving the historical fixed
+ * PID file. A hard link is the create-if-absent CAS against both old and new
+ * binaries; private generation files carry the identity needed for safe cleanup.
  */
 export async function acquireDaemonLock(
   maxAttempts: number = 5,
   delayIncrementMs: number = 200
 ): Promise<DaemonLockHandle | null> {
+  await garbageCollectDaemonArtifacts();
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const ownerToken = randomUUID();
+    const artifactBase = `${basename(configuration.daemonStateFile)}.generation.${process.pid}.${ownerToken}`;
+    const temporaryPath = join(dirname(configuration.daemonStateFile), `${artifactBase}.tmp`);
+    const generationPath = join(dirname(configuration.daemonStateFile), artifactBase);
+    const privateLock = join(generationPath, daemonPrivateLockFile);
     try {
-      // mkdir is atomic and fails when either a legacy file or a generation
-      // directory already occupies the shared path. In particular, unlike a
-      // Windows directory rename, it cannot replace a legacy PID file that is
-      // installed concurrently.
-      mkdirSync(configuration.daemonLockFile);
-      writeFileSync(
-        join(configuration.daemonLockFile, daemonLockOwnerFile),
-        JSON.stringify({ pid: process.pid, ownerToken } satisfies PersistedDaemonLockOwner),
-        'utf-8',
-      );
-      // A new generation never uses the legacy fixed-path state. Once this
-      // lock is ours, removing a leftover legacy snapshot cannot affect a
-      // successor because no successor can acquire the shared lock yet.
+      mkdirSync(temporaryPath);
+      writeFileSync(join(temporaryPath, daemonPrivateLockFile), String(process.pid), 'utf-8');
+      renameSync(temporaryPath, generationPath);
+      linkSync(privateLock, configuration.daemonLockFile);
+      // A predecessor may have crashed after removing its fixed lock but
+      // before removing its fixed state. Holding the newly published lock
+      // makes this removal safe against both old and new successors.
       try {
         unlinkSync(configuration.daemonStateFile);
-      } catch { }
+      } catch (error: any) {
+        if (error?.code !== 'ENOENT') throw error;
+      }
       return {
         ownerToken,
         pid: process.pid,
-        stateFile: `${configuration.daemonStateFile}.owner.${ownerToken}`,
+        generationPath,
+        lockFile: privateLock,
+        stateFile: join(generationPath, daemonPrivateStateFile),
         released: false,
       };
     } catch (error: any) {
-      const observation = readDaemonLockObservation();
-      const currentOwner = observation?.owner ?? null;
-      let lockIsStale = false;
-      if (currentOwner && !currentOwner.ownerToken.startsWith('legacy-')) {
+      try { rmSync(temporaryPath, { recursive: true, force: true }); } catch { }
+      if (sameFile(configuration.daemonLockFile, privateLock)) {
+        try { unlinkSync(configuration.daemonLockFile); } catch { }
+      }
+      if (!sameFile(configuration.daemonLockFile, privateLock)) {
+        try { rmSync(generationPath, { recursive: true, force: true }); } catch { }
+      }
+      const observation = observeDaemonLock();
+      let ownerIsDead = false;
+      if (observation && observation.kind !== 'invalid') {
         try {
-          process.kill(currentOwner.pid, 0);
+          process.kill(observation.pid, 0);
         } catch (probeError: any) {
-          // EPERM (and unknown platform errors) mean the process may still be
-          // alive. Only ESRCH is affirmative evidence that the PID is absent.
-          lockIsStale = probeError?.code === 'ESRCH';
+          ownerIsDead = probeError?.code === 'ESRCH';
         }
       }
-
-      if (lockIsStale) {
-        const confirmed = readDaemonLockObservation();
-        if (
-          observation
-          && confirmed?.generationToken === observation.generationToken
-          && retireDaemonLock(observation.generationToken)
-        ) {
-          try {
-            unlinkSync(`${configuration.daemonStateFile}.owner.${observation.generationToken}`);
-          } catch { }
-          continue;
-        }
+      if (ownerIsDead && observation?.kind === 'generation' && await claimAndRemoveGeneration(observation)) {
+        continue;
+      }
+      if (ownerIsDead && observation?.kind === 'legacy' && claimAndRemoveLegacy(observation)) {
+        continue;
       }
 
       if (attempt === maxAttempts) {
-        if (currentOwner?.ownerToken.startsWith('legacy-')) {
+        if (observation?.kind === 'legacy') {
           logger.warn(
-            `[PERSISTENCE] Refusing to replace legacy daemon lock ${configuration.daemonLockFile} for PID ${currentOwner.pid} without generation proof. Stop the old Happy daemon, or confirm that PID is absent before removing the lock file manually.`,
+            `[PERSISTENCE] Refusing to replace legacy daemon lock ${configuration.daemonLockFile} for PID ${observation.pid} without a completed legacy claim.`,
           );
-        } else if (observation && !currentOwner) {
+        } else if (observation?.kind === 'invalid') {
           logger.warn(
             `[PERSISTENCE] Refusing to replace unreadable daemon lock ${configuration.daemonLockFile}; automatic cleanup cannot prove ownership.`,
           );
@@ -623,10 +877,14 @@ export async function releaseDaemonLock(lockHandle: DaemonLockHandle): Promise<v
   if (lockHandle.released) {
     return;
   }
-
-  await Promise.resolve();
-  const retired = retireDaemonLock(lockHandle.ownerToken);
-  if (retired || !daemonLockIsOwnedBy(lockHandle)) {
+  const observation = observeDaemonLock();
+  if (
+    observation?.kind === 'generation'
+    && observation.ownerToken === lockHandle.ownerToken
+    && await claimAndRemoveGeneration(observation)
+  ) {
+    lockHandle.released = true;
+  } else if (!handleOwnsFixedLock(lockHandle)) {
     lockHandle.released = true;
   }
 }

--- a/packages/happy-cli/src/persistence.ts
+++ b/packages/happy-cli/src/persistence.ts
@@ -316,15 +316,46 @@ export function writeDaemonState(state: DaemonLocallyPersistedState): void {
   writeFileSync(configuration.daemonStateFile, JSON.stringify(state, null, 2), 'utf-8');
 }
 
+function daemonLockIsOwnedBy(pid: number): boolean {
+  try {
+    return readFileSync(configuration.daemonLockFile, 'utf-8').trim() === String(pid);
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Clean up daemon state file and lock file
+ * Refresh daemon state only while the caller still owns the persisted state.
+ * Returns false when a successor daemon has already taken ownership.
  */
-export async function clearDaemonState(): Promise<void> {
-  if (existsSync(configuration.daemonStateFile)) {
+export async function writeDaemonStateIfOwned(state: DaemonLocallyPersistedState): Promise<boolean> {
+  const persistedState = await readDaemonState();
+  if (persistedState && persistedState.pid !== state.pid) {
+    return false;
+  }
+
+  if (!daemonLockIsOwnedBy(state.pid)) {
+    return false;
+  }
+
+  writeDaemonState(state);
+  return true;
+}
+
+/**
+ * Clean up daemon state file and lock file. When expectedOwnerPid is provided,
+ * only files still owned by that daemon are removed.
+ */
+export async function clearDaemonState(expectedOwnerPid?: number): Promise<void> {
+  const stateIsOwned = expectedOwnerPid === undefined
+    || (await readDaemonState())?.pid === expectedOwnerPid;
+  if (stateIsOwned && existsSync(configuration.daemonStateFile)) {
     await unlink(configuration.daemonStateFile);
   }
-  // Also clean up lock file if it exists (for stale cleanup)
-  if (existsSync(configuration.daemonLockFile)) {
+
+  const lockIsOwned = expectedOwnerPid === undefined || daemonLockIsOwnedBy(expectedOwnerPid);
+
+  if (lockIsOwned && existsSync(configuration.daemonLockFile)) {
     try {
       await unlink(configuration.daemonLockFile);
     } catch {
@@ -399,7 +430,7 @@ export async function acquireDaemonLock(
 }
 
 /**
- * Release daemon lock by closing handle and deleting lock file
+ * Release this daemon's lock without deleting a successor's replacement lock.
  */
 export async function releaseDaemonLock(lockHandle: FileHandle): Promise<void> {
   try {
@@ -407,7 +438,7 @@ export async function releaseDaemonLock(lockHandle: FileHandle): Promise<void> {
   } catch { }
 
   try {
-    if (existsSync(configuration.daemonLockFile)) {
+    if (existsSync(configuration.daemonLockFile) && daemonLockIsOwnedBy(process.pid)) {
       unlinkSync(configuration.daemonLockFile);
     }
   } catch { }

--- a/packages/happy-cli/src/persistence.ts
+++ b/packages/happy-cli/src/persistence.ts
@@ -4,10 +4,11 @@
  * Handles settings and private key storage in ~/.happy/ or local .happy/
  */
 
-import { FileHandle } from 'node:fs/promises'
 import { readFile, writeFile, mkdir, open, unlink, rename, stat } from 'node:fs/promises'
-import { existsSync, writeFileSync, readFileSync, unlinkSync, renameSync, linkSync } from 'node:fs'
+import { existsSync, writeFileSync, readFileSync, unlinkSync, renameSync, mkdirSync, rmSync, statSync } from 'node:fs'
 import { constants } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { join } from 'node:path'
 import { configuration } from '@/configuration'
 import * as z from 'zod';
 import { encodeBase64, decodeBase64 } from '@/api/encryption';
@@ -75,6 +76,7 @@ export interface DaemonLocallyPersistedState {
   httpPort: number;
   startTime: string;
   startedWithCliVersion: string;
+  ownerToken?: string;
   lastHeartbeat?: string;
   daemonLogPath?: string;
 }
@@ -296,29 +298,175 @@ export async function clearMachineId(): Promise<void> {
  * Read daemon state from local file
  */
 export async function readDaemonState(): Promise<DaemonLocallyPersistedState | null> {
-  try {
-    if (!existsSync(configuration.daemonStateFile)) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const before = readDaemonLockObservation();
+    if (!before?.owner) {
       return null;
     }
-    const content = await readFile(configuration.daemonStateFile, 'utf-8');
-    return JSON.parse(content) as DaemonLocallyPersistedState;
-  } catch (error) {
-    // State corrupted somehow :(
-    console.error(`[PERSISTENCE] Daemon state file corrupted: ${configuration.daemonStateFile}`, error);
+
+    const isLegacy = before.owner.ownerToken.startsWith('legacy-');
+    const stateFile = isLegacy
+      ? configuration.daemonStateFile
+      : `${configuration.daemonStateFile}.owner.${before.owner.ownerToken}`;
+
+    let content: string;
+    try {
+      content = await readFile(stateFile, 'utf-8');
+    } catch (error: any) {
+      const after = readDaemonLockObservation();
+      if (after?.generationToken !== before.generationToken) {
+        continue;
+      }
+      if (error?.code !== 'ENOENT') {
+        console.error(`[PERSISTENCE] Daemon state file corrupted: ${stateFile}`, error);
+      }
+      return null;
+    }
+
+    const after = readDaemonLockObservation();
+    if (after?.generationToken !== before.generationToken) {
+      continue;
+    }
+
+    try {
+      const state = JSON.parse(content) as DaemonLocallyPersistedState;
+      if (
+        !Number.isSafeInteger(state.pid)
+        || state.pid <= 0
+        || state.pid !== before.owner.pid
+      ) {
+        return null;
+      }
+      if (!isLegacy && state.ownerToken !== before.owner.ownerToken) {
+        return null;
+      }
+      return state;
+    } catch (error) {
+      console.error(`[PERSISTENCE] Daemon state file corrupted: ${stateFile}`, error);
+      return null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Publish the initial state for one lock generation.
+ *
+ * New generations never mutate the legacy fixed path. State lives only at the
+ * owner-token path selected by the current generation lock.
+ */
+export function writeDaemonState(
+  lockHandle: DaemonLockHandle,
+  state: DaemonLocallyPersistedState,
+): void {
+  writeDaemonGenerationState(lockHandle, state);
+}
+
+function writeDaemonGenerationState(
+  lockHandle: DaemonLockHandle,
+  state: DaemonLocallyPersistedState,
+): void {
+  const tempPath = `${lockHandle.stateFile}.tmp.${randomUUID()}`;
+  try {
+    writeFileSync(
+      tempPath,
+      JSON.stringify({ ...state, pid: lockHandle.pid, ownerToken: lockHandle.ownerToken }, null, 2),
+      'utf-8',
+    );
+    renameSync(tempPath, lockHandle.stateFile);
+  } finally {
+    try {
+      unlinkSync(tempPath);
+    } catch { }
+  }
+}
+
+export interface DaemonLockHandle {
+  ownerToken: string;
+  pid: number;
+  stateFile: string;
+  released: boolean;
+}
+
+type PersistedDaemonLockOwner = {
+  pid: number;
+  ownerToken: string;
+};
+
+const daemonLockOwnerFile = 'owner.json';
+const daemonOwnerTokenPattern = /^[A-Za-z0-9._-]{1,200}$/;
+
+function isSafeDaemonOwnerToken(ownerToken: string): boolean {
+  return daemonOwnerTokenPattern.test(ownerToken);
+}
+
+type DaemonLockObservation = {
+  owner: PersistedDaemonLockOwner | null;
+  generationToken: string;
+};
+
+function readDaemonLockObservation(): DaemonLockObservation | null {
+  try {
+    const lockStat = statSync(configuration.daemonLockFile);
+    const kind = lockStat.isDirectory() ? 'dir' : 'file';
+    const unknownGenerationToken = `unknown-${kind}-${lockStat.dev}-${lockStat.ino}-${lockStat.birthtimeMs}`;
+
+    if (lockStat.isDirectory()) {
+      try {
+        const owner = JSON.parse(
+          readFileSync(join(configuration.daemonLockFile, daemonLockOwnerFile), 'utf-8'),
+        ) as PersistedDaemonLockOwner;
+        if (
+          Number.isSafeInteger(owner.pid)
+          && owner.pid > 0
+          && isSafeDaemonOwnerToken(owner.ownerToken)
+        ) {
+          return { owner, generationToken: owner.ownerToken };
+        }
+      } catch { }
+      return { owner: null, generationToken: unknownGenerationToken };
+    }
+
+    try {
+      // Compatibility with the legacy PID-only lock file. New acquisitions use
+      // generation-specific lock directories, but a running older daemon must
+      // still block a replacement after an upgrade.
+      const pid = Number(readFileSync(configuration.daemonLockFile, 'utf-8').trim());
+      if (Number.isSafeInteger(pid) && pid > 0) {
+        const owner = {
+          pid,
+          ownerToken: `legacy-${pid}-${lockStat.birthtimeMs}-${lockStat.ino}`,
+        };
+        return { owner, generationToken: owner.ownerToken };
+      }
+    } catch { }
+    return { owner: null, generationToken: unknownGenerationToken };
+  } catch {
     return null;
   }
 }
 
-/**
- * Write daemon state to local file (synchronously for atomic operation)
- */
-export function writeDaemonState(state: DaemonLocallyPersistedState): void {
-  writeFileSync(configuration.daemonStateFile, JSON.stringify(state, null, 2), 'utf-8');
+function readDaemonLockOwner(): PersistedDaemonLockOwner | null {
+  return readDaemonLockObservation()?.owner ?? null;
 }
 
-function daemonLockIsOwnedBy(pid: number): boolean {
+function daemonLockIsOwnedBy(owner: PersistedDaemonLockOwner): boolean {
+  const persistedOwner = readDaemonLockOwner();
+  return persistedOwner?.pid === owner.pid && persistedOwner.ownerToken === owner.ownerToken;
+}
+
+function retireDaemonLock(ownerToken: string): boolean {
+  if (!isSafeDaemonOwnerToken(ownerToken)) {
+    return false;
+  }
+  const retiredPath = `${configuration.daemonLockFile}.retired.${ownerToken}`;
   try {
-    return readFileSync(configuration.daemonLockFile, 'utf-8').trim() === String(pid);
+    // The generation-specific destination is deliberately retained as a
+    // tombstone. A delayed operation for this generation then fails instead of
+    // renaming or deleting a successor that occupies the shared lock path.
+    renameSync(configuration.daemonLockFile, retiredPath);
+    return true;
   } catch {
     return false;
   }
@@ -328,98 +476,137 @@ function daemonLockIsOwnedBy(pid: number): boolean {
  * Refresh daemon state only while the caller still owns the persisted state.
  * Returns false when a successor daemon has already taken ownership.
  */
-export async function writeDaemonStateIfOwned(state: DaemonLocallyPersistedState): Promise<boolean> {
-  const persistedState = await readDaemonState();
-  if (persistedState && persistedState.pid !== state.pid) {
+export async function writeDaemonStateIfOwned(
+  lockHandle: DaemonLockHandle,
+  state: DaemonLocallyPersistedState,
+): Promise<boolean> {
+  if (!daemonLockIsOwnedBy(lockHandle)) {
     return false;
   }
 
-  if (!daemonLockIsOwnedBy(state.pid)) {
-    return false;
-  }
-
-  writeDaemonState(state);
-  return true;
+  // Intentional scheduling seam: correctness must survive ownership changing
+  // after validation, not merely the ordered-before-call test case.
+  await Promise.resolve();
+  writeDaemonGenerationState(lockHandle, state);
+  return daemonLockIsOwnedBy(lockHandle);
 }
 
 /**
- * Clean up daemon state file and lock file. When expectedOwnerPid is provided,
- * only files still owned by that daemon are removed.
+ * Retire one daemon generation and remove only its private state. PID-only
+ * callers are deliberately ignored because they cannot prove a generation.
  */
-export async function clearDaemonState(expectedOwnerPid?: number): Promise<void> {
-  const stateIsOwned = expectedOwnerPid === undefined
-    || (await readDaemonState())?.pid === expectedOwnerPid;
-  if (stateIsOwned && existsSync(configuration.daemonStateFile)) {
-    await unlink(configuration.daemonStateFile);
+export async function clearDaemonState(
+  expectedOwner: DaemonLockHandle | DaemonLocallyPersistedState | number,
+): Promise<void> {
+  if (typeof expectedOwner === 'number') {
+    // PID-only cleanup cannot distinguish a reused PID or legacy successor.
+    // Leave it for generation-aware acquisition to reclaim once safely stale.
+    return;
   }
 
-  const lockIsOwned = expectedOwnerPid === undefined || daemonLockIsOwnedBy(expectedOwnerPid);
-
-  if (lockIsOwned && existsSync(configuration.daemonLockFile)) {
-    try {
-      await unlink(configuration.daemonLockFile);
-    } catch {
-      // Lock file might be held by running daemon, ignore error
-    }
+  const ownerToken = expectedOwner.ownerToken;
+  if (!ownerToken || !isSafeDaemonOwnerToken(ownerToken)) {
+    return;
   }
+  await Promise.resolve();
+  retireDaemonLock(ownerToken);
+
+  const ownerStateFile = 'stateFile' in expectedOwner
+    ? expectedOwner.stateFile
+    : `${configuration.daemonStateFile}.owner.${ownerToken}`;
+  try {
+    await unlink(ownerStateFile);
+  } catch { }
 }
 
 /**
- * Acquire an exclusive lock file for the daemon.
- * The lock file proves the daemon is running and prevents multiple instances.
- * Returns the file handle to hold for the daemon's lifetime, or null if locked.
+ * Destructive reset for isolated Vitest processes only. Production callers
+ * must always use generation-scoped cleanup so delayed work remains fenced.
+ */
+export async function clearDaemonStateForTests(): Promise<void> {
+  if (!process.env.VITEST) {
+    throw new Error('Unscoped daemon-state cleanup is only available under Vitest');
+  }
+  try {
+    await unlink(configuration.daemonStateFile);
+  } catch { }
+  try {
+    rmSync(configuration.daemonLockFile, { recursive: true, force: true });
+  } catch { }
+}
+
+/**
+ * Acquire an exclusive generation lock for the daemon. Creating the shared
+ * directory is the cross-platform no-replace CAS, including against legacy
+ * PID files. An ownerless/partial directory is untrusted and never reclaimed.
  */
 export async function acquireDaemonLock(
   maxAttempts: number = 5,
   delayIncrementMs: number = 200
-): Promise<FileHandle | null> {
-  // Lock creation is atomic INCLUDING the PID payload: the PID is written to
-  // a private temp file first and hard-linked into place (link fails with
-  // EEXIST exactly like O_EXCL). A lock file therefore never exists in an
-  // empty/partially-written state, so any lock without a live-PID payload is
-  // unambiguously stale and can be reclaimed immediately.
-  const tempPath = `${configuration.daemonLockFile}.${process.pid}.tmp`;
+): Promise<DaemonLockHandle | null> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const ownerToken = randomUUID();
     try {
-      writeFileSync(tempPath, String(process.pid));
-      linkSync(tempPath, configuration.daemonLockFile);
-      unlinkSync(tempPath);
-      // Hold an open handle for the daemon's lifetime (released by releaseDaemonLock)
-      return await open(configuration.daemonLockFile, constants.O_RDONLY);
-    } catch (error: any) {
+      // mkdir is atomic and fails when either a legacy file or a generation
+      // directory already occupies the shared path. In particular, unlike a
+      // Windows directory rename, it cannot replace a legacy PID file that is
+      // installed concurrently.
+      mkdirSync(configuration.daemonLockFile);
+      writeFileSync(
+        join(configuration.daemonLockFile, daemonLockOwnerFile),
+        JSON.stringify({ pid: process.pid, ownerToken } satisfies PersistedDaemonLockOwner),
+        'utf-8',
+      );
+      // A new generation never uses the legacy fixed-path state. Once this
+      // lock is ours, removing a leftover legacy snapshot cannot affect a
+      // successor because no successor can acquire the shared lock yet.
       try {
-        unlinkSync(tempPath);
+        unlinkSync(configuration.daemonStateFile);
       } catch { }
-
-      if (error.code === 'EEXIST') {
-        // Lock file exists, check if its owner is still running
-        let lockIsStale = false;
+      return {
+        ownerToken,
+        pid: process.pid,
+        stateFile: `${configuration.daemonStateFile}.owner.${ownerToken}`,
+        released: false,
+      };
+    } catch (error: any) {
+      const observation = readDaemonLockObservation();
+      const currentOwner = observation?.owner ?? null;
+      let lockIsStale = false;
+      if (currentOwner && !currentOwner.ownerToken.startsWith('legacy-')) {
         try {
-          const lockPid = readFileSync(configuration.daemonLockFile, 'utf-8').trim();
-          const lockPidNumber = Number(lockPid);
-          if (!lockPid || !Number.isSafeInteger(lockPidNumber) || lockPidNumber <= 0) {
-            lockIsStale = true;
-          } else {
-            try {
-              process.kill(lockPidNumber, 0); // Check if process exists
-            } catch {
-              lockIsStale = true;
-            }
-          }
-        } catch {
-          // Can't read the lock file — corrupted leftovers, reclaim
-          lockIsStale = true;
+          process.kill(currentOwner.pid, 0);
+        } catch (probeError: any) {
+          // EPERM (and unknown platform errors) mean the process may still be
+          // alive. Only ESRCH is affirmative evidence that the PID is absent.
+          lockIsStale = probeError?.code === 'ESRCH';
         }
+      }
 
-        if (lockIsStale) {
+      if (lockIsStale) {
+        const confirmed = readDaemonLockObservation();
+        if (
+          observation
+          && confirmed?.generationToken === observation.generationToken
+          && retireDaemonLock(observation.generationToken)
+        ) {
           try {
-            unlinkSync(configuration.daemonLockFile);
-            continue; // Retry acquisition
+            unlinkSync(`${configuration.daemonStateFile}.owner.${observation.generationToken}`);
           } catch { }
+          continue;
         }
       }
 
       if (attempt === maxAttempts) {
+        if (currentOwner?.ownerToken.startsWith('legacy-')) {
+          logger.warn(
+            `[PERSISTENCE] Refusing to replace legacy daemon lock ${configuration.daemonLockFile} for PID ${currentOwner.pid} without generation proof. Stop the old Happy daemon, or confirm that PID is absent before removing the lock file manually.`,
+          );
+        } else if (observation && !currentOwner) {
+          logger.warn(
+            `[PERSISTENCE] Refusing to replace unreadable daemon lock ${configuration.daemonLockFile}; automatic cleanup cannot prove ownership.`,
+          );
+        }
         return null;
       }
       const delayMs = attempt * delayIncrementMs;
@@ -432,16 +619,16 @@ export async function acquireDaemonLock(
 /**
  * Release this daemon's lock without deleting a successor's replacement lock.
  */
-export async function releaseDaemonLock(lockHandle: FileHandle): Promise<void> {
-  try {
-    await lockHandle.close();
-  } catch { }
+export async function releaseDaemonLock(lockHandle: DaemonLockHandle): Promise<void> {
+  if (lockHandle.released) {
+    return;
+  }
 
-  try {
-    if (existsSync(configuration.daemonLockFile) && daemonLockIsOwnedBy(process.pid)) {
-      unlinkSync(configuration.daemonLockFile);
-    }
-  } catch { }
+  await Promise.resolve();
+  const retired = retireDaemonLock(lockHandle.ownerToken);
+  if (retired || !daemonLockIsOwnedBy(lockHandle)) {
+    lockHandle.released = true;
+  }
 }
 
 // ─── Session persistence (survives daemon restarts) ───


### PR DESCRIPTION
## Summary
- Skip daemon ensure/replacement for sessions that were started by the daemon.
- Preserve live daemon state after a transient control timeout while retaining stale-PID cleanup for non-timeout failures.
- Prevent a losing daemon from rewriting heartbeat state and scope state/lock cleanup to the current owner.

Fixes #1654

## Testing
- Focused unit tests: pnpm --filter happy exec vitest run --project unit src/daemon/ensureDaemonRunning.test.ts src/daemon/controlClient.test.ts src/persistence.test.ts src/commands/codexCommand.test.ts (25 passed)
- pnpm --filter happy typecheck
- pnpm --filter happy build

## Notes
- The authenticated daemon integration test was not run because it stops and restarts the local daemon.
- The full Windows unit suite reported 794 passed and 34 failures across six untouched platform/tooling-sensitive test files.
