### PR TITLE
feat(app): add GPT-6 Astra and Claude Fable 5.1 to the model pickers

### DIFF
--- a/packages/happy-app/sources/components/modelModeOptions.test.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.test.ts
@@ -104,11 +104,12 @@ describe('modelModeOptions', () => {
     it('only offers the curated codex harness models', () => {
         const models = getCodexModelModes();
         expect(models.map((model) => model.key)).toEqual([
+            'gpt-6-astra',
             'gpt-5.6-sol',
             'gpt-5.6-terra',
             'gpt-5.6-luna',
         ]);
-        expect(models[0].name).toBe('GPT-5.6 Sol');
+        expect(models[0].name).toBe('GPT-6 Astra');
     });
 
     it('adds a configured custom codex model without expanding the shared catalog', () => {
@@ -116,24 +117,27 @@ describe('modelModeOptions', () => {
         const withCustom = includeConfiguredModel('codex', models, 'my-workspace-model');
 
         expect(withCustom.map((model) => model.key)).toEqual([
+            'gpt-6-astra',
             'gpt-5.6-sol',
             'gpt-5.6-terra',
             'gpt-5.6-luna',
             'my-workspace-model',
         ]);
-        expect(models).toHaveLength(3);
+        expect(models).toHaveLength(4);
         expect(includeConfiguredModel('claude', models, 'my-workspace-model')).toBe(models);
     });
 
     it('only offers the current-generation claude models', () => {
         const models = getClaudeModelModes();
         expect(models.map((model) => model.key)).toEqual([
+            'claude-fable-5-1',
             'claude-fable-5',
             'claude-opus-5',
             'claude-opus-5[1m]',
             'claude-sonnet-5',
         ]);
         expect(models.map((model) => model.name)).toEqual([
+            'Fable 5.1',
             'Fable 5',
             'Opus 5',
             'Opus 5 [1M]',
@@ -146,9 +150,11 @@ describe('modelModeOptions', () => {
     });
 
     it('offers every codex model the levels its own registry publishes', () => {
-        // Straight from codex-rs/models-manager/models.json: sol and terra
-        // publish ultra, luna does not. The difference is the whole point of
-        // asking per model rather than per flavor.
+        // Straight from codex-rs/models-manager/models.json: astra, sol and
+        // terra publish ultra, luna does not. The difference is the whole point
+        // of asking per model rather than per flavor.
+        expect(getEffortLevelsForModel('codex', 'gpt-6-astra').map((level) => level.key))
+            .toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
         expect(getEffortLevelsForModel('codex', 'gpt-5.6-sol').map((level) => level.key))
             .toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
         expect(getEffortLevelsForModel('codex', 'gpt-5.6-terra').map((level) => level.key))
@@ -165,7 +171,7 @@ describe('modelModeOptions', () => {
     it('offers claude the SDK effort union for every model', () => {
         // Claude's scale belongs to the SDK, not the model: an unreachable level
         // is silently downgraded, so all three models get the same list.
-        for (const model of ['claude-fable-5', 'claude-opus-5', 'claude-sonnet-5']) {
+        for (const model of ['claude-fable-5-1', 'claude-fable-5', 'claude-opus-5', 'claude-sonnet-5']) {
             const keys = getEffortLevelsForModel('claude', model).map((level) => level.key);
             expect(keys).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
             // Claude's floor is `low`; there is no off.

--- a/packages/happy-app/sources/components/modelModeOptions.ts
+++ b/packages/happy-app/sources/components/modelModeOptions.ts
@@ -138,6 +138,7 @@ export function getGeminiPermissionModes(translate: Translate): PermissionMode[]
 // suffix is honored rather than silently dropped (#1721).
 export function getClaudeModelModes(): ModelMode[] {
     return [
+        { key: 'claude-fable-5-1', name: 'Fable 5.1', description: null },
         { key: 'claude-fable-5', name: 'Fable 5', description: null },
         { key: 'claude-opus-5', name: 'Opus 5', description: null },
         { key: 'claude-opus-5[1m]', name: 'Opus 5 [1M]', description: '1M context' },
@@ -145,8 +146,17 @@ export function getClaudeModelModes(): ModelMode[] {
     ];
 }
 
+// GPT-6 Astra leads because it is the newest and most capable of these, and
+// it is the one row here that can fail for reasons the picker cannot see.
+// Codex's own registry marks it `visibility: hide` (it is configurable but
+// absent from Codex's picker) and `minimal_client_version: 0.153.0`, and access
+// rolls out per plan — so an older Codex CLI, or an account without Astra yet,
+// gets an error from Codex rather than a different model. There is no version
+// gate for it here: sinceCliVersion tags the happy-cli version, and nothing in
+// session metadata reports the Codex CLI's own version.
 export function getCodexModelModes(): ModelMode[] {
     return [
+        { key: 'gpt-6-astra', name: 'GPT-6 Astra', description: null },
         { key: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', description: null },
         { key: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', description: null },
         { key: 'gpt-5.6-luna', name: 'GPT-5.6 Luna', description: null },
@@ -493,12 +503,14 @@ function effortLevels(keys: readonly string[]): EffortLevel[] {
 const CLAUDE_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
 
 // Exactly what each model publishes in Codex's own registry, in its order
-// (codex-rs/models-manager/models.json, min client 0.144). This really is
-// per-model: sol and terra reach `ultra`, luna stops at `max`. `ultra` is
-// documented as maximum reasoning with automatic task delegation, so it is a
-// different kind of run rather than one more notch — but it is a level these
-// two models accept, so the picker offers it rather than deciding for you.
+// (codex-rs/models-manager/models.json; min client 0.153 for astra, 0.144 for
+// the gpt-5.6 family). This really is per-model: astra, sol and terra reach
+// `ultra`, luna stops at `max`. `ultra` is documented as maximum reasoning with
+// automatic task delegation, so it is a different kind of run rather than one
+// more notch — but it is a level these models accept, so the picker offers it
+// rather than deciding for you.
 const CODEX_EFFORTS_BY_MODEL: Record<string, readonly string[]> = {
+    'gpt-6-astra': ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
     'gpt-5.6-sol': ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
     'gpt-5.6-terra': ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
     'gpt-5.6-luna': ['low', 'medium', 'high', 'xhigh', 'max'],


### PR DESCRIPTION
## What

Adds the two newest models to the hardcoded picker catalogs, leading their lists. Existing rows and code defaults are unchanged.

- **Codex**: `gpt-6-astra` (GPT-6 Astra), with its published reasoning levels `low/medium/high/xhigh/max/ultra` added to `CODEX_EFFORTS_BY_MODEL`.
- **Claude**: `claude-fable-5-1` (Fable 5.1).

## Why these exact keys

- `gpt-6-astra` is the slug in Codex's own bundled registry (openai/codex `codex-rs/models-manager/models.json`, added in openai/codex#42607; `minimal_client_version: 0.153.0`). The effort levels are copied from its `supported_reasoning_levels`.
- `claude-fable-5-1` is in Claude Code's model table since 2.1.258. No `[1m]` row: 1M context is this model's default rather than a bracket variant.
- No **Astra Pro** row on purpose: “GPT-6 Astra Pro” is a ChatGPT plan feature, not an API/Codex model slug, so a row for it would error on every send.

## Caveat documented in-code

Astra can fail for reasons the picker cannot see: Codex's registry marks it `visibility: hide`, and account access is still rolling out per plan (a ChatGPT account without it gets `The 'gpt-6-astra' model is not supported when using Codex with a ChatGPT account`). The comment next to the row explains why there is no client-side gate: `sinceCliVersion` tags the happy-cli version, and session metadata does not carry the Codex CLI's own version.

## Testing

- `vitest run sources/components/modelModeOptions.test.ts` — 32 passing on top of current `main` (assertions updated alongside).
- Verified end to end on a locally hosted web build: both rows appear in the session picker, new-session composer, and agent-defaults settings; `claude --model claude-fable-5-1` spawns correctly; Astra correctly surfaces the server-side rollout error above.