### PR TITLE
fix(app): archive orphaned sessions via server fallback

### DIFF
--- a/packages/happy-app/sources/-session/SessionView.tsx
+++ b/packages/happy-app/sources/-session/SessionView.tsx
@@ -858,7 +858,9 @@ export function SessionViewLoaded({
     const handleAbort = React.useCallback(() => {
         // Stop cancels only the active turn. Permission, model, and effort are
         // session choices and must remain sticky for the next message.
-        sessionAbort(sessionId);
+        // Best-effort: an orphaned session has no RPC target to abort (#1739),
+        // and there is nothing to cancel when the process is already gone.
+        sessionAbort(sessionId).catch(() => {});
     }, [sessionId]);
 
     const handleFileViewerPress = React.useCallback(() => {

--- a/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/packages/happy-app/sources/components/ActiveSessionsGroupCompact.tsx
@@ -16,7 +16,7 @@ import { useHappyAction } from '@/hooks/useHappyAction';
 import { HappyError } from '@/utils/errors';
 import { SessionActionsAnchor, SessionActionsPopover } from './SessionActionsPopover';
 import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
-import { sessionKill } from '@/sync/ops';
+import { sessionKillOrArchive } from '@/sync/ops';
 import { isWorktreePath, getRepoPath, getWorktreeName } from '@/utils/worktree';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
 import { useRouter } from 'expo-router';
@@ -237,9 +237,12 @@ export const CompactSessionRow = React.memo(({ session, selected, showBorder }: 
     const [actionsAnchor, setActionsAnchor] = React.useState<SessionActionsAnchor | null>(null);
 
     const [archivingSession, performArchive] = useHappyAction(async () => {
-        const result = await sessionKill(session.id);
-        if (!result.success) {
-            throw new HappyError(result.message || t('sessionInfo.failedToArchiveSession'), false);
+        // Kill the CLI process; if it's already dead, force-archive via the
+        // server so an orphaned session can't get stuck active (#1739).
+        try {
+            await sessionKillOrArchive(session.id);
+        } catch (error) {
+            throw new HappyError(error instanceof Error ? error.message : t('sessionInfo.failedToArchiveSession'), false);
         }
     });
 

--- a/packages/happy-app/sources/components/FlatSessionRow.tsx
+++ b/packages/happy-app/sources/components/FlatSessionRow.tsx
@@ -13,7 +13,7 @@ import { useNavigateToSession } from '@/hooks/useNavigateToSession';
 import { useSessionActionAlert } from '@/hooks/useSessionQuickActions';
 import { useHappyAction } from '@/hooks/useHappyAction';
 import { HappyError } from '@/utils/errors';
-import { sessionKill } from '@/sync/ops';
+import { sessionKillOrArchive } from '@/sync/ops';
 import type { FlatSessionRowData } from '@/utils/flatSessionList';
 import { formatSessionListTimestamp } from '@/utils/sessionListTimestamp';
 import type { Theme } from '@/theme';
@@ -106,9 +106,12 @@ export const FlatSessionRow = React.memo(({ row, selected, showBorder, archived 
     );
 
     const [archiving, performArchive] = useHappyAction(async () => {
-        const result = await sessionKill(session.id);
-        if (!result.success) {
-            throw new HappyError(result.message || t('sessionInfo.failedToArchiveSession'), false);
+        // Kill the CLI process; if it's already dead, force-archive via the
+        // server so an orphaned session can't get stuck active (#1739).
+        try {
+            await sessionKillOrArchive(session.id);
+        } catch (error) {
+            throw new HappyError(error instanceof Error ? error.message : t('sessionInfo.failedToArchiveSession'), false);
         }
     });
 

--- a/packages/happy-app/sources/sync/ops.killOrArchive.test.ts
+++ b/packages/happy-app/sources/sync/ops.killOrArchive.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sessionRPC, request } = vi.hoisted(() => ({
+    sessionRPC: vi.fn(),
+    request: vi.fn(),
+}));
+
+vi.mock('./apiSocket', () => ({ apiSocket: { sessionRPC, request } }));
+vi.mock('./sync', () => ({ sync: {} }));
+vi.mock('./storage', () => ({ storage: {} }));
+
+describe('sessionKillOrArchive', () => {
+    beforeEach(() => {
+        sessionRPC.mockReset();
+        request.mockReset();
+    });
+
+    it('kills the CLI process and never archives when the kill succeeds', async () => {
+        sessionRPC.mockResolvedValue({ success: true, message: 'Killing happy-cli process' });
+
+        const { sessionKillOrArchive } = await import('./ops');
+        await expect(sessionKillOrArchive('session-1')).resolves.toBeUndefined();
+
+        expect(sessionRPC).toHaveBeenCalledWith('session-1', 'killSession', {});
+        expect(request).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the server-side archive when the CLI process is unreachable', async () => {
+        sessionRPC.mockRejectedValue(new Error('RPC method not available'));
+        request.mockResolvedValue({ ok: true, status: 200 });
+
+        const { sessionKillOrArchive } = await import('./ops');
+        await expect(sessionKillOrArchive('session-1')).resolves.toBeUndefined();
+
+        expect(request).toHaveBeenCalledWith('/v1/sessions/session-1/archive', { method: 'POST' });
+    });
+
+    it('throws when both the kill RPC and the server archive fail', async () => {
+        sessionRPC.mockResolvedValue({ success: false, message: 'The computer did not respond' });
+        request.mockResolvedValue({ ok: false, status: 503 });
+
+        const { sessionKillOrArchive } = await import('./ops');
+        await expect(sessionKillOrArchive('session-1')).rejects.toThrow('Server error: 503');
+    });
+
+    it('throws the kill error path when the archive request itself rejects', async () => {
+        sessionRPC.mockResolvedValue({ success: false, message: 'The computer did not respond' });
+        request.mockRejectedValue(new Error('Network down'));
+
+        const { sessionKillOrArchive } = await import('./ops');
+        await expect(sessionKillOrArchive('session-1')).rejects.toThrow('Network down');
+    });
+});

--- a/packages/happy-app/sources/sync/ops.ts
+++ b/packages/happy-app/sources/sync/ops.ts
@@ -1075,6 +1075,26 @@ export async function sessionArchive(sessionId: string): Promise<{ success: bool
 }
 
 /**
+ * Archive a session, stopping its CLI process first. When the CLI process is
+ * unreachable (killed, crashed, or never registered an RPC handler) the kill
+ * RPC fails, so fall back to the server-side force archive — otherwise an
+ * orphaned session would stay active with no way to archive it (#1739).
+ *
+ * Throws only when both the kill RPC and the server archive fail, so callers
+ * can surface that as a user-facing error.
+ */
+export async function sessionKillOrArchive(sessionId: string): Promise<void> {
+    const killResult = await sessionKill(sessionId);
+    if (killResult.success) {
+        return;
+    }
+    const archiveResult = await sessionArchive(sessionId);
+    if (!archiveResult.success) {
+        throw new Error(archiveResult.message || 'Failed to archive session');
+    }
+}
+
+/**
  * Permanently delete a session from the server
  * This will remove the session and all its associated data (messages, usage reports, access keys)
  * The session should be inactive/archived before deletion


### PR DESCRIPTION
## Summary

When a session's CLI process dies (crash or `kill`), the server keeps the session marked `active`, and **Archive in the home session list dead-ends**: it only sends the `killSession` RPC, which cannot reach a dead process — the caller waits out the RPC failure and then gets an error instead of an archive. Four other app surfaces (session info page, quick actions, side chats, draft-cleanup) already fall back from kill to the server-side force archive; the two home-list row components (`FlatSessionRow`, `CompactSessionRow`) were missing that fallback, so an orphaned session could not be cleared from the primary screen. This PR extracts the fallback into a shared op, `sessionKillOrArchive` (kill the CLI process; on failure, force-archive via `POST /v1/sessions/:id/archive`; throw only if both fail), uses it in both row components, and stops the session view's Stop button from dying with an unhandled `RPC method not available` rejection when its RPC target is gone.

## Before

With the CLI process dead, Archive from the home list spun for ~15s and then errored (`RPC method not available`). The session stayed `active: true` on the server: stop had no process to signal, archive refused to run, so the ghost session sat in the list with no way to clear it — the stop/archive deadlock from #1739.

## After

The same action on an orphaned session: the kill RPC fails as before, the fallback then force-archives via the server, and the session leaves the active list. Server state verified flipping `active: true → false` around the action.

**Demo video and Proof:**   https://github.com/user-attachments/assets/836a99a8-fa6d-4ae5-9542-fc99aa1aadc5



## Tests

- New `ops.killOrArchive.test.ts`: kill succeeds → no archive call; kill unreachable → server archive runs; both fail → throws with the server message.
- `pnpm --filter happy-app typecheck` passes; full happy-app vitest suite passes (one pre-existing flaky `encryption/blob.test.ts` perf test unrelated to this change).

Fixes #1739
