### PR TITLE
feat(cli): add kimi and qwen presets to `happy acp`

### DIFF
--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KNOWN_ACP_AGENTS, resolveAcpAgentConfig } from './acpAgentConfig';
 
 describe('KNOWN_ACP_AGENTS', () => {
-  it('defines built-in Gemini and OpenCode command mappings', () => {
+  it('defines built-in Gemini, OpenCode, Kimi and Qwen command mappings', () => {
     expect(KNOWN_ACP_AGENTS).toEqual({
       gemini: { command: 'gemini', args: ['--experimental-acp'] },
       opencode: { command: 'opencode', args: ['acp'] },
+      kimi: { command: 'kimi', args: ['acp'] },
+      qwen: { command: 'qwen', args: ['--acp'] },
     });
   });
 });
@@ -32,6 +34,19 @@ describe('resolveAcpAgentConfig', () => {
       agentName: 'opencode',
       command: 'opencode',
       args: ['acp', '--foo'],
+    });
+  });
+
+  it('resolves kimi and qwen presets', () => {
+    expect(resolveAcpAgentConfig(['kimi'])).toEqual({
+      agentName: 'kimi',
+      command: 'kimi',
+      args: ['acp'],
+    });
+    expect(resolveAcpAgentConfig(['qwen', '--model', 'qwen3-coder'])).toEqual({
+      agentName: 'qwen',
+      command: 'qwen',
+      args: ['--acp', '--model', 'qwen3-coder'],
     });
   });
 

--- a/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
+++ b/packages/happy-cli/src/agent/acp/acpAgentConfig.ts
@@ -6,6 +6,8 @@ export type AcpAgentConfig = {
 export const KNOWN_ACP_AGENTS: Record<string, AcpAgentConfig> = {
   gemini: { command: 'gemini', args: ['--experimental-acp'] },
   opencode: { command: 'opencode', args: ['acp'] },
+  kimi: { command: 'kimi', args: ['acp'] },
+  qwen: { command: 'qwen', args: ['--acp'] },
 };
 
 export type ResolvedAcpAgentConfig = {


### PR DESCRIPTION
## Summary

`happy acp` ships presets for `gemini` and `opencode`, but Kimi Code CLI (`kimi acp`) and Qwen Code (`qwen --acp`) both speak ACP too, so users have to spell the long form (`happy acp -- kimi acp`). This PR adds `kimi` and `qwen` to `KNOWN_ACP_AGENTS` so `happy acp kimi` / `happy acp qwen [args]` just work, with passthrough args preserved. No behavior change for existing aliases.

## Proof

`resolveAcpAgentConfig` on this branch (run with tsx):

```
$ resolveAcpAgentConfig(['kimi'])
{"agentName":"kimi","command":"kimi","args":["acp"]}
$ resolveAcpAgentConfig(['qwen','--model','qwen3-coder'])
{"agentName":"qwen","command":"qwen","args":["--acp","--model","qwen3-coder"]}
```

The target commands exist as documented by the vendors (Kimi Code CLI 0.39.1 on my machine):

```
$ kimi acp --help
Usage: kimi acp [options]
Run kimi-code as an Agent Client Protocol (ACP) server over stdio.
```

Qwen Code's flag is `--acp` (also accepts `--experimental-acp`).

Unit tests (`packages/happy-cli`, `vitest run --project unit src/agent/acp/acpAgentConfig.test.ts`): 9 passed, including new cases for both presets. `tsc --noEmit` clean.

## Notes

- Kimi runs ACP over stdio exactly like OpenCode; I use `happy acp kimi` from a self-hosted happy server on a daily basis via the `--` form today, this only shortens it.
- No changes to sync/RPC/encryption/server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBfUsLSj8DBVvVmHSqCDqZ