### PR TITLE
chore: stamp CI/CD hygiene (dependabot auto-merge template)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      all-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    groups:
+      actions-all:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,50 @@
+name: Dependabot Auto-Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      # Pinned to a reviewed commit SHA, not a mutable tag — this workflow holds
+      # write permission and merges PRs, so a moved tag is a privileged-path risk.
+      # SHA is dependabot/fetch-metadata v2.5.0. Bump deliberately. (Codex 2026-08-26 #3)
+      - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        id: metadata
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Fail closed: only auto-merge when the base branch actually has required
+      # status checks. Without this, a repo with allow_auto_merge + no protection
+      # would merge minor/patch PRs with NO CI gate. A no-CI repo therefore does
+      # NOT auto-merge (clean skip, not a red run) until it gains a CI check.
+      # (Codex 2026-08-26 #2)
+      - name: Check base branch has required status checks
+        id: protection
+        run: |
+          contexts=$(gh api "repos/${GITHUB_REPOSITORY}/branches/${BASE}/protection/required_status_checks" --jq '.contexts | length' 2>/dev/null || echo "0")
+          if [ "${contexts:-0}" -ge 1 ]; then
+            echo "has_checks=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_checks=false" >> "$GITHUB_OUTPUT"
+            echo "No required status checks on ${BASE}; auto-merge will not fire (fail-closed)."
+          fi
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: |
+          steps.protection.outputs.has_checks == 'true' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reconciles .github/workflows/dependabot-auto-merge.yml (and .github/dependabot.yml where missing) with the canonical template in ~/.claude/c-suite/scripts/repo-bootstrap.sh, closing drift flagged by the weekly hygiene audit. Mechanical, files-only. No GitHub-side settings changed by this PR.