### PR TITLE
feat: add gemini 3.7 model

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -244,6 +244,10 @@ describe('modelModeOptions', () => {
         // the agentDefaults agy default must be selectable
         expect(keys).toContain('Gemini 3.1 Pro (High)');
         expect(getDefaultModelKey('agy')).toBe('Gemini 3.1 Pro (High)');
+        // includes new Gemini 3.7 Flash models
+        expect(keys).toContain('Gemini 3.7 Flash (High)');
+        expect(keys).toContain('Gemini 3.7 Flash (Medium)');
+        expect(keys).toContain('Gemini 3.7 Flash (Low)');
         // no 'default' entry — agy would receive the literal string "default" as --model
         expect(keys).not.toContain('default');
         // not the claude list

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -299,6 +299,9 @@ export function getOpenClawModelModes(): ModelMode[] {
 // Keys are the exact display names `agy --model` accepts (as printed by `agy models`).
 export function getAgyModelModes(): ModelMode[] {
     return [
+        { key: 'Gemini 3.7 Flash (High)', name: 'Gemini 3.7 Flash (High)', description: null },
+        { key: 'Gemini 3.7 Flash (Medium)', name: 'Gemini 3.7 Flash (Medium)', description: null },
+        { key: 'Gemini 3.7 Flash (Low)', name: 'Gemini 3.7 Flash (Low)', description: null },
         { key: 'Gemini 3.6 Flash (High)', name: 'Gemini 3.6 Flash (High)', description: null },
         { key: 'Gemini 3.6 Flash (Medium)', name: 'Gemini 3.6 Flash (Medium)', description: null },
         { key: 'Gemini 3.6 Flash (Low)', name: 'Gemini 3.6 Flash (Low)', description: null },

--- a/packages/happy-cli/src/agy/constants.test.ts
+++ b/packages/happy-cli/src/agy/constants.test.ts
@@ -45,3 +45,13 @@ describe('resolveAgyBin', () => {
     );
   });
 });
+
+describe('AGY_MODELS', () => {
+  it('includes Gemini 3.7 Flash models', async () => {
+    const { AGY_MODELS, DEFAULT_AGY_MODEL } = await import('./constants');
+    expect(AGY_MODELS).toContain('Gemini 3.7 Flash (High)');
+    expect(AGY_MODELS).toContain('Gemini 3.7 Flash (Medium)');
+    expect(AGY_MODELS).toContain('Gemini 3.7 Flash (Low)');
+    expect(AGY_MODELS).toContain(DEFAULT_AGY_MODEL);
+  });
+});

--- a/packages/happy-cli/src/agy/constants.ts
+++ b/packages/happy-cli/src/agy/constants.ts
@@ -66,6 +66,9 @@ export function resolveAgyBin(): string {
  * agy expects the full display string, not a slug.
  */
 export const AGY_MODELS = [
+  'Gemini 3.7 Flash (High)',
+  'Gemini 3.7 Flash (Medium)',
+  'Gemini 3.7 Flash (Low)',
   'Gemini 3.6 Flash (Medium)',
   'Gemini 3.6 Flash (High)',
   'Gemini 3.6 Flash (Low)',


### PR DESCRIPTION
## Summary
Adds Gemini 3.7 Flash model options (`Gemini 3.7 Flash (High)`, `Gemini 3.7 Flash (Medium)`, `Gemini 3.7 Flash (Low)`) to the Antigravity (`agy`) backend constants and app model mode picker options, matching the models supported by `agy models`.

Follows #1649. cc @bra1nDump

## Changes
- **`packages/happy-cli`**: Added Gemini 3.7 Flash (High/Medium/Low) to `AGY_MODELS` in `src/agy/constants.ts` and added unit test coverage in `src/agy/constants.test.ts`.
- **`packages/happy-app`**: Added Gemini 3.7 Flash (High/Medium/Low) options to `getAgyModelModes()` in `sources/components/modelModeOptions.ts` and updated test assertions in `sources/components/modelModeOptions.test.ts`.